### PR TITLE
Fix four security/correctness bugs: timing oracle, SSH cleanup, state wipe, P2P fallback

### DIFF
--- a/lib/auth-state.js
+++ b/lib/auth-state.js
@@ -5,7 +5,7 @@
  * immutable operations (all methods return new instances).
  */
 
-import { randomBytes } from "crypto";
+import { randomBytes, timingSafeEqual } from "crypto";
 
 export class AuthState {
   /**
@@ -81,12 +81,28 @@ export class AuthState {
   }
 
   /**
-   * Find a setup token by value
+   * Find a setup token by value using constant-time comparison to prevent timing attacks.
+   * Iterates all tokens without short-circuiting to avoid leaking which token matched.
    * @param {string} tokenValue - Token string
    * @returns {object|null} Token object or null
    */
   findSetupToken(tokenValue) {
-    return this.setupTokens.find(t => t.token === tokenValue) || null;
+    const candidateBuf = Buffer.from(tokenValue || '');
+    let found = null;
+    for (const t of this.setupTokens) {
+      const tokenBuf = Buffer.from(t.token || '');
+      let match = false;
+      if (tokenBuf.length === candidateBuf.length && candidateBuf.length > 0) {
+        match = timingSafeEqual(tokenBuf, candidateBuf);
+      } else {
+        // Consume constant time even when lengths differ
+        timingSafeEqual(tokenBuf.length > 0 ? tokenBuf : Buffer.alloc(1), tokenBuf.length > 0 ? tokenBuf : Buffer.alloc(1));
+      }
+      if (match && found === null) {
+        found = t;
+      }
+    }
+    return found;
   }
 
   /**

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -362,6 +362,11 @@ export async function withStateLock(modifier) {
       return result;
     }
 
+    // Guard: never save null/undefined — modifier signalled "no change"
+    if (result === null || result === undefined) {
+      return result;
+    }
+
     // Otherwise, treat result as the new state
     saveState(result);
     return result;

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -64,6 +64,8 @@ export function startSSHServer({ port, hostKey, password, daemonRPC, daemonSend,
 
   const server = new Server({ hostKeys: [hostKey] }, (client) => {
     let authenticatedUser = null;
+    // Track clientIds that belong to this specific SSH client connection
+    const clientIds = new Set();
 
     client.on("authentication", (ctx) => {
       if (ctx.method === "password") {
@@ -131,6 +133,7 @@ export function startSSHServer({ port, hostKey, password, daemonRPC, daemonSend,
             rows: ptyInfo.rows,
           }).then((result) => {
             sshClients.set(clientId, { stream, session: sessionName });
+            clientIds.add(clientId);
             log.debug("SSH client attached", { clientId, session: sessionName });
 
             if (result.buffer) {
@@ -174,17 +177,20 @@ export function startSSHServer({ port, hostKey, password, daemonRPC, daemonSend,
     });
 
     client.on("close", () => {
-      // Clean up any streams owned by this client
-      for (const [clientId, info] of sshClients) {
-        try {
-          if (info.stream?.destroyed === false) {
-            info.stream.close();
+      // Clean up only the streams owned by this specific SSH client connection
+      for (const clientId of clientIds) {
+        const info = sshClients.get(clientId);
+        if (info) {
+          try {
+            if (info.stream?.destroyed === false) {
+              info.stream.close();
+            }
+          } catch {
+            // stream already closed
           }
-        } catch {
-          // stream already closed
+          sshClients.delete(clientId);
+          daemonSend({ type: "detach", clientId });
         }
-        sshClients.delete(clientId);
-        daemonSend({ type: "detach", clientId });
       }
     });
   });

--- a/server.js
+++ b/server.js
@@ -1054,8 +1054,8 @@ function sendToSession(sessionName, payload, { preferP2P = false } = {}) {
     if (preferP2P && info.p2pConnected && info.p2pPeer) {
       try {
         info.p2pPeer.send(encoded);
+        continue; // Only skip WS if P2P send succeeded
       } catch { /* fall through to WS */ }
-      continue;
     }
     if (info.ws.readyState === 1) {
       info.ws.send(encoded);


### PR DESCRIPTION
## Summary

- **#188 (security):** `AuthState.findSetupToken` used `===` for setup token comparison, enabling timing-oracle brute-force. Replaced with `timingSafeEqual`, iterating all tokens without short-circuiting so the match position is not leaked via timing.
- **#189 (correctness):** SSH client `close` handler iterated the entire `sshClients` Map and destroyed every connection — not just the disconnecting client's. Added a per-client `clientIds` Set so cleanup is scoped to the closing connection. Fixes multi-user SSH sessions.
- **#190 (data integrity):** `withStateLock` fell through to `saveState(result)` when a modifier returned `null`/`undefined` (e.g. `refreshSessionActivity` on a missing state file), writing `"null"` to disk and wiping all credentials, sessions, and setup tokens. Added an explicit null/undefined guard before the save.
- **#191 (correctness):** In `sendToSession`, `continue` ran unconditionally after the P2P `try/catch`, skipping WebSocket fallback even when `p2pPeer.send()` threw. Moved `continue` inside the `try` block so failures fall through to WebSocket delivery.

## Test plan

- [x] All pre-existing unit tests pass (5 pre-existing failures unchanged)
- [x] `findSetupToken` unit tests pass with constant-time implementation
- [x] SSH close handler fix verified by code inspection against the per-client `clientIds` Set pattern
- [x] `withStateLock` null guard prevents `saveState(null)` in the `refreshSessionActivity` race

Closes #188
Closes #189
Closes #190
Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)