### PR TITLE
feat: add local CLI management commands

### DIFF
--- a/bin/katulong
+++ b/bin/katulong
@@ -19,6 +19,9 @@ const COMMANDS = {
   open: "Open Katulong in your browser",
   info: "Show system information and configuration",
   update: "Update Katulong to the latest version",
+  token: "Manage setup tokens (create, list, revoke)",
+  credential: "Manage passkey credentials (list, revoke)",
+  session: "Manage PTY sessions (list, create, kill, rename)",
 };
 
 function showHelp() {
@@ -48,6 +51,11 @@ EXAMPLES:
   katulong update             Update to latest version
   katulong update --check     Check if update is available
   katulong update --no-restart Update code but skip restart
+  katulong token create "My Phone"  Create a setup token
+  katulong token list         List setup tokens
+  katulong credential list    List registered passkeys
+  katulong session list       List active PTY sessions
+  katulong session kill dev   Kill a PTY session
 
 For more information, visit: https://github.com/dorky-robot/katulong
 `);

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,204 @@
+# CLI Reference
+
+Katulong provides a command-line interface for managing the server, tokens, credentials, and terminal sessions.
+
+## Service Management
+
+### start
+
+Start the daemon and/or server.
+
+```bash
+katulong start              # Start both daemon and server
+katulong start server       # Start only the server
+katulong start daemon       # Start only the daemon
+katulong start --foreground # Run in foreground (don't daemonize)
+```
+
+### stop
+
+Stop the daemon and/or server.
+
+```bash
+katulong stop               # Stop both
+katulong stop server        # Stop only the server
+katulong stop daemon        # Stop only the daemon
+```
+
+### restart
+
+Restart the daemon and/or server.
+
+```bash
+katulong restart            # Restart both
+katulong restart server     # Restart only the server
+katulong restart --rolling  # Rolling restart (zero-downtime)
+```
+
+### status
+
+Check if Katulong is running.
+
+```bash
+katulong status
+```
+
+### logs
+
+Stream logs from the daemon, server, or both.
+
+```bash
+katulong logs               # Stream all logs
+katulong logs daemon        # Stream daemon logs only
+katulong logs server        # Stream server logs only
+```
+
+### open
+
+Open Katulong in your default browser.
+
+```bash
+katulong open
+```
+
+### info
+
+Show system information and configuration.
+
+```bash
+katulong info
+```
+
+### update
+
+Update Katulong to the latest version.
+
+```bash
+katulong update             # Update and restart
+katulong update --check     # Check if update is available
+katulong update --no-restart # Update code but skip restart
+```
+
+## Token Management
+
+Setup tokens allow pairing new devices via WebAuthn. Each token can be used once to register a passkey.
+
+!!! note
+    The server must be running for token commands to work.
+
+### token create
+
+Create a new setup token.
+
+```bash
+katulong token create "My Phone"
+katulong token create "Work Laptop" --json
+```
+
+The token value is shown **once** — save it immediately.
+
+### token list
+
+List all setup tokens and their linked credentials.
+
+```bash
+katulong token list
+katulong token list --json
+```
+
+### token revoke
+
+Revoke a token by ID. If a credential was registered with the token, it is also revoked.
+
+```bash
+katulong token revoke abc123def456
+katulong token revoke abc123def456 --json
+```
+
+## Credential Management
+
+Credentials are WebAuthn passkeys registered to your Katulong instance.
+
+### credential list
+
+List all registered passkeys.
+
+```bash
+katulong credential list
+katulong credential list --json
+```
+
+### credential revoke
+
+Revoke a passkey by ID.
+
+```bash
+katulong credential revoke abc123def456
+katulong credential revoke abc123def456 --json
+```
+
+!!! warning
+    Revoking the last credential from a remote connection will lock you out. Use localhost or SSH to recover.
+
+## Session Management
+
+Sessions are PTY (terminal) sessions managed by the daemon.
+
+### session list
+
+List active PTY sessions.
+
+```bash
+katulong session list
+katulong session list --json
+```
+
+### session create
+
+Create a new named PTY session.
+
+```bash
+katulong session create dev
+katulong session create "my-project" --json
+```
+
+### session kill
+
+Kill a PTY session by name.
+
+```bash
+katulong session kill dev
+katulong session kill dev --json
+```
+
+### session rename
+
+Rename a PTY session.
+
+```bash
+katulong session rename dev production
+katulong session rename old-name new-name --json
+```
+
+## SSH CLI
+
+All token, credential, and session commands are also available over SSH for remote management:
+
+```bash
+ssh -p 2222 user@host "katulong token create 'My Phone'"
+ssh -p 2222 user@host "katulong token list --json"
+ssh -p 2222 user@host "katulong credential list"
+ssh -p 2222 user@host "katulong session list"
+ssh -p 2222 user@host "katulong status"
+ssh -p 2222 user@host "katulong help"
+```
+
+The SSH CLI also supports a `status` command that shows credential, token, session, and daemon status.
+
+## Global Options
+
+| Option | Description |
+|---|---|
+| `--help`, `-h` | Show help message |
+| `--version`, `-v` | Show version number |
+| `--json` | Output as JSON (token, credential, session commands) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,7 +62,18 @@ katulong stop    # Stop services
 
 Run `katulong --help` to see all available commands.
 
-### 4. Pair Additional Devices
+### 4. Manage Tokens and Sessions
+
+```bash
+katulong token create "My Phone"  # Create a setup token for pairing
+katulong token list               # List tokens
+katulong credential list          # List registered passkeys
+katulong session list             # List active terminal sessions
+```
+
+See the [CLI Reference](cli-reference.md) for all available commands.
+
+### 5. Pair Additional Devices
 
 From Settings > "Pair New Device", scan the QR code on your mobile device
 and enter the PIN to pair securely.

--- a/lib/cli/api-client.js
+++ b/lib/cli/api-client.js
@@ -1,0 +1,74 @@
+/**
+ * Shared HTTP client for CLI commands.
+ *
+ * Talks to the running Katulong server on localhost.
+ * Localhost requests bypass auth and CSRF automatically.
+ */
+
+import { isServerRunning } from "./process-manager.js";
+import envConfig from "../env-config.js";
+
+const BASE = `http://localhost:${envConfig.port}`;
+
+/**
+ * Ensure the server is running. Exits with a message if not.
+ */
+export function ensureRunning() {
+  const status = isServerRunning();
+  if (!status.running) {
+    console.error("Server is not running. Start with: katulong start");
+    process.exit(1);
+  }
+}
+
+/**
+ * Make an HTTP request to the local server.
+ * @param {string} method - HTTP method
+ * @param {string} path - URL path (e.g. "/api/tokens")
+ * @param {object} [body] - JSON body for POST/PUT/PATCH
+ * @returns {Promise<{status: number, data: any}>}
+ */
+async function request(method, path, body) {
+  const opts = {
+    method,
+    headers: {},
+  };
+
+  if (body !== undefined) {
+    opts.headers["Content-Type"] = "application/json";
+    opts.body = JSON.stringify(body);
+  }
+
+  let response;
+  try {
+    response = await fetch(`${BASE}${path}`, opts);
+  } catch (err) {
+    if (err.cause?.code === "ECONNREFUSED" || err.code === "ECONNREFUSED") {
+      console.error("Server is not running. Start with: katulong start");
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const text = await response.text();
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    data = text;
+  }
+
+  if (!response.ok) {
+    const msg = data?.error || `HTTP ${response.status}`;
+    throw new Error(msg);
+  }
+
+  return data;
+}
+
+export const api = {
+  get: (path) => request("GET", path),
+  post: (path, body) => request("POST", path, body),
+  put: (path, body) => request("PUT", path, body),
+  del: (path) => request("DELETE", path),
+};

--- a/lib/cli/commands/credential.js
+++ b/lib/cli/commands/credential.js
@@ -1,0 +1,88 @@
+/**
+ * CLI: katulong credential <subcommand>
+ *
+ * Manages passkey credentials via the local server API.
+ */
+
+import { ensureRunning, api } from "../api-client.js";
+import { formatTable, formatRelativeTime } from "../../ssh-commands.js";
+
+function usage() {
+  console.log(`
+Usage: katulong credential <subcommand> [options]
+
+Subcommands:
+  list            List registered passkeys
+  revoke <id>     Revoke a passkey
+
+Options:
+  --json          Output as JSON
+`);
+}
+
+async function list(args) {
+  const jsonMode = args.includes("--json");
+
+  ensureRunning();
+  const data = await api.get("/api/credentials");
+  const credentials = data.credentials || [];
+
+  if (jsonMode) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  if (credentials.length === 0) {
+    console.log("No credentials.");
+    return;
+  }
+
+  const rows = credentials.map(c => [
+    c.id,
+    c.name || "Unknown",
+    formatRelativeTime(c.createdAt),
+    formatRelativeTime(c.lastUsedAt),
+  ]);
+  process.stdout.write(formatTable(["ID", "NAME", "CREATED", "LAST USED"], rows));
+}
+
+async function revoke(args) {
+  const jsonMode = args.includes("--json");
+  const id = args.find(a => a !== "--json");
+  if (!id) {
+    console.error("Usage: katulong credential revoke <id>");
+    process.exit(1);
+  }
+
+  ensureRunning();
+  const data = await api.del(`/api/credentials/${encodeURIComponent(id)}`);
+
+  if (jsonMode) {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    console.log("Credential revoked.");
+  }
+}
+
+const subcommands = { list, revoke };
+
+export default async function credential(args) {
+  const sub = args[0];
+  if (!sub || sub === "--help" || sub === "-h") {
+    usage();
+    process.exit(sub ? 0 : 1);
+  }
+
+  if (!subcommands[sub]) {
+    console.error(`Unknown subcommand: ${sub}`);
+    usage();
+    process.exit(1);
+  }
+
+  try {
+    await subcommands[sub](args.slice(1));
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/lib/cli/commands/session.js
+++ b/lib/cli/commands/session.js
@@ -1,0 +1,125 @@
+/**
+ * CLI: katulong session <subcommand>
+ *
+ * Manages PTY sessions via the local server API.
+ */
+
+import { ensureRunning, api } from "../api-client.js";
+import { formatTable } from "../../ssh-commands.js";
+
+function usage() {
+  console.log(`
+Usage: katulong session <subcommand> [options]
+
+Subcommands:
+  list                  List active PTY sessions
+  create <name>         Create a new PTY session
+  kill <name>           Kill a PTY session
+  rename <old> <new>    Rename a PTY session
+
+Options:
+  --json                Output as JSON
+`);
+}
+
+async function list(args) {
+  const jsonMode = args.includes("--json");
+
+  ensureRunning();
+  const sessions = await api.get("/sessions");
+
+  if (jsonMode) {
+    console.log(JSON.stringify(sessions, null, 2));
+    return;
+  }
+
+  if (!Array.isArray(sessions) || sessions.length === 0) {
+    console.log("No active sessions.");
+    return;
+  }
+
+  const rows = sessions.map(s => [
+    s.name,
+    String(s.clients || 0),
+    s.alive ? "yes" : "no",
+  ]);
+  process.stdout.write(formatTable(["NAME", "CLIENTS", "ALIVE"], rows));
+}
+
+async function create(args) {
+  const jsonMode = args.includes("--json");
+  const name = args.filter(a => a !== "--json").join(" ").trim();
+  if (!name) {
+    console.error("Usage: katulong session create <name>");
+    process.exit(1);
+  }
+
+  ensureRunning();
+  const data = await api.post("/sessions", { name });
+
+  if (jsonMode) {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    console.log(`Session "${data.name}" created.`);
+  }
+}
+
+async function kill(args) {
+  const jsonMode = args.includes("--json");
+  const name = args.find(a => a !== "--json");
+  if (!name) {
+    console.error("Usage: katulong session kill <name>");
+    process.exit(1);
+  }
+
+  ensureRunning();
+  const data = await api.del(`/sessions/${encodeURIComponent(name)}`);
+
+  if (jsonMode) {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    console.log(`Session "${name}" killed.`);
+  }
+}
+
+async function rename(args) {
+  const jsonMode = args.includes("--json");
+  const filtered = args.filter(a => a !== "--json");
+  if (filtered.length < 2) {
+    console.error("Usage: katulong session rename <old> <new>");
+    process.exit(1);
+  }
+  const [oldName, newName] = filtered;
+
+  ensureRunning();
+  const data = await api.put(`/sessions/${encodeURIComponent(oldName)}`, { name: newName });
+
+  if (jsonMode) {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    console.log(`Session renamed to "${data.name}".`);
+  }
+}
+
+const subcommands = { list, create, kill, rename };
+
+export default async function session(args) {
+  const sub = args[0];
+  if (!sub || sub === "--help" || sub === "-h") {
+    usage();
+    process.exit(sub ? 0 : 1);
+  }
+
+  if (!subcommands[sub]) {
+    console.error(`Unknown subcommand: ${sub}`);
+    usage();
+    process.exit(1);
+  }
+
+  try {
+    await subcommands[sub](args.slice(1));
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/lib/cli/commands/token.js
+++ b/lib/cli/commands/token.js
@@ -1,0 +1,113 @@
+/**
+ * CLI: katulong token <subcommand>
+ *
+ * Manages setup tokens via the local server API.
+ */
+
+import { ensureRunning, api } from "../api-client.js";
+import { formatTable, formatExpiry } from "../../ssh-commands.js";
+
+function usage() {
+  console.log(`
+Usage: katulong token <subcommand> [options]
+
+Subcommands:
+  create <name>   Create a setup token (shown once)
+  list            List setup tokens
+  revoke <id>     Revoke a token (and linked credential)
+
+Options:
+  --json          Output as JSON
+`);
+}
+
+async function create(args) {
+  const jsonMode = args.includes("--json");
+  const name = args.filter(a => a !== "--json").join(" ").trim();
+  if (!name) {
+    console.error("Usage: katulong token create <name>");
+    process.exit(1);
+  }
+
+  ensureRunning();
+  const data = await api.post("/api/tokens", { name });
+
+  if (jsonMode) {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    console.log(`Token created:
+  ID:      ${data.id}
+  Name:    ${data.name}
+  Token:   ${data.token}
+  Expires: ${formatExpiry(data.expiresAt)}
+
+Save this token — it will not be shown again.`);
+  }
+}
+
+async function list(args) {
+  const jsonMode = args.includes("--json");
+
+  ensureRunning();
+  const data = await api.get("/api/tokens");
+  const tokens = data.tokens || [];
+
+  if (jsonMode) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  if (tokens.length === 0) {
+    console.log("No tokens.");
+    return;
+  }
+
+  const rows = tokens.map(t => [
+    t.id,
+    t.name,
+    formatExpiry(t.expiresAt),
+    t.credential ? t.credential.name : "-",
+  ]);
+  process.stdout.write(formatTable(["ID", "NAME", "EXPIRES", "CREDENTIAL"], rows));
+}
+
+async function revoke(args) {
+  const jsonMode = args.includes("--json");
+  const id = args.find(a => a !== "--json");
+  if (!id) {
+    console.error("Usage: katulong token revoke <id>");
+    process.exit(1);
+  }
+
+  ensureRunning();
+  const data = await api.del(`/api/tokens/${encodeURIComponent(id)}`);
+
+  if (jsonMode) {
+    console.log(JSON.stringify(data, null, 2));
+  } else {
+    console.log("Token revoked.");
+  }
+}
+
+const subcommands = { create, list, revoke };
+
+export default async function token(args) {
+  const sub = args[0];
+  if (!sub || sub === "--help" || sub === "-h") {
+    usage();
+    process.exit(sub ? 0 : 1);
+  }
+
+  if (!subcommands[sub]) {
+    console.error(`Unknown subcommand: ${sub}`);
+    usage();
+    process.exit(1);
+  }
+
+  try {
+    await subcommands[sub](args.slice(1));
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/lib/ssh-commands.js
+++ b/lib/ssh-commands.js
@@ -87,7 +87,7 @@ function respond(data, text, args, exitCode = 0) {
   return { output, exitCode };
 }
 
-function formatRelativeTime(timestamp) {
+export function formatRelativeTime(timestamp) {
   if (!timestamp) return "never";
   const diff = Date.now() - timestamp;
   const minutes = Math.floor(diff / 60000);
@@ -99,7 +99,7 @@ function formatRelativeTime(timestamp) {
   return `${days}d ago`;
 }
 
-function formatExpiry(timestamp) {
+export function formatExpiry(timestamp) {
   if (!timestamp) return "none";
   const diff = timestamp - Date.now();
   if (diff <= 0) return "expired";

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Features: features.md
+  - CLI Reference: cli-reference.md
   - Security:
       - Overview: security/index.md
       - Improvements: security/improvements.md


### PR DESCRIPTION
## Summary

- Add `katulong token create/list/revoke` commands to local CLI
- Add `katulong credential list/revoke` commands to local CLI
- Add `katulong session list/create/kill/rename` commands to local CLI
- All commands support `--json` for scripting
- Add CLI Reference documentation page
- Uses HTTP API calls to localhost (bypasses auth/CSRF automatically)

## Test plan

- [x] `npm test` — all 1105 tests pass
- [x] `katulong token create "Test"` → shows token
- [x] `katulong token list` → table output
- [x] `katulong token list --json` → JSON output
- [x] `katulong token revoke <id>` → revokes
- [x] Pre-push hooks pass (unit + integration + e2e)