### PR TITLE
fix(tiles): don't unsubscribe terminal on file-browser dismiss

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -516,6 +516,10 @@
           }
           return;
         }
+        // File-browser tiles are views over a session, not owners.
+        // Dismissing one must not unsubscribe the real terminal session.
+        // Regression: #542 (545b110) — see test/file-browser-dismiss.test.js.
+        if (tile?.type === "file-browser") return;
         const sessionName = tileSessionName(tileId);
         // Detach: remove from this window's tab set (session stays on server)
         if (windowTabSet) windowTabSet.removeTab(sessionName);

--- a/test/file-browser-dismiss.test.js
+++ b/test/file-browser-dismiss.test.js
@@ -1,0 +1,124 @@
+/**
+ * Regression test for file-browser tile dismissal (#542).
+ *
+ * PR #542 (545b110) added the file-browser as a first-class tile. The tile
+ * factory stores whatever sessionName it's passed and exposes it via
+ * `get sessionName()`. When app.js opens a file-browser, it passes the
+ * currently focused terminal's session name — so the file-browser tile
+ * aliases a real tmux session it does not own.
+ *
+ * Bug: onCardDismissed fell through to the generic dismiss path that calls
+ * wsConnection.sendUnsubscribe(sessionName) and windowTabSet.removeTab().
+ * This unsubscribed the real terminal session and removed its tab, leaving
+ * the tmux pane running but unreachable from the client.
+ *
+ * Fix: early return for file-browser tiles in onCardDismissed. The file
+ * browser is a *view* over a session, not the owner — no sendUnsubscribe,
+ * no removeTab.
+ *
+ * Mirrors the pattern from 7fa1e22 (PR #538) which fixed the analogous
+ * bug for cluster tiles — see test/cluster-composite.test.js.
+ *
+ * Test harness pattern: mirrors the real onCardDismissed logic from app.js
+ * (same approach as websocket-subscribe.test.js). The callback is an inline
+ * closure in app.js and can't be imported directly.
+ */
+
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+
+describe("file-browser tile dismissal (regression: #542)", () => {
+  let wsConnection;
+  let windowTabSet;
+  let tiles;
+  let onCardDismissed;
+
+  beforeEach(() => {
+    wsConnection = { sendUnsubscribe: mock.fn() };
+    windowTabSet = { removeTab: mock.fn() };
+    tiles = new Map();
+
+    // Mirrors app.js onCardDismissed (public/app.js ~line 505).
+    // Keep in sync — if the real callback changes shape, update here.
+    onCardDismissed = (tileId) => {
+      const tile = tiles.get(tileId);
+      if (tile?.type === "cluster") {
+        for (const { tile: subTile } of tile.getSubTiles()) {
+          const subName = subTile?.sessionName;
+          if (!subName) continue;
+          if (windowTabSet) windowTabSet.removeTab(subName);
+          wsConnection.sendUnsubscribe(subName);
+        }
+        return;
+      }
+      // The fix under test: file-browser tiles must not unsubscribe.
+      if (tile?.type === "file-browser") return;
+
+      const sessionName = tile?.sessionName || tileId;
+      if (windowTabSet) windowTabSet.removeTab(sessionName);
+      wsConnection.sendUnsubscribe(sessionName);
+    };
+  });
+
+  it("does not unsubscribe the aliased terminal session", () => {
+    // Terminal tile owns "session-xyz"
+    tiles.set("term-1", { type: "terminal", sessionName: "session-xyz" });
+    // File-browser tile aliases "session-xyz" (opened from term-1)
+    tiles.set("fb-1", { type: "file-browser", sessionName: "session-xyz" });
+
+    onCardDismissed("fb-1");
+
+    assert.equal(
+      wsConnection.sendUnsubscribe.mock.callCount(),
+      0,
+      "sendUnsubscribe must NOT be called when dismissing a file-browser tile"
+    );
+  });
+
+  it("does not remove the terminal tab from windowTabSet", () => {
+    tiles.set("term-1", { type: "terminal", sessionName: "session-xyz" });
+    tiles.set("fb-1", { type: "file-browser", sessionName: "session-xyz" });
+
+    onCardDismissed("fb-1");
+
+    assert.equal(
+      windowTabSet.removeTab.mock.callCount(),
+      0,
+      "removeTab must NOT be called when dismissing a file-browser tile"
+    );
+  });
+
+  it("still unsubscribes when a real terminal tile is dismissed (positive control)", () => {
+    tiles.set("term-1", { type: "terminal", sessionName: "session-xyz" });
+    tiles.set("fb-1", { type: "file-browser", sessionName: "session-xyz" });
+
+    onCardDismissed("term-1");
+
+    assert.equal(
+      wsConnection.sendUnsubscribe.mock.callCount(),
+      1,
+      "sendUnsubscribe MUST be called when dismissing a terminal tile"
+    );
+    assert.deepEqual(
+      wsConnection.sendUnsubscribe.mock.calls[0].arguments,
+      ["session-xyz"]
+    );
+    assert.equal(
+      windowTabSet.removeTab.mock.callCount(),
+      1,
+      "removeTab MUST be called when dismissing a terminal tile"
+    );
+  });
+
+  it("falls back to tileId when tile has no sessionName", () => {
+    tiles.set("orphan-tile", { type: "terminal" });
+
+    onCardDismissed("orphan-tile");
+
+    assert.deepEqual(
+      wsConnection.sendUnsubscribe.mock.calls[0].arguments,
+      ["orphan-tile"],
+      "must fall back to tileId when sessionName is undefined"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes regression from #542 (545b110): dismissing a file-browser tile unsubscribed and detached the underlying terminal session, leaving the tmux pane alive but unreachable from the client (no input, no output, refresh didn't help, only "Kill session" recovered).
- **Root cause:** `onCardDismissed` fell through to the generic dismiss path which called `sendUnsubscribe(sessionName)` and `windowTabSet.removeTab()` using the file-browser tile's aliased sessionName — the real terminal's name.
- **Fix:** Early return for `tile?.type === "file-browser"` in `onCardDismissed`, sibling to the existing cluster branch. A file-browser tile is a *view* over a session, not the owner.
- Mirrors the fix pattern from 7fa1e22 (PR #538) which fixed the analogous bug for cluster tiles.

## Changes

- `public/app.js` — 4 lines added (early return guard in `onCardDismissed`)
- `test/file-browser-dismiss.test.js` — regression test verifying file-browser dismiss does NOT call `sendUnsubscribe` or `removeTab`

## Test plan

- [x] `npm test` passes (2006 tests, 0 failures)
- [ ] Manual: open a terminal session, open file browser from it, dismiss the file-browser tile → terminal should remain fully functional (input + output)
- [ ] Manual: dismiss a terminal tile → should still unsubscribe normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)