### PR TITLE
Extract P2P UI indicator into composable module

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -36,6 +36,7 @@
     import { createSettingsHandlers } from "/lib/settings-handlers.js";
     import { createTerminalKeyboard } from "/lib/terminal-keyboard.js";
     import { createInputSender } from "/lib/input-sender.js";
+    import { createP2PIndicator } from "/lib/p2p-ui.js";
 
     // --- Modal Manager ---
     const modals = new ModalRegistry();
@@ -162,17 +163,12 @@
       getWS: () => state.connection.ws
     });
 
-    // P2P UI indicator (pure effect)
-    function updateP2PIndicator() {
-      const dot = document.getElementById("p2p-indicator");
-      if (!dot) return;
-      const p2pState = p2pManager.getState();
-      dot.classList.toggle("p2p-active", p2pState.connected);
-      dot.classList.toggle("p2p-relay", state.connection.attached && !p2pState.connected);
-      dot.title = p2pState.connected ? "Connected (direct)"
-        : state.connection.attached ? "Connected (relay)"
-        : "Disconnected";
-    }
+    // P2P UI indicator
+    const p2pIndicator = createP2PIndicator({
+      p2pManager,
+      getConnectionState: () => ({ attached: state.connection.attached })
+    });
+    const updateP2PIndicator = () => p2pIndicator.update();
 
     document.title = state.session.name;
 

--- a/public/lib/p2p-ui.js
+++ b/public/lib/p2p-ui.js
@@ -1,0 +1,43 @@
+/**
+ * P2P UI Indicator
+ *
+ * Composable P2P connection status indicator.
+ */
+
+/**
+ * Create P2P UI indicator updater
+ */
+export function createP2PIndicator(options = {}) {
+  const {
+    p2pManager,
+    getConnectionState,
+    indicatorId = "p2p-indicator"
+  } = options;
+
+  /**
+   * Update P2P indicator UI
+   */
+  function update() {
+    const dot = document.getElementById(indicatorId);
+    if (!dot) return;
+
+    const p2pState = p2pManager ? p2pManager.getState() : { connected: false };
+    const connectionState = getConnectionState ? getConnectionState() : {};
+    const attached = connectionState.attached || false;
+
+    // Update CSS classes
+    dot.classList.toggle("p2p-active", p2pState.connected);
+    dot.classList.toggle("p2p-relay", attached && !p2pState.connected);
+
+    // Update title/tooltip
+    dot.title = p2pState.connected
+      ? "Connected (direct)"
+      : attached
+        ? "Connected (relay)"
+        : "Disconnected";
+  }
+
+  return {
+    update
+  };
+}


### PR DESCRIPTION
## Summary

Extract P2P connection status indicator into a composable module.

## Changes

- Create `p2p-ui.js` for P2P indicator UI updates
- Composable updater with callbacks for state access
- Remove ~4 lines from `app.js` (now 906 lines)

## Benefits

- **Reusable** - Can be used independently
- **Testable** - Isolated UI logic
- **Clear separation** - UI concerns separated from business logic

## Testing

- All 666 unit tests passing ✅
- No breaking changes

## Stats

- **Before:** 910 lines
- **After:** 906 lines
- **Reduction:** 4 lines

🤖 Part of ongoing modularization (70% reduction total)