### PR TITLE
fix(key-island): prevent duplicate "type..." input on re-render

### DIFF
--- a/public/lib/key-island.js
+++ b/public/lib/key-island.js
@@ -92,6 +92,15 @@ export function renderKeyIsland(opts) {
   function showInlineInput() {
     if (inputRow) return;
 
+    // Defensive: if a previous renderKeyIsland() call left a stale
+    // .bar-input-row in the DOM (it's a sibling of #key-island, not a child,
+    // so it survives the tool-row removal at the top of renderKeyIsland),
+    // this closure's `inputRow` would be null and we'd end up with TWO
+    // "type..." boxes. Clear any orphans before creating a new one.
+    if (parentEl) {
+      parentEl.querySelectorAll(".bar-input-row").forEach((el) => el.remove());
+    }
+
     inputRow = document.createElement("div");
     inputRow.className = "bar-input-row";
 


### PR DESCRIPTION
## Summary
- Two "type..." text boxes could stack above the tool row; keyboard button failed to dismiss them
- Root cause: `.bar-input-row` is a sibling of `#key-island`, so it survives the tool-row removal at the top of `renderKeyIsland()`, orphaning the DOM node while the new closure's `inputRow` ref is null — next keyboard press appends a second row instead of toggling
- Fix: `showInlineInput()` now sweeps any stale `.bar-input-row` elements before creating a new one

## Test plan
- [ ] On phone/iPad, open a session, tap keyboard button → exactly one "type..." appears
- [ ] Tap keyboard button again → input dismisses
- [ ] Switch sessions / rotate / resize to force re-render, then tap keyboard → still exactly one input