### PR TITLE
Fix paste in dictation modal intercepted by terminal

### DIFF
--- a/public/lib/paste-handler.js
+++ b/public/lib/paste-handler.js
@@ -20,6 +20,14 @@ export function createPasteHandler(options = {}) {
    * Handle paste event
    */
   function handlePaste(e) {
+    // Let native paste work in input/textarea elements (e.g., dictation modal)
+    // except for xterm's hidden textarea which we always intercept
+    const target = e.target;
+    if ((target.tagName === "TEXTAREA" || target.tagName === "INPUT") &&
+        !target.classList.contains("xterm-helper-textarea")) {
+      return;
+    }
+
     // Check for pasted images first (e.g., screenshots)
     const imageFiles = [...(e.clipboardData?.files || [])].filter(isImageFileFn);
     if (imageFiles.length > 0) {


### PR DESCRIPTION
## Summary

- The document-level paste handler in `paste-handler.js` intercepted **all** paste events, including those targeting the dictation modal textarea and other input fields
- Pasting into the dictation textarea would send text directly to the terminal instead of appending to the textarea
- Now skips interception when the paste target is a `<textarea>` or `<input>` (except xterm's hidden helper textarea, which still routes to the terminal)

## Test plan

- [ ] Open dictation modal (long-press on terminal)
- [ ] Paste text into the textarea — should appear in textarea, not terminal
- [ ] Close modal, paste in terminal — should still send to terminal as before
- [ ] Paste into session name input — should appear in input field
- [ ] Paste an image — should still be handled by the image upload flow