### PR TITLE
Release v0.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katulong",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump version to 0.4.4

## Background
Users running v0.4.3 may have certificates generated by older versions that don't include LAN IP addresses in Subject Alternative Names (SANs). This causes "Not Secure" warnings when accessing Katulong from other machines on the LAN.

## What's in this release
The code for LAN IP support was already merged in v0.4.3, but this release encourages users to regenerate their certificates to get the full benefit.

## User action required
After upgrading to v0.4.4, users should run:
```bash
katulong clean
brew services restart katulong
```

This will regenerate certificates with LAN IPs included, allowing secure access from other machines on the local network.

## Test plan
- [x] Unit tests pass (772/773)
- [x] E2E tests pass (246 passed, 2 flaky passed on retry)
- [x] Pre-push hooks pass