### PR TITLE
Wrap daemon fire-and-forget handlers in try/catch to prevent crash

### DIFF
--- a/.sipag-marker
+++ b/.sipag-marker
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Disease

In `daemon.js:188`, the fire-and-forget input handler throws `SessionNotAliveError` if the PTY exits between the alive check and the write call (TOCTOU race):

```js
if (type === "input") aliveSessionFor(msg.clientId)?.write(msg.data);
```

`Session.write()` throws `SessionNotAliveError` when `!this.alive`. Since this path has no try/catch, the error propagates as an uncaught exception, crashing the daemon and killing all active terminal sessions.

## Approach

1. Wrap the fire-and-forget `input` handler in try/catch:

```js
if (type === "input") {
  try { aliveSessionFor(msg.clientId)?.write(msg.data); } catch { /* session died */ }
}
```

2. Check for similar unprotected fire-and-forget paths in daemon.js (e.g., `resize`)
3. Remove the `.sipag-marker` placeholder file
4. Add a test that verifies writing to a dead session does not crash the daemon

## Files

- `daemon.js` line 188 — the unprotected write call
- `lib/session.js` lines 74-79 — the write method that throws

## Validation

- `npm test` passes
- The daemon should not crash when input arrives for a recently-exited session

Closes #192