### PR TITLE
Simplify origin validation to localhost-only

### DIFF
--- a/lib/access-method.js
+++ b/lib/access-method.js
@@ -3,7 +3,6 @@
  *
  * Determines how the user is accessing Katulong:
  * - "localhost" - Direct access from same machine (127.0.0.1, localhost)
- * - "lan" - Local network access (192.168.x.x, 10.x.x.x, katulong.local)
  * - "internet" - Remote access via reverse proxy (ngrok, Cloudflare Tunnel, etc.)
  *
  * This classification is used to determine:
@@ -59,45 +58,17 @@ export function isLocalRequest(req) {
 }
 
 /**
- * Detect if request is coming from local area network.
- *
- * LAN access is characterized by:
- * - Private IP addresses (192.168.x.x, 10.x.x.x, 172.16-31.x.x)
- * - .local mDNS domains (katulong.local)
- * - Link-local addresses (169.254.x.x)
- *
- * @param {import('http').IncomingMessage} req - HTTP request
- * @returns {boolean} True if request is from LAN
- */
-export function isLanRequest(req) {
-  const host = (req.headers.host || "").toLowerCase().split(":")[0];
-
-  // Check for .local mDNS domains
-  if (host.endsWith(".local")) return true;
-
-  // Check for private IP addresses (RFC 1918)
-  if (/^10\./.test(host)) return true;                          // 10.0.0.0/8
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;    // 172.16.0.0/12
-  if (/^192\.168\./.test(host)) return true;                    // 192.168.0.0/16
-  if (/^169\.254\./.test(host)) return true;                    // 169.254.0.0/16 (link-local)
-
-  return false;
-}
-
-/**
  * Get the access method for this request.
  *
  * Returns one of:
  * - "localhost" - Same machine, auto-authenticated
- * - "lan" - Local network, requires cert trust + pairing or passkey
- * - "internet" - Remote access, requires passkey + setup token
+ * - "internet" - Remote access via tunnel or direct connection
  *
  * @param {import('http').IncomingMessage} req - HTTP request
- * @returns {"localhost" | "lan" | "internet"} Access method
+ * @returns {"localhost" | "internet"} Access method
  */
 export function getAccessMethod(req) {
   if (isLocalRequest(req)) return "localhost";
-  if (isLanRequest(req)) return "lan";
   return "internet";
 }
 
@@ -116,8 +87,6 @@ export function getAccessDescription(req) {
   switch (method) {
     case "localhost":
       return `localhost (${addr})`;
-    case "lan":
-      return `lan (${host})`;
     case "internet":
       return `internet (${host})`;
     default:

--- a/lib/https-enforcement.js
+++ b/lib/https-enforcement.js
@@ -4,15 +4,15 @@
  * Handles HTTPS redirection logic for different access methods.
  * Key principles:
  * - Localhost: No HTTPS required (auto-authenticated)
- * - LAN: Requires HTTPS after certificate trust (cert install paths allowed on HTTP)
- * - Internet (ngrok): Requires HTTPS (provided by reverse proxy, but allow public paths on HTTP)
+ * - Internet (ngrok, Cloudflare Tunnel, etc.): TLS is terminated at the tunnel edge;
+ *   public paths allowed over HTTP, protected paths redirect to /login
  */
 
 import { getAccessMethod } from './access-method.js';
 
 /**
  * Paths that are explicitly allowed over HTTP for certificate installation.
- * These are needed to bootstrap HTTPS on LAN (chicken-and-egg problem).
+ * These are needed to bootstrap HTTPS (cert install paths must be reachable over HTTP).
  */
 export const HTTP_ALLOWED_PATHS = [
   "/connect/trust",
@@ -26,13 +26,12 @@ export const HTTP_ALLOWED_PATHS = [
  * Returns one of:
  * - null: HTTPS not required (allow request to proceed)
  * - { redirect: string }: Redirect to this URL
- * - { block: string }: Block request with this error message
  *
  * @param {import('http').IncomingMessage} req - HTTP request
  * @param {string} pathname - Request pathname
  * @param {Function} isPublicPath - Function to check if path is public
  * @param {Function} isHttpsConnection - Function to check if connection is HTTPS (including tunnels)
- * @returns {null | {redirect: string} | {block: string}} Enforcement action
+ * @returns {null | {redirect: string}} Enforcement action
  */
 export function checkHttpsEnforcement(req, pathname, isPublicPath, isHttpsConnection) {
   // Already HTTPS (including tunnels like ngrok) - nothing to enforce
@@ -52,67 +51,14 @@ export function checkHttpsEnforcement(req, pathname, isPublicPath, isHttpsConnec
     return null;
   }
 
-  // Public paths (login assets, etc.): Allow HTTP for internet access (ngrok)
-  // This allows ngrok to serve the login page over HTTP locally before TLS termination
+  // Public paths (login assets, etc.): Allow HTTP for internet access
+  // Tunnel services (ngrok, Cloudflare) terminate TLS at their edge
   if (isPublicPath(pathname)) {
-    // LAN: Require HTTPS even for public paths (after cert trust)
-    // This prevents accessing login page over HTTP on LAN
-    if (accessMethod === "lan") {
-      // Exception: Allow /connect/trust page itself to be served over HTTP
-      if (pathname.startsWith("/connect/trust")) {
-        return null;
-      }
-      // All other paths on LAN require HTTPS
-      return { redirect: `https://${getHost(req)}:${getHttpsPort()}${req.url}` };
-    }
-    // Internet: Allow public paths over HTTP (ngrok terminates TLS upstream)
     return null;
   }
 
-  // Protected paths: Always require HTTPS (except localhost)
-  // Determine redirect target based on access method
-  const redirectTarget = getHttpsRedirectTarget(accessMethod, pathname);
-  return { redirect: redirectTarget };
-}
-
-/**
- * Get the redirect target for HTTPS enforcement.
- *
- * @param {"lan" | "internet"} accessMethod - Access method (not localhost)
- * @param {string} currentPath - Current pathname
- * @returns {string} Redirect URL
- */
-function getHttpsRedirectTarget(accessMethod, currentPath) {
-  if (accessMethod === "lan") {
-    // LAN: Redirect to certificate trust page (need to install cert first)
-    // Exception: If already on /connect/trust, allow it through
-    if (currentPath === "/connect/trust") {
-      return currentPath; // No redirect, allow it through (handled by null check above)
-    }
-    return "/connect/trust";
-  } else {
-    // Internet: Redirect to login page (ngrok provides valid TLS)
-    return "/login";
-  }
-}
-
-/**
- * Get the host without port for redirect URLs.
- *
- * @param {import('http').IncomingMessage} req - HTTP request
- * @returns {string} Host without port
- */
-function getHost(req) {
-  return (req.headers.host || "localhost").replace(/:\d+$/, "");
-}
-
-/**
- * Get the HTTPS port from environment or default.
- *
- * @returns {number} HTTPS port
- */
-function getHttpsPort() {
-  return parseInt(process.env.HTTPS_PORT || "3002", 10);
+  // Protected paths: Redirect to login
+  return { redirect: "/login" };
 }
 
 /**
@@ -123,55 +69,23 @@ function getHttpsPort() {
  * @returns {string} Redirect path
  */
 export function getUnauthenticatedRedirect(req) {
-  const accessMethod = getAccessMethod(req);
-
-  // LAN over HTTP: Redirect to certificate trust page
-  if (accessMethod === "lan" && !req.socket.encrypted) {
-    return "/connect/trust";
-  }
-
-  // All other cases: Redirect to login
+  // All unauthenticated non-localhost requests redirect to login
   return "/login";
 }
 
 /**
  * Check if request needs session validation and HTTPS redirect.
- * For LAN users who have a valid session but are accessing over HTTP,
- * redirect them to HTTPS (they've already installed the cert).
+ * With tunnel-based access, HTTPS is terminated at the tunnel edge, so
+ * no local HTTPS redirect is needed. This function always returns null.
  *
  * @param {import('http').IncomingMessage} req - HTTP request
  * @param {string} pathname - Request pathname
  * @param {Function} isPublicPath - Function to check if path is public
  * @param {Function} validateSession - Function to validate session
- * @returns {null | {redirect: string}} Redirect action or null
+ * @returns {null} Always null (no local HTTPS redirect needed)
  */
 export function checkSessionHttpsRedirect(req, pathname, isPublicPath, validateSession) {
-  // Only check if:
-  // 1. Not already on HTTPS
-  // 2. Not localhost
-  // 3. Not a public path
-  // 4. Not a cert installation path
-  if (req.socket.encrypted) return null;
-
-  const accessMethod = getAccessMethod(req);
-
-  if (accessMethod === "localhost") return null;
-  if (isPublicPath(pathname)) return null;
-  if (HTTP_ALLOWED_PATHS.includes(pathname)) return null;
-
-  // Internet access (ngrok, etc.): Don't redirect to local HTTPS port
-  // The reverse proxy already handles HTTPS at the edge
-  if (accessMethod === "internet") return null;
-
-  // LAN access: Check if user has a valid session (they've installed cert)
-  const hasValidSession = validateSession(req);
-
-  if (hasValidSession) {
-    // User has cert installed, redirect to HTTPS
-    const host = getHost(req);
-    const httpsPort = getHttpsPort();
-    return { redirect: `https://${host}:${httpsPort}${req.url}` };
-  }
-
+  // With tunnel-based remote access, HTTPS is handled at the tunnel edge.
+  // No local HTTPS redirect is needed.
   return null;
 }

--- a/lib/websocket-validation.js
+++ b/lib/websocket-validation.js
@@ -110,6 +110,32 @@ export function validateResize(msg) {
 }
 
 /**
+ * Validate WebSocket origin to prevent Cross-Site WebSocket Hijacking (CSWSH).
+ *
+ * Only accepts connections where the Origin header host matches the Host header.
+ * Localhost requests should bypass this check (browsers may omit Origin for local pages).
+ *
+ * @param {string|undefined} origin - Value of the Origin request header
+ * @param {string|undefined} host - Value of the Host request header
+ * @returns {{ valid: boolean, error?: string }}
+ */
+export function validateOrigin(origin, host) {
+  if (!origin) {
+    return { valid: false, error: "Missing Origin header" };
+  }
+  let originHost;
+  try {
+    originHost = new URL(origin).host;
+  } catch {
+    return { valid: false, error: "Invalid Origin header" };
+  }
+  if (originHost !== host) {
+    return { valid: false, error: `Origin mismatch: ${origin} != ${host}` };
+  }
+  return { valid: true };
+}
+
+/**
  * Validate any WebSocket message
  * Routes to specific validator based on type
  */


### PR DESCRIPTION
Closes #82

## Context

Part of #74 — Deprecate LAN support in favor of tunnel-based remote access.

Should be done after TLS and P2P removal so the LAN code paths are already gone.

## Requirements

- Simplify WebSocket origin validation in `lib/websocket-validation.js` to only accept localhost origins
- Remove LAN IP, hostname, and `.local` domain matching logic
- Remove mDNS / Bonjour discovery if present
- Simplify `isLocalRequest()` in `lib/http-util.js` if it has LAN-specific logic beyond `127.0.0.1`/`::1`
- Tunnel services (cloudflared, ngrok) forward requests as localhost, so this should work transparently
- Ensure the origin check still allows tunnel-forwarded requests (they arrive as localhost)

## Acceptance criteria

- [ ] Origin validation only accepts localhost origins (`127.0.0.1`, `::1`, `localhost`)
- [ ] LAN IP/hostname matching removed from websocket-validation
- [ ] mDNS/Bonjour discovery removed if present
- [ ] WebSocket connections via tunnel services still work (they arrive as localhost)
- [ ] Existing tests updated to reflect simplified validation
- [ ] No regression in localhost WebSocket functionality

---
*This PR was opened by a sipag worker. Commits will appear as work progresses.*