### PR TITLE
Use LAN IP as certificate CN instead of localhost

### DIFF
--- a/lib/certificate-manager.js
+++ b/lib/certificate-manager.js
@@ -833,9 +833,10 @@ export class CertificateManager {
       cert.validity.notBefore.getFullYear() + SERVER_YEARS,
     );
 
+    const primaryIp = ips.find(ip => ip !== "127.0.0.1" && ip !== "::1") || "localhost";
     const attrs = [
       { name: "organizationName", value: this.instanceName },
-      { name: "commonName", value: "localhost" },
+      { name: "commonName", value: primaryIp },
     ];
     cert.setSubject(attrs);
     cert.setIssuer(caCert.subject.attributes);

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -73,9 +73,11 @@ function generateServerCert(caCert, caKey, instanceName) {
     cert.validity.notBefore.getFullYear() + SERVER_YEARS,
   );
 
+  const lanIPs = getLanIPs();
+  const primaryHost = lanIPs[0] || "localhost";
   const attrs = [
     { name: "organizationName", value: instanceName },
-    { name: "commonName", value: "localhost" },
+    { name: "commonName", value: primaryHost },
   ];
   cert.setSubject(attrs);
   cert.setIssuer(caCert.subject.attributes);


### PR DESCRIPTION
## Summary
- Server certificates for LAN access had `CN=localhost` even though they were for LAN IPs like `192.168.1.138`
- Updated `generateNetworkCert()` in `certificate-manager.js` and `generateServerCert()` in `tls.js` to use the primary LAN IP as the CN
- SANs already contained the correct IPs; this fixes the CN to match

## Test plan
- [x] All 783 unit/integration tests pass
- [ ] CI green
- [ ] After upgrade, regenerate cert and verify `CN=<LAN IP>` via `openssl x509 -noout -subject`

🤖 Generated with [Claude Code](https://claude.com/claude-code)