### PR TITLE
Harden server: path traversal guard, error handling, reconnect backoff

### DIFF
--- a/daemon.js
+++ b/daemon.js
@@ -213,6 +213,9 @@ async function start() {
 
   process.on("SIGINT", cleanup);
   process.on("SIGTERM", cleanup);
+  process.on("unhandledRejection", (err) => {
+    log.error("Unhandled rejection", { error: err?.message || String(err) });
+  });
 
   server.listen(SOCKET_PATH, () => {
     log.info("Katulong daemon listening", { socket: SOCKET_PATH });


### PR DESCRIPTION
## Summary
- **Path traversal prevention**: Static file handler now resolves paths and rejects requests outside `public/`
- **Error handling**: Wrap `readFileSync` in try/catch so a single bad file doesn't crash the server; add `process.on('unhandledRejection')` to both `server.js` and `daemon.js`
- **Daemon reconnect backoff**: Exponential backoff (1s → 30s cap) on daemon socket reconnect to avoid tight retry loops

Addresses items from #2.

## Test plan
- [x] `npx playwright test` — all E2E tests pass
- [x] Verify static files still served correctly
- [x] Confirm `/../` path requests return 404
- [x] Kill daemon, verify server reconnects with increasing delay in logs