### PR TITLE
fix: replace storedCred.counter mutation with immutable updateCredential()

### DIFF
--- a/lib/auth-handlers.js
+++ b/lib/auth-handlers.js
@@ -139,15 +139,15 @@ export async function processAuthentication({
     // Verify WebAuthn authentication
     const newCounter = await verifyAuth(credential, storedCred, challenge, origin, rpID);
 
-    // Update counter (mutation is OK here since we'll create new state object)
-    storedCred.counter = newCounter;
-
     // Create new session
     const session = createSession();
 
-    // Build updated state immutably
+    // Build updated state immutably — use updateCredential() so the counter
+    // update goes through the AuthState immutable API instead of mutating the
+    // cached credential object in-place.
     const updatedState = currentState
       .pruneExpired()
+      .updateCredential(storedCred.id, { counter: newCounter, lastUsedAt: Date.now() })
       .addSession(session.token, session.expiry, storedCred.id, session.csrfToken, session.lastActivityAt);
 
     return new Success({ session, updatedState });

--- a/test/auth-state.test.js
+++ b/test/auth-state.test.js
@@ -519,6 +519,70 @@ describe("AuthState", () => {
     });
   });
 
+  describe("updateCredential", () => {
+    it("returns new state with credential fields updated", () => {
+      const original = new AuthState({
+        user: { id: "user123", name: "owner" },
+        credentials: [{ id: "cred1", counter: 0, name: "Device" }],
+        sessions: {},
+      });
+
+      const updated = original.updateCredential("cred1", { counter: 5 });
+
+      assert.strictEqual(updated.credentials[0].counter, 5);
+      assert.strictEqual(updated.credentials[0].name, "Device");
+    });
+
+    it("does not mutate original state credential", () => {
+      const original = new AuthState({
+        user: { id: "user123", name: "owner" },
+        credentials: [{ id: "cred1", counter: 0 }],
+        sessions: {},
+      });
+
+      original.updateCredential("cred1", { counter: 99 });
+
+      // Original credential must be unchanged
+      assert.strictEqual(original.credentials[0].counter, 0);
+    });
+
+    it("returns new AuthState instance", () => {
+      const original = AuthState.empty("user123").addCredential({ id: "cred1", counter: 0 });
+      const updated = original.updateCredential("cred1", { counter: 1 });
+
+      assert.notStrictEqual(original, updated);
+    });
+
+    it("leaves other credentials unchanged", () => {
+      const original = new AuthState({
+        user: { id: "user123", name: "owner" },
+        credentials: [
+          { id: "cred1", counter: 0 },
+          { id: "cred2", counter: 0 },
+        ],
+        sessions: {},
+      });
+
+      const updated = original.updateCredential("cred1", { counter: 7 });
+
+      assert.strictEqual(updated.credentials[0].counter, 7);
+      assert.strictEqual(updated.credentials[1].counter, 0);
+    });
+
+    it("preserves sessions and user", () => {
+      const original = new AuthState({
+        user: { id: "user123", name: "owner" },
+        credentials: [{ id: "cred1", counter: 0 }],
+        sessions: { tok: { expiry: 9999999, credentialId: "cred1", csrfToken: null, lastActivityAt: null } },
+      });
+
+      const updated = original.updateCredential("cred1", { counter: 3 });
+
+      assert.deepStrictEqual(updated.user, original.user);
+      assert.deepStrictEqual(updated.sessions, original.sessions);
+    });
+  });
+
   describe("toJSON", () => {
     it("serializes to plain object", () => {
       const state = new AuthState({


### PR DESCRIPTION
## Summary

- Fixes the credential counter mutation bug in `processAuthentication()` (Issue #125): `storedCred.counter = newCounter` silently mutated the cached `_cachedState.credentials` object in place, bypassing the AuthState immutable update pattern. The fix chains `.updateCredential(storedCred.id, { counter, lastUsedAt })` into the existing immutable state-building sequence — consistent with how `processRegistration` builds its `updatedState`.
- Adds `updateCredential()` unit tests to `test/auth-state.test.js` (previously zero coverage for this method).

## Issues

- Closes #125 — `storedCred.counter` mutation inside immutable auth state

## Not addressed

- **Issue #155** (`urls.https` undefined in status.js): Already resolved in the codebase — `status.js` no longer references `urls.https` (fixed in a prior commit, "Fix P0 bugs and security gaps from codebase review").
- **Issue #194** (TransportBridge refactor): The refactor is significant and touches security-critical server/SSH relay code. Kept out of scope to avoid introducing bugs in a single broad PR; should be addressed as a standalone change.

## Test plan

- [x] `node --test test/auth-state.test.js` — 58/58 pass (includes 5 new `updateCredential` tests)
- [x] `npm run test:unit` — 533 pass, 5 pre-existing failures (missing optional packages: `@simplewebauthn/server`, `simple-peer`, `ssh2`) unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)