### PR TITLE
Extract modal initialization to modal-init.js

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -38,42 +38,12 @@
     import { createInputSender } from "/lib/input-sender.js";
     import { createP2PIndicator } from "/lib/p2p-ui.js";
     import { loadQRLib, getConnectInfo, checkPairingStatus } from "/lib/wizard-utils.js";
+    import { initModals } from "/lib/modal-init.js";
 
     // --- Modal Manager ---
     const modals = new ModalRegistry();
 
-    // Register modals (will be called after terminal is created)
-    function initModals(terminal) {
-      modals.register('shortcuts', 'shortcuts-overlay', {
-        returnFocus: terminal,
-        onClose: () => terminal.focus()
-      });
-      modals.register('edit', 'edit-overlay', {
-        returnFocus: terminal,
-        onClose: () => terminal.focus()
-      });
-      modals.register('add', 'add-modal', {
-        returnFocus: terminal,
-        onOpen: () => {
-          // Focus the key composer input after modal opens
-          const keyInput = document.getElementById("key-composer-input");
-          if (keyInput) keyInput.focus();
-        },
-        onClose: () => terminal.focus()
-      });
-      modals.register('session', 'session-overlay', {
-        returnFocus: terminal,
-        onClose: () => terminal.focus()
-      });
-      modals.register('dictation', 'dictation-overlay', {
-        returnFocus: terminal,
-        onClose: () => terminal.focus()
-      });
-      modals.register('settings', 'settings-overlay', {
-        returnFocus: terminal,
-        onClose: () => terminal.focus()
-      });
-    }
+    // Modal registration imported from /lib/modal-init.js
 
     // --- Theme (using composable theme manager) ---
     const themeManager = createThemeManager({
@@ -189,7 +159,7 @@
     term.open(document.getElementById("terminal-container"));
 
     // Initialize modals with terminal reference
-    initModals(term);
+    initModals(modals, term);
 
     // Disable mobile autocorrect/suggestions on xterm's hidden textarea
     function patchTextarea() {

--- a/public/lib/modal-init.js
+++ b/public/lib/modal-init.js
@@ -1,0 +1,51 @@
+/**
+ * Modal Initialization
+ *
+ * Register all application modals with the modal registry.
+ */
+
+/**
+ * Initialize all modals
+ */
+export function initModals(modals, terminal) {
+  // Shortcuts modal
+  modals.register('shortcuts', 'shortcuts-overlay', {
+    returnFocus: terminal,
+    onClose: () => terminal.focus()
+  });
+
+  // Edit shortcuts modal
+  modals.register('edit', 'edit-overlay', {
+    returnFocus: terminal,
+    onClose: () => terminal.focus()
+  });
+
+  // Add shortcut modal
+  modals.register('add', 'add-modal', {
+    returnFocus: terminal,
+    onOpen: () => {
+      // Focus the key composer input after modal opens
+      const keyInput = document.getElementById("key-composer-input");
+      if (keyInput) keyInput.focus();
+    },
+    onClose: () => terminal.focus()
+  });
+
+  // Session manager modal
+  modals.register('session', 'session-overlay', {
+    returnFocus: terminal,
+    onClose: () => terminal.focus()
+  });
+
+  // Dictation modal
+  modals.register('dictation', 'dictation-overlay', {
+    returnFocus: terminal,
+    onClose: () => terminal.focus()
+  });
+
+  // Settings modal
+  modals.register('settings', 'settings-overlay', {
+    returnFocus: terminal,
+    onClose: () => terminal.focus()
+  });
+}


### PR DESCRIPTION
## Summary
- Extracted modal registration logic from app.js to `/public/lib/modal-init.js`
- Updated function signature to `initModals(modals, terminal)` for better composability
- Reduces app.js by ~31 lines (854 → 823)

## Changes
- Created `/public/lib/modal-init.js` with `initModals()` function
- Updated app.js to import and call the new module
- All 666 tests passing ✅

Part of the ongoing app.js modularization effort.