### PR TITLE
RingBuffer.evict() uses Array.shift() in a loop which is O(n^2)

### DIFF
--- a/lib/ring-buffer.js
+++ b/lib/ring-buffer.js
@@ -31,14 +31,16 @@ export class RingBuffer {
    * Always keeps at least one item to handle oversized chunks
    */
   evict() {
+    let removeCount = 0;
     while (
-      this.items.length > 1 &&
-      (this.items.length > this.maxItems || this.bytes > this.maxBytes)
+      this.items.length - removeCount > 1 &&
+      (this.items.length - removeCount > this.maxItems || this.bytes > this.maxBytes)
     ) {
-      const removed = this.items.shift();
-      if (removed) {
-        this.bytes -= removed.length;
-      }
+      this.bytes -= this.items[removeCount].length;
+      removeCount++;
+    }
+    if (removeCount > 0) {
+      this.items.splice(0, removeCount);
     }
   }
 


### PR DESCRIPTION
Closes #170

## Problem

In `lib/ring-buffer.js` lines 33-42, the `evict()` method uses `Array.shift()` in a while loop:

```js
evict() {
  while (
    this.items.length > 1 &&
    (this.items.length > this.maxItems || this.bytes > this.maxBytes)
  ) {
    const removed = this.items.shift();
    if (removed) {
      this.bytes -= removed.length;
    }
  }
}
```

`Array.shift()` is O(n) because it re-indexes all remaining elements. When the buffer is near capacity (5000 items), calling `shift()` repeatedly in a loop results in O(n^2) behavior. For a terminal output buffer receiving frequent small chunks, this can cause noticeable latency spikes.

The class is named "RingBuffer" but it's actually a resizable array with head-removal — not a true ring buffer with O(1) circular access.

## Suggestion

Implement a proper circular buffer using a fixed-size array with head/tail pointers, or use a linked list. Alternatively, if simplicity is preferred, use a deque approach where items are stored in chunks and the oldest chunk is dropped as a unit (amortizing the cost).

For a quick fix, batch the eviction:
```js
evict() {
  let removeCount = 0;
  while (
    this.items.length - removeCount > 1 &&
    (this.items.length - removeCount > this.maxItems || this.bytes > this.maxBytes)
  ) {
    this.bytes -= this.items[removeCount].length;
    removeCount++;
  }
  if (removeCount > 0) {
    this.items.splice(0, removeCount); // Single splice instead of N shifts
  }
}
```

## Files

- `lib/ring-buffer.js` lines 33-42

---
*This PR was opened by a sipag worker. Commits will appear as work progresses.*