### PR TITLE
Code hygiene: fix inconsistent error handling patterns

### DIFF
--- a/daemon.js
+++ b/daemon.js
@@ -261,9 +261,11 @@ async function start() {
     // Restore original umask
     process.umask(oldUmask);
     // Double-check permissions (defense-in-depth)
-    try { chmodSync(SOCKET_PATH, 0o600); } catch { /* best-effort */ }
+    try { chmodSync(SOCKET_PATH, 0o600); } catch { /* best-effort on platforms that don't support chmod */ }
     // Write PID file for safe process management
-    try { writeFileSync(PID_PATH, String(process.pid), { mode: 0o600 }); } catch {}
+    try { writeFileSync(PID_PATH, String(process.pid), { mode: 0o600 }); } catch (err) {
+      log.warn("Failed to write PID file", { path: PID_PATH, error: err.message });
+    }
     log.info("Katulong daemon listening", { socket: SOCKET_PATH, pid: process.pid });
   });
 }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -9,6 +9,7 @@ import {
   verifyAuthenticationResponse,
 } from "@simplewebauthn/server";
 import { AuthState } from "./auth-state.js";
+import { log } from "./log.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = process.env.KATULONG_DATA_DIR || join(__dirname, "..");
@@ -65,7 +66,7 @@ export function loadState() {
         credentials: migratedCredentials,
         sessions: state.sessions,
       });
-      console.log('Migrated credentials to include device metadata');
+      log.info('Migrated credentials to include device metadata');
     }
 
     // Migration: Remove orphaned sessions (sessions for non-existent credentials)
@@ -105,7 +106,7 @@ export function loadState() {
         credentials: state.credentials,
         sessions: cleanedSessions,
       });
-      console.log('Cleaned up orphaned sessions');
+      log.info('Cleaned up orphaned sessions');
     }
 
     // Migration: Add lastActivityAt to sessions that don't have it (for sliding expiry)
@@ -127,7 +128,7 @@ export function loadState() {
         credentials: state.credentials,
         sessions: migratedSessions,
       });
-      console.log('Added lastActivityAt to existing sessions');
+      log.info('Added lastActivityAt to existing sessions');
     }
 
     // Save migrated state if any changes were made
@@ -139,7 +140,7 @@ export function loadState() {
     return _cachedState;
   } catch (err) {
     // Corrupt JSON - log error and treat as if file doesn't exist
-    console.error(`Failed to parse ${STATE_PATH}: ${err.message}. Starting with fresh state.`);
+    log.error(`Failed to parse auth state`, { path: STATE_PATH, error: err.message });
     _cachedState = null;
     return null;
   }
@@ -365,6 +366,10 @@ export async function withStateLock(modifier) {
     saveState(result);
     return result;
   });
-  _stateLock = operation.catch(() => {}); // Swallow errors for next operation
+  _stateLock = operation.catch((err) => {
+    // Swallow errors so the mutex chain continues for subsequent operations.
+    // Log at warn level so failures are visible without blocking callers.
+    log.warn("withStateLock operation failed", { error: err?.message || String(err) });
+  });
   return operation;
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, existsSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import { hostname } from "node:os";
 import { randomUUID } from "node:crypto";
+import { log } from "./log.js";
 
 /**
  * ConfigManager handles instance configuration
@@ -49,7 +50,7 @@ export class ConfigManager {
           this.save();
         }
       } catch (error) {
-        console.error("Failed to load config, using defaults:", error.message);
+        log.error("Failed to load config, using defaults", { path: this.configPath, error: error.message });
         this.config = this.getDefaultConfig();
       }
     } else {

--- a/lib/static-files.js
+++ b/lib/static-files.js
@@ -76,6 +76,7 @@ export function serveStaticFile(res, publicDir, pathname, options = {}) {
       return false;
     }
   } catch {
+    // File disappeared between existsSync and statSync, or permission error — treat as not found
     return false;
   }
 
@@ -88,6 +89,7 @@ export function serveStaticFile(res, publicDir, pathname, options = {}) {
   try {
     content = readFileSync(filePath);
   } catch {
+    // File disappeared between statSync and readFileSync, or permission error — treat as not found
     return false;
   }
 

--- a/server.js
+++ b/server.js
@@ -1706,6 +1706,12 @@ wss.on("connection", (ws) => {
     }
   });
 
+  ws.on("error", (err) => {
+    log.error("WebSocket client error", { clientId, error: err.message });
+    wsClients.delete(clientId);
+    daemonSend({ type: "detach", clientId });
+  });
+
   ws.on("close", () => {
     log.debug("Client disconnected", { clientId });
     wsClients.delete(clientId);
@@ -1715,10 +1721,13 @@ wss.on("connection", (ws) => {
 
 // Live-reload (dev only)
 if (process.env.NODE_ENV !== "production") {
-  watch(join(__dirname, "public"), { recursive: true }, () => {
+  const watcher = watch(join(__dirname, "public"), { recursive: true }, () => {
     for (const client of wss.clients) {
       if (client.readyState === 1) client.send(JSON.stringify({ type: "reload" }));
     }
+  });
+  watcher.on("error", (err) => {
+    log.warn("Live-reload watcher error", { error: err.message });
   });
 }
 


### PR DESCRIPTION
Closes #90

## Context

General code health pass. Error handling across the codebase uses mixed patterns -- some places use try/catch, some use callbacks, some swallow errors silently. This makes debugging harder and can hide real issues.

## Requirements

- Audit all try/catch blocks for swallowed errors (empty catch blocks or catch blocks that only log but should propagate)
- Ensure all async operations have proper error handling (no unhandled promise rejections)
- Standardize error logging -- use the existing `lib/log.js` logger consistently instead of raw `console.error`
- Add error handling to any unprotected file I/O, network calls, or IPC operations
- Ensure WebSocket error/close handlers clean up resources properly
- Check daemon IPC error paths -- ensure the server handles daemon disconnects gracefully
- Do NOT change the error handling contract of public APIs -- only improve internal consistency

## Acceptance criteria

- [ ] No empty catch blocks
- [ ] No unhandled promise rejections
- [ ] Consistent use of `lib/log.js` for error logging
- [ ] File I/O and network calls have proper error handling
- [ ] WebSocket and IPC cleanup on error/close
- [ ] Full test suite passes
- [ ] No functional changes beyond improved error resilience

---
*This PR was opened by a sipag worker. Commits will appear as work progresses.*