### PR TITLE
Add deprecation warnings to lib/tls.js and lib/p2p.js

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -3,9 +3,21 @@ import { networkInterfaces, hostname } from "node:os";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
+import { log } from "./log.js";
 
 const CA_YEARS = 10;
 const SERVER_YEARS = 2;
+
+let deprecationWarned = false;
+
+function warnDeprecated() {
+  if (deprecationWarned) return;
+  deprecationWarned = true;
+  log.warn(
+    "[DEPRECATED] LAN TLS (auto-generated certificates) is deprecated and will be removed in a future release. " +
+    "Use a tunnel service instead (e.g. cloudflared, ngrok) for secure remote access without managing certificates.",
+  );
+}
 
 export function getLanIPs() {
   const ips = [];
@@ -325,6 +337,7 @@ export function generateMobileConfig(caCertPem, instanceName, instanceId) {
 }
 
 export function ensureCerts(dataDir, instanceName, instanceId, options = {}) {
+  warnDeprecated();
   const { force = false } = options;
 
   const tlsDir = join(dataDir, "tls");


### PR DESCRIPTION
Closes #79

## Context

Part of #74 — Deprecate LAN support in favor of tunnel-based remote access.

This is the first incremental step: add runtime deprecation warnings so users know these features are going away.

## Requirements

- Add deprecation warnings to `lib/tls.js` — when TLS certificates are auto-generated or used, log a warning that LAN TLS support is deprecated and users should switch to a tunnel service (cloudflared, ngrok, etc.)
- Add deprecation warnings to `lib/p2p.js` — when WebRTC P2P connections are initiated, log a warning that P2P transport is deprecated and WebSocket over tunnel is the recommended path
- Use the existing `lib/log.js` logger for warnings
- Warnings should be clear and actionable: tell users what's deprecated and what to use instead
- Warnings should only fire once per server startup (not on every connection) to avoid log spam
- Do NOT remove any functionality — this is warnings only

## Acceptance criteria

- [ ] `lib/tls.js` logs a deprecation warning on first use
- [ ] `lib/p2p.js` logs a deprecation warning on first use
- [ ] Warnings reference tunnel services as the alternative
- [ ] Warnings fire once per process, not per-connection
- [ ] Existing tests pass
- [ ] No functional changes to TLS or P2P behavior

---
*This PR was opened by a sipag worker. Commits will appear as work progresses.*