### PR TITLE
Code hygiene: remove dead code and unused imports

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -206,10 +206,8 @@
       isAtBottom,
       onRefresh: () => {
         if (state.connection.ws && state.connection.ws.readyState === WebSocket.OPEN && state.connection.attached) {
-          console.log("[Pull-refresh] Connected - sending Ctrl-L");
           rawSend("\x0C"); // Ctrl-L: refresh screen
         } else {
-          console.log("[Pull-refresh] Disconnected - forcing reconnect");
           if (state.connection.ws) state.connection.ws.close();
         }
       }

--- a/public/connect.js
+++ b/public/connect.js
@@ -1,6 +1,5 @@
 (function() {
   var trustUrl = document.body.dataset.trustUrl || '';
-  var httpsPort = document.body.dataset.httpsPort || '3002';
 
   var steps = [
     document.getElementById('step-1'),

--- a/public/login.js
+++ b/public/login.js
@@ -38,18 +38,14 @@
     async function checkStatus() {
       const res = await fetch("/auth/status");
       const { setup, accessMethod } = await res.json();
-      console.log("checkStatus: setup =", setup, ", accessMethod =", accessMethod);
       loadingView.classList.add("hidden");
       if (setup) {
         // Decide which login flow based on access method
         if (accessMethod === "lan") {
           // LAN access → show QR pairing flow (even over HTTPS)
-          console.log("Showing LAN pairing view");
           pairView.classList.remove("hidden");
         } else if (hasWebAuthn) {
           // localhost or internet with WebAuthn → passkey login/registration
-          console.log("Showing passkey login view (accessMethod:", accessMethod, ")");
-
           loginView.classList.remove("hidden");
 
           // Check if user has passkeys for this domain
@@ -93,9 +89,8 @@
             loginError.style.marginBottom = '1rem';
           }
         }
-      } catch (err) {
+      } catch {
         // Silently fail - user can still try to login and get proper error
-        console.log('Could not check for existing passkeys:', err);
       }
     }
 

--- a/public/pair.js
+++ b/public/pair.js
@@ -13,7 +13,6 @@
       div.textContent = `[${new Date().toLocaleTimeString()}] ${msg}`;
       debugLog.appendChild(div);
       debugLog.scrollTop = debugLog.scrollHeight;
-      console.log(msg);
     }
 
     logDebug(`Page loaded. Code: ${code ? code.substring(0, 8) + "..." : "MISSING"}`);

--- a/server.js
+++ b/server.js
@@ -1,10 +1,10 @@
 import "dotenv/config";
 import { createServer } from "node:http";
 import { createConnection } from "node:net";
-import { readFileSync, realpathSync, existsSync, watch, mkdirSync, writeFileSync } from "node:fs";
+import { readFileSync, existsSync, watch, mkdirSync, writeFileSync } from "node:fs";
 import { networkInterfaces } from "node:os";
 import { fileURLToPath } from "node:url";
-import { dirname, join, extname, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import { WebSocketServer } from "ws";
 import { randomUUID, randomBytes } from "node:crypto";
 import { encode, decoder } from "./lib/ndjson.js";
@@ -37,7 +37,7 @@ import { ensureHostKey, startSSHServer } from "./lib/ssh.js";
 import { validateMessage } from "./lib/websocket-validation.js";
 import { CredentialLockout } from "./lib/credential-lockout.js";
 import { isLocalRequest, getAccessMethod, getAccessDescription } from "./lib/access-method.js";
-import { serveStaticFile, MIME_TYPES } from "./lib/static-files.js";
+import { serveStaticFile } from "./lib/static-files.js";
 import mdns from "multicast-dns";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -257,8 +257,6 @@ async function parseJSON(req, maxSize = MAX_REQUEST_BODY_SIZE) {
 }
 
 // --- HTTP routes ---
-
-// MIME_TYPES is now imported from lib/static-files.js
 
 function isLanHost(req) {
   const host = (req.headers.host || "").replace(/:\d+$/, "");


### PR DESCRIPTION
Closes #89

## Context

General code health pass. The codebase has accumulated dead code paths, unused imports, and stale references over time -- especially as features have been added and refactored.

## Requirements

- Scan all server-side files (`server.js`, `daemon.js`, `lib/*.js`, `bin/*`) for unused imports and dead code paths
- Scan all frontend files (`public/*.js`, `public/lib/*.js`) for unused imports, unreachable code, and stale references
- Remove any commented-out code blocks that are not serving as documentation
- Remove unused variables and parameters
- Remove any debug/console.log statements that should not be in production
- Do NOT remove code that is intentionally kept for future use (check git blame if unclear)
- Do NOT change any functionality -- this is strictly cleanup

## Acceptance criteria

- [ ] No unused imports remain
- [ ] No dead code paths remain
- [ ] No stale commented-out code blocks
- [ ] Full test suite passes
- [ ] No functional changes -- only cleanup

---
*This PR was opened by a sipag worker. Commits will appear as work progresses.*