### PR TITLE
fix: add setup token expiration and re-validation in /register/verify

### DIFF
--- a/.sipag-marker
+++ b/.sipag-marker
@@ -1,0 +1,1 @@
+placeholder for PR creation


### PR DESCRIPTION
## Problem

Closes #146
Closes #168

Two setup token security gaps:

### No re-validation in /register/verify (#146)
Setup token is validated in `/register/options` but NOT re-validated in `/register/verify`. A revoked token between steps still works.

### No expiration (#168)
Setup tokens remain valid indefinitely.

## Assignment

1. Add `createdAt` timestamp to setup tokens when created (if not already present)
2. Add expiration check (1 hour TTL) in `findSetupToken()` in `lib/auth-state.js`
3. Re-validate setup token in `/register/verify` handler inside `withStateLock` for atomicity
4. First registration from localhost should be exempt (no token required)
5. Export TTL constant for testability
6. Add tests: expired tokens rejected, valid tokens accepted, revoked tokens caught, backward compat for legacy tokens without createdAt

## Architecture notes

- `findSetupToken()` in `lib/auth-state.js` uses constant-time comparison
- Registration flow: `POST /register/options` → `POST /register/verify`
- `isSetup()` checks if credentials exist; first registration from localhost doesn't need a token
- `isLocalRequest(req)` detects localhost connections
- Token data has: id, token, name, createdAt, lastUsedAt