### PR TITLE
fix: add CSRF protection to PUT /api/config/* endpoints

### DIFF
--- a/.sipag-marker
+++ b/.sipag-marker
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Assignment

Fix issue #222: The three config mutation endpoints lack CSRF protection.

## Problem

`PUT /api/config/instance-name`, `PUT /api/config/instance-icon`, and `PUT /api/config/toolbar-color` in `server.js` check `isAuthenticated()` but do NOT validate CSRF tokens for non-localhost requests.

Every other mutation endpoint follows the pattern:
```js
if (!isLocalRequest(req)) {
  const state = loadState();
  if (!validateCsrfToken(req, state)) {
    return json(res, 403, { error: "Invalid or missing CSRF token" });
  }
}
```

The config endpoints omit this entirely.

## Required Fix

Add the standard CSRF validation block to all three `PUT /api/config/*` handlers, matching the pattern used elsewhere in the codebase. The fix is straightforward — add the CSRF check block after the `isAuthenticated()` check in each handler.

## Files to modify

- `server.js` — the three PUT /api/config/* handlers (around lines 986-1032)
- Add tests verifying CSRF is enforced on these endpoints

## Testing

- `npm test` must pass
- Add test cases that verify:
  - PUT requests without CSRF token from non-local origins get 403
  - PUT requests with valid CSRF token succeed
  - Local requests bypass CSRF (existing behavior)

Closes #222