### PR TITLE
Code hygiene: improve test coverage for edge cases

### DIFF
--- a/test/ndjson.test.js
+++ b/test/ndjson.test.js
@@ -63,3 +63,80 @@ describe("decoder", () => {
     assert.deepEqual(messages, [{ buf: true }]);
   });
 });
+
+describe("decoder - edge cases", () => {
+  it("does not dispatch partial message without trailing newline", () => {
+    const messages = [];
+    const handler = decoder((msg) => messages.push(msg));
+    handler('{"incomplete": true}'); // No newline
+    assert.equal(messages.length, 0, "partial message without newline should not be dispatched");
+  });
+
+  it("dispatches partial message once newline arrives in later chunk", () => {
+    const messages = [];
+    const handler = decoder((msg) => messages.push(msg));
+    handler('{"key": "val');      // incomplete
+    assert.equal(messages.length, 0);
+    handler('ue"}\n');            // completes the message
+    assert.equal(messages.length, 1);
+    assert.deepEqual(messages[0], { key: "value" });
+  });
+
+  it("handles very large JSON messages (1MB+ payload)", () => {
+    const messages = [];
+    const handler = decoder((msg) => messages.push(msg));
+    const bigValue = "x".repeat(1024 * 1024); // 1MB string
+    handler(JSON.stringify({ data: bigValue }) + "\n");
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].data.length, 1024 * 1024);
+  });
+
+  it("handles unicode characters including emoji and multi-byte sequences", () => {
+    const messages = [];
+    const handler = decoder((msg) => messages.push(msg));
+    handler('{"emoji": "🎉🌍", "cjk": "日本語"}\n');
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].emoji, "🎉🌍");
+    assert.equal(messages[0].cjk, "日本語");
+  });
+
+  it("handles message arriving in many tiny chunks", () => {
+    const messages = [];
+    const handler = decoder((msg) => messages.push(msg));
+    const parts = ['{"', 'k', 'e', 'y', '"', ':', '"', 'v', 'a', 'l', '"', '}', '\n'];
+    for (const part of parts) {
+      handler(part);
+    }
+    assert.equal(messages.length, 1);
+    assert.deepEqual(messages[0], { key: "val" });
+  });
+
+  it("handles connection drop mid-message: data before newline is silently dropped", () => {
+    // Simulates connection drop by never sending the newline.
+    // The buffered incomplete message should not be dispatched.
+    const messages = [];
+    const handler = decoder((msg) => messages.push(msg));
+    handler('{"drop": "this"'); // half a message, no newline
+    // Simulate EOF / connection drop — just stop sending data
+    assert.equal(messages.length, 0, "incomplete message at EOF should not be dispatched");
+  });
+
+  it("skips malformed lines and continues parsing subsequent valid messages", () => {
+    const messages = [];
+    const handler = decoder((msg) => messages.push(msg));
+    // Three messages: valid, invalid JSON, valid
+    handler('{"a":1}\nnot-json\n{"b":2}\n');
+    assert.equal(messages.length, 2);
+    assert.deepEqual(messages[0], { a: 1 });
+    assert.deepEqual(messages[1], { b: 2 });
+  });
+
+  it("handles a message whose value is JSON null", () => {
+    const messages = [];
+    const handler = decoder((msg) => messages.push(msg));
+    handler("null\n");
+    // null is valid JSON — decoder calls onMessage(null)
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0], null);
+  });
+});


### PR DESCRIPTION
Closes #91

## Context

General code health pass. While the test suite has good coverage of happy paths, edge cases around connection failures, malformed input, and race conditions could use more coverage to prevent regressions.

## Requirements

- Review existing test files and identify gaps in edge case coverage
- Add tests for:
  - Malformed WebSocket messages (invalid JSON, missing fields, oversized payloads)
  - Daemon disconnect/reconnect during active sessions
  - Concurrent session creation/deletion race conditions
  - Auth edge cases: expired sessions, corrupted state files, concurrent logins
  - Cookie parsing edge cases: malformed cookies, missing values, encoding issues
  - NDJSON protocol edge cases: partial lines, large messages, connection drops mid-message
- Ensure new tests follow existing test patterns and conventions
- Fix any bugs discovered during edge case testing (Boy Scout Rule)

## Acceptance criteria

- [ ] At least 10 new edge case tests added
- [ ] Tests cover connection failure scenarios
- [ ] Tests cover malformed input handling
- [ ] Tests cover concurrent operation safety
- [ ] All new tests pass
- [ ] Any bugs found during testing are fixed
- [ ] Full test suite passes

---
*This PR was opened by a sipag worker. Commits will appear as work progresses.*