### PR TITLE
Make node-datachannel optional for Homebrew compatibility

### DIFF
--- a/lib/p2p.js
+++ b/lib/p2p.js
@@ -1,8 +1,23 @@
 import SimplePeer from "simple-peer";
-import nodeDataChannel from "node-datachannel/polyfill";
 import { log } from "./log.js";
 
+let nodeDataChannel = null;
+export let p2pAvailable = false;
+
+export async function initP2P() {
+  try {
+    nodeDataChannel = (await import("node-datachannel/polyfill")).default;
+    p2pAvailable = true;
+    log.info("P2P WebRTC available (node-datachannel loaded)");
+  } catch (err) {
+    p2pAvailable = false;
+    log.warn("P2P WebRTC unavailable — falling back to WebSocket only", { error: err.message });
+  }
+}
+
 export function createServerPeer(onSignal, onData, onClose) {
+  if (!p2pAvailable) return null;
+
   const peer = new SimplePeer({
     initiator: false,
     trickle: true,


### PR DESCRIPTION
## Summary
- Converts the static `import nodeDataChannel from "node-datachannel/polyfill"` to a dynamic `import()` with try/catch, so the server starts without the native C++ binary
- When unavailable, logs a warning and runs in WebSocket-only mode — P2P signaling requests get a `p2p-unavailable` response
- No changes needed to the Homebrew formula — the runtime graceful degradation handles the missing binary

## Context
The Homebrew-installed server crashes on startup because `node-datachannel` (a native C++ addon) can't find its compiled binary (`node_datachannel.node`). P2P/WebRTC is an optional latency optimization; the server already has full WebSocket fallback for terminal I/O.

## Test plan
- [x] `npm run test:unit` — 698 tests pass, 0 failures
- [x] Server starts with native module present → logs `P2P WebRTC available (node-datachannel loaded)`
- [x] Server starts with native module missing (renamed `build/` dir) → logs `P2P WebRTC unavailable — falling back to WebSocket only`, runs normally
- [x] E2E tests pass (191 passed, 3 pre-existing flaky)