### PR TITLE
fix: add CSRF protection to PUT /api/config/* endpoints

### DIFF
--- a/.sipag-marker
+++ b/.sipag-marker
@@ -1,0 +1,1 @@
+sipag worker placeholder


### PR DESCRIPTION
## Problem

Closes #222

The three config mutation endpoints (`PUT /api/config/instance-name`, `PUT /api/config/instance-icon`, `PUT /api/config/toolbar-color`) at server.js:986-1032 check `isAuthenticated()` but do NOT validate CSRF tokens for non-localhost requests.

Every other mutation endpoint follows the standard pattern:
```js
if (!isLocalRequest(req)) {
  const state = loadState();
  if (!validateCsrfToken(req, state)) {
    return json(res, 403, { error: "Invalid or missing CSRF token" });
  }
}
```

The config endpoints omit this entirely.

## Assignment

1. In `server.js`, add the standard CSRF validation block to all three PUT /api/config/* handlers (lines 986-1032), matching the pattern used by `PUT /shortcuts` (line 911-914), `DELETE /api/credentials/*` (line 550-554), `POST /api/tokens` (line 649-653)
2. The CSRF check should use the `isLocalRequest(req)` bypass for localhost, consistent with other handlers
3. Add tests verifying:
   - CSRF token is required for non-localhost requests to each config endpoint
   - Localhost requests bypass CSRF (existing behavior preserved)
   - Valid CSRF token allows the request through
4. Remove the `.sipag-marker` placeholder file
5. Run `npm test` to validate all existing tests still pass

## Architecture notes

- Follow the exact pattern from `PUT /shortcuts` handler — this is a one-line-per-handler fix
- The CSRF token is available via `validateCsrfToken(req, state)` from `lib/http-util.js`
- `isLocalRequest(req)` is from `lib/access-method.js`
- `loadState()` is from `lib/auth.js`
- All three are already imported in server.js

## Files
- `server.js` — lines 986-1032 (three PUT handlers need CSRF blocks added)
- `test/` — add config endpoint CSRF tests