### PR TITLE
fix: iPad viewport gap and scroll button positioning

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="auto">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content, viewport-fit=cover">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="theme-color" content="#1e1e2e">
@@ -82,7 +82,7 @@
     /* --- Reset & base --- */
     * { margin: 0; padding: 0; box-sizing: border-box; }
     button, input { font-family: inherit; }
-    html, body { height: 100%; background: var(--bg); overflow: hidden; color: var(--text); font-family: var(--font-mono); }
+    html, body { height: 100dvh; background: var(--bg); overflow: hidden; color: var(--text); font-family: var(--font-mono); }
 
     /* --- Focus & motion --- */
     :focus-visible {
@@ -233,7 +233,7 @@
 
     /* --- Scroll to bottom --- */
     #scroll-bottom {
-      position: fixed; bottom: 1rem; left: 1rem; z-index: 10;
+      position: fixed; bottom: calc(1rem + env(safe-area-inset-bottom, 0px)); left: 50%; transform: translateX(-50%); z-index: 10;
       width: 2.5rem; height: 2.5rem; border-radius: 50%; border: none;
       background: var(--overlay-bg); color: var(--text); font-size: 1.25rem;
       cursor: pointer; display: none; align-items: center; justify-content: center;

--- a/public/lib/viewport-manager.js
+++ b/public/lib/viewport-manager.js
@@ -32,7 +32,15 @@ export function createViewportManager(options = {}) {
       // In Chromium mobile emulation (isMobile: true), vv.height can be 0 during
       // initial JS module execution before the visual viewport is fully initialised.
       // Fall back to window.innerHeight so the terminal container gets a valid height.
-      const h = (vv && vv.height > 0) ? vv.height : window.innerHeight;
+      const vvH = (vv && vv.height > 0) ? vv.height : window.innerHeight;
+      const innerH = window.innerHeight;
+      // Only override layout height when a keyboard or similar input is shrinking
+      // the visual viewport (vv.height significantly less than innerHeight).
+      // Otherwise let CSS 100dvh handle layout — this avoids a gap on iPad
+      // where the floating toolbar reduces visualViewport.height but the app
+      // should still fill the full screen.
+      const keyboardOpen = innerH - vvH > 100;
+      const h = keyboardOpen ? vvH : innerH;
       const layoutHeight = h + "px";
       if (appLayout) {
         appLayout.style.height = layoutHeight;


### PR DESCRIPTION
## Summary

- Fix gap at bottom of terminal/sidebar on iPad by only using `visualViewport.height` when a keyboard is open (>100px shrink), otherwise using `window.innerHeight`
- Center scroll-to-bottom button horizontally to avoid sidebar overlap
- Add `viewport-fit=cover` and `safe-area-inset-bottom` for proper iPad toolbar clearance

## Test plan

- [x] `npm test` passes (unit + integration)
- [ ] Manual: iPad — no gap at bottom of screen
- [ ] Manual: iPad — scroll button visible above floating toolbar
- [ ] Manual: iPad — keyboard still resizes terminal correctly