### PR TITLE
Fix P0 bugs and security gaps

### DIFF
--- a/lib/cli/commands/status.js
+++ b/lib/cli/commands/status.js
@@ -25,7 +25,6 @@ export default async function status() {
   if (server.running) {
     console.log("\nAccess URLs:");
     console.log(`  HTTP:  ${urls.http}`);
-    console.log(`  HTTPS: ${urls.https}`);
     console.log(`  SSH:   ${urls.ssh}`);
   } else {
     console.log("\nTo start Katulong, run: katulong start");

--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -3,27 +3,27 @@
  * Tracks request counts per IP address with sliding window
  */
 
-const rateLimitStore = new Map(); // ip -> { count, resetAt }
+const rateLimitStore = new Map(); // key -> { count, resetAt }
 
 /**
  * Rate limit middleware
  * @param {number} maxAttempts - Maximum attempts allowed
  * @param {number} windowMs - Time window in milliseconds
+ * @param {function} [keyFn] - Optional function to derive rate-limit key from request. Defaults to req.socket.remoteAddress.
  * @returns {function} Middleware function
  */
-export function rateLimit(maxAttempts, windowMs) {
+export function rateLimit(maxAttempts, windowMs, keyFn) {
   return (req, res, next) => {
-    // Get client IP
-    const ip = req.socket.remoteAddress;
+    const key = keyFn ? keyFn(req) : req.socket.remoteAddress;
     const now = Date.now();
 
     // Get or create rate limit entry
-    let entry = rateLimitStore.get(ip);
+    let entry = rateLimitStore.get(key);
 
     // Reset if window expired
     if (!entry || now > entry.resetAt) {
       entry = { count: 0, resetAt: now + windowMs };
-      rateLimitStore.set(ip, entry);
+      rateLimitStore.set(key, entry);
     }
 
     // Increment count

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -230,7 +230,7 @@ export function startSSHServer({ port, hostKey, password, daemonRPC, daemonSend,
     }
   }
 
-  server.listen(port, "0.0.0.0", () => {
+  server.listen(port, "127.0.0.1", () => {
     log.info("Katulong SSH started", { port });
   });
 

--- a/public/lib/token-form.js
+++ b/public/lib/token-form.js
@@ -4,6 +4,7 @@
  * Generic composable form manager for token creation.
  * Follows composition pattern with callbacks for actions.
  */
+import { addCsrfHeader } from "./csrf.js";
 
 /**
  * Create token form manager
@@ -70,7 +71,7 @@ export function createTokenFormManager(options = {}) {
     try {
       const res = await fetch("/api/tokens", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: addCsrfHeader({ "Content-Type": "application/json" }),
         body: JSON.stringify({ name }),
       });
 
@@ -102,7 +103,7 @@ export function createTokenFormManager(options = {}) {
     try {
       const res = await fetch(`/api/tokens/${tokenId}`, {
         method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        headers: addCsrfHeader({ "Content-Type": "application/json" }),
         body: JSON.stringify({ name: newName.trim() }),
       });
 
@@ -129,6 +130,7 @@ export function createTokenFormManager(options = {}) {
     try {
       const res = await fetch(`/api/tokens/${tokenId}`, {
         method: "DELETE",
+        headers: addCsrfHeader({}),
       });
 
       if (!res.ok) throw new Error("Failed to revoke token");


### PR DESCRIPTION
## Summary
- **Fix `broadcast()` ReferenceError** — `broadcast()` → `broadcastToAll()` in logout handler (server.js)
- **Fix `urls.https` undefined** — removed reference to nonexistent `urls.https` in status CLI command
- **Add CSRF protection to token endpoints** — `POST /api/tokens`, `DELETE /api/tokens/:id`, `PATCH /api/tokens/:id` now validate CSRF tokens (skipped for localhost which bypasses auth). Frontend `token-form.js` updated to send `X-CSRF-Token` header.
- **Bind SSH server to localhost** — changed from `0.0.0.0` to `127.0.0.1`, matching the localhost-only security model
- **Improve rate limiting behind tunnels** — rate limiter accepts optional `keyFn`; auth endpoints now bucket by `addr:user-agent:origin` instead of a single shared `127.0.0.1` bucket

## Test plan
- [x] `npm test` — 626 unit/integration tests pass
- [x] E2E tests pass (including clipboard and token management flows)
- [x] Pre-push hooks pass (secrets scan, all test suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)