### PR TITLE
fix: use isHttpsConnection() for logout cookie secure flag

### DIFF
--- a/.sipag-marker
+++ b/.sipag-marker
@@ -1,0 +1,1 @@
+placeholder for PR creation


### PR DESCRIPTION
## Problem

Closes #157

The logout handler at `POST /auth/logout` uses `req.socket.encrypted` to determine whether to set the `Secure` cookie flag. This fails behind reverse proxies (ngrok, Cloudflare Tunnel) where TLS terminates at the proxy.

The codebase already has `isHttpsConnection(req)` which correctly detects proxy HTTPS.

## Assignment

1. Replace `req.socket.encrypted` with `isHttpsConnection(req)` in both logout handlers (`POST /auth/logout` and the revoke-all handler)
2. `isHttpsConnection` is already imported in server.js
3. Add integration tests verifying logout behind a proxy correctly sets the Secure flag

## Architecture notes

- `isHttpsConnection(req)` checks CF-Visitor, X-Forwarded-Proto, and socket.encrypted
- Two logout handlers exist: single-session logout and revoke-all
- Search for `clearCookie` and `req.socket.encrypted` in server.js