### PR TITLE
Add test-results/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .DS_Store
 *.log
 katulong-auth.json
+test-results/


### PR DESCRIPTION
## Summary
- Add `test-results/` to `.gitignore` so Playwright test artifacts don't get committed

Addresses item from #2.

## Test plan
- [x] `git status` no longer shows `test-results/` as untracked