### PR TITLE
Fix O(n^2) eviction in RingBuffer by replacing shift() loop with single splice

### DIFF
--- a/.sipag-placeholder
+++ b/.sipag-placeholder
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Assignment

Fix the O(n^2) performance issue in `lib/ring-buffer.js` where `evict()` calls `Array.shift()` in a loop. Each `shift()` is O(n) because it re-indexes all remaining elements. With a 5000-item buffer receiving frequent terminal output chunks, this causes latency spikes.

## Disease

The class is named "RingBuffer" but uses a resizable array with head-removal — not a true ring buffer with O(1) circular access. The eviction path is the hot path and it's quadratic.

## Target fix

Replace the `shift()` loop with a counted approach that does a single `splice()`:

1. Walk forward counting items to remove and adjusting `this.bytes`
2. Do one `this.items.splice(0, removeCount)` at the end
3. This turns O(n^2) into O(n) — one array copy instead of N

## Files to change

- `lib/ring-buffer.js` — `evict()` method (lines 33-42)

## Constraints

- Keep the same public API (`push()`, `evict()`, `clear()`, `toArray()`)
- Keep the `items.length > 1` guard (always keep at least one item)
- Maintain the dual condition: evict when over `maxItems` OR over `maxBytes`
- Update or add tests to verify the fix works correctly
- Run `npm test` to validate

## Closes

Closes #170