### PR TITLE
Fix daemon crash, session limit, and Docker non-root hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash zsh curl \
   && rm -rf /var/lib/apt/lists/*
 
+RUN adduser --disabled-password --gecos '' katulong
+
 WORKDIR /app
 COPY --from=build /app .
 
-RUN mkdir -p /data
+RUN mkdir -p /data && chown katulong:katulong /data
 
 ENV NODE_ENV=production
 ENV KATULONG_DATA_DIR=/data
@@ -31,4 +33,5 @@ EXPOSE 2222
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
   CMD curl -f http://localhost:3001/auth/status || exit 1
 
+USER katulong
 ENTRYPOINT ["node", "entrypoint.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
     environment:
       - KATULONG_DATA_DIR=/data
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          pids: 200
 
 volumes:
   katulong-data:


### PR DESCRIPTION
## Summary

Addresses three related security and stability issues in a single cohesive PR:

- **#192** — Daemon crashes on `SessionNotAliveError` in fire-and-forget input handler: wrap the write call in try/catch to prevent an uncaught exception from killing the daemon (and all active sessions) on TOCTOU race.
- **#193** — Docker container runs as root: add a dedicated non-root `katulong` user, chown `/data` to it, and set `USER katulong` before ENTRYPOINT so all processes (server, daemon, PTY shells) run as non-root.
- **#195** — No maximum session count: add `MAX_SESSIONS = 20` and enforce it in the `create-session` RPC handler, returning a clear error when the limit is reached.
- **#193 + #195** — Add `deploy.resources.limits` (memory: 512m, pids: 200) to `docker-compose.yml` to bound resource exhaustion.

## Changes

### `daemon.js`
- Add `MAX_SESSIONS = 20` constant
- Guard `create-session` with session count check before spawning
- Wrap fire-and-forget `input` handler in try/catch so `SessionNotAliveError` is swallowed instead of crashing the daemon

### `Dockerfile`
- `RUN adduser --disabled-password --gecos '' katulong` (non-root user)
- `RUN mkdir -p /data && chown katulong:katulong /data` (writable state dir)
- `USER katulong` before `ENTRYPOINT`

### `docker-compose.yml`
- `deploy.resources.limits.memory: 512m`
- `deploy.resources.limits.pids: 200`

## Test plan

- [x] All unit tests pass (`npm run test:unit`)
- [x] Session and NDJSON tests pass (the files directly affected)
- [ ] Docker build and run as non-root verified locally
- [ ] Manual test: verify `POST /sessions` returns error after 20 sessions

Closes #192
Closes #193
Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)