### PR TITLE
fix: remove global pgrep/pkill fallback from daemon detection

### DIFF
--- a/lib/cli/process-manager.js
+++ b/lib/cli/process-manager.js
@@ -70,19 +70,6 @@ export function isDaemonRunning() {
     }
   }
 
-  // Method 3: Check by process name
-  try {
-    const result = execSync("pgrep -f katulong-daemon 2>/dev/null || true", {
-      encoding: "utf-8",
-    }).trim();
-    if (result) {
-      const namePid = parseInt(result.split("\n")[0], 10);
-      return { running: true, pid: namePid, method: "processname" };
-    }
-  } catch {
-    // Not found
-  }
-
   return { running: false, pid: null, method: null };
 }
 

--- a/scripts/kill-daemon.sh
+++ b/scripts/kill-daemon.sh
@@ -23,15 +23,7 @@ if [ -f "$PID_FILE" ]; then
   fi
 fi
 
-# Method 2: Use process title
-if pkill -0 katulong-daemon 2>/dev/null; then
-  echo "Killing daemon by process name..."
-  pkill katulong-daemon || pkill -9 katulong-daemon
-  echo "Daemon stopped."
-  exit 0
-fi
-
-# Method 3: Use socket file
+# Method 2: Use socket file
 SOCKET_PATH="${KATULONG_SOCK:-/tmp/katulong-daemon.sock}"
 if [ -e "$SOCKET_PATH" ]; then
   PID=$(lsof -t "$SOCKET_PATH" 2>/dev/null || true)


### PR DESCRIPTION
## Summary

- Remove `pgrep -f katulong-daemon` fallback (Method 3) from `isDaemonRunning()` in `lib/cli/process-manager.js` — matched stale daemons from other instances after `brew upgrade`, causing 503 errors
- Remove `pkill katulong-daemon` (Method 2) from `scripts/kill-daemon.sh` — same global scope issue could kill daemons from other instances
- PID file and socket file methods are correctly scoped to the instance's `DATA_DIR`/`SOCKET_PATH` and sufficient

## Test plan

- [x] All 984 tests pass (`npm test`)
- [ ] Kill all stale daemons, `brew services start katulong`, verify daemon starts and connects
- [ ] Confirm stale daemon processes from other instances don't interfere