### PR TITLE
feat: sidebar improvements and instant session switching

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -635,8 +635,10 @@ export function createAppRoutes(ctx) {
     }))},
 
     { method: "DELETE", prefix: "/sessions/", handler: auth(csrf((req, res, name) => {
-      const result = sessionManager.deleteSession(name);
-      json(res, result.error ? 404 : 200, result.error ? { error: result.error } : { ok: true });
+      const url = new URL(req.url, "http://localhost");
+      const detachOnly = url.searchParams.get("action") === "detach";
+      const result = sessionManager.deleteSession(name, { detachOnly });
+      json(res, result.error ? 404 : 200, result.error ? { error: result.error } : { ok: true, action: result.action });
     }))},
 
     { method: "PUT", prefix: "/sessions/", handler: auth(csrf(async (req, res, name) => {

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -280,25 +280,27 @@ export function createSessionManager({ bridge, shell, home }) {
     /**
      * Delete a session.
      * @param {string} name
-     * @returns {{ ok: true } | { error: string }}
+     * @param {{ detachOnly?: boolean }} [opts]
+     * @returns {{ ok: true, action: string } | { error: string }}
      */
-    deleteSession(name) {
+    deleteSession(name, { detachOnly = false } = {}) {
       const session = sessions.get(name);
       if (!session) return { error: "Not found" };
-      if (session.external) {
-        // External tmux session — just detach, don't destroy it
+      if (detachOnly) {
+        // Detach: close control mode but keep tmux session alive
         session.detach();
       } else {
-        // Katulong-managed session — kill the tmux session
+        // Delete: kill the tmux session
         session.kill();
       }
+      const action = detachOnly ? "detached" : "deleted";
       sessions.delete(name);
       for (const [cid, info] of clients) {
         if (info.session === name) clients.delete(cid);
       }
       bridge.relay({ type: "session-removed", session: name });
-      log.info("Session removed", { session: name, external: session.external });
-      return { ok: true };
+      log.info("Session removed", { session: name, action });
+      return { ok: true, action };
     },
 
     /**
@@ -349,7 +351,23 @@ export function createSessionManager({ bridge, shell, home }) {
       if (session.alive) {
         session.resize(cols, rows);
       }
-      return { buffer: session.getBuffer(), alive: session.alive };
+      // Use capture-pane for the reconnect buffer instead of raw output history.
+      // The raw RingBuffer contains all cursor positioning and partial writes which
+      // can produce garbled text on replay when the terminal size has changed (common
+      // with TUI apps like Claude Code). capture-pane gives us the current tmux screen
+      // state properly formatted for the current dimensions.
+      let buffer = "";
+      if (session.alive) {
+        const paneContent = await captureScrollback(session.tmuxName);
+        if (paneContent) {
+          // Reset terminal + convert \n to \r\n for xterm.js rendering
+          buffer = "\x1b[H\x1b[2J" + paneContent.replace(/\n/g, "\r\n");
+        }
+      }
+      if (!buffer) {
+        buffer = session.getBuffer();
+      }
+      return { buffer, alive: session.alive };
     },
 
     /**

--- a/lib/websocket-validation.js
+++ b/lib/websocket-validation.js
@@ -61,6 +61,38 @@ export function validateAttach(msg) {
 }
 
 /**
+ * Validate 'switch' message
+ * { type: "switch", session: string, cols: number, rows: number }
+ */
+export function validateSwitch(msg) {
+  if (!isObject(msg)) {
+    return { valid: false, error: "Message must be an object" };
+  }
+
+  if (msg.type !== "switch") {
+    return { valid: false, error: "Invalid type" };
+  }
+
+  if (!isString(msg.session)) {
+    return { valid: false, error: "session must be a string" };
+  }
+
+  if (!isPositiveInteger(msg.cols)) {
+    return { valid: false, error: "cols must be a positive integer" };
+  }
+
+  if (!isPositiveInteger(msg.rows)) {
+    return { valid: false, error: "rows must be a positive integer" };
+  }
+
+  if (msg.cols > 1000 || msg.rows > 1000) {
+    return { valid: false, error: "cols and rows must be <= 1000" };
+  }
+
+  return { valid: true };
+}
+
+/**
  * Validate 'input' message
  * { type: "input", data: string }
  */
@@ -145,6 +177,8 @@ export function validateMessage(msg) {
   switch (msg.type) {
     case "attach":
       return validateAttach(msg);
+    case "switch":
+      return validateSwitch(msg);
     case "input":
       return validateInput(msg);
     case "resize":

--- a/lib/ws-manager.js
+++ b/lib/ws-manager.js
@@ -175,6 +175,23 @@ export function createWebSocketManager({ bridge, sessionManager }) {
             ws.send(JSON.stringify({ type: "error", message: "Session manager error" }));
           }
         },
+        async switch() {
+          const name = msg.session || "default";
+          try {
+            // Just re-point the client at the new session — all tmux control
+            // mode processes stay attached in the background.
+            const result = await sessionManager.attachClient(clientId, name, msg.cols, msg.rows);
+            const info = wsClients.get(clientId);
+            if (info) info.session = name;
+            log.debug("Client switched session", { clientId, session: name });
+            ws.send(JSON.stringify({ type: "switched", session: name }));
+            if (result.buffer) ws.send(JSON.stringify({ type: "output", data: result.buffer }));
+            if (!result.alive) ws.send(JSON.stringify({ type: "exit", code: -1 }));
+          } catch (err) {
+            log.error("Switch failed", { clientId, error: err.message });
+            ws.send(JSON.stringify({ type: "error", message: "Session switch error" }));
+          }
+        },
         input() {
           sessionManager.writeInput(clientId, msg.data);
         },

--- a/public/app.js
+++ b/public/app.js
@@ -510,12 +510,16 @@
       // Close port forward / file browser — switching sessions returns to terminal
       if (portForwardEl?.classList.contains("active")) closePortForward();
       if (fileBrowserEl?.classList.contains("active")) closeFileBrowser();
-      state.update('session.name', name);
-      document.title = name;
       term.clear();
       term.reset();
-      if (state.connection.ws && state.connection.ws.readyState === WebSocket.OPEN) {
-        state.connection.ws.close();
+      const ws = state.connection.ws;
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        // Switch session over the existing WebSocket — no disconnect/reconnect needed
+        ws.send(JSON.stringify({ type: "switch", session: name, cols: term.cols, rows: term.rows }));
+      } else {
+        // No open connection — update state and let reconnect handle it
+        state.update('session.name', name);
+        document.title = name;
       }
       if (shortcutBarInstance) shortcutBarInstance.render(name);
       invalidateSessions(sessionStore, name);
@@ -817,6 +821,7 @@
       loadTokens,
       isAtBottom,
       renderBar,
+      invalidateSessions: (name) => invalidateSessions(sessionStore, name),
       fit: () => withPreservedScroll(term, () => fit.fit())
     });
     wsConnection.initVisibilityReconnect();

--- a/public/index.html
+++ b/public/index.html
@@ -587,6 +587,15 @@
       padding: 0 0.5rem; flex-shrink: 0;
       height: var(--height-btn-md); border-bottom: 1px solid var(--border);
     }
+    /* iPadOS Stage Manager: window controls overlay top-left corner */
+    @supports (-webkit-touch-callout: none) {
+      @media (pointer: coarse) {
+        :root { --bar-top-pad: 1rem; }
+        #sidebar-toolbar { height: calc(var(--height-btn-md) + var(--bar-top-pad)); padding-top: var(--bar-top-pad); }
+        #sidebar.collapsed #sidebar-toolbar { padding-top: calc(var(--bar-top-pad) + 0.5rem); }
+        #shortcut-bar { height: calc(var(--height-btn-md) + var(--bar-top-pad)); padding-top: var(--bar-top-pad); }
+      }
+    }
     .sidebar-icon-btn {
       width: 2rem; height: 2rem; border: none; border-radius: var(--radius-sm);
       background: transparent; color: var(--text-muted); font-size: 1.125rem;
@@ -644,7 +653,7 @@
     /* --- Mobile/Tablet: sidebar as floating overlay (overlay breakpoint: 1024px) --- */
     @media (max-width: 1023px) {
       #sidebar {
-        position: fixed; top: var(--height-btn-md); left: 0; bottom: 0; z-index: 100;
+        position: fixed; top: calc(var(--height-btn-md) + var(--bar-top-pad, 0px)); left: 0; bottom: 0; z-index: 100;
         width: 280px; min-width: 280px;
         transform: translateX(-100%);
         transition: transform 0.2s ease;
@@ -724,15 +733,14 @@
       cursor: text; outline: none;
     }
     .session-card.active .session-card-name { color: var(--accent-active); }
-    /* Session card actions on hover */
+    /* Session card actions — always visible (mobile-friendly) */
     .session-card-actions {
-      position: absolute; top: 0.25rem; right: 0.25rem;
-      display: none; gap: 0.125rem;
+      display: flex; gap: 0.125rem;
+      margin-left: auto; flex-shrink: 0;
     }
-    .session-card:hover .session-card-actions { display: flex; }
     .session-card-action {
       width: 1.5rem; height: 1.5rem; border: none; border-radius: var(--radius-sm);
-      background: var(--bg-surface); color: var(--text-muted); font-size: 0.75rem;
+      background: transparent; color: var(--text-muted); font-size: 0.75rem;
       cursor: pointer; display: flex; align-items: center; justify-content: center;
     }
     .session-card-action:hover { color: var(--text); }

--- a/public/lib/session-list-component.js
+++ b/public/lib/session-list-component.js
@@ -139,7 +139,7 @@ export function createSessionListComponent(store, options = {}) {
 
       card.appendChild(footer);
 
-      // Action buttons (shown on hover)
+      // Action buttons — always visible (mobile-friendly)
       const actions = document.createElement("div");
       actions.className = "session-card-actions";
 
@@ -164,47 +164,43 @@ export function createSessionListComponent(store, options = {}) {
         location.href = `/?s=${encodeURIComponent(next.name)}`;
       }
 
-      if (s.external) {
-        // External tmux session — show eject button (detach from katulong, keep tmux session)
-        const ejectBtn = document.createElement("button");
-        ejectBtn.className = "session-card-action";
-        ejectBtn.setAttribute("aria-label", `Detach session ${s.name} from katulong`);
-        ejectBtn.innerHTML = '<i class="ph ph-eject"></i>';
-        ejectBtn.addEventListener("click", async (e) => {
-          e.stopPropagation();
-          try {
-            await api.delete(`/sessions/${encodeURIComponent(s.name)}`);
-            switchAfterRemove(s.name);
-          } catch (err) {
-            console.error('[Session] Detach failed:', err);
-          }
-        });
-        actions.appendChild(ejectBtn);
-      } else {
-        // Katulong-managed session — show delete button
-        const delBtn = document.createElement("button");
-        delBtn.className = "session-card-action delete";
-        delBtn.setAttribute("aria-label", `Delete session ${s.name}`);
-        delBtn.innerHTML = '<i class="ph ph-trash"></i>';
-        delBtn.addEventListener("click", async (e) => {
-          e.stopPropagation();
-          if (s.hasChildProcesses) {
-            const confirmed = confirm(
-              `Session "${s.name}" contains running processes or important content (like Claude Code history). Deleting it will lose this data.\n\nAre you sure you want to delete this session?`
-            );
-            if (!confirmed) return;
-          }
-          try {
-            await api.delete(`/sessions/${encodeURIComponent(s.name)}`);
-            switchAfterRemove(s.name);
-          } catch (err) {
-            console.error('[Session] Delete failed:', err);
-          }
-        });
-        actions.appendChild(delBtn);
-      }
+      // Detach button — removes from katulong but keeps tmux session alive
+      const detachBtn = document.createElement("button");
+      detachBtn.className = "session-card-action";
+      detachBtn.setAttribute("aria-label", `Detach session ${s.name}`);
+      detachBtn.innerHTML = '<i class="ph ph-eject"></i>';
+      detachBtn.addEventListener("click", async (e) => {
+        e.stopPropagation();
+        try {
+          await api.delete(`/sessions/${encodeURIComponent(s.name)}?action=detach`);
+          switchAfterRemove(s.name);
+        } catch (err) {
+          console.error('[Session] Detach failed:', err);
+        }
+      });
+      actions.appendChild(detachBtn);
 
-      card.appendChild(actions);
+      // Delete button — kills the tmux session (always confirms)
+      const delBtn = document.createElement("button");
+      delBtn.className = "session-card-action delete";
+      delBtn.setAttribute("aria-label", `Delete session ${s.name}`);
+      delBtn.innerHTML = '<i class="ph ph-trash"></i>';
+      delBtn.addEventListener("click", async (e) => {
+        e.stopPropagation();
+        const message = s.hasChildProcesses
+          ? `Session "${s.name}" has running processes. Deleting it will lose this data.\n\nAre you sure?`
+          : `Delete session "${s.name}"?\n\nThis will kill the tmux session.`;
+        if (!confirm(message)) return;
+        try {
+          await api.delete(`/sessions/${encodeURIComponent(s.name)}`);
+          switchAfterRemove(s.name);
+        } catch (err) {
+          console.error('[Session] Delete failed:', err);
+        }
+      });
+      actions.appendChild(delBtn);
+
+      footer.appendChild(actions);
       container.appendChild(card);
     }
   };

--- a/public/lib/websocket-connection.js
+++ b/public/lib/websocket-connection.js
@@ -38,6 +38,19 @@ export function createWebSocketConnection(deps = {}) {
       ]
     }),
 
+    switched: (msg) => ({
+      stateUpdates: {
+        'connection.attached': true,
+        'session.name': msg.session,
+      },
+      effects: [
+        { type: 'updateSessionUI', name: msg.session },
+        { type: 'invalidateSessions', name: msg.session },
+        { type: 'fit' },
+        { type: 'scrollToBottomIfNeeded', condition: true }
+      ]
+    }),
+
     output: (msg) => ({
       stateUpdates: {},
       effects: [
@@ -149,6 +162,9 @@ export function createWebSocketConnection(deps = {}) {
         break;
       case 'reload':
         location.reload();
+        break;
+      case 'invalidateSessions':
+        if (deps.invalidateSessions) deps.invalidateSessions(effect.name);
         break;
       case 'updateSessionUI':
         document.title = effect.name;

--- a/test/websocket-validation.test.js
+++ b/test/websocket-validation.test.js
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   validateAttach,
+  validateSwitch,
   validateInput,
   validateResize,
   validateP2PSignal,
@@ -94,6 +95,42 @@ describe("validateAttach", () => {
     const result = validateAttach(null);
     assert.strictEqual(result.valid, false);
     assert.match(result.error, /object/i);
+  });
+});
+
+describe("validateSwitch", () => {
+  it("accepts valid switch message", () => {
+    const msg = { type: "switch", session: "my-session", cols: 80, rows: 24 };
+    const result = validateSwitch(msg);
+    assert.strictEqual(result.valid, true);
+  });
+
+  it("rejects when session is missing", () => {
+    const msg = { type: "switch", cols: 80, rows: 24 };
+    const result = validateSwitch(msg);
+    assert.strictEqual(result.valid, false);
+    assert.match(result.error, /session/i);
+  });
+
+  it("rejects when session is not a string", () => {
+    const msg = { type: "switch", session: 123, cols: 80, rows: 24 };
+    const result = validateSwitch(msg);
+    assert.strictEqual(result.valid, false);
+    assert.match(result.error, /session/i);
+  });
+
+  it("rejects when cols is missing", () => {
+    const msg = { type: "switch", session: "test" };
+    const result = validateSwitch(msg);
+    assert.strictEqual(result.valid, false);
+    assert.match(result.error, /cols/i);
+  });
+
+  it("rejects when dimensions exceed limit", () => {
+    const msg = { type: "switch", session: "test", cols: 1001, rows: 24 };
+    const result = validateSwitch(msg);
+    assert.strictEqual(result.valid, false);
+    assert.match(result.error, /1000/);
   });
 });
 
@@ -231,6 +268,12 @@ describe("validateP2PSignal", () => {
 describe("validateMessage", () => {
   it("routes to validateAttach for attach messages", () => {
     const msg = { type: "attach", cols: 80, rows: 24 };
+    const result = validateMessage(msg);
+    assert.strictEqual(result.valid, true);
+  });
+
+  it("routes to validateSwitch for switch messages", () => {
+    const msg = { type: "switch", session: "test", cols: 80, rows: 24 };
     const result = validateMessage(msg);
     assert.strictEqual(result.valid, true);
   });


### PR DESCRIPTION
## Summary

- Always show detach (eject) and delete (trash) buttons on every session card — no hover-only UI
- Always confirm before deleting a tmux session
- Add explicit detach/delete via `?action=detach` query param on DELETE endpoint
- Switch sessions over existing WebSocket (`switch` message) instead of disconnect/reconnect
- Use `capture-pane` for reconnect buffer to fix garbled TUI output (Claude Code)
- Add iPadOS Stage Manager top padding for window controls

## Test plan

- [x] `npm test` passes (1026 tests)
- [x] Pre-push hooks pass (unit + integration + smoke E2E + review agents)
- [ ] Manual: verify session card buttons visible on mobile/iPad
- [ ] Manual: verify session switching is instant (no disconnect)