### PR TITLE
Fix iPad Safari joystick unresponsive to touch

### DIFF
--- a/public/lib/joystick.js
+++ b/public/lib/joystick.js
@@ -219,7 +219,7 @@ export function createJoystickManager(options = {}) {
         const rect = joystick.getBoundingClientRect();
         const zone = getZone(t, rect);
         dispatch({ type: 'TOUCH_START', zone, x: t.clientX, y: t.clientY });
-      });
+      }, { passive: false });
 
       joystick.addEventListener("touchmove", (e) => {
         e.preventDefault();
@@ -229,7 +229,7 @@ export function createJoystickManager(options = {}) {
         const rect = joystick.getBoundingClientRect();
         const newZone = (joyState.mode === 'hold') ? getZone(t, rect) : null;
         dispatch({ type: 'TOUCH_MOVE', dx, dy, newZone });
-      });
+      }, { passive: false });
 
       joystick.addEventListener("touchend", (e) => {
         e.preventDefault();
@@ -247,12 +247,12 @@ export function createJoystickManager(options = {}) {
         }
 
         dispatch({ type: 'TOUCH_END' });
-      });
+      }, { passive: false });
 
       joystick.addEventListener("touchcancel", (e) => {
         e.preventDefault();
         dispatch({ type: 'TOUCH_CANCEL' });
-      });
+      }, { passive: false });
     },
 
     getState: () => joyState


### PR DESCRIPTION
## Summary
- Adds `{ passive: false }` to all four touch event listeners (`touchstart`, `touchmove`, `touchend`, `touchcancel`) in the joystick's `init()` method
- Safari treats touch event listeners as passive by default, which silently ignores `preventDefault()` calls, causing the joystick to be visible but completely unresponsive on iPad Safari
- The browser was processing touches as native scroll/gesture events instead of routing them to the custom joystick handlers

## Test plan
- [ ] Open Katulong on iPad Safari and verify the joystick responds to touch input
- [ ] Verify hold-left/right produces repeated arrow keys
- [ ] Verify flick up/down produces single arrow key
- [ ] Verify long-press center sends Enter
- [ ] Verify joystick still works on Chrome/Firefox mobile
- [ ] Run `npm run test:unit` -- all 771 tests pass

Fixes #75