### PR TITLE
fix: logout 403 and image paste not working

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -287,24 +287,12 @@ export function createAuthRoutes(ctx) {
       const cookies = parseCookies(req.headers.cookie);
       const token = cookies.get("katulong_session");
       if (token) {
-        try {
-          const result = await withStateLock(async (state) => {
-            if (state && state.isValidSession(token)) {
-              return state.endSession(token, { allowRemoveLast: isLocalRequest(req) });
-            }
-            return { removedCredentialId: null };
-          });
-
-          if (result && result.removedCredentialId) {
-            broadcastToAll({ type: 'credential-removed', credentialId: result.removedCredentialId });
-            closeWebSocketsForCredential(result.removedCredentialId);
+        await withStateLock(async (state) => {
+          if (state && state.isValidSession(token)) {
+            return { state: state.removeSession(token) };
           }
-        } catch (err) {
-          if (err instanceof LastCredentialError) {
-            return json(res, 403, { error: "Cannot end session for the last credential" });
-          }
-          throw err;
-        }
+          return {};
+        });
       }
       let clearCookie = "katulong_session=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0";
       if (isHttpsConnection(req)) clearCookie += "; Secure";

--- a/public/app.js
+++ b/public/app.js
@@ -570,7 +570,6 @@
     // --- Global paste ---
 
     const pasteHandler = createPasteHandler({
-      onText: (text) => rawSend(text),
       onImage: (file) => uploadImageToTerminal(file)
     });
     pasteHandler.init();

--- a/public/lib/settings-handlers.js
+++ b/public/lib/settings-handlers.js
@@ -280,7 +280,11 @@ export function createSettingsHandlers(options = {}) {
 
     // Remote access - show logout button
     logoutBtn.addEventListener("click", async () => {
-      await api.post("/auth/logout");
+      try {
+        await api.post("/auth/logout");
+      } catch {
+        // Cookie may have been cleared even if the request failed — redirect anyway
+      }
 
       if (onLogout) {
         onLogout();


### PR DESCRIPTION
## Summary

- **Logout 403**: Replaced `endSession()` with `removeSession()` in `/auth/logout`. `endSession()` removes the credential, which throws `LastCredentialError` when there's only one passkey. `removeSession()` just invalidates the session token so users can log back in with their existing passkey.
- **Image paste**: Switched paste handler from bubble phase to capture phase (`addEventListener("paste", handler, true)`) so it fires before xterm.js 5.5.0's `stopPropagation()`. Only intercepts image pastes — text paste is handled natively by xterm's bracket paste mode.
- Added try/catch to frontend logout handler so redirect to `/login` happens even if the API call fails.
- Simplified logout integration test (one credential instead of two, updated assertions).

## Test plan

- [x] All 1049 tests pass (`npm test`)
- [ ] Click "End Session" → redirects to login (no 403)
- [ ] Log back in with passkey → works (credential not removed)
- [ ] Paste screenshot (Cmd+V) → image uploads and path sent to terminal
- [ ] Paste text (Cmd+V) → works normally via xterm
- [ ] Drag image onto terminal → continues to work (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)