### PR TITLE
docs: add "Why not just SSH?" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ First device registers via WebAuthn passkey. Subsequent devices pair via QR code
 
 No passwords to manage. No tokens in URLs. No `X-Forwarded-*` header trust. The only thing that proves identity is a cryptographic passkey or a physically-proximate pairing flow.
 
+## Why not just SSH?
+
+SSH is great. Katulong actually includes an SSH server. But SSH alone has friction that adds up:
+
+- **You need a client.** Your phone doesn't have one. Your partner's laptop doesn't have one. A Chromebook at a coffee shop doesn't have one. A browser is universal.
+- **You need keys or passwords.** SSH key management is a chore — generating keys, copying them to servers, rotating them, dealing with `Permission denied (publickey)`. Katulong uses WebAuthn passkeys. Register once with your fingerprint, done.
+- **You need network plumbing.** SSH requires an open port, which means firewall rules, port forwarding, dynamic DNS, or a VPN. Katulong works over HTTPS through any tunnel — same port, same protocol as every other website.
+- **Sessions require tmux.** SSH doesn't persist sessions on its own. You need tmux or screen, which means learning keybindings, configuring `.tmux.conf`, and remembering to attach. Katulong sessions persist by default. Close your browser, open it tomorrow, your session is there.
+- **Mobile is painful.** Even with an SSH app, typing commands on a phone keyboard without Ctrl, Tab, or arrow keys is miserable. Katulong has swipe navigation, a shortcut toolbar, and a full-screen text area that works with speech-to-text.
+- **Drag-and-drop doesn't work.** Try dragging an image into Claude Code over SSH — you get a file path dumped into the input, not the image. A browser terminal handles drag-and-drop, clipboard, and file uploads natively because it's a browser.
+- **Sharing is hard.** Showing someone your terminal over SSH means giving them credentials and hoping they have a client. With Katulong, you share a URL. Multiple people can join the same session instantly — open the same link and you're pair programming in real time.
+
+SSH is the right tool when you have a proper terminal, a configured client, and network access. Katulong is for everything else — the phone in your pocket, the tablet on the couch, the browser tab you can open anywhere.
+
 ## Install
 
 ### Homebrew (macOS)


### PR DESCRIPTION
## Summary
- Adds a new "Why not just SSH?" section to the README between "The idea" and "Install"
- Covers 7 friction points: no client needed, no key management, no network plumbing, built-in session persistence, mobile-first UX, native drag-and-drop/clipboard, and instant session sharing
- Honest framing — acknowledges SSH is great when you have a proper setup, positions Katulong for everything else

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] No broken links or formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)