### PR TITLE
Remove SSH password from startup log output

### DIFF
--- a/.sipag-marker
+++ b/.sipag-marker
@@ -1,1 +1,0 @@
-placeholder

--- a/server.js
+++ b/server.js
@@ -90,7 +90,7 @@ const authRateLimit = rateLimit(10, 60000, (req) => {
 });
 
 if (!process.env.SSH_PASSWORD) {
-  log.info("SSH password generated", { password: SSH_PASSWORD });
+  log.info("SSH password generated (retrieve via GET /ssh/password)");
 }
 
 if (process.env.KATULONG_NO_AUTH === "1") {


### PR DESCRIPTION
## Disease

When SSH_PASSWORD is not set, the server generates a random password and logs it at startup at info level:

\`\`\`js
log.info("SSH password generated", { password: SSH_PASSWORD });
\`\`\`

This exposes the SSH password in container logs, systemd journal, and any log aggregation system. The GET /ssh/password endpoint already provides authenticated access to the password.

## Approach

1. Remove the password value from the log message
2. Log only that a password was generated, pointing to the authenticated endpoint:
   \`log.info("SSH password generated (retrieve via GET /ssh/password)")\`
3. Remove the \`.sipag-marker\` placeholder file
4. Run \`npm test\` to validate

## Files

- \`server.js\` — line 91-93, the startup log

Closes #161

## Implementation

Changed the log line in \`server.js\` from:
\`\`\`js
log.info("SSH password generated", { password: SSH_PASSWORD });
\`\`\`
to:
\`\`\`js
log.info("SSH password generated (retrieve via GET /ssh/password)");
\`\`\`

Also removed the \`.sipag-marker\` placeholder file as specified.

No tests reference this log message. The 5 pre-existing unit test failures (and integration test failure) are caused by missing npm dependencies (\`@simplewebauthn/server\`, \`dotenv\`) — unrelated to this change.