### PR TITLE
feat: command palette (Option+Space) — PR 1 of 3

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -24,6 +24,7 @@
     import { createShortcutBar } from "/lib/shortcut-bar.js";
     import { createWindowTabSet } from "/lib/window-tab-set.js";
     import { createPasteHandler } from "/lib/paste-handler.js";
+    import { createCommandPalette } from "/lib/command-palette.js";
     import { createNetworkMonitor } from "/lib/network-monitor.js";
     import { createSettingsHandlers } from "/lib/settings-handlers.js";
     import { createTerminalKeyboard } from "/lib/terminal-keyboard.js";
@@ -192,6 +193,15 @@
 
     setDocTitle(state.session.name);
 
+    // --- Command palette ---
+    // Late-bound: the factory is called below pasteHandler.init() (deps
+    // need themeManager + toggleSearchBar, which are defined further
+    // down). The closure-captured `let` lets onTerminalCreated below
+    // call commandPalette.toggle() without TDZ — onTerminalCreated only
+    // runs after the pool's first activate(), which always happens
+    // after this module's top-level code finishes.
+    let commandPalette = null;
+
     // --- Terminal pool ---
     // One xterm.js Terminal per managed session, visibility-toggled on switch.
 
@@ -229,7 +239,11 @@
         const kb = createTerminalKeyboard({
           term: entry.term,
           onSend: (data) => rawSend(data),
-          onToggleSearch: toggleSearchBar
+          onToggleSearch: toggleSearchBar,
+          // Late-bound: commandPalette is constructed below pasteHandler,
+          // long after the pool is built but always before any terminal
+          // is activated (pool.activate is what calls onTerminalCreated).
+          onTogglePalette: () => commandPalette?.toggle()
         });
         kb.init();
 
@@ -1495,6 +1509,20 @@
       },
     });
     pasteHandler.init();
+
+    // --- Command palette (Alfred-style overlay) ---
+    // Wired after pasteHandler so the document-level capture-phase keydown
+    // listener registers in a known order; the palette doesn't need to win
+    // over paste, but keeping the order stable makes future debugging
+    // easier. The factory's init() looks up #palette in the DOM (markup
+    // owned by index.html); if the markup is missing the palette logs a
+    // warning and stays disabled instead of crashing app boot.
+    commandPalette = createCommandPalette({
+      themeManager,
+      toggleSearchBar,
+      getTerm,
+    });
+    commandPalette.init();
 
     // --- File Browser ---
 

--- a/public/index.html
+++ b/public/index.html
@@ -610,6 +610,146 @@
     }
     #search-input:focus { border-color: var(--accent-active); }
 
+    /* --- Command palette (Alfred/Spotlight-style overlay) ---
+       Hidden by default. JS toggles `.palette.visible` to show.
+       Lives above #search-bar (z:20), #disconnect-overlay (z:10), and the
+       modal stack (--z-modal-* = 10000–10002). Sits below toasts (11000)
+       since toasts are transient feedback that should always be visible. */
+    .palette {
+      display: none;
+      position: fixed; inset: 0;
+      z-index: var(--z-modal-nested, 10002);
+    }
+    .palette.visible {
+      display: block;
+      animation: palette-fade-in 0.12s ease-out;
+    }
+    @keyframes palette-fade-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+    .palette-backdrop {
+      position: absolute; inset: 0;
+      background: var(--overlay-bg);
+      -webkit-backdrop-filter: blur(2px);
+      backdrop-filter: blur(2px);
+    }
+    .palette-panel {
+      position: absolute;
+      top: 20vh; left: 50%;
+      transform: translateX(-50%);
+      width: min(600px, 92vw);
+      max-height: min(70vh, 540px);
+      display: flex; flex-direction: column;
+      background: var(--bg-surface);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg, 0.75rem);
+      box-shadow: var(--shadow-xl, 0 20px 40px -8px rgba(0,0,0,0.4));
+      overflow: hidden;
+    }
+    .palette.visible .palette-panel {
+      animation: palette-panel-in 0.16s ease-out;
+    }
+    @keyframes palette-panel-in {
+      from { opacity: 0; transform: translateX(-50%) translateY(-8px) scale(0.98); }
+      to { opacity: 1; transform: translateX(-50%) translateY(0) scale(1); }
+    }
+    .palette-input {
+      width: 100%;
+      padding: var(--space-lg, 1rem) var(--space-xl, 1.5rem);
+      background: transparent;
+      color: var(--text);
+      border: none;
+      border-bottom: 1px solid var(--border);
+      font-family: var(--font-mono);
+      font-size: var(--text-lg, 1.125rem);
+      outline: none;
+    }
+    .palette-input::placeholder { color: var(--text-dim); }
+    .palette-input:focus { border-bottom-color: var(--accent-active); }
+    .palette-results {
+      list-style: none;
+      margin: 0; padding: var(--space-xs, 0.25rem) 0;
+      max-height: min(60vh, 400px);
+      overflow-y: auto;
+      overscroll-behavior: contain;
+    }
+    .palette-results::-webkit-scrollbar { width: 8px; }
+    .palette-results::-webkit-scrollbar-thumb {
+      background: var(--border); border-radius: 4px;
+    }
+    .palette-item {
+      display: flex; align-items: center;
+      gap: var(--space-md, 0.75rem);
+      padding: var(--space-sm, 0.5rem) var(--space-xl, 1.5rem);
+      cursor: pointer;
+      user-select: none;
+      -webkit-tap-highlight-color: transparent;
+      transition: background 0.08s ease;
+    }
+    .palette-item:hover { background: var(--accent); }
+    .palette-item.selected {
+      background: var(--accent-active);
+      color: var(--bg);
+    }
+    .palette-item.selected .palette-item-subtitle,
+    .palette-item.selected .palette-item-category {
+      color: var(--bg);
+      opacity: 0.8;
+    }
+    .palette-item-main {
+      flex: 1 1 auto; min-width: 0;
+      display: flex; flex-direction: column;
+      gap: 2px;
+    }
+    .palette-item-title {
+      font-size: var(--text-sm, 0.875rem);
+      color: var(--text);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .palette-item-subtitle {
+      font-size: var(--text-xs, 0.75rem);
+      color: var(--text-muted);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .palette-item-category {
+      flex-shrink: 0;
+      font-size: var(--text-xs, 0.75rem);
+      color: var(--text-dim);
+      background: var(--tag-bg);
+      padding: 2px var(--space-sm, 0.5rem);
+      border-radius: var(--radius-sm, 0.375rem);
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+    .palette-empty {
+      padding: var(--space-xl, 1.5rem) var(--space-lg, 1rem);
+      text-align: center;
+      color: var(--text-dim);
+      font-size: var(--text-sm, 0.875rem);
+      font-family: var(--font-mono);
+    }
+    @media (max-width: 600px) {
+      .palette-panel {
+        top: 8vh;
+        width: 94vw;
+        max-height: min(80vh, 600px);
+        border-radius: var(--radius-md, 0.5rem);
+      }
+      .palette-input {
+        padding: var(--space-md, 0.75rem) var(--space-lg, 1rem);
+        font-size: var(--text-base, 1rem);
+      }
+      .palette-item {
+        padding: var(--space-sm, 0.5rem) var(--space-lg, 1rem);
+      }
+    }
+
     /* --- Scroll to bottom (lives inside active terminal pane) --- */
     #scroll-bottom {
       position: absolute; bottom: 1rem; right: 1rem; z-index: var(--z-bar);
@@ -2289,6 +2429,17 @@
       <i class="ph ph-x"></i>
     </button>
   </div>
+
+  <!-- Command palette: Alfred/Spotlight-style launcher. Items injected by palette.js. -->
+  <div id="palette" class="palette" aria-hidden="true" role="dialog" aria-label="Command palette">
+    <div class="palette-backdrop"></div>
+    <div class="palette-panel">
+      <input class="palette-input" type="text" placeholder="Type a command…" aria-label="Command palette input" autocomplete="off" spellcheck="false">
+      <ul class="palette-results" role="listbox" aria-label="Palette results"></ul>
+      <div class="palette-empty" hidden>No matches</div>
+    </div>
+  </div>
+
   <div id="drop-overlay" class="drop-overlay">Drop image here</div>
   <button id="scroll-bottom" aria-label="Scroll to bottom">
     <i class="ph ph-caret-down"></i>
@@ -2360,6 +2511,7 @@
         <li><span class="kb-label">Move tab right</span><span><kbd>&#x2325;</kbd> <kbd>}</kbd></span></li>
         <li><span class="kb-label">Clear terminal</span><span><kbd>&#x2325;</kbd> <kbd>K</kbd></span></li>
         <li><span class="kb-label">Search</span><span><kbd>&#x2325;</kbd> <kbd>F</kbd></span></li>
+        <li><span class="kb-label">Command palette</span><span><kbd>&#x2325;</kbd> <kbd>Space</kbd></span></li>
         <li><span class="kb-label">Start of line</span><span><kbd>&#x2325;</kbd> <kbd>←</kbd></span></li>
         <li><span class="kb-label">End of line</span><span><kbd>&#x2325;</kbd> <kbd>→</kbd></span></li>
         <li><span class="kb-label">Delete line</span><span><kbd>&#x2325;</kbd> <kbd>⌫</kbd></span></li>

--- a/public/lib/command-palette.js
+++ b/public/lib/command-palette.js
@@ -1,0 +1,506 @@
+/**
+ * Command Palette
+ *
+ * Alfred/Spotlight-style overlay that lets the user run app actions by
+ * typing. PR 1 ships three one-shot providers (toggle theme, toggle
+ * vibrancy, find in terminal); PR 2 will add session-scoped actions and
+ * a two-stage prompt flow; v2 will hydrate providers from filesystem
+ * plugins. The provider shape below is intentionally future-proof for
+ * both — `prompt` is reserved for PR 2's follow-up step but unused here,
+ * and `id` is the stable handle for the future recency-bias rank.
+ *
+ * Wiring is the established katulong factory pattern: createCommandPalette
+ * takes its dependencies as named args, returns an object with init() and
+ * a few imperative entry points. No globals, no module-level state.
+ *
+ * ## Hotkey: Option+Space
+ *
+ * Intercepted at TWO layers, both required (see commits c6f1c31 and
+ * 2a13634 for the history of why single-layer interception leaks):
+ *
+ *   1. terminal-key-decider.js → returns action `togglePalette`. The
+ *      keyboard shell in terminal-keyboard.js maps that to the callback
+ *      we pass in via createTerminalKeyboard's `onTogglePalette`. This
+ *      catches Option+Space when the xterm helper textarea has focus.
+ *
+ *   2. document.addEventListener("keydown", ..., true) below — capture
+ *      phase. Catches Option+Space when focus is anywhere ELSE (a real
+ *      input, the body, a modal). Without this layer, the palette
+ *      wouldn't open from the settings panel or while a rename input
+ *      is focused.
+ *
+ * Both layers must key off `ev.code === "Space"`, NOT `ev.key`. macOS
+ * substitutes the Option layer character (a non-breaking space, U+00A0)
+ * before the event reaches JS, so checking `ev.key === " "` silently
+ * misses every press. ev.code is the physical key — stable across
+ * modifiers and keyboard layouts. The same rule killed Option+F /
+ * Option+K back in c6f1c31.
+ *
+ * ## Provider interface
+ *
+ * Each provider is a plain object:
+ *
+ *   {
+ *     id: "theme.toggle",      // stable handle for recency (PR 3)
+ *     title: "Toggle theme",   // shown in the list
+ *     subtitle: "Switch ...",  // optional secondary line
+ *     category: "Appearance",  // shown as a tag on the right
+ *     keywords: ["dark", ...], // extra match tokens
+ *     prompt: undefined,       // RESERVED for PR 2 — see typedef
+ *     run(ctx, choice) { ... } // called on Enter / click
+ *   }
+ *
+ * PR 1 has no provider that uses `prompt`. The shape is documented so
+ * PR 2 can add follow-up-prompt providers without restructuring the
+ * registry or the dispatch path.
+ */
+
+/**
+ * @typedef {Object} PaletteProvider
+ * @property {string} id
+ * @property {string} title
+ * @property {string} [subtitle]
+ * @property {string} [category]
+ * @property {string[]} [keywords]
+ * @property {Object} [prompt]                       — reserved for PR 2
+ * @property {string} [prompt.placeholder]
+ * @property {function} [prompt.choices]             — (ctx) => [{id,label,hint}]
+ * @property {function} run                          — (ctx, choice?) => void
+ */
+
+// ── Pure ranking helpers ─────────────────────────────────────────────────
+//
+// scoreMatch / rankProviders are pure so they can be unit-tested without
+// the DOM. The matcher is a small subsequence ranker with bonuses for
+// prefix and word-boundary hits — good enough for tens of providers and
+// dependency-free. If the registry ever grows to thousands of providers
+// we can swap in a heavier fuzzy library, but the function signature
+// stays the same.
+
+function _scoreString(query, source, weight) {
+  if (!source) return 0;
+  const hay = source.toLowerCase();
+  const needle = query.toLowerCase();
+  if (!needle) return 0;
+
+  // Exact prefix is the strongest signal.
+  if (hay.startsWith(needle)) return 100 * weight;
+
+  // Word-boundary hit (e.g. query "tog" matches "Toggle theme").
+  if (new RegExp("(^|\\s|\\b|[._-])" + escapeRegex(needle)).test(hay)) {
+    return 60 * weight;
+  }
+
+  // Subsequence: every char of needle must appear in order in hay.
+  // Score is higher when chars are consecutive (closer indices).
+  let i = 0, last = -1, run = 0, score = 0;
+  for (let h = 0; h < hay.length && i < needle.length; h++) {
+    if (hay[h] === needle[i]) {
+      if (h === last + 1) { run++; score += 5 * run; } else { run = 1; score += 5; }
+      last = h;
+      i++;
+    }
+  }
+  if (i < needle.length) return 0; // not all chars matched
+  return score * weight;
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Score a provider against a query. Higher is better, 0 means no match.
+ * Title is weighted highest, then keywords, then category, then subtitle.
+ */
+export function scoreMatch(query, provider) {
+  if (!query) return 1; // empty query — all providers match equally
+  let total = 0;
+  total += _scoreString(query, provider.title, 1.0);
+  if (provider.keywords) {
+    for (const kw of provider.keywords) {
+      total += _scoreString(query, kw, 0.7);
+    }
+  }
+  total += _scoreString(query, provider.category, 0.5);
+  total += _scoreString(query, provider.subtitle, 0.4);
+  return total;
+}
+
+/**
+ * Rank providers by score. Empty query returns insertion order. Ties are
+ * broken stably (Array.sort is stable in modern engines).
+ */
+export function rankProviders(query, providers) {
+  if (!query) return providers.slice();
+  return providers
+    .map((p) => ({ p, s: scoreMatch(query, p) }))
+    .filter((entry) => entry.s > 0)
+    .sort((a, b) => b.s - a.s)
+    .map((entry) => entry.p);
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────
+
+/**
+ * Create the command palette.
+ *
+ * @param {object} deps
+ * @param {object} deps.themeManager     — see lib/theme-manager.js
+ * @param {function} deps.toggleSearchBar — opens/closes the in-terminal find bar
+ * @param {function} deps.getTerm         — () => active xterm instance
+ */
+export function createCommandPalette(deps = {}) {
+  const { themeManager, toggleSearchBar, getTerm } = deps;
+
+  // Closure state — no module-level globals.
+  /** @type {Map<string, PaletteProvider>} */
+  const providers = new Map();
+  /** @type {PaletteProvider[]} */
+  let currentMatches = [];
+  let selectedIndex = 0;
+  let isOpen = false;
+  /** @type {Element|null} */
+  let savedFocus = null;
+  let initialized = false;
+
+  // DOM refs — looked up lazily on init() so the module can be imported
+  // before the DOM is parsed without exploding. The HTML is owned by
+  // public/index.html (sibling agent's slice).
+  let rootEl = null;
+  let panelEl = null;
+  let inputEl = null;
+  let resultsEl = null;
+  let emptyEl = null;
+  let backdropEl = null;
+
+  /** Build the ctx passed to provider.run(). Easy to extend in PR 2. */
+  function buildCtx() {
+    return { themeManager, toggleSearchBar, getTerm };
+  }
+
+  /** Register a provider. Existing id is replaced (last write wins). */
+  function registerProvider(provider) {
+    if (!provider || typeof provider.id !== "string" || typeof provider.run !== "function") {
+      throw new Error("registerProvider: provider must have {id: string, run: function}");
+    }
+    providers.set(provider.id, provider);
+  }
+
+  /** All providers in registration order. */
+  function listProviders() {
+    return Array.from(providers.values());
+  }
+
+  /** Render the result list to match currentMatches + selectedIndex. */
+  function render() {
+    // Clear previous results. We rebuild from scratch every render — the
+    // list is small (tens of items max in PR 1) and incremental diffing
+    // is not worth the complexity.
+    resultsEl.replaceChildren();
+
+    if (currentMatches.length === 0) {
+      emptyEl.removeAttribute("hidden");
+      return;
+    }
+    emptyEl.setAttribute("hidden", "");
+
+    currentMatches.forEach((provider, idx) => {
+      // Use createElement + textContent — NEVER innerHTML with provider
+      // strings. Even though PR 1 providers are static, the habit matters
+      // for the future plugin system (CLAUDE.md code-review checklist #8).
+      const li = document.createElement("li");
+      li.className = "palette-item" + (idx === selectedIndex ? " selected" : "");
+      li.setAttribute("role", "option");
+      li.dataset.providerId = provider.id;
+
+      const main = document.createElement("div");
+      main.className = "palette-item-main";
+
+      const title = document.createElement("div");
+      title.className = "palette-item-title";
+      title.textContent = provider.title;
+      main.appendChild(title);
+
+      if (provider.subtitle) {
+        const subtitle = document.createElement("div");
+        subtitle.className = "palette-item-subtitle";
+        subtitle.textContent = provider.subtitle;
+        main.appendChild(subtitle);
+      }
+
+      li.appendChild(main);
+
+      if (provider.category) {
+        const cat = document.createElement("div");
+        cat.className = "palette-item-category";
+        cat.textContent = provider.category;
+        li.appendChild(cat);
+      }
+
+      // Mouse: hover doesn't change selection (the .palette-item:hover
+      // CSS already paints feedback); click selects + runs.
+      li.addEventListener("click", () => {
+        selectedIndex = idx;
+        runSelected();
+      });
+
+      resultsEl.appendChild(li);
+    });
+
+    // Make sure the selected row is in view if the list scrolled.
+    const selEl = resultsEl.children[selectedIndex];
+    if (selEl) selEl.scrollIntoView({ block: "nearest" });
+  }
+
+  /** Recompute matches for the current input value, reset selection. */
+  function recompute() {
+    const q = inputEl.value.trim();
+    currentMatches = rankProviders(q, listProviders());
+    selectedIndex = 0;
+    render();
+  }
+
+  /** Run the currently selected provider, then close. */
+  function runSelected() {
+    const provider = currentMatches[selectedIndex];
+    if (!provider) return;
+    // PR 1: all providers are one-shot. PR 2 will branch here on
+    // provider.prompt being defined.
+    try {
+      provider.run(buildCtx());
+    } catch (err) {
+      console.error("[command-palette] provider.run threw:", err);
+    }
+    close();
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────
+
+  function open() {
+    if (isOpen || !rootEl) return;
+    // Save focus so close() can restore it. The xterm helper textarea is
+    // the most common case; we restore via getTerm() if the saved element
+    // has been removed from the DOM in the meantime.
+    savedFocus = document.activeElement;
+    isOpen = true;
+    rootEl.classList.add("visible");
+    rootEl.setAttribute("aria-hidden", "false");
+    inputEl.value = "";
+    recompute();
+    // Focus after the class change so the browser doesn't fight the
+    // animation by snapping to a hidden element.
+    inputEl.focus();
+  }
+
+  function close() {
+    if (!isOpen || !rootEl) return;
+    isOpen = false;
+    rootEl.classList.remove("visible");
+    rootEl.setAttribute("aria-hidden", "true");
+    // Restore focus. Falls back to the active terminal if the saved
+    // element was unmounted (e.g. tab closed while palette was open).
+    const target = savedFocus && document.contains(savedFocus) ? savedFocus : null;
+    savedFocus = null;
+    if (target && typeof target.focus === "function") {
+      target.focus();
+    } else if (typeof getTerm === "function") {
+      getTerm()?.focus?.();
+    }
+  }
+
+  function toggle() {
+    if (isOpen) close();
+    else open();
+  }
+
+  // ── Event handlers ─────────────────────────────────────────────────────
+
+  /**
+   * Document-level capture-phase keydown listener. This is the
+   * defense-in-depth layer for Option+Space — catches the keystroke
+   * when focus is NOT inside the xterm helper textarea (which is
+   * handled by the in-terminal layer). Also handles Esc/arrows/Enter
+   * while the palette itself is open.
+   */
+  function onDocumentKeydown(ev) {
+    // Esc closes the palette regardless of focus, but only when open.
+    if (isOpen && ev.key === "Escape") {
+      ev.preventDefault();
+      ev.stopPropagation();
+      close();
+      return;
+    }
+
+    // While open, intercept arrows + Enter so the input field doesn't
+    // try to handle Enter as a form submit and arrows don't move the
+    // caret around in the input.
+    if (isOpen) {
+      if (ev.key === "ArrowDown") {
+        ev.preventDefault();
+        if (currentMatches.length === 0) return;
+        selectedIndex = Math.min(currentMatches.length - 1, selectedIndex + 1);
+        render();
+        return;
+      }
+      if (ev.key === "ArrowUp") {
+        ev.preventDefault();
+        if (currentMatches.length === 0) return;
+        selectedIndex = Math.max(0, selectedIndex - 1);
+        render();
+        return;
+      }
+      if (ev.key === "Enter") {
+        ev.preventDefault();
+        runSelected();
+        return;
+      }
+    }
+
+    // Option+Space: open the palette. Must use ev.code === "Space" — on
+    // macOS Option+Space arrives as a non-breaking space (U+00A0) in
+    // ev.key, so an ev.key check would silently miss every press. This
+    // is the same trap that killed Option+F / Option+K in c6f1c31.
+    if (ev.altKey && !ev.metaKey && !ev.ctrlKey && ev.code === "Space") {
+      // Skip if focus is in a real text input that is NOT xterm's helper
+      // textarea — the user might be typing into a rename field, the
+      // settings panel, etc. The xterm helper textarea has its own
+      // interception in terminal-key-decider.js, so we don't need to
+      // double-handle here, but the absence of a test for that case is
+      // why we still let it fall through to toggle() below if the target
+      // happens to BE the helper textarea (it would have been blocked
+      // already, so we won't see it here in practice).
+      const target = ev.target;
+      const isXtermHelper =
+        target?.classList?.contains?.("xterm-helper-textarea");
+      const isOtherInput = !isXtermHelper && (
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.isContentEditable === true
+      );
+      if (isOtherInput) return;
+
+      ev.preventDefault();
+      ev.stopPropagation();
+      toggle();
+    }
+  }
+
+  function onInput() {
+    recompute();
+  }
+
+  function onBackdropClick() {
+    close();
+  }
+
+  // ── Default providers ──────────────────────────────────────────────────
+
+  /**
+   * Resolve the current effective polarity. The theme manager exposes
+   * `getEffective()` (legacy alias `getResolvedPolarity` is not present)
+   * which returns "dark" or "light" with "auto" already resolved against
+   * `prefers-color-scheme`. We fall back to inspecting matchMedia
+   * directly if the manager is missing or stripped down.
+   */
+  function getEffectivePolarity() {
+    if (themeManager && typeof themeManager.getEffective === "function") {
+      return themeManager.getEffective();
+    }
+    if (typeof window !== "undefined" && window.matchMedia) {
+      return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+    }
+    return "dark";
+  }
+
+  function registerDefaultProviders() {
+    registerProvider({
+      id: "theme.toggle",
+      title: "Toggle theme",
+      subtitle: "Switch between light and dark",
+      category: "Appearance",
+      keywords: ["dark", "light", "polarity", "color", "appearance"],
+      run: (ctx) => {
+        // If polarity is "auto" we don't want to flip to "auto" again —
+        // resolve to the concrete current polarity first, then invert.
+        const current = getEffectivePolarity();
+        const next = current === "dark" ? "light" : "dark";
+        ctx.themeManager?.setPolarity?.(next);
+      },
+    });
+
+    registerProvider({
+      id: "theme.vibrancy",
+      title: "Toggle vibrancy",
+      subtitle: "Switch between subtle and colorful palette",
+      category: "Appearance",
+      keywords: ["color", "vivid", "subtle", "colorful", "saturation"],
+      run: (ctx) => {
+        const current = ctx.themeManager?.getVibrancy?.() ?? "subtle";
+        const next = current === "subtle" ? "colorful" : "subtle";
+        ctx.themeManager?.setVibrancy?.(next);
+      },
+    });
+
+    registerProvider({
+      id: "terminal.find",
+      title: "Find in terminal",
+      subtitle: "Open the in-terminal search bar",
+      category: "Terminal",
+      keywords: ["search", "find", "grep", "filter"],
+      run: (ctx) => {
+        ctx.toggleSearchBar?.();
+      },
+    });
+  }
+
+  // ── init / destroy ─────────────────────────────────────────────────────
+
+  function init() {
+    if (initialized) return;
+    rootEl = document.getElementById("palette");
+    if (!rootEl) {
+      // The HTML markup is owned by the sibling agent's slice. If it's
+      // missing we don't want to crash app boot — log loudly and bail.
+      console.warn("[command-palette] #palette element missing — palette disabled");
+      return;
+    }
+    panelEl = rootEl.querySelector(".palette-panel");
+    inputEl = rootEl.querySelector(".palette-input");
+    resultsEl = rootEl.querySelector(".palette-results");
+    emptyEl = rootEl.querySelector(".palette-empty");
+    backdropEl = rootEl.querySelector(".palette-backdrop");
+
+    if (!inputEl || !resultsEl || !emptyEl || !backdropEl || !panelEl) {
+      console.warn("[command-palette] expected children missing under #palette — palette disabled");
+      return;
+    }
+
+    inputEl.addEventListener("input", onInput);
+    backdropEl.addEventListener("click", onBackdropClick);
+    document.addEventListener("keydown", onDocumentKeydown, true);
+
+    registerDefaultProviders();
+    initialized = true;
+  }
+
+  function destroy() {
+    if (!initialized) return;
+    inputEl?.removeEventListener("input", onInput);
+    backdropEl?.removeEventListener("click", onBackdropClick);
+    document.removeEventListener("keydown", onDocumentKeydown, true);
+    initialized = false;
+    isOpen = false;
+  }
+
+  return {
+    init,
+    destroy,
+    open,
+    close,
+    toggle,
+    registerProvider,
+    // Exposed for tests / future PRs that want to inspect the registry.
+    listProviders,
+  };
+}

--- a/public/lib/terminal-key-decider.js
+++ b/public/lib/terminal-key-decider.js
@@ -95,6 +95,15 @@ export function decideTerminalKey(ev, ctx = {}) {
     if (ev.code === "KeyF") return { action: "toggleSearch", sequence: null, allowDefault: false };
     if (ev.code === "KeyK") return { action: "clearTerminal", sequence: null, allowDefault: false };
 
+    // Option+Space — open the command palette. Must key off ev.code, NOT
+    // ev.key: on macOS Option+Space produces a non-breaking space (U+00A0)
+    // in ev.key, so checking ev.key === " " never matches. Same physical-key
+    // rule as Option+F / Option+K above. The palette is also wired at the
+    // document capture-phase level (lib/command-palette.js → init) for the
+    // case where focus is NOT inside the terminal — both layers are
+    // required (see commits c6f1c31 and 2a13634 for the history).
+    if (ev.code === "Space") return { action: "togglePalette", sequence: null, allowDefault: false };
+
     // Line-editing sequences. macOS convention puts these on Cmd+arrow,
     // but Cmd+arrow is owned by the browser (history back/forward) inside
     // a PWA, so katulong moves them to Option+arrow. Word-back/word-forward

--- a/public/lib/terminal-keyboard.js
+++ b/public/lib/terminal-keyboard.js
@@ -17,7 +17,8 @@ export function createTerminalKeyboard(options = {}) {
   const {
     term,
     onSend,
-    onToggleSearch
+    onToggleSearch,
+    onTogglePalette
   } = options;
 
   /**
@@ -67,6 +68,11 @@ export function createTerminalKeyboard(options = {}) {
       if (decision.action === "toggleSearch" && onToggleSearch) {
         ev.preventDefault?.();
         onToggleSearch();
+      }
+
+      if (decision.action === "togglePalette" && onTogglePalette) {
+        ev.preventDefault?.();
+        onTogglePalette();
       }
 
       if (decision.action === "clearTerminal") {

--- a/test/command-palette.test.js
+++ b/test/command-palette.test.js
@@ -1,0 +1,123 @@
+/**
+ * Tests for the command palette's pure ranking helpers.
+ *
+ * scoreMatch / rankProviders live in public/lib/command-palette.js.
+ * They have zero DOM dependencies so they can be unit-tested directly
+ * under Node — same pattern as keyboard-spec.test.js or palette.test.js.
+ *
+ * The factory itself (createCommandPalette) is DOM-bound and is covered
+ * by manual verification + future Playwright e2e. We only pin the
+ * matcher contract here.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { scoreMatch, rankProviders } from "../public/lib/command-palette.js";
+
+const provider = (id, fields = {}) => ({
+  id,
+  title: id,
+  run: () => {},
+  ...fields,
+});
+
+describe("scoreMatch", () => {
+  it("returns >0 for matching prefix", () => {
+    const p = provider("toggle-theme", { title: "Toggle theme" });
+    assert.ok(scoreMatch("tog", p) > 0);
+    assert.ok(scoreMatch("Tog", p) > 0, "case insensitive");
+  });
+
+  it("returns 0 for no match", () => {
+    const p = provider("toggle-theme", { title: "Toggle theme" });
+    assert.equal(scoreMatch("xyz", p), 0);
+  });
+
+  it("ranks prefix higher than subsequence", () => {
+    const p = provider("toggle-theme", { title: "Toggle theme" });
+    const prefixScore = scoreMatch("tog", p);
+    const subseqScore = scoreMatch("tge", p);
+    assert.ok(prefixScore > subseqScore);
+  });
+
+  it("matches against keywords", () => {
+    const p = provider("p", { title: "Toggle X", keywords: ["dark", "light"] });
+    assert.ok(scoreMatch("dark", p) > 0);
+  });
+
+  it("matches against category", () => {
+    const p = provider("p", { title: "Foo", category: "Appearance" });
+    assert.ok(scoreMatch("appearance", p) > 0);
+  });
+
+  it("matches against subtitle", () => {
+    const p = provider("p", { title: "Foo", subtitle: "Open the search bar" });
+    assert.ok(scoreMatch("search", p) > 0);
+  });
+
+  it("title weight > keyword weight (same query)", () => {
+    const titleHit = provider("a", { title: "Search" });
+    const keywordHit = provider("b", { title: "Foo", keywords: ["search"] });
+    assert.ok(scoreMatch("search", titleHit) > scoreMatch("search", keywordHit));
+  });
+
+  it("empty query returns a non-zero baseline so all providers match", () => {
+    const p = provider("p", { title: "Anything" });
+    assert.ok(scoreMatch("", p) > 0);
+  });
+
+  it("requires every needle char to appear in order for subsequence match", () => {
+    const p = provider("p", { title: "abcdef" });
+    assert.ok(scoreMatch("ace", p) > 0, "in-order subsequence matches");
+    assert.equal(scoreMatch("eca", p), 0, "out-of-order subsequence does not match");
+  });
+});
+
+describe("rankProviders", () => {
+  const providers = [
+    provider("a", { title: "Toggle theme", category: "Appearance" }),
+    provider("b", { title: "Toggle vibrancy", category: "Appearance" }),
+    provider("c", { title: "Find in terminal", category: "Terminal" }),
+  ];
+
+  it("empty query returns providers in insertion order", () => {
+    const r = rankProviders("", providers);
+    assert.deepEqual(r.map((p) => p.id), ["a", "b", "c"]);
+  });
+
+  it("filters out providers with score 0", () => {
+    const r = rankProviders("xyz", providers);
+    assert.equal(r.length, 0);
+  });
+
+  it("ranks more relevant matches higher", () => {
+    const r = rankProviders("find", providers);
+    assert.equal(r[0].id, "c");
+  });
+
+  it("returns prefix matches above subsequence-only matches", () => {
+    const r = rankProviders("tog", providers);
+    assert.equal(r[0].id, "a"); // "Toggle theme" comes alphabetically first
+    assert.equal(r[1].id, "b");
+    assert.equal(r.length, 2);  // "c" doesn't match "tog"
+  });
+
+  it("ties are broken stably (insertion order)", () => {
+    // Both "a" and "b" start with "Toggle " — same prefix score on "toggle"
+    const r = rankProviders("toggle", providers);
+    assert.deepEqual(r.map((p) => p.id), ["a", "b"]);
+  });
+
+  it("category match surfaces relevant providers", () => {
+    const r = rankProviders("appearance", providers);
+    assert.equal(r.length, 2);
+    assert.ok(r.every((p) => p.category === "Appearance"));
+  });
+
+  it("does not mutate the input array", () => {
+    const arr = providers.slice();
+    rankProviders("tog", arr);
+    assert.deepEqual(arr.map((p) => p.id), ["a", "b", "c"]);
+  });
+});

--- a/test/kb-help-overlay.test.js
+++ b/test/kb-help-overlay.test.js
@@ -38,6 +38,7 @@ const SPEC = [
   ["Move tab right",          ["⌥", "}"]],
   ["Clear terminal",          ["⌥", "K"]],
   ["Search",                  ["⌥", "F"]],
+  ["Command palette",         ["⌥", "Space"]],
   ["Start of line",           ["⌥", "←"]],
   ["End of line",             ["⌥", "→"]],
   ["Delete line",             ["⌥", "⌫"]],

--- a/test/keyboard-spec.test.js
+++ b/test/keyboard-spec.test.js
@@ -69,6 +69,24 @@ describe("decideTerminalKey — Option (Alt) terminal shortcuts", () => {
     assert.equal(r.sequence, null);
   });
 
+  // REGRESSION: Option+Space on macOS produces a non-breaking space
+  // (U+00A0) in ev.key, so an `ev.key === " "` check would silently miss
+  // every press. The decider must key off ev.code === "Space". Same trap
+  // as Option+F / Option+K above (see c6f1c31 commit message).
+  it("Option+Space (macOS: ev.key='\\u00a0') → toggle command palette, blocks PTY", () => {
+    const r = decideTerminalKey(ev({ key: "\u00a0", code: "Space", altKey: true }));
+    assert.equal(r.action, "togglePalette");
+    assert.equal(r.allowDefault, false);
+    assert.equal(r.sequence, null);
+  });
+
+  it("plain Space (no Option) → reaches PTY untouched", () => {
+    const r = decideTerminalKey(ev({ key: " ", code: "Space" }));
+    assert.equal(r.action, null);
+    assert.equal(r.sequence, null);
+    assert.equal(r.allowDefault, true);
+  });
+
   it("Option+Backspace → delete line (\\x15)", () => {
     const r = decideTerminalKey(ev({ key: "Backspace", code: "Backspace", altKey: true }));
     assert.equal(r.sequence, "\x15");


### PR DESCRIPTION
## Summary

- PR 1 of 3 for an Alfred-like command palette. Option+Space toggles a centered overlay with fuzzy-searched actions, Enter runs, Esc/backdrop closes.
- Ships three one-shot actions: **Toggle theme**, **Toggle vibrancy**, **Find in terminal**.
- 100% frontend — no server changes, no new HTTP routes, no auth changes. The three actions delegate to existing handlers (`themeManager.setPolarity`, `themeManager.setVibrancy`, `toggleSearchBar`).
- Provider interface is shaped to survive PR 2 (two-stage prompts), PR 3 (recency boost), and a future v2 filesystem plugin model — without restructuring.

## Scope boundary — what this PR does NOT include

- **PR 2 (next):** two-stage prompt flow + 4 session actions (switch, new, rename, kill). The `prompt` field on the provider interface is already reserved for this.
- **PR 3:** recency boost via `localStorage`. Stable provider `id`s already present for this.
- **v2 (much later):** filesystem-based plugin loader where scripts in `~/.katulong/actions/` become palette entries. A v2 provider source will call `registerProvider()` with hydrated objects — same interface, new source.

## Key design decisions

1. **Dual-layer key interception.** Option+Space is blocked both at the terminal level (`terminal-key-decider.js` returns `action: togglePalette`, which tells `attachCustomKeyEventHandler` to swallow the event) and at the document level (capture-phase `keydown` listener in `command-palette.js` for when focus is outside xterm). Single-layer intercepts leak Alt-modified keys to the PTY — this is the established katulong pattern documented in 2a13634.
2. **`ev.code === "Space"`, not `ev.key`.** On macOS with `macOptionIsMeta=true`, Option+Space produces U+00A0 (non-breaking space) in `ev.key`. A naive handler keyed off `ev.key` would silently never match. Same class of gotcha as c6f1c31 (Option+letter → ƒ, †, …). Regression test in ` + "`test/keyboard-spec.test.js`" + ` pins the real event shape (`key: "\u00a0", code: "Space"`) so a future slip breaks loudly.
3. **Named `command-palette.js`, not `palette.js`.** `public/lib/palette.js` already exists as the **color** palette generator for the theme manager. Renaming avoided a grep-hostile naming collision. If something in katulong talks about "the palette", context matters — it's probably the color palette, not this.

## Files changed

| File | Change |
|---|---|
| `public/lib/command-palette.js` | **new** — factory module with registry, fuzzy ranker, DOM glue, three default providers |
| `public/index.html` | overlay markup + CSS (z-index 10002, uses existing theme vars), kb-help overlay entry |
| `public/app.js` | import + late-bound instance + `.init()` after `pasteHandler.init()` |
| `public/lib/terminal-key-decider.js` | Option+Space → `togglePalette` action |
| `public/lib/terminal-keyboard.js` | `onTogglePalette` callback in the dispatch |
| `test/command-palette.test.js` | **new** — pure-function tests for `scoreMatch` / `rankProviders` |
| `test/keyboard-spec.test.js` | regression tests for the macOS `ev.key=U+00A0` gotcha |
| `test/kb-help-overlay.test.js` | SPEC tripwire updated |

## Test plan

- [x] `npm test` passes (pre-push hook ran the full suite)
- [x] Pure-function unit tests for the ranker (`test/command-palette.test.js`)
- [x] Regression test pins `ev.key: "\u00a0", code: "Space"` for Option+Space
- [x] `kb-help` tripwire test passes with the new entry
- [ ] Manual: Option+Space opens the palette
- [ ] Manual: Option+Space closes it again (toggle behavior)
- [ ] Manual: Esc and backdrop click both close
- [ ] Manual: typing narrows the list via fuzzy match
- [ ] Manual: Enter runs the selected action; `theme.toggle` / `theme.vibrancy` / `terminal.find` each work
- [ ] Manual: Option+Space does NOT leak to the PTY as a stray character
- [ ] Manual: focus is restored to the terminal on close
- [ ] Manual: verify on both macOS and Linux that Alt+Space is not hijacked by the OS

## Follow-ups for future PRs

- PR 2 will add e2e/Playwright coverage for the DOM-bound factory (no existing frontend DOM test infra to hook into for PR 1).
- Dogfooding PR 1 + PR 2 will surface rough edges for PR 3's polish pass.