### PR TITLE
fix: service worker POST cache bug

### DIFF
--- a/.claude/commands/ship-it.md
+++ b/.claude/commands/ship-it.md
@@ -175,9 +175,10 @@ Once the review loop completes with APPROVE:
    gh pr merge <PR_NUMBER> --squash --delete-branch
    ```
 
-3. Switch back to main and pull:
+3. Switch back to main, pull, and delete the local branch:
    ```
-   git checkout main && git pull
+   BRANCH=$(git branch --show-current)
+   git checkout main && git pull && git branch -d "$BRANCH"
    ```
 
-4. Tell the user the PR has been merged and the branch cleaned up. Include the PR URL in the final message.
+4. Tell the user the PR has been merged and the branch cleaned up (both remote and local). Include the PR URL in the final message.

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "katulong-v4";
+const CACHE_NAME = "katulong-v5";
 const PRECACHE = [
   "/",
   "/icon-192.png",
@@ -55,6 +55,9 @@ self.addEventListener("fetch", (e) => {
     );
     return;
   }
+
+  // Only cache GET requests (Cache API doesn't support POST/PUT/etc.)
+  if (e.request.method !== "GET") return;
 
   // Cache-first for static assets (icons, fonts)
   e.respondWith(


### PR DESCRIPTION
## Summary
- Fix service worker trying to cache POST requests (auth endpoints), which throws `TypeError: Failed to execute 'put' on 'Cache': Request method 'POST' is unsupported`
- Added `e.request.method !== "GET"` guard before the cache-first handler
- Bumped cache version to v5 so the fix takes effect on existing installations
- Updated ship-it command to delete local branch after merge

## Test plan
- [x] `npm test` passes (1049 tests, 0 failures)
- [x] E2E smoke tests pass
- [ ] Manual verification: no more `sw.js` TypeError in console on auth endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)