### PR TITLE
Fix credential counter mutation in auth-handlers processAuthentication

### DIFF
--- a/.sipag-marker
+++ b/.sipag-marker
@@ -1,1 +1,0 @@
-placeholder

--- a/lib/auth-handlers.js
+++ b/lib/auth-handlers.js
@@ -139,15 +139,14 @@ export async function processAuthentication({
     // Verify WebAuthn authentication
     const newCounter = await verifyAuth(credential, storedCred, challenge, origin, rpID);
 
-    // Update counter (mutation is OK here since we'll create new state object)
-    storedCred.counter = newCounter;
-
     // Create new session
     const session = createSession();
 
-    // Build updated state immutably
+    // Build updated state immutably — clone the credential to update counter without
+    // mutating the shared AuthState (storedCred is a reference into currentState.credentials)
     const updatedState = currentState
       .pruneExpired()
+      .updateCredential(storedCred.id, { counter: newCounter })
       .addSession(session.token, session.expiry, storedCred.id, session.csrfToken, session.lastActivityAt);
 
     return new Success({ session, updatedState });


### PR DESCRIPTION
## Disease

In `lib/auth-handlers.js`, `processAuthentication()` mutates the stored credential's counter directly:

\`\`\`js
storedCred.counter = newCounter;
\`\`\`

`storedCred` is a reference to an object inside `currentState.credentials`. This mutates the cached AuthState, violating its immutability contract. If the subsequent operation fails, the counter is incremented in cache but not persisted, creating a divergence.

## Approach

1. Clone the credential before mutating: `const updatedCred = { ...storedCred, counter: newCounter }`
2. Build the updated state using the cloned credential instead of relying on in-place mutation
3. Verify the state update path creates a new AuthState with the updated counter
4. Remove the `.sipag-marker` placeholder file
5. Run `npm test` to validate

## Files

- `lib/auth-handlers.js` — line 143, the mutation

Closes #125

## Implementation

Used `AuthState.updateCredential()` (already present in `lib/auth-state.js:303`) to build the updated state immutably — this replaces the in-place `storedCred.counter = newCounter` mutation with a proper immutable update chained into the `pruneExpired().updateCredential().addSession()` pipeline.

The misleading comment ("mutation is OK here since we'll create new state object") was removed — it was wrong: `pruneExpired()` copies credential array references, so `storedCred` still pointed into the original cached state.

All 602 unit tests and 26 integration tests pass.