### PR TITLE
Canonicalize Homebrew distribution on Dorky-Robot/homebrew-tap

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,4 +1,4 @@
-Cut a new release for katulong — bump version, tag, push, update Homebrew formulas, and verify the install.
+Cut a new release for katulong — bump version, tag, push, update the Homebrew formula in `Dorky-Robot/homebrew-tap`, and verify the install.
 
 ## Step 1: Pre-flight checks
 
@@ -84,9 +84,11 @@ Compute the SHA:
 shasum -a 256 "/tmp/katulong-v${NEW_VERSION}.tar.gz"
 ```
 
-## Step 6: Update both formula files
+## Step 6: Update local formula
 
-### 6a: Local formula (`Formula/katulong.rb`)
+`Formula/katulong.rb` is the source-of-truth template. CI propagates it to
+`Dorky-Robot/homebrew-tap` on tag push — you only need to update the local
+copy here.
 
 Read the file, then update the `url` and `sha256` lines using the Edit tool.
 
@@ -97,16 +99,6 @@ git pull origin main
 git add Formula/katulong.rb
 git commit -m "formula: update to v${NEW_VERSION}"
 git push origin main
-```
-
-### 6b: Tap formula (`homebrew-katulong/Formula/katulong.rb`)
-
-Read the tap formula file, update `url` and `sha256` with the same values.
-
-Commit and push. **Note**: the tap repo uses `master` as its default branch:
-
-```bash
-cd homebrew-katulong && git pull origin master && git add Formula/katulong.rb && git commit -m "formula: update to v${NEW_VERSION}" && git push origin master
 ```
 
 ## Step 7: Brew upgrade

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           SHA=$(curl -fsSL "$URL" | sha256sum | cut -d' ' -f1)
           echo "SOURCE_SHA=${SHA}" >> "$GITHUB_ENV"
 
-      - name: Update tap repos
+      - name: Update homebrew-tap
         env:
           TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
         run: |
@@ -45,25 +45,24 @@ jobs:
           sed -i "s|url \".*\"|url \"https://github.com/Dorky-Robot/katulong/archive/refs/tags/${TAG}.tar.gz\"|" /tmp/katulong.rb
           sed -i "s|sha256 \".*\"|sha256 \"${SOURCE_SHA}\"|" /tmp/katulong.rb
 
-          # Update both tap repos (homebrew-tap and homebrew-katulong)
-          for REPO in homebrew-tap homebrew-katulong; do
-            BRANCH="main"
-            if [ "$REPO" = "homebrew-katulong" ]; then BRANCH="master"; fi
+          # Update the canonical multi-formula tap (Dorky-Robot/homebrew-tap).
+          # The standalone Dorky-Robot/homebrew-katulong repo is deprecated —
+          # see docs/ecosystem-refocus.md for the canonicalization rationale.
+          echo "Updating dorky-robot/homebrew-tap (main)..."
+          git clone --depth 1 -b main \
+            "https://x-access-token:${TAP_TOKEN}@github.com/Dorky-Robot/homebrew-tap.git" \
+            /tmp/homebrew-tap
 
-            echo "Updating dorky-robot/${REPO} (${BRANCH})..."
-            git clone --depth 1 -b "$BRANCH" \
-              "https://x-access-token:${TAP_TOKEN}@github.com/Dorky-Robot/${REPO}.git" \
-              "/tmp/${REPO}" 2>/dev/null || continue
-
-            mkdir -p "/tmp/${REPO}/Formula"
-            cp /tmp/katulong.rb "/tmp/${REPO}/Formula/katulong.rb"
-            cd "/tmp/${REPO}"
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add Formula/katulong.rb
-            git diff --cached --quiet && echo "  No changes" && cd - && continue
+          mkdir -p /tmp/homebrew-tap/Formula
+          cp /tmp/katulong.rb /tmp/homebrew-tap/Formula/katulong.rb
+          cd /tmp/homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/katulong.rb
+          if git diff --cached --quiet; then
+            echo "  No changes"
+          else
             git commit -m "katulong ${VERSION}"
             git push
             echo "  Updated to ${VERSION}"
-            cd -
-          done
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ test-results.txt
 blob-report/
 ssh/
 tls/
-homebrew-katulong/
 site/
 .claude/worktrees/
 .worktrees/

--- a/Formula/README.md
+++ b/Formula/README.md
@@ -2,13 +2,17 @@
 
 This directory contains the Homebrew formula for installing Katulong.
 
+This file is the source-of-truth template. CI publishes it to the
+canonical multi-formula tap at `Dorky-Robot/homebrew-tap` on every
+release.
+
 ## For Users
 
 ### Installation
 
 ```bash
 # Add the tap
-brew tap dorky-robot/katulong
+brew tap dorky-robot/tap
 
 # Install katulong
 brew install katulong
@@ -77,22 +81,6 @@ brew services stop katulong
    brew services start katulong
    brew services list | grep katulong
    ```
-
-### Setting Up the Tap
-
-For the first release, create the tap repository:
-
-```bash
-# Create a new repository: dorky-robot/homebrew-katulong
-# Copy Formula/katulong.rb to the tap repository
-
-cd ../homebrew-katulong
-mkdir -p Formula
-cp ../katulong/Formula/katulong.rb Formula/
-git add Formula/katulong.rb
-git commit -m "Add katulong formula"
-git push origin main
-```
 
 ## Formula Details
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # Release katulong: bump version, update Formula, tag, and push.
 #
 # The CI release workflow (.github/workflows/release.yml) takes over from
-# the tag push — it creates the GitHub release and updates both tap repos
-# (homebrew-tap, homebrew-katulong) with the correct SHA256.
+# the tag push — it creates the GitHub release and updates the canonical
+# Dorky-Robot/homebrew-tap with the correct SHA256.
 #
 # Usage:
 #   ./scripts/release.sh <patch|minor|major>
@@ -188,8 +188,7 @@ log "Released v${NEW_VERSION}!"
 log ""
 log "CI will now:"
 log "  1. Create GitHub release"
-log "  2. Update homebrew-tap and homebrew-katulong with correct SHA256"
-log "  3. Trigger bottle builds in homebrew-katulong"
+log "  2. Update Dorky-Robot/homebrew-tap with correct SHA256"
 log ""
-log "After bottles are built, users can upgrade with:"
+log "After CI completes, users can upgrade with:"
 log "  brew update && brew upgrade katulong"


### PR DESCRIPTION
## Summary

- Stop dual-publishing the katulong formula. Canonical home is now Dorky-Robot/homebrew-tap (multi-formula).
- Part of the dorky robot ecosystem refocus — see \`docs/ecosystem-refocus.md\` in the meta-repo.
- Standalone Dorky-Robot/homebrew-katulong is being deprecated. A follow-up will push a deprecation README and archive the repo.

## What changed

- \`.github/workflows/release.yml\` — replaced the \`for REPO in homebrew-tap homebrew-katulong\` loop with a single block that publishes only to \`homebrew-tap\`. Also removed the \`|| continue\` swallowing — the previous loop would silently skip a tap on clone failure, which is part of how the two taps drifted in the first place.
- \`scripts/release.sh\` — comment header and summary log no longer mention the standalone tap.
- \`Formula/README.md\` — install instructions now say \`brew tap dorky-robot/tap\`. Removed the obsolete "Setting Up the Tap" section.
- \`.claude/commands/release.md\` — collapsed step 6a/6b into a single "update the local template" step. CI handles the tap update.
- \`.gitignore\` — removed the dead \`homebrew-katulong/\` entry.

## Why two taps was a bug, not a feature

The standalone repo predates homebrew-tap and was kept in lockstep by the CI loop. Having two install paths (\`brew tap dorky-robot/katulong\` and \`brew tap dorky-robot/tap\`) split the user base and meant every release wrote two repos for one formula. The multi-formula tap also fits the broader ecosystem direction: sipag, kubo, katulong, hulma, etc. should all live in one tap so a single \`brew tap dorky-robot/tap\` gives users the whole stack.

## Test plan

- [ ] Tag a no-op patch release after merge and watch the workflow run — verify only \`homebrew-tap\` gets pushed
- [ ] \`brew tap dorky-robot/tap && brew install katulong\` works on a clean machine
- [ ] Existing \`brew tap dorky-robot/katulong\` users see no errors yet (deprecation comes in the follow-up)

## Caveats

- Existing users on \`brew tap dorky-robot/katulong\` silently stop receiving updates after this merges. The deprecation README + archive comes in a separate diff so the migration has its own surface.
- \`test/dispatch.test.js\` fixture string \`"homebrew-katulong"\` is left in place — it's a sort-test fixture, not a real reference.