### PR TITLE
test: add mobile viewport regression tests for issue #259

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -19,9 +19,10 @@ export async function setupTest({ page, context }) {
  * Wait for app to be ready (terminal loaded)
  */
 export async function waitForAppReady(page) {
-  await page.waitForSelector(".xterm", { timeout: 10000 });
-  // Wait for terminal to be interactive (not just visible)
-  await page.waitForSelector(".xterm-screen", { timeout: 5000 });
+  // state:'visible' requires a non-zero bounding box — catches the mobile
+  // Chromium regression where visualViewport.height===0 makes xterm height 0.
+  await page.waitForSelector(".xterm", { state: "visible", timeout: 10000 });
+  await page.waitForSelector(".xterm-screen", { state: "visible", timeout: 5000 });
 }
 
 /**

--- a/test/e2e/mobile-viewport.e2e.js
+++ b/test/e2e/mobile-viewport.e2e.js
@@ -1,0 +1,54 @@
+/**
+ * Mobile Viewport Rendering Tests
+ *
+ * Regression tests for issue #259: mobile E2E shard failing because
+ * window.visualViewport.height === 0 during initial JS module execution
+ * in Chromium mobile emulation (isMobile: true). Without the fix in
+ * public/lib/viewport-manager.js, #terminal-container gets height: -44px
+ * (invalid CSS → 0), making .xterm { height: 100% } resolve to 0 and
+ * Playwright's waitForSelector('.xterm') time out.
+ *
+ * These tests verify that the terminal is truly rendered with non-zero
+ * dimensions after page load, catching any future regression regardless
+ * of browser project (desktop or mobile).
+ */
+
+import { test, expect } from "@playwright/test";
+import { waitForAppReady } from "./helpers.js";
+
+test.describe("Viewport rendering", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await waitForAppReady(page);
+  });
+
+  test("Terminal container has non-zero height after load", async ({ page }) => {
+    // Regression: on mobile Chromium, visualViewport.height === 0 during init
+    // caused termContainer.style.height to become '-44px' → browser clamps to 0.
+    const height = await page.evaluate(
+      () => document.getElementById("terminal-container")?.offsetHeight ?? 0,
+    );
+    expect(height).toBeGreaterThan(0);
+  });
+
+  test("--viewport-h CSS custom property is set to a positive value", async ({ page }) => {
+    // resizeToViewport() sets --viewport-h to the resolved visual viewport height.
+    // If it stays at 0 or unset, layout is broken and xterm renders invisibly.
+    const vpH = await page.evaluate(() =>
+      parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue("--viewport-h"),
+      ),
+    );
+    expect(vpH).toBeGreaterThan(0);
+  });
+
+  test("xterm element has non-zero bounding box", async ({ page }) => {
+    // This is the exact assertion that waitForAppReady relies on.
+    // If the terminal container has height 0, .xterm inherits height 0
+    // and Playwright's state:'visible' check fails — reproducing issue #259.
+    const box = await page.locator(".xterm").boundingBox();
+    expect(box).not.toBeNull();
+    expect(box.height).toBeGreaterThan(0);
+    expect(box.width).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `test/e2e/mobile-viewport.e2e.js` with three regression tests that directly verify the fix from #260 (guard against `visualViewport.height === 0` in mobile Chromium emulation) cannot silently regress
- Makes `state: 'visible'` explicit in `waitForAppReady()` with a comment explaining why non-zero bounding box is the meaningful check

## Tests added

| Test | What it catches |
|---|---|
| `Terminal container has non-zero height after load` | `termContainer.style.height` becoming invalid (`-44px` → 0) |
| `--viewport-h CSS custom property is set to a positive value` | `resizeToViewport()` not running or using `vv.height === 0` |
| `xterm element has non-zero bounding box` | `.xterm { height: 100% }` collapsing to 0 from zero-height parent |

These tests would have **caught issue #259** before it reached production, and will prevent future regressions in the `resizeToViewport()` fallback path.

## Motivation

Flagged by test adequacy review as the highest-priority gap: the existing E2E suite tests functional I/O but never asserts terminal dimensions, so the height-collapse bug went undetected across mobile and desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)