### PR TITLE
Code hygiene: remove dead code and unused imports

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -65,7 +65,6 @@ export function loadState() {
         credentials: migratedCredentials,
         sessions: state.sessions,
       });
-      console.log('Migrated credentials to include device metadata');
     }
 
     // Migration: Remove orphaned sessions (sessions for non-existent credentials)
@@ -105,7 +104,6 @@ export function loadState() {
         credentials: state.credentials,
         sessions: cleanedSessions,
       });
-      console.log('Cleaned up orphaned sessions');
     }
 
     // Migration: Add lastActivityAt to sessions that don't have it (for sliding expiry)
@@ -127,7 +125,6 @@ export function loadState() {
         credentials: state.credentials,
         sessions: migratedSessions,
       });
-      console.log('Added lastActivityAt to existing sessions');
     }
 
     // Save migrated state if any changes were made

--- a/public/login.js
+++ b/public/login.js
@@ -38,18 +38,14 @@
     async function checkStatus() {
       const res = await fetch("/auth/status");
       const { setup, accessMethod } = await res.json();
-      console.log("checkStatus: setup =", setup, ", accessMethod =", accessMethod);
       loadingView.classList.add("hidden");
       if (setup) {
         // Decide which login flow based on access method
         if (accessMethod === "lan") {
           // LAN access → show QR pairing flow (even over HTTPS)
-          console.log("Showing LAN pairing view");
           pairView.classList.remove("hidden");
         } else if (hasWebAuthn) {
           // localhost or internet with WebAuthn → passkey login/registration
-          console.log("Showing passkey login view (accessMethod:", accessMethod, ")");
-
           loginView.classList.remove("hidden");
 
           // Check if user has passkeys for this domain
@@ -93,9 +89,8 @@
             loginError.style.marginBottom = '1rem';
           }
         }
-      } catch (err) {
+      } catch {
         // Silently fail - user can still try to login and get proper error
-        console.log('Could not check for existing passkeys:', err);
       }
     }
 

--- a/server.js
+++ b/server.js
@@ -2,10 +2,10 @@ import "dotenv/config";
 import { createServer } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
 import { createConnection } from "node:net";
-import { readFileSync, realpathSync, existsSync, watch, mkdirSync, writeFileSync } from "node:fs";
+import { readFileSync, existsSync, watch, mkdirSync, writeFileSync } from "node:fs";
 import { networkInterfaces } from "node:os";
 import { fileURLToPath } from "node:url";
-import { dirname, join, extname, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import { WebSocketServer } from "ws";
 import { randomUUID, randomBytes } from "node:crypto";
 import { encode, decoder } from "./lib/ndjson.js";
@@ -33,20 +33,20 @@ import {
 import { SessionName } from "./lib/session-name.js";
 import { PairingChallengeStore } from "./lib/pairing-challenge.js";
 import { AuthState } from "./lib/auth-state.js";
-import { ensureCerts, generateMobileConfig, needsRegeneration, inspectCert, regenerateServerCert, getLanIPs } from "./lib/tls.js";
+import { ensureCerts, generateMobileConfig, getLanIPs } from "./lib/tls.js";
 import { CertificateManager } from "./lib/certificate-manager.js";
 import { ConfigManager } from "./lib/config.js";
 import { ensureHostKey, startSSHServer } from "./lib/ssh.js";
 import { validateMessage } from "./lib/websocket-validation.js";
 import { CredentialLockout } from "./lib/credential-lockout.js";
-import { isLocalRequest, getAccessMethod, getAccessDescription } from "./lib/access-method.js";
+import { isLocalRequest, getAccessMethod } from "./lib/access-method.js";
 import {
   HTTP_ALLOWED_PATHS,
   checkHttpsEnforcement,
   getUnauthenticatedRedirect,
   checkSessionHttpsRedirect
 } from "./lib/https-enforcement.js";
-import { serveStaticFile, MIME_TYPES } from "./lib/static-files.js";
+import { serveStaticFile } from "./lib/static-files.js";
 import mdns from "multicast-dns";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -299,8 +299,6 @@ async function parseJSON(req, maxSize = MAX_REQUEST_BODY_SIZE) {
 }
 
 // --- HTTP routes ---
-
-// MIME_TYPES is now imported from lib/static-files.js
 
 function isLanHost(req) {
   const host = (req.headers.host || "").replace(/:\d+$/, "");


### PR DESCRIPTION
Closes #89

## Context

General code health pass. The codebase has accumulated dead code paths, unused imports, and stale references over time -- especially as features have been added and refactored.

## Requirements

- Scan all server-side files (`server.js`, `daemon.js`, `lib/*.js`, `bin/*`) for unused imports and dead code paths
- Scan all frontend files (`public/*.js`, `public/lib/*.js`) for unused imports, unreachable code, and stale references
- Remove any commented-out code blocks that are not serving as documentation
- Remove unused variables and parameters
- Remove any debug/console.log statements that should not be in production
- Do NOT remove code that is intentionally kept for future use (check git blame if unclear)
- Do NOT change any functionality -- this is strictly cleanup

## Acceptance criteria

- [ ] No unused imports remain
- [ ] No dead code paths remain
- [ ] No stale commented-out code blocks
- [ ] Full test suite passes
- [ ] No functional changes -- only cleanup

---
*This PR was opened by a sipag worker. Commits will appear as work progresses.*