### PR TITLE
Tile state rewrite: reducer-driven UI, renderer capabilities, coordinate model

### DIFF
--- a/docs/terminal-data-pipeline.md
+++ b/docs/terminal-data-pipeline.md
@@ -1,0 +1,406 @@
+# Terminal Data Pipeline
+
+How terminal bytes flow from tmux to the browser in katulong, and why
+each layer exists. This is the canonical reference for anyone touching
+the terminal rendering path.
+
+## The Pipeline at a Glance
+
+```
+tmux -u -C attach-session -d -t <name>
+  │  raw stdout bytes (Buffer chunks, split anywhere)
+  ▼
+tmux-output-parser.js          ← byte-level, no string conversion
+  │  decoded UTF-8 strings
+  ▼
+session.js
+  ├─→ RingBuffer (bounded circular buffer, 20 MB)
+  ├─→ ScreenState (headless xterm.js mirror for snapshots)
+  └─→ output-coalescer.js (2 ms idle + 16 ms hard-cap)
+        │  coalesced flush
+        ▼
+      session-manager.js → transport-bridge.js
+        │  { type: "output", data, fromSeq, cursor }
+        ▼
+      ws-manager.js
+        ├─ push inline (fast path, zero round trips)
+        └─ data-available (backpressure, client pulls later)
+              │
+              ▼
+        Browser: pull-manager.js → terminal-pool.js → xterm.js
+```
+
+## Layer 1: tmux Control Mode
+
+**File:** `lib/session.js`
+
+tmux is spawned in UTF-8 control mode:
+
+```
+tmux -u -C attach-session -d -t <session-name>
+```
+
+- **`-u`**: UTF-8 mode. Tells tmux to emit high bytes (0x80+) literally
+  instead of always octal-escaping them. Without this flag, every
+  non-ASCII byte becomes `\NNN`, tripling wire size for UTF-8 text.
+- **`-C`**: Control mode. tmux wraps all output in a line-based protocol:
+  `%output %<pane_id> <escaped-payload>\n`. Everything else (`%begin`,
+  `%end`, `%session-changed`) is framing noise we discard.
+- **`-d`**: Detach other clients. We're the sole control-mode consumer.
+
+Raw `stdout` chunks (Buffers) are piped directly to the parser:
+```js
+proc.stdout.on("data", (chunk) => this._parser.write(chunk));
+```
+
+### The Splitting Problem
+
+tmux wraps `%output` lines at a fixed byte limit with no regard for
+encoding boundaries. A 3-byte character like `─` (e2 94 80) can end
+up split across two lines:
+
+```
+%output %0 hello\342          ← line ends with lead byte e2
+%output %0 \224\200world      ← continuation bytes 94 80 on next line
+```
+
+This is not a bug in tmux. It is the fundamental constraint the parser
+must handle.
+
+## Layer 2: Byte-Level Parser
+
+**File:** `lib/tmux-output-parser.js`
+
+This is the most critical module for rendering correctness. It operates
+entirely in byte space (Buffers) until the very last step.
+
+### Why Byte-Level?
+
+If you run a `StringDecoder` over raw tmux stdout, orphaned lead bytes
+(like `e2` at the end of a chunk) emit U+FFFD *before you ever see the
+payload layer*. The damage is done before parsing begins. Every approach
+that converts to strings early is fundamentally broken for non-ASCII.
+
+### Three Pieces of State
+
+1. **`lineBuf`** — Buffer of partial line bytes. Node chunks can split
+   mid-line (rare but possible).
+
+2. **`payloadDecoder`** — A single persistent `StringDecoder("utf-8")`.
+   This is the ONE AND ONLY place byte-to-string conversion happens.
+   It correctly carries partial multi-byte characters across calls.
+
+3. **`octalCarry`** — Buffer of 1-3 bytes from a partial `\NNN` octal
+   escape deferred from the previous `%output` line.
+
+### Processing Steps
+
+For each complete line (delimited by `\n`):
+
+1. **Prefix match** — Does it start with `%output ` (ASCII bytes)?
+   If not, skip (framing noise).
+
+2. **Pane ID extraction** — Find the space after `%<pane_id>` to locate
+   the payload start.
+
+3. **Octal unescape** — `unescapeOutputBytes(buf, octalCarry)` converts
+   `\NNN` sequences back to raw bytes. Stays in Buffer space throughout.
+   Returns `{ bytes, carry }` where `carry` holds any incomplete escape.
+
+4. **UTF-8 decode** — `payloadDecoder.write(rawBytes)` converts the
+   clean bytes to a JS string. The decoder buffers incomplete multi-byte
+   sequences internally and completes them on the next call.
+
+5. **Emit** — `onData(decodedString)` fires once per decoded `%output`
+   line.
+
+### The Octal Carry
+
+tmux escapes bytes `< 0x20` and `\` as `\NNN` (3-digit octal). Each
+`█` character (e2 96 88) becomes `\342\226\210` — 12 wire bytes. A
+banner of 26 blocks is 312 bytes, easily exceeding tmux's wrap limit.
+When the wrap falls inside an escape:
+
+```
+%output %0 ...\34            ← partial escape: only \34 of \342
+%output %0 2\226\210...      ← remaining digits on next line
+```
+
+The parser defers the `\34` as `octalCarry` and prepends it to the next
+line's payload before unescaping. Without this, the parser desyncs and
+every subsequent escape on the line produces U+FFFD.
+
+## Layer 3: Session and RingBuffer
+
+**File:** `lib/session.js`, `lib/ring-buffer.js`, `lib/screen-state.js`
+
+When the parser emits a decoded string:
+
+```js
+_handleOutputPayload(payload) {
+  this.outputBuffer.push(payload);   // RingBuffer
+  this._screen.write(payload);       // headless xterm.js
+  this._onData(this.name, fromSeq);  // notify coalescer
+}
+```
+
+### RingBuffer
+
+Bounded circular buffer (20 MB per session). Stores raw decoded strings
+including escape sequences. Clients pull byte ranges via `sliceFrom(offset)`.
+When a client's cursor is evicted (ring has wrapped past it), the server
+sends a full snapshot instead.
+
+Key property: `totalBytes` is monotonic — it never decreases, even after
+eviction. This gives every byte a unique position in the stream, like a
+Kafka offset.
+
+### ScreenState (Headless xterm.js)
+
+A server-side `@xterm/headless` Terminal + SerializeAddon. Mirrors the
+live terminal state so `serialize()` can produce a snapshot for:
+- Client attach (new connection gets current screen)
+- Client resync (drift detected, send fresh snapshot)
+- Cursor eviction recovery (ring wrapped, full reset)
+
+The headless is written live at the current PTY dimensions and resized
+in lockstep with tmux. There is ONE shared headless per session.
+
+**Why not per-client headless?** Per-client headless terminals (PCH-1
+through PCH-3) were tried extensively. They solved multi-device viewport
+mismatch but introduced worse problems: TUI apps use absolute cursor
+positioning (`\e[row;colH`) calculated for tmux's current size, so
+replaying the RingBuffer into a differently-sized headless lands those
+escapes on wrong cells. PCH-7 deleted `ClientHeadless`. See "What Was
+Tried and Failed" below.
+
+## Layer 4: Output Coalescer
+
+**File:** `lib/output-coalescer.js`
+
+TUI apps like htop render a full frame across many `%output` lines
+delivered over multiple Node.js I/O ticks. Without coalescing, each
+line becomes a separate WebSocket message, breaking xterm.js synchronized
+rendering and causing visible tearing.
+
+### Dual-Timer Strategy
+
+- **2 ms idle timer**: Resets on each new `%output`. Fires when output
+  stops (inter-frame gap). Captures complete TUI frames.
+- **16 ms hard cap**: Fires regardless of activity. Guarantees ~60fps
+  delivery for continuous streams (tail -f, cargo build). Without this,
+  the idle timer would starve clients indefinitely.
+
+On flush, the session manager pulls `RingBuffer.sliceFrom(fromSeq)` and
+relays the coalesced chunk to all subscribed clients.
+
+## Layer 5: WebSocket Transport
+
+**File:** `lib/ws-manager.js`, `lib/transport-bridge.js`
+
+### Push vs Pull
+
+The server tries to **push** output inline (zero round trips):
+
+```js
+transport.send(JSON.stringify({ type: "output", data, fromSeq, cursor }));
+```
+
+When the WebSocket's `bufferedAmount` exceeds 1 MB (backpressure), it
+falls back to a lightweight notification:
+
+```js
+transport.send(JSON.stringify({ type: "data-available", session }));
+```
+
+The client then explicitly **pulls** data at its own pace.
+
+### Client Lifecycle Messages
+
+| Message | Direction | Purpose |
+|---------|-----------|---------|
+| `attach` | client→server | Join session, get initial snapshot |
+| `attached` | server→client | Snapshot + session name |
+| `subscribe` | client→server | Watch session without being active |
+| `seq-init` | server→client | Initialize client's cursor position |
+| `output` | server→client | Pushed terminal data (fast path) |
+| `data-available` | server→client | Backpressure notification |
+| `pull` | client→server | Request data from cursor |
+| `pull-response` | server→client | Requested data + new cursor |
+| `pull-snapshot` | server→client | Full reset (cursor evicted) |
+| `resize` | client→server | Terminal dimensions changed |
+
+## Layer 6: Client-Side Pull Manager
+
+**File:** `public/lib/pull-manager.js`
+
+Pure state machine per session. Tracks:
+- **cursor**: byte offset into the server's stream
+- **pulling**: waiting for a pull-response
+- **writing**: waiting for xterm.js to finish rendering
+- **pending**: more data arrived while busy
+
+Key invariant: the next pull only fires **after xterm.js finishes
+rendering the current write**. This provides natural backpressure without
+explicit flow control. The server never overwhelms the client because the
+client controls its own consumption rate.
+
+### Gap Detection
+
+When the server pushes `{ fromSeq: 1000 }` but the client's cursor is
+at 800, there's a gap (bytes 800-999 were missed). The pull manager
+detects this and falls back to an explicit pull request to fill the gap.
+
+## Layer 7: Browser Rendering
+
+**File:** `public/lib/terminal-pool.js`
+
+One xterm.js `Terminal` instance per session, managed in a pool. The
+active session's container is visible; others are hidden but alive (no
+re-initialization on switch).
+
+```js
+term.write(data);  // xterm.js handles escape sequences, reflow, rendering
+```
+
+### Resize Flow
+
+```
+Browser viewport change
+  → terminal-pool.js: scaleToFit() calculates cols/rows from container
+  → 80ms debounce (rapid events coalesce)
+  → WebSocket: { type: "resize", cols, rows }
+  → ws-manager.js → session-manager.js
+  → session.js: resize gate (defer if output arrived < 50ms ago)
+  → tmux: refresh-client -C <cols>x<rows>
+  → ScreenState.resize(cols, rows)
+```
+
+The resize gate prevents SIGWINCH storms during rapid resize (e.g.,
+window drag). Without it, TUI apps receive a barrage of dimension
+changes mid-render, producing garbled output.
+
+## What Was Tried and Failed
+
+This section exists so future developers don't repeat these dead ends.
+
+### 1. StringDecoder on Raw Stdout (pre-v0.52.5)
+
+**Approach:** `proc.stdout.on('data', chunk => decoder.write(chunk))`
+
+**Why it failed:** tmux splits `%output` lines at byte boundaries. An
+orphaned lead byte (e.g., `e2` at end of chunk) reaches the decoder
+*before* the parser extracts the payload, emitting U+FFFD at the wrong
+layer. Corruption happens before parsing even begins.
+
+**Symptom:** Bursts of diamond question marks (U+FFFD) replacing
+box-drawing characters, stacked spinners, garbled TUI after any
+non-ASCII output.
+
+### 2. Latin1 String Round-Trip (v0.52.5-alpha)
+
+**Approach:** Convert the `%output` payload to a latin1 string
+(`buf.toString("latin1")`), then unescape octal sequences as string
+operations.
+
+**Why it failed:** Literal byte `0xe2` (lead byte of `─`) becomes
+U+00E2 in latin1, which re-encodes to UTF-8 as `c3 a2` — a
+double-encoding that turns every non-ASCII byte into a 2-byte mojibake
+sequence.
+
+**Symptom:** Box-drawing characters and Unicode text replaced with
+accented Latin characters (`â`, `ã`, etc.).
+
+### 3. Per-Client Headless Terminals (PCH-1 through PCH-6)
+
+**Approach:** Give each connected client its own server-side headless
+xterm.js instance at that client's dimensions. Replay the shared
+RingBuffer into each headless independently. Serialize per-client
+snapshots for attach/resync/drift-detection.
+
+**Why it failed:** TUI applications use absolute cursor positioning
+(`\e[row;colH`) calculated for tmux's current PTY dimensions. When
+those escape sequences are replayed into a headless terminal at
+*different* dimensions, cursors land on wrong cells, status bars float
+in the middle of the screen, and borders misalign. The per-client
+headless doesn't reflow the content — it just renders it wrong.
+
+**Additional problems:**
+- Lazy replay was O(N) per serialize, causing lag
+- Dispose races between disconnect and serialize
+- Dimension changes on carousel swipe kept stale headless sizes
+- Drift detection fingerprints differed across clients, causing
+  resync storms
+
+**Resolution:** PCH-7 deleted `ClientHeadless`. All serialization now
+uses the shared `session._headless`, which is written live at current
+PTY dimensions and resized in lockstep with tmux.
+
+### 4. setImmediate Output Coalescing (pre-v0.52.3)
+
+**Approach:** Coalesce output within a single `setImmediate` tick.
+
+**Why it failed:** TUI frames span multiple I/O ticks. `setImmediate`
+only captures one tick's worth of `%output` lines, splitting frames
+across multiple WebSocket messages. xterm.js renders each message
+independently, producing visible tearing.
+
+**Resolution:** Dual-timer coalescer (2ms idle + 16ms cap).
+
+### 5. Fixed 8ms Timer Coalescing
+
+**Approach:** Fixed 8ms delay before flushing.
+
+**Why it failed:** Too short for slow TUI apps (missed tail end of
+frames), too long for interactive typing (added perceptible latency).
+One timer cannot serve both use cases.
+
+**Resolution:** Idle timer (adapts to actual output rate) + hard cap
+(bounds worst-case latency).
+
+### 6. Resize Without Idle Gate
+
+**Approach:** Send `refresh-client -C` to tmux immediately on every
+resize message.
+
+**Why it failed:** During window drag, the browser fires dozens of
+resize events per second. Each triggers a SIGWINCH in the PTY, causing
+the running TUI app to redraw mid-frame while the *previous* redraw is
+still being emitted. The interleaved escape sequences produce garbled
+output.
+
+**Resolution:** 50ms idle gate — defer resize until output has been
+quiet for 50ms, with a 500ms hard deadline so resize isn't blocked
+forever by continuous output.
+
+## Invariants
+
+These must hold for correct rendering. Violating any one causes garble.
+
+1. **No string conversion before the parser.** Raw stdout bytes must
+   reach `tmux-output-parser.js` as Buffers. Any `toString()` or
+   `StringDecoder` on the raw stream corrupts multi-byte characters
+   split at chunk boundaries.
+
+2. **One persistent StringDecoder per parser.** The decoder carries
+   partial multi-byte sequences across `%output` lines. Creating a new
+   decoder per line loses the carry and emits U+FFFD.
+
+3. **Octal unescape in byte space.** The `\NNN` → byte conversion must
+   operate on Buffers, not strings. String-level unescape causes latin1
+   double-encoding of literal high bytes.
+
+4. **Coalesce before relay.** Individual `%output` lines must be merged
+   before sending to clients. Sending per-line breaks xterm.js
+   synchronized rendering.
+
+5. **Resize after idle.** Dimension changes must wait for output to
+   settle. Resizing mid-frame interleaves old and new escape sequences.
+
+6. **Single shared headless.** The server-side ScreenState must reflect
+   the current PTY dimensions. Per-client headless at different
+   dimensions produces wrong absolute cursor positioning.
+
+7. **Client controls pull pace.** The next pull fires only after xterm
+   finishes rendering. Server-driven push without backpressure
+   overwhelms slow clients and causes buffer bloat.

--- a/docs/tile-clusters-design.md
+++ b/docs/tile-clusters-design.md
@@ -1,0 +1,154 @@
+# Tile Clusters — Design Notes
+
+Living design doc for the tile-cluster / virtual-desktop UX. Captured from a brainstorming session so subagents can pick up individual iterations without losing the high-level model. Update as decisions evolve.
+
+## Core mental model
+
+- **Cluster = virtual desktop.** A cluster is a *container of tiles*, not a tile itself. Each cluster is its own independent workspace, like a macOS Space.
+- **Tiles** are the existing terminal tiles. They live inside a cluster.
+- **The `+` button on the tile bar creates a new terminal in the current cluster.** No "New Cluster" option there. Cluster create/manage lives in the zoomed-out view.
+- The carousel-of-tiles UI we have today is *one view mode of one cluster*. Everything below extends from there.
+
+## Zoom levels
+
+There are (at least) two zoom levels, navigated by **pinch**:
+
+### Level 1 — Focused (current default)
+Single cluster fills the screen, in one of its view modes (carousel or exposé).
+
+### Level 2 — Cluster overview
+Pinch out from Level 1. You see **all clusters as a vertical stack of horizontal strips**. Think: multiple stacked copies of <https://auto-replicating-draggable-carousel.webflow.io/>, each strip scrollable horizontally and independently.
+
+- **Uniform mode**: every strip renders in the *same* mode as the one you pinched out from. If you were in carousel, all strips are mini-carousels. If you were in exposé, all strips are mini-exposés. Not heterogeneous.
+- **Vertical scroll** moves between cluster strips.
+- **`+` button** at this level creates a new cluster. Position TBD.
+- **Tap a cluster (or pinch in)** to zoom back into Level 1 on that cluster.
+
+### Level 3 — Spatial canvas (parked)
+Maybe a freeform 2D canvas like the Cosmic / Stage Manager screenshots — clusters placed at xy positions, pan-and-zoom. Iterate on this once Level 2 is alive. **Not in scope yet.**
+
+## Level 1 view modes
+
+A cluster has two view modes:
+
+### Carousel
+1D horizontal axis of **columns** (see "Columns" below). One column is focused; neighbors peek. Existing behavior, generalized.
+
+### Exposé
+All tiles in the cluster visible at once via the existing tiling/packing algorithm — but **packed more tightly than the macOS reference**. Tiles use the cluster's tiling algorithm to land at non-overlapping positions.
+
+**Mode switch is animated**, not a teardown/rebuild. Same DOM elements morph from carousel layout to exposé layout. Implementation technique: FLIP (First-Last-Invert-Play) — measure old positions, change layout, measure new, transform-back-then-transition. The user-visible behavior is "macOS Exposé morph", FLIP is just the web technique.
+
+## Columns (vertical stacking within a carousel slot)
+
+Carousel x-slots are not "one tile fills the viewport." Each x-slot is a **column** that may contain 1..N tiles.
+
+- **Default**: 1 tile per column. Existing behavior.
+- **Stacking**: drag tile B onto tile A → column of two. Drag tile B back out → its own column again. **Stacking is a drag verb, not a "split" button.** No menu, no mode switch.
+- **Resize**: same edge-handle pattern as today's left/right column-width handles, mirrored on top/bottom for tile-height-within-column. Symmetric.
+- **Sane default / min / max**: same pattern as horizontal sizing today. Default = sensible split. Min = some floor. Max = viewport.
+- **Vertical scroll within a column** when total tile heights exceed viewport. Each column scrolls independently. Same behavior as horizontal carousel scroll, rotated 90°.
+- **A single tile can be taller than the viewport** if the user resizes it that way; the column scrolls to expose the rest. (Mirrors the horizontal "tile can be wider than viewport" affordance.)
+- **Anti-pattern**: the macOS Terminal.app vertical-split behavior where each split shrinks all siblings into uselessness. We explicitly do not want that.
+
+### Drag-to-stack collision target (decision pending, leaning)
+- **Center of target tile** = stack into this column.
+- **Left/right edges of target tile** = insert as new column on that side.
+- Visual highlight on the drop zone as you hover.
+- Lets drag-to-reorder and drag-to-stack coexist unambiguously.
+
+### Active tile / focus navigation
+- Each column has its own active tile (the one keystrokes go to).
+- **Option+↑ / Option+↓** moves focus within a column (vertical analogue of how horizontal arrows snap-to-active across columns).
+- **Option+←/→** for column navigation (add for symmetry if not already present).
+- Focus snap = scroll the column so the active tile is in view.
+
+### Exposé treatment of stacked columns
+- Stacked columns become **deck-of-cards** in z-space. Each column = one card pile in the 2D pack, slightly fanned so you can see depth.
+- Tap a deck → fans out → tap a card → returns to Level 1 carousel with that column focused and that tile active. (Two-step, more spatial. Pending confirmation.)
+
+### Level 2 thumbnail of stacked columns
+Same deck-of-cards metaphor, miniaturized. A column with 3 tiles renders as a tiny card stack in the mini-strip, not as 3 stacked rectangles. Honest about structure, visually quiet.
+
+## Pinch gesture
+
+- **Pinch is the zoom verb.** Pinch out = zoom out (Level 1 → Level 2). Pinch in = zoom in.
+- Pinch is **not** the carousel↔exposé switch. That's a different verb (TBD: button, gesture, or keyboard).
+- **Trackpad pinch on desktop** arrives as `wheel` events with `ctrlKey` set. Support both touch and trackpad from day one so dev iteration is possible on the Mac mini.
+- Greenfield in the codebase as far as we know — verify before implementing. If greenfield, raw pointer events with two-pointer tracking, no gesture lib.
+
+## File browser as a tile
+
+> **Status:** The /consult review revealed PR #533 already converted the file browser from a fullscreen overlay into a real tile (`public/lib/tiles/file-browser-tile.js`). What remains is captured below; most of it is absorbed into **T1b** in the build order.
+
+- **Multi-instance**: clicking the folder button on terminal A and then on terminal B creates **two independent file browser tiles**. Not one that jumps around. Today `openFileBrowserTile` in `app.js` has a singleton guard that focuses an existing FB tile; delete it.
+- **Spawn position**: a new file browser tile appears as a **new column immediately to the LEFT of the spawning terminal**, pushing earlier columns over. Matches the Finder mental model (file list on the left, terminal on the right).
+- **cwd inheritance**: the new file browser opens at the spawning terminal's current working directory.
+- **Repeat click**: each click on a terminal's folder button creates a **new** file browser tile. No reuse-if-exists.
+- **Lifetime**: once created, a file browser tile is independent of its spawning terminal. Closing the terminal does not close the file browser.
+- **Sized like a tile**, not a sidebar. Participates in carousel scroll, exposé pack, column resize, drag-to-stack, and Level 2 thumbnails like any terminal tile.
+- **Component root-class collision**: `file-browser-component.js` currently clobbers its container's className, forcing `file-browser-tile.js` to wrap it in an extra `<div>`. Fix the component so it owns a child (e.g. `.fb-root`) rather than stamping on its parent's class.
+
+Note: the `#sidebar` element in `index.html` is the **session-list launcher**, *not* the file browser — do not conflate it with this work.
+
+## Future input modes (parked, not in scope)
+
+Discussed but explicitly deferred until pinch + Level 1/2 are working:
+
+- **Multi-touch**: two-finger swipe between clusters, three-finger gestures, long-press-drag to rearrange in exposé.
+- **Gyro**: ambient parallax, peek at neighbors, tilt-to-switch.
+- **Camera tracking**: face-tracking like the felixflor.es experiment. Aesthetic / "feels alive", or load-bearing (look-away-to-blur for shoulder-surfing protection). Permission/battery/privacy cost is real — treat as separate experiment.
+
+## Build order
+
+**Step 1 (landed, `edf8c88`)** — Pinch + Level 1 carousel↔exposé morph. Pinch gesture plumbing (touch + trackpad `wheel`+`ctrlKey`), mode switch via same-DOM transform morph, no tmux resize in exposé. Columns are still 1-tile-each at this stage.
+
+Everything after Step 1 follows the **Tier 1 / Tier 2 / Tier 3** plan in "Architectural decisions" below — a refactor lands *before* the new features so columns, file-browser-as-tile, and Level 2 build on a clean substrate instead of bolting onto the flat-array model.
+
+## Architectural decisions (from /consult, 2026-04-09)
+
+The /consult agent revealed the file browser is *already* a tile (PR #533). The real structural problems are in the **container** (`card-carousel.js`), not the content. Recorded decisions:
+
+1. **Auto-flip-on-idle stays load-bearing.** `ctx.faceStack` (the new abstraction replacing `setBackTile`/`flipCard`/`isFlipped`) must be observable from inside a tile so terminal-tile can keep driving its own flip-on-idle without reaching `deps.carousel`.
+2. **`cluster-tile.js` is extracted, not deleted.** The reusable primitive is a **tile container** — the same abstraction used by Level 1 carousel, Level 2 cluster overview, and existing composite tiles (`cluster-tile`, `crew-tile` from `da66182`). `cluster-tile` becomes a thin wrapper that mounts a container inside itself. One implementation, three use sites. Prior history: `9f58df9` introduced the generic tile container, `816cf08` added a plugin SDK / manifest discovery, PR #533 deliberately killed the SDK and registry. This extract is *internal* and **must not** re-introduce a plugin SDK, manifest discovery, or extensibility surface — all tile types remain in-tree.
+3. **Persistence is per-cluster.** `MAX_PERSISTED_CARDS = 50` becomes a per-cluster cap. Storage schema bumps to a workspace shape: `{ clusters: [{ id, columns, ... }], activeClusterId }`.
+4. **No tab bar at Level 2.** The shortcut/tab bar belongs to Level 1 only. Level 2 navigates via the cluster strips themselves (and pinch-in to return). The `onLayoutChange` snapshot contract from T2b only feeds Level 1.
+5. **Plugin SDK stays dead.** PR #533's deletion stands. `TileContext` is an *internal* contract, not a stability boundary, and can change as the team needs.
+
+### Build order (revised by consult)
+
+The original Step 1.5 / 1.6 order is replaced with a three-tier plan that lands a refactor *before* the new features:
+
+- **Tier 1 (small, ~1 day):**
+  - **T1a** — move flip off the carousel surface; `terminal-tile` calls `ctx.faceStack` instead of `deps.carousel`. Delete the lazy-getter circular wiring.
+  - **T1b** — fix `file-browser-component` root-class collision, drop the inner-div wrapper, delete the singleton guard in `openFileBrowserTile`. Step 1.6 essentially done after this.
+- **Tier 2 (large, 2–4 days, one PR):**
+  - **T2a** — `cards: string[]` → `columns: Array<Column>` with single-slot columns initially. Pure data-shape change, behavior identical, persistence migrates legacy.
+  - **T2b** — carousel emits `onLayoutChange` snapshot; shortcut-bar consumes it, stops importing carousel directly. Kills the dual-source-of-truth nerve that bit `4285396`/`48b48b2`.
+  - **T2c** — face-stack of N; current 2-face flip becomes the n=2 case. Same primitive supports the deck-of-cards in exposé.
+- **Tier 3 — features on top of the new substrate:**
+  - Step 1.5 (columns / drag-to-stack)
+  - Step 1.6 polish (the few remaining file-browser-as-tile bits not covered by T1b)
+  - Step 2 (Level 2 cluster overview, no tab bar)
+
+## Open questions / decisions to revisit
+
+- Carousel↔exposé switch verb (since pinch is reserved for zoom levels). Button? Keyboard? Different gesture?
+- Level 2 `+` button placement.
+- Drag-to-stack collision zones — confirm center=stack / edges=insert-column model with a real prototype.
+- Exposé deck interaction — single-tap-to-jump vs fan-out-then-pick.
+- Level 3 form factor.
+
+## Anti-patterns (do not do)
+
+- Tearing down and recreating tile DOM elements when switching modes. Same elements must morph.
+- Per-client xterm.js replay at different dimensions. Cursor-positioned TUI output cannot be reflowed. (See `CLAUDE.md` "Multi-device terminal dimensions".)
+- macOS Terminal.app-style vertical splits that shrink siblings to uselessness.
+- Adding "New Cluster" to the per-tile `+` menu. Cluster management lives at Level 2.
+- Bundling pinch animation and column stacking into the same implementation pass.
+
+## Reference material
+
+- Webflow draggable carousel that matches Level 2 strip behavior: <https://auto-replicating-draggable-carousel.webflow.io/>
+- macOS Mission Control / Exposé as the reference for the Level 1 morph visual.
+- macOS virtual-desktops strip as the reference for the Level 2 mental model (though our Level 2 is a *vertical* stack of cluster strips, not a horizontal strip of desktop thumbnails).

--- a/docs/tile-state-rewrite.md
+++ b/docs/tile-state-rewrite.md
@@ -1,0 +1,294 @@
+# Tile State Rewrite — First Principles
+
+## The problem we're solving
+
+After shipping file-browser-as-a-tile (`f32f40e`), the tile system
+"kinda works" but every bug fix chased the same underlying shape:
+
+- Three sources of truth maintained by hand
+  1. `carousel` (internal card list, order, focus)
+  2. `windowTabSet` (sessionStorage per-window tab id list)
+  3. `sessionStore` (terminal session list for the bar)
+- Every mutation site (drag reorder, tab click, focus change, restore,
+  add tile, remove tile) has to update all three in the right order or
+  they drift.
+- Persistence sneaks in as a fourth: `localStorage["katulong-carousel"]`
+  is written reactively from the carousel, but URL-driven boot clobbers
+  it before the 500 ms `setTimeout` restore runs, so we had to snapshot
+  localStorage at carousel construction.
+- Tiles are long-lived stateful objects (`mount/unmount/focus/blur/
+  serialize/getTitle`). When the file browser navigates, it has to push
+  its title upward via `ctx.setTitle`, which has to re-render the bar,
+  which has to re-read the tile via a shim in `getSessionList`. The
+  title is live in three places.
+- Non-terminal tile ids can't live in `?s=`, so `onFocusChange`,
+  `onTabClick`, and `bar.render` each branch on "is this a terminal".
+- `NON_PERSISTABLE_TILE_TYPES` is a host-side string set that has to
+  stay in lockstep with `persistable:` flags on tile prototypes.
+
+Every bug in the checkpoint PR was some variant of "source A and source
+B disagreed." The fix was always another manual sync call.
+
+## First principles
+
+1. **One state atom.** There is exactly one object describing the UI.
+   It lives in `localStorage` (persisted) and in a `createStore`
+   instance (in memory). Everything derives from it.
+2. **Render is a pure function of state.** Tab bar, carousel pane,
+   and focus highlight are views. You never mutate DOM without first
+   mutating state.
+3. **Tiles are descriptors, not objects.** A tile is a plain
+   `{id, type, props}` record in state. A `type` has a matching
+   **renderer** (pure function of `props` → DOM or mount callback).
+   No per-tile classes with lifecycle methods the host has to call in
+   the right order.
+4. **URL `?s=` is a boot hint, not live state.** At boot we read it
+   once and dispatch an action that adds or focuses a terminal tile.
+   After boot the URL is never the source of truth; it's written from
+   state for bookmarkability only.
+5. **Terminal sessions stay decoupled.** The session manager and
+   `sessionStore` continue to own PTY session lifecycle. The tile
+   state references sessions by name via `props.sessionName`. The bar
+   does *not* merge `sessionStore` into its tab list any more — tabs
+   are strictly derived from tile state.
+
+## The state shape
+
+```js
+// localStorage["katulong-ui-v1"]
+{
+  version: 1,
+  tiles: {
+    "session-abc": {
+      id: "session-abc",
+      type: "terminal",
+      props: { sessionName: "session-abc" }
+    },
+    "file-browser-xyz": {
+      id: "file-browser-xyz",
+      type: "file-browser",
+      props: { cwd: "/Users/felixflores" }
+    }
+  },
+  order: ["file-browser-xyz", "session-abc"],  // left → right
+  focusedId: "file-browser-xyz"
+}
+```
+
+Invariants:
+
+- `order` is a permutation of `Object.keys(tiles)`.
+- `focusedId` is either `null` or a key of `tiles`.
+- Duplicate ids are impossible (tiles is a map).
+- Every mutation returns a new state object (structural sharing).
+
+## Actions
+
+```
+ADD_TILE       { tile: {id, type, props}, focus?: bool, insertAt?: "end"|"afterFocus" }
+REMOVE_TILE    { id }
+REORDER        { order: [id,...] }                  // full new order
+FOCUS_TILE     { id }
+UPDATE_PROPS   { id, patch }                        // merge into tile.props
+RESET          { state }                            // for boot / restore
+```
+
+That's the whole API. No `reorderCards` + `reorderTabs` + `save()`
+triad. One dispatch.
+
+## Renderers — replacing tile prototypes
+
+Each tile `type` registers a **renderer** at module load:
+
+```js
+// public/lib/tile-renderers/terminal.js
+export const terminalRenderer = {
+  type: "terminal",
+
+  // Pure: props → view metadata. Used by the tab bar.
+  describe(props) {
+    return {
+      title: props.sessionName,
+      icon: "terminal",
+      persistable: true,
+    };
+  },
+
+  // Imperative mount onto a DOM node. Returns teardown + an optional
+  // focus() handle. The renderer may dispatch UPDATE_PROPS at any time
+  // to push state back into the atom (e.g. fb dispatching new cwd).
+  mount(el, { id, props, dispatch, ctx }) {
+    // ...xterm setup, WS wiring, etc.
+    return {
+      unmount() { /* ... */ },
+      focus()   { /* ... */ },
+      resize()  { /* ... */ },
+    };
+  },
+};
+```
+
+`describe()` is what the tab bar calls — no more `tile.getTitle()`
+method-on-instance. Because `describe` is pure and takes `props`, when
+`props.cwd` changes the new title falls out automatically the next
+render.
+
+The file-browser renderer's `mount` subscribes to its internal store
+and calls `dispatch({ type: "UPDATE_PROPS", id, patch: { cwd: deepest }})`
+whenever navigation changes. The tab bar re-renders on the next state
+change and picks up the new title via `describe(newProps)`. No
+`ctx.setTitle`, no bar-specific shim.
+
+## The render pipeline
+
+```
+state change
+    ↓
+subscribe listener
+    ↓
+renderUI(state, prevState)
+    ├── diffTiles(prev.tiles, next.tiles)
+    │     → mount new, unmount removed, leave kept alone
+    ├── reorderDom(state.order)
+    │     → move existing nodes (cheap) instead of remount
+    ├── applyFocus(state.focusedId)
+    │     → set active class + call renderer.focus()
+    └── renderTabBar(state)
+          → pure derive: state.order.map(id => describe(state.tiles[id].props))
+```
+
+Two rules:
+
+- **Never remount a tile that didn't change.** Reorder moves its DOM
+  node; prop updates go through the renderer's own subscription.
+- **Tab bar is a pure derive.** No caching, no shim, no `sessionStore`
+  merge. The whole bar is `renderTabs(state.order, state.focusedId,
+  state.tiles)`.
+
+## Persistence
+
+```js
+store.subscribe((state) => {
+  localStorage.setItem("katulong-ui-v1", JSON.stringify(serialize(state)));
+});
+```
+
+`serialize(state)` drops tiles whose type's `describe().persistable ===
+false` from the persisted copy. That's the *only* place the persistable
+flag is consulted, and it reads from the renderer, not a host-side
+constant set. `NON_PERSISTABLE_TILE_TYPES` goes away.
+
+Boot:
+
+```js
+const initial = loadFromLocalStorage() || { tiles: {}, order: [], focusedId: null };
+const hintedSession = new URL(location).searchParams.get("s");
+if (hintedSession && !initial.tiles[hintedSession]) {
+  initial.tiles[hintedSession] = { id: hintedSession, type: "terminal", props: { sessionName: hintedSession }};
+  initial.order.push(hintedSession);
+}
+if (hintedSession) initial.focusedId = hintedSession;
+store.dispatch({ type: "RESET", state: initial });
+```
+
+No `setTimeout(500)`. No "carousel-already-active" merge path. Boot is
+a single reducer call.
+
+## URL sync (terminal-only)
+
+```js
+store.subscribe((state) => {
+  const focused = state.tiles[state.focusedId];
+  if (focused?.type === "terminal") {
+    const url = new URL(location);
+    url.searchParams.set("s", focused.props.sessionName);
+    history.replaceState(null, "", url);
+  }
+  // Non-terminal focus: leave URL alone. The ?s= hint keeps pointing
+  // at whatever terminal the user last focused.
+});
+```
+
+That's the entire URL sync. The branching in `onFocusChange`,
+`onTabClick`, `bar.render` collapses to this one subscribe.
+
+## Drag reorder
+
+```js
+// In tab bar drag handler
+function onDrop(newOrder) {
+  store.dispatch({ type: "REORDER", order: newOrder });
+}
+```
+
+That's it. `windowTabSet` is deleted. `carousel.reorderCards` is
+deleted. The subscribe-bridge is deleted. Rendering re-derives from
+`state.order` and moves DOM nodes.
+
+## What gets deleted
+
+- `windowTabSet` module (subsumed by state atom)
+- `NON_PERSISTABLE_TILE_TYPES` set
+- Carousel's internal localStorage save/restore/snapshot logic
+- `tile.getTitle()` / `tile.getIcon()` / `tile.serialize()` methods
+- `ctx.setTitle` / `ctx.setIcon`
+- The `500 ms setTimeout` restore merge path
+- The "carousel-already-active" branch in app.js restore
+- `getSessionList()`'s sessionStore-merge shim in shortcut-bar
+- Per-mutation-site "sync these three stores" boilerplate
+- All `console.log("[carousel.save] ..."` debug logs (dev artifact)
+
+## What stays as-is
+
+- xterm.js, terminal pool, WS connection, session manager — none of
+  this knows or cares about tiles.
+- `sessionStore` keeps its job: tracking server-side PTY sessions (for
+  the "new session" list and API bookkeeping). It just stops being
+  consulted by the tab bar.
+- The file-browser component/store internals.
+- Tile-chrome, card faces, pinch/expose/morph gestures — carousel
+  continues to own the visual presentation of cards; it just exposes a
+  pure `setTiles(order, focused)` API driven by the store.
+
+## Build order
+
+1. **Add `ui-store.js`** — reducer, actions, persistence, URL sync.
+   Standalone; no consumers yet.
+2. **Add renderer registry** (`tile-renderers/index.js`) with
+   `terminal`, `file-browser`, `cluster` renderers as thin wrappers
+   over the existing tile factories. Each exposes `describe(props)`
+   and `mount(el, api)`.
+3. **New `tile-host.js`** — subscribes to the store, diffs
+   `prev.tiles`/`next.tiles`, mounts/unmounts/reorders via renderers.
+   Replaces the imperative carousel add/remove/focus API from app.js's
+   perspective. Carousel stays internal to tile-host.
+4. **Rewrite tab bar tab-rendering path** to derive purely from
+   `state.order` + `state.tiles` + `state.focusedId`. Drag reorder
+   dispatches `REORDER`. Click dispatches `FOCUS_TILE`.
+5. **Rewrite app.js boot** — single `RESET` dispatch from localStorage
+   + `?s=` hint. Delete the setTimeout restore path.
+6. **Delete dead code** (see "What gets deleted"). Remove debug logs.
+7. **Manual test matrix:**
+   - Fresh boot with `?s=term`
+   - Fresh boot with persisted fb tile
+   - Add fb tile → reload → fb returns at same cwd, focused
+   - Drag reorder (fb + term) → reload → order preserved
+   - Navigate fb into folder → tab label updates live
+   - Close fb → tab disappears → reload → still gone
+   - Click terminal tab while fb focused → terminal focuses, URL
+     updates, fb stays in list
+
+## Out of scope for this rewrite
+
+- Clusters keep their existing internal structure (they're a tile that
+  manages child PTYs). `cluster` renderer just wraps the existing
+  factory.
+- Pinch/expose/morph gestures stay exactly as they are; the carousel's
+  external surface is what changes, not its gesture handling.
+- No new features. This is pure architecture simplification.
+
+## Rollback plan
+
+The checkpoint commit `f32f40e` is the last "imperative but working"
+state. If the rewrite lands and regresses something we didn't catch,
+`git revert` is a clean escape hatch.

--- a/public/app.js
+++ b/public/app.js
@@ -532,7 +532,13 @@
         // unsubscribe. Sending `unsubscribe` with a tile ID like
         // `file-browser-abc` used to produce a spurious server-side
         // unsubscribe for a session that never existed.
-        if (tile && tile.type !== "terminal") return;
+        if (tile && tile.type !== "terminal") {
+          // Mirror the add path: since non-terminal tiles bypass
+          // windowTabSet, we must push a bar re-render manually so the
+          // now-removed tab actually disappears from the tab strip.
+          if (shortcutBarInstance) shortcutBarInstance.render(state.session.name);
+          return;
+        }
         const sessionName = tileSessionName(tileId);
         // Detach: remove from this window's tab set (session stays on server)
         if (windowTabSet) windowTabSet.removeTab(sessionName);
@@ -1697,6 +1703,12 @@
         carousel.addCard(tileId, tile, insertAtRightOfActive());
         carousel.focusCard(tileId);
       }
+      // Non-terminal tiles don't participate in windowTabSet, which is
+      // what normally triggers a shortcut-bar re-render. Without this
+      // explicit nudge, the new file-browser tile is invisible in the
+      // tab bar — no tab element, no right-click menu, nothing. The
+      // carousel has the card; the bar just hasn't learned about it.
+      if (shortcutBarInstance) shortcutBarInstance.render(state.session.name);
       if (isOverlayViewport()) setOverlaySidebar(false);
     }
 

--- a/public/app.js
+++ b/public/app.js
@@ -351,14 +351,16 @@
     const getSearchAddon = () => terminalPool.getActive()?.searchAddon;
 
     // --- Tile Factories ---
-    // terminalDeps uses a getter for carousel since it's created after the factories.
     // Two factories, no registry: terminals and clusters (grids of terminals).
     // The generic tile plugin system was removed — these are the only tile
     // kinds katulong ships, and both are owned by app.js directly.
-    const terminalDeps = {
-      terminalPool,
-      get carousel() { return carousel; },
-    };
+    //
+    // Note: terminalDeps used to carry a `get carousel()` lazy getter so
+    // the tile could reach back into the container for setBackTile/flipCard.
+    // That circular wiring was removed in Tier 1 T1a — the carousel now
+    // exposes `ctx.faceStack` to tiles at mount time. See
+    // docs/tile-clusters-design.md and public/lib/tiles/terminal-tile.js.
+    const terminalDeps = { terminalPool };
     const terminalTileFactory = createTerminalTileFactory(terminalDeps);
     const clusterTileFactory = createClusterTileFactory({
       createTerminalTile: (options) => terminalTileFactory(options),

--- a/public/app.js
+++ b/public/app.js
@@ -449,9 +449,9 @@
     // with `persistable: false` on the tile prototype — the carousel's
     // save() path filters on the instance flag, but restore() only has
     // the serialized type string to work with, so the type-side
-    // opt-out lives here at the host. One entry per ephemeral tile
-    // kind; Tier 2 replaces this with a polymorphic capability snapshot.
-    const NON_PERSISTABLE_TILE_TYPES = new Set(["file-browser"]);
+    // opt-out lives here at the host. Empty for now; Tier 2 replaces
+    // this with a polymorphic capability snapshot.
+    const NON_PERSISTABLE_TILE_TYPES = new Set();
     const carousel = createCardCarousel({
       container: document.getElementById("terminal-container"),
       isTypePersistable: (type) => !NON_PERSISTABLE_TILE_TYPES.has(type),
@@ -467,20 +467,39 @@
           return () => {};
         },
         setTitle(_title) {
-          // Future: update tab bar dynamically
+          // Re-render the shortcut bar so tile-provided labels (file
+          // browser tracks its cwd, future tiles may have dynamic titles)
+          // flow into tab labels via getSessionList()/tile.getTitle().
+          if (shortcutBarInstance) shortcutBarInstance.render(state.session.name);
         },
         setIcon(_icon) {
           // Future: update tab icon dynamically
         },
       }),
       onFocusChange: (tileId) => {
+        const focusedTile = carousel.getTile(tileId);
+        const isTerminal = focusedTile?.type === "terminal";
         const sessionName = tileSessionName(tileId);
-        state.update('session.name', sessionName);
-        setDocTitle(sessionName);
-        const url = new URL(window.location);
-        url.searchParams.set("s", sessionName);
-        history.replaceState(null, "", url);
-        if (shortcutBarInstance) shortcutBarInstance.setActiveTab(sessionName);
+        // Only update state.session.name and the URL ?s= when focusing a
+        // terminal. Non-terminal tiles (file browser, future kinds) have
+        // no backing tmux session; writing their tile id into the URL
+        // turns a refresh into "attach a terminal named file-browser-xyz",
+        // which then races with the carousel restore and leaves orphan
+        // phantom tabs. Keep the underlying session pointer on whatever
+        // terminal was previously active.
+        if (isTerminal) {
+          state.update('session.name', sessionName);
+          setDocTitle(sessionName);
+          const url = new URL(window.location);
+          url.searchParams.set("s", sessionName);
+          history.replaceState(null, "", url);
+        }
+        if (shortcutBarInstance) shortcutBarInstance.setActiveTab(tileId);
+        // Non-terminal tiles have no PTY, so there's nothing to switch,
+        // resize, or reconnect. Bail early — the WS bookkeeping below is
+        // terminal-only and would otherwise try to send a `switch` for a
+        // nonexistent session.
+        if (!isTerminal) return;
         // For terminals with content (tab switch): just resize, no switch needed.
         // For empty terminals (new session): send switch to get seq-init + start pulling.
         const ws = state.connection.ws;
@@ -1478,6 +1497,16 @@
       },
       onTabClick: (name) => {
         if (carousel.isActive()) {
+          // Tab bar items can be either terminal session names or
+          // non-terminal tile ids (e.g. file browser). routeToSession
+          // assumes the name is a terminal and spawns one if missing —
+          // calling it with a fb tile id would create a phantom terminal.
+          // Detect non-terminal tiles up front and just focus them.
+          const existingTile = carousel.getTile(name);
+          if (existingTile && existingTile.type !== "terminal") {
+            carousel.focusCard(name);
+            return;
+          }
           routeToSession(name);
         } else {
           switchSession(name);
@@ -2186,18 +2215,26 @@
     loadShortcuts();
     getTerm()?.focus();
 
-    // Restore carousel state from sessionStorage after a short delay
+    // Restore carousel state from localStorage after a short delay.
+    //
+    // Two boot shapes to handle:
+    //   (a) No URL ?s= and nothing pre-activated — carousel is empty, so we
+    //       reconstruct the full persisted state via carousel.activate().
+    //   (b) URL ?s= pointed at an existing session, so app.js already
+    //       activated the carousel with that one terminal tile. In that
+    //       case we need to MERGE any persisted non-terminal tiles (e.g.
+    //       file browsers) that aren't already present — a plain activate()
+    //       would either be skipped or duplicate the terminal.
     setTimeout(() => {
       const carouselState = carousel.restore();
-      if (carouselState && carouselState.tiles?.length > 0 && !carousel.isActive()) {
-        // Restore entries one at a time and drop any that fail to
-        // reconstruct — corrupt sessionStorage, a tile type written by a
-        // newer version, or any tile whose factory throws. A single bad
-        // entry must not take down the entire restore path.
+      if (!carouselState || !carouselState.tiles?.length) return;
+
+      if (!carousel.isActive()) {
         const tiles = [];
         for (const t of carouselState.tiles) {
           try {
             const tile = restoreTile(t.type, t);
+            if (!tile) continue;
             tiles.push({ id: t.id, tile, cardWidth: t.cardWidth });
           } catch (err) {
             console.warn(`[carousel] skipping tile ${t.id} (${t.type}):`, err.message);
@@ -2205,10 +2242,46 @@
         }
         if (tiles.length > 0) {
           carousel.activate(tiles, carouselState.focused);
-          // Sync tab set to carousel order (carousel is source of truth)
           if (windowTabSet) windowTabSet.reorderTabs(carousel.getCards());
         }
+        return;
       }
+
+      // Carousel already active — append any persisted tiles not already
+      // present. Preserves whatever the URL-driven boot set up.
+      const existing = new Set(carousel.getCards());
+      for (const t of carouselState.tiles) {
+        if (existing.has(t.id)) continue;
+        try {
+          const tile = restoreTile(t.type, t);
+          if (!tile) continue;
+          carousel.addCard(t.id, tile);
+        } catch (err) {
+          console.warn(`[carousel] skipping tile ${t.id} (${t.type}):`, err.message);
+        }
+      }
+      // Reorder the carousel to match the persisted order. Without this,
+      // addCard() appends newly-merged tiles to the end, so a pre-refresh
+      // layout of [fb, terminal] comes back as [terminal, fb] because the
+      // URL-driven boot inserts the terminal first.
+      carousel.reorderCards(carouselState.tiles.map(t => t.id));
+      if (windowTabSet) windowTabSet.reorderTabs(carousel.getCards());
+      // Restore focused tile if it's a non-terminal — the URL ?s= param
+      // always wins for terminals (URL is the canonical attachment point),
+      // but non-terminal tiles like the file browser have no URL analogue,
+      // so persisted focus is the only way to put them back in front.
+      const persistedFocus = carouselState.focused;
+      if (persistedFocus && carousel.getCards().includes(persistedFocus)) {
+        const focusedTile = carousel.getTile(persistedFocus);
+        if (focusedTile && focusedTile.type !== "terminal") {
+          carousel.focusCard(persistedFocus);
+        }
+      }
+      // Re-render the tab bar so non-terminal tiles merged in above pick
+      // up their tile-provided label/icon via getSessionList(). Without
+      // this, the initial bar render ran before restore and fell back to
+      // raw tile ids (e.g. `file-browser-mnrzz1`) as tab labels.
+      if (shortcutBarInstance) shortcutBarInstance.render(state.session.name);
     }, 500);
 
     if ("serviceWorker" in navigator) {

--- a/public/app.js
+++ b/public/app.js
@@ -519,6 +519,12 @@
           }
           return;
         }
+        // Non-terminal tiles (file-browser, future kinds) have no tmux
+        // session behind them — skip tab-set cleanup and the WS
+        // unsubscribe. Sending `unsubscribe` with a tile ID like
+        // `file-browser-abc` used to produce a spurious server-side
+        // unsubscribe for a session that never existed.
+        if (tile && tile.type !== "terminal") return;
         const sessionName = tileSessionName(tileId);
         // Detach: remove from this window's tab set (session stays on server)
         if (windowTabSet) windowTabSet.removeTab(sessionName);

--- a/public/app.js
+++ b/public/app.js
@@ -382,6 +382,14 @@
     // carousel + windowTabSet + sessionStore synchronization.
     const uiStore = createUiStore({ isPersistable });
 
+    /** Derive renderer capabilities for a tile descriptor.
+     *  Returns {} for unknown tiles so callers can safely destructure. */
+    function describeTile(tile) {
+      if (!tile) return {};
+      const renderer = getRenderer(tile.type);
+      return renderer?.describe(tile.props) || {};
+    }
+
     /**
      * Dispatcher for reconstructing tiles from serialized state (carousel
      * restore). Accepts the legacy `"dashboard"` type for forward-compat
@@ -450,12 +458,6 @@
       wsConnection.connect();
     }
 
-    /** Resolve the session name for a tile ID (works for terminal tiles). */
-    function tileSessionName(tileId) {
-      const tile = carousel.getTile(tileId);
-      return tile?.sessionName || tileId;
-    }
-
     // --- Card Carousel (iPad/tablet) ---
     // Tile types that opt out of carousel persistence. Keep in lockstep
     // with `persistable: false` on the tile prototype — the carousel's
@@ -488,95 +490,20 @@
           // Future: update tab icon dynamically
         },
       }),
+      // Thin dispatcher — all business logic lives in tile-host's
+      // onFocusChange callback (capability-driven, no type checks).
       onFocusChange: (tileId) => {
-        const focusedTile = carousel.getTile(tileId);
-        const isTerminal = focusedTile?.type === "terminal";
-        const sessionName = tileSessionName(tileId);
-        // Only update state.session.name and the URL ?s= when focusing a
-        // terminal. Non-terminal tiles (file browser, future kinds) have
-        // no backing tmux session; writing their tile id into the URL
-        // turns a refresh into "attach a terminal named file-browser-xyz",
-        // which then races with the carousel restore and leaves orphan
-        // phantom tabs. Keep the underlying session pointer on whatever
-        // terminal was previously active.
-        if (isTerminal) {
-          state.update('session.name', sessionName);
-          setDocTitle(sessionName);
-          const url = new URL(window.location);
-          url.searchParams.set("s", sessionName);
-          history.replaceState(null, "", url);
-        }
-        if (shortcutBarInstance) shortcutBarInstance.setActiveTab(tileId);
-        // Non-terminal tiles have no PTY, so there's nothing to switch,
-        // resize, or reconnect. Bail early — the WS bookkeeping below is
-        // terminal-only and would otherwise try to send a `switch` for a
-        // nonexistent session.
-        if (!isTerminal) return;
-        // For terminals with content (tab switch): just resize, no switch needed.
-        // For empty terminals (new session): send switch to get seq-init + start pulling.
-        const ws = state.connection.ws;
-        const wsOpen = ws?.readyState === WebSocket.OPEN;
-        const entry = terminalPool.get(sessionName);
-        const buf = entry?.term?.buffer?.active;
-        // Treat undefined buffer as empty — safer to send switch than to skip it.
-        // A skipped switch leaves the terminal with no seq-init and no output,
-        // making it appear permanently unresponsive to keyboard input.
-        const isEmpty = !buf || (buf.baseY === 0 && buf.cursorY === 0 && buf.cursorX === 0);
-        if (wsOpen && entry) {
-          if (isEmpty) {
-            // New session — need switch to get attached + seq-init
-            ws.send(JSON.stringify({ type: "switch", session: sessionName, cols: entry.term.cols, rows: entry.term.rows }));
-          } else {
-            // Existing session — just resize, content is already there
-            ws.send(JSON.stringify({ type: "resize", session: sessionName, cols: entry.term.cols, rows: entry.term.rows }));
-          }
-        } else if (isEmpty) {
-          // WS not open but we're switching to a new empty terminal.
-          // Trigger reconnection — onopen will send "attach" for the
-          // current state.session.name (just updated above), which
-          // attaches the client to the new session and initializes
-          // the pull mechanism. Without this, the terminal stays
-          // permanently stuck with no output and no input routing.
-          wsConnection.enableReconnect();
-          wsConnection.connect();
-        }
-        syncCarouselSubscriptions();
-        // Reattach scroll-to-bottom button to the newly focused terminal
-        _attachScrollButton();
+        uiStore.focusTile(tileId);
       },
+      // Thin dispatcher — tile-host's onTileRemoved handles WS cleanup
+      // generically via getSessions() (no type checks).
       onCardDismissed: (tileId) => {
-        const tile = carousel.getTile(tileId);
-        if (tile?.type === "cluster") {
-          // Cluster dismiss must unsubscribe every sub-session. Using the
-          // cluster's own sessionName (the first sub-tile) would leak the
-          // remaining sub-sessions as live subscriptions on the server.
-          for (const { tile: subTile } of tile.getSubTiles()) {
-            const subName = subTile?.sessionName;
-            if (!subName) continue;
-            if (windowTabSet) windowTabSet.removeTab(subName);
-            wsConnection.sendUnsubscribe(subName);
-          }
-          return;
-        }
-        // Non-terminal tiles (file-browser, future kinds) have no tmux
-        // session behind them — skip tab-set cleanup and the WS
-        // unsubscribe. Sending `unsubscribe` with a tile ID like
-        // `file-browser-abc` used to produce a spurious server-side
-        // unsubscribe for a session that never existed.
-        if (tile && tile.type !== "terminal") {
-          // Mirror the add path: since non-terminal tiles bypass
-          // windowTabSet, we must push a bar re-render manually so the
-          // now-removed tab actually disappears from the tab strip.
-          if (shortcutBarInstance) shortcutBarInstance.render(state.session.name);
-          return;
-        }
-        const sessionName = tileSessionName(tileId);
-        // Detach: remove from this window's tab set (session stays on server)
-        if (windowTabSet) windowTabSet.removeTab(sessionName);
-        wsConnection.sendUnsubscribe(sessionName);
+        uiStore.removeTile(tileId);
       },
       onAllCardsDismissed: () => {
-        // All cards dismissed — clear state so refresh shows blank stage
+        // Dispatch empty state — tile-host's onTileRemoved fires for
+        // each tile, handling WS unsubscribe generically.
+        uiStore.reset(EMPTY_STATE);
         wsConnection.disconnect();
         state.update('session.name', null);
         setDocTitle(null);
@@ -613,34 +540,47 @@
         setIcon(_icon) {},
       }),
       onFocusChange: (tileId, tileType) => {
-        // WS bookkeeping: only terminals need state.session.name, URL
-        // update, and WS switch/resize. Non-terminal tiles are no-ops.
-        if (tileType === "terminal") {
-          const sessionName = tileId; // terminal tile ids ARE session names
-          state.update("session.name", sessionName);
-          setDocTitle(sessionName);
-          const url = new URL(window.location);
-          url.searchParams.set("s", sessionName);
-          history.replaceState(null, "", url);
+        // Legacy shortcut bar — <tile-tab-bar> updates via store subscription
+        if (shortcutBarInstance) shortcutBarInstance.setActiveTab(tileId);
+
+        // Capability-driven WS bookkeeping — no type checks
+        const desc = getRenderer(tileType)?.describe(
+          uiStore.getState().tiles[tileId]?.props || {},
+        ) || {};
+
+        if (desc.session) {
+          state.update("session.name", desc.session);
+          setDocTitle(desc.session);
 
           const ws = state.connection.ws;
           const wsOpen = ws?.readyState === WebSocket.OPEN;
-          const entry = terminalPool.get(sessionName);
+          const entry = terminalPool.get(desc.session);
           const buf = entry?.term?.buffer?.active;
           const isEmpty = !buf || (buf.baseY === 0 && buf.cursorY === 0 && buf.cursorX === 0);
           if (wsOpen && entry) {
             if (isEmpty) {
-              ws.send(JSON.stringify({ type: "switch", session: sessionName, cols: entry.term.cols, rows: entry.term.rows }));
+              ws.send(JSON.stringify({ type: "switch", session: desc.session, cols: entry.term.cols, rows: entry.term.rows }));
             } else {
-              ws.send(JSON.stringify({ type: "resize", session: sessionName, cols: entry.term.cols, rows: entry.term.rows }));
+              ws.send(JSON.stringify({ type: "resize", session: desc.session, cols: entry.term.cols, rows: entry.term.rows }));
             }
           } else if (isEmpty) {
             wsConnection.enableReconnect();
             wsConnection.connect();
           }
-          syncCarouselSubscriptions();
-          _attachScrollButton();
         }
+        syncCarouselSubscriptions();
+        _attachScrollButton();
+      },
+      onTileRemoved: (id, handle) => {
+        // Generic cleanup via getSessions() — works for terminals,
+        // clusters (sub-sessions), and no-ops for sessionless tiles.
+        const sessions = handle.getSessions?.() || [];
+        for (const sessionName of sessions) {
+          if (windowTabSet) windowTabSet.removeTab(sessionName);
+          wsConnection.sendUnsubscribe(sessionName);
+        }
+        // Legacy shortcut bar re-render
+        if (shortcutBarInstance) shortcutBarInstance.render(state.session.name);
       },
     });
 
@@ -651,9 +591,10 @@
     // (the file-browser focus-loss bug — see tile-host init comment).
     uiStore.subscribe((uiState) => {
       const focused = uiState.tiles[uiState.focusedId];
+      const desc = describeTile(focused);
       const url = new URL(window.location);
-      if (focused?.type === "terminal") {
-        url.searchParams.set("s", focused.props.sessionName);
+      if (desc.updatesUrl && desc.session) {
+        url.searchParams.set("s", desc.session);
       } else if (focused) {
         url.searchParams.delete("s");
       }
@@ -700,37 +641,22 @@
       pinch.attach();
     }
 
-    /** Subscribe all carousel terminal tiles to WS output.
+    /** Subscribe all carousel tiles to WS output via getSessions().
      *  ALL tiles need subscriptions — including the focused one — because
      *  carousel swipe doesn't send `switch` (no server round-trip). Without
      *  a subscription, data-available notifications are dropped and the
      *  terminal appears stuck. */
     function syncCarouselSubscriptions() {
       if (!carousel.isActive()) return;
-      const cards = carousel.getCards();
-      for (const tileId of cards) {
-        const tile = carousel.getTile(tileId);
-        if (tile?.type === "terminal") {
-          // Send cols/rows so the server resizes the PTY before serializing
-          // the snapshot. Without this, the snapshot wraps at the wrong
-          // column width and live output renders garbled.
-          const entry = terminalPool.get(tile.sessionName);
-          const cols = entry?.term?.cols;
-          const rows = entry?.term?.rows;
-          wsConnection.sendSubscribe(tile.sessionName, cols, rows);
-        } else if (tile?.type === "cluster") {
-          // Cluster tiles host multiple independent sub-sessions. Each
-          // sub-terminal needs its own subscription; without this every
-          // sub-terminal past the first appears stuck (data-available
-          // notifications dropped for unsubscribed sessions).
-          for (const { tile: subTile } of tile.getSubTiles()) {
-            const subName = subTile?.sessionName;
-            if (!subName) continue;
-            const entry = terminalPool.get(subName);
-            const cols = entry?.term?.cols;
-            const rows = entry?.term?.rows;
-            wsConnection.sendSubscribe(subName, cols, rows);
-          }
+      for (const tileId of carousel.getCards()) {
+        const handle = tileHost.getHandle(tileId);
+        if (!handle) continue;
+        // getSessions() returns all WS session names this tile manages:
+        // one for terminals, multiple for clusters, none for file-browsers.
+        const sessions = handle.getSessions?.() || [];
+        for (const sessionName of sessions) {
+          const entry = terminalPool.get(sessionName);
+          wsConnection.sendSubscribe(sessionName, entry?.term?.cols, entry?.term?.rows);
         }
       }
       carousel.fitAll();
@@ -1569,17 +1495,14 @@
       },
       onTabClick: (name) => {
         if (carousel.isActive()) {
-          // Tab bar items can be either terminal session names or
-          // non-terminal tile ids (e.g. file browser). routeToSession
-          // assumes the name is a terminal and spawns one if missing —
-          // calling it with a fb tile id would create a phantom terminal.
-          // Detect non-terminal tiles up front and just focus them.
-          const existingTile = carousel.getTile(name);
-          if (existingTile && existingTile.type !== "terminal") {
-            carousel.focusCard(name);
-            return;
+          // If tile exists in ui-store, just focus it. routeToSession
+          // would create a phantom terminal for non-session tiles.
+          const uiState = uiStore.getState();
+          if (uiState.tiles[name]) {
+            uiStore.focusTile(name);
+          } else {
+            routeToSession(name);
           }
-          routeToSession(name);
         } else {
           switchSession(name);
         }
@@ -1664,47 +1587,48 @@
 
     bar.addEventListener("tab-rename", (e) => {
       const { id, oldName, newName } = e.detail;
-      // Terminal rename: update pool, notepad, carousel, server
       const uiState = uiStore.getState();
       const tile = uiState.tiles[id];
-      if (tile?.type === "terminal") {
-        if (carousel.isActive()) carousel.renameCard(oldName, newName);
-        terminalPool.rename(oldName, newName);
-        notepad.rename(oldName, newName);
-        windowTabSet.renameTab(oldName, newName);
-        invalidateSessions(sessionStore, newName);
-        // Update ui-store: remove old tile, add new one with new id
-        uiStore.removeTile(id);
-        uiStore.addTile(
-          { id: newName, type: "terminal", props: { sessionName: newName } },
-          { focus: uiState.focusedId === id },
-        );
-        if (state.session.name === oldName) {
-          state.update("session.name", newName);
-          setDocTitle(newName);
-        }
+      const desc = describeTile(tile);
+      if (!desc.renameable || !desc.session) return;
+
+      if (carousel.isActive()) carousel.renameCard(oldName, newName);
+      terminalPool.rename(oldName, newName);
+      notepad.rename(oldName, newName);
+      windowTabSet.renameTab(oldName, newName);
+      invalidateSessions(sessionStore, newName);
+      // Update ui-store: remove old tile, add new one with new id+session
+      uiStore.removeTile(id);
+      uiStore.addTile(
+        { id: newName, type: tile.type, props: { ...tile.props, sessionName: newName } },
+        { focus: uiState.focusedId === id },
+      );
+      if (state.session.name === oldName) {
+        state.update("session.name", newName);
+        setDocTitle(newName);
       }
     });
 
     bar.addEventListener("tab-context-menu", (e) => {
       const { id, type, anchorEl } = e.detail;
-      const isTerminalLike = !type || type === "terminal" || type === "cluster";
+      const tileDesc = uiStore.getState().tiles[id];
+      const desc = describeTile(tileDesc);
 
-      const items = [
-        { icon: "pencil-simple", label: "Rename", action: () => {
-          // Find the tab element and trigger rename inline
+      const items = [];
+      if (desc.renameable) {
+        items.push({ icon: "pencil-simple", label: "Rename", action: () => {
           const tabEl = bar.querySelector(`.tab-bar-tab[data-session="${CSS.escape(id)}"]`);
           if (tabEl) {
             const tabBarEl = bar.querySelector("tile-tab-bar");
             tabBarEl?._startRename(tabEl, id);
           }
-        }},
-      ];
-      if (isTerminalLike) {
+        }});
+      }
+      if (desc.session) {
+        // Session-backed tiles: detach (keep server session), kill, tear-off
         items.push({ icon: "eject", label: "Detach", action: async () => {
           try { await api.delete(`/sessions/${encodeURIComponent(id)}?action=detach`); } catch (_) {}
           uiStore.removeTile(id);
-          wsConnection.sendUnsubscribe(id);
         }});
         items.push({ icon: "x-circle", label: "Kill session", danger: true, action: async () => {
           if (!confirm(`Kill session "${id}"?\n\nThis will terminate the tmux session and all its processes.`)) return;
@@ -1717,14 +1641,13 @@
           uiStore.removeTile(id);
         }});
       }
-      if (isTerminalLike) {
+      if (desc.session) {
         items.push({ divider: true });
         items.push({ icon: "arrow-square-out", label: "Open in new window", action: () => {
-          window.open(`${window.location.origin}?s=${encodeURIComponent(id)}`, "_blank");
+          window.open(`${window.location.origin}?s=${encodeURIComponent(desc.session)}`, "_blank");
           uiStore.removeTile(id);
         }});
       }
-      // Use the shortcut bar's menu system
       if (shortcutBarInstance?.showMenuFromHost) {
         shortcutBarInstance.showMenuFromHost(items, anchorEl);
       }
@@ -1805,12 +1728,12 @@
     const dragDropManager = createDragDropManager({
       isImageFile,
       shouldIgnore: (_e) => {
-        // Don't hijack drops when the active tile is a file browser —
-        // the file-browser component handles its own upload dnd.
+        // Don't hijack drops when the active tile handles its own dnd
+        // (e.g. file-browser has built-in file upload drag-drop).
         if (!carousel.isActive()) return false;
-        const focusedId = carousel.getFocusedCard?.();
-        const activeTile = focusedId ? carousel.getTile(focusedId) : null;
-        return activeTile?.type === "file-browser";
+        const focusedId = uiStore.getState().focusedId;
+        const desc = describeTile(uiStore.getState().tiles[focusedId]);
+        return desc.handlesDnd === true;
       },
       onDrop: async (imageFiles, totalFiles) => {
         if (imageFiles.length === 0) {
@@ -2190,9 +2113,10 @@
     let bootReconcileDone = false;
 
     function removeDeadSession(name) {
-      // Remove from ui-store — tile-host will unmount and remove from carousel
+      // Remove from ui-store if it's a session-backed tile
       const uiState = uiStore.getState();
-      if (uiState.tiles[name]?.type === "terminal") {
+      const desc = describeTile(uiState.tiles[name]);
+      if (desc.session) {
         uiStore.removeTile(name);
       }
       // Tab set: remove + broadcast to other windows on this browser
@@ -2229,13 +2153,14 @@
         if (serverSet.has(tab)) windowTabSet.confirmTab(tab);
       }
 
-      // Find dead terminal sessions: present in ui-store, missing from server,
-      // not in the just-added grace period. Non-terminal tiles (file browser,
-      // clusters) are skipped — they have no server-side session.
+      // Find dead session-backed tiles: present in ui-store with a
+      // server session, but missing from the server list and not in the
+      // just-added grace period. Sessionless tiles (file browser) are
+      // skipped — they have no server-side session to reconcile against.
       const dead = new Set();
       const uiState = uiStore.getState();
       for (const [tileId, tile] of Object.entries(uiState.tiles)) {
-        if (tile.type !== "terminal") continue;
+        if (!describeTile(tile).session) continue;
         if (!serverSet.has(tileId) && !windowTabSet.isRecentlyAdded(tileId)) {
           dead.add(tileId);
         }
@@ -2244,7 +2169,7 @@
       for (const tab of windowTabSet.getTabs()) {
         if (serverSet.has(tab) || windowTabSet.isRecentlyAdded(tab)) continue;
         const tile = uiState.tiles[tab];
-        if (tile && tile.type !== "terminal") continue;
+        if (tile && !describeTile(tile).session) continue;
         dead.add(tab);
       }
 
@@ -2388,11 +2313,12 @@
     function bootFromState(bootState) {
       if (Object.keys(bootState.tiles).length === 0) return;
 
-      // Set the terminal session for WS bookkeeping
+      // Set active session for WS bookkeeping — capability-driven
       const focused = bootState.tiles[bootState.focusedId];
-      if (focused?.type === "terminal") {
-        state.update("session.name", focused.props.sessionName);
-        setDocTitle(focused.props.sessionName);
+      const desc = describeTile(focused);
+      if (desc.session) {
+        state.update("session.name", desc.session);
+        setDocTitle(desc.session);
       }
 
       // Single dispatch — tile-host is already subscribed (init'd

--- a/public/app.js
+++ b/public/app.js
@@ -35,6 +35,7 @@
     import { createPortForwardComponent } from "/lib/port-forward/port-forward-component.js";
     import { createNotepad } from "/lib/notepad.js";
     import { createCardCarousel } from "/lib/card-carousel.js";
+    import { createPinchGesture } from "/lib/pinch-gesture.js";
     import { createTerminalTileFactory } from "/lib/tiles/terminal-tile.js";
     import { createClusterTileFactory } from "/lib/tiles/cluster-tile.js";
     import { createFileBrowserTileFactory } from "/lib/tiles/file-browser-tile.js";
@@ -532,6 +533,44 @@
         sessionStorage.setItem("katulong-empty-state", "1");
       },
     });
+
+    // ── Pinch-to-expose gesture ──────────────────────────────────────
+    //
+    // Step 1 of the tile-clusters design: pinch is the zoom verb.
+    // Pinch-out morphs the carousel into exposé (all tiles visible at
+    // once); pinch-in returns to carousel. Once Level 2 (cluster
+    // overview) exists this same gesture will carry through to it —
+    // the commit thresholds below are intentionally conservative so
+    // they can be re-framed as "level change" without rewriting.
+    //
+    // Commit thresholds: we only switch mode on gesture end, and only
+    // if the final scale crossed ~15%. Mid-gesture we do NOT live-morph
+    // — that would require interpolating transforms per frame while
+    // dodging the running CSS transition, which in turn means reading
+    // offsetWidth mid-animation (the exact trap called out in
+    // positionCards's cachedCardW comment). A discrete commit-on-end
+    // is simpler, passes tests, and still feels gestural because the
+    // subsequent CSS transition is fast (350ms). Live interpolation
+    // can be layered on later without changing this contract.
+    const pinchCommitOut = 1.15; // >= this at end => carousel -> expose
+    const pinchCommitIn  = 0.87; // <= this at end => expose -> carousel
+    const pinchTarget = document.getElementById("terminal-container");
+    if (pinchTarget) {
+      const pinch = createPinchGesture({
+        target: pinchTarget,
+        onPinch: ({ scale, phase }) => {
+          if (!carousel.isActive()) return;
+          if (phase !== "end") return;
+          const cur = carousel.getMode();
+          if (cur === "carousel" && scale >= pinchCommitOut) {
+            carousel.setMode("expose");
+          } else if (cur === "expose" && scale <= pinchCommitIn) {
+            carousel.setMode("carousel");
+          }
+        },
+      });
+      pinch.attach();
+    }
 
     /** Subscribe all carousel terminal tiles to WS output.
      *  ALL tiles need subscriptions — including the focused one — because

--- a/public/app.js
+++ b/public/app.js
@@ -445,8 +445,16 @@
     }
 
     // --- Card Carousel (iPad/tablet) ---
+    // Tile types that opt out of carousel persistence. Keep in lockstep
+    // with `persistable: false` on the tile prototype — the carousel's
+    // save() path filters on the instance flag, but restore() only has
+    // the serialized type string to work with, so the type-side
+    // opt-out lives here at the host. One entry per ephemeral tile
+    // kind; Tier 2 replaces this with a polymorphic capability snapshot.
+    const NON_PERSISTABLE_TILE_TYPES = new Set(["file-browser"]);
     const carousel = createCardCarousel({
       container: document.getElementById("terminal-container"),
+      isTypePersistable: (type) => !NON_PERSISTABLE_TILE_TYPES.has(type),
       createTileContext: (tileId, _tile) => ({
         tileId,
         sendWs(msg) {

--- a/public/app.js
+++ b/public/app.js
@@ -1016,17 +1016,16 @@
     }
 
     function moveTab(direction) {
-      const tabs = carousel.isActive() ? carousel.getCards() : windowTabSet.getTabs();
+      const tabs = uiStore.getState().order;
       if (tabs.length <= 1) return;
       const idx = tabs.indexOf(state.session.name);
       if (idx === -1) return;
       const newIdx = idx + direction;
       if (newIdx < 0 || newIdx >= tabs.length) return; // don't wrap
-      // Swap in the tab array
       const reordered = [...tabs];
       [reordered[idx], reordered[newIdx]] = [reordered[newIdx], reordered[idx]];
-      windowTabSet.reorderTabs(reordered);
-      if (carousel.isActive()) carousel.reorderCards(reordered);
+      // Route through ui-store — tile-host drives carousel.reorderCards
+      uiStore.reorder(reordered);
     }
 
     // Positional tab jump — Option+1..9 → tabs 1..9, Option+0 → tab 10.
@@ -1081,24 +1080,16 @@
     function removeFocusedSessionFromUI() {
       const name = state.session.name;
       if (!name) return { name: null, hasNext: false };
-      // Capture currentId BEFORE switchSession — otherwise getFocusedCard()
-      // would return the neighbor we just moved to and we'd remove the
-      // wrong card from the carousel.
       const currentId = carousel.isActive() ? (carousel.getFocusedCard() || name) : name;
-      const next = pickRightNeighbor(name);
-      if (next) switchSession(next);
-      if (carousel.isActive()) {
-        carousel.removeCard(currentId);
-      } else {
-        windowTabSet.removeTab(name);
-        wsConnection.sendUnsubscribe(name);
-      }
-      terminalPool.dispose(name);
-      if (!next && shortcutBarInstance) {
+      const hasNext = !!pickRightNeighbor(name);
+      // Route through ui-store — tile-host's reconcile handles carousel
+      // removal, unmount, and onTileRemoved (WS cleanup, pool dispose).
+      uiStore.removeTile(currentId);
+      if (!hasNext && shortcutBarInstance) {
         const addBtn = document.querySelector(".ipad-add-btn, .tab-add-btn");
         shortcutBarInstance.showAddMenu(addBtn);
       }
-      return { name, hasNext: !!next };
+      return { name, hasNext };
     }
 
     function closeCurrentSession() {
@@ -1465,6 +1456,17 @@
         if (shortcutBarInstance) shortcutBarInstance.renameTabEl(oldName, newName);
         windowTabSet.renameTab(oldName, newName);
         invalidateSessions(sessionStore, newName);
+        // Keep ui-store in sync: rename = remove old tile + add new tile
+        // at the same position. This matches the tile-tab-bar rename path.
+        const st = uiStore.getState();
+        const oldTile = st.tiles[oldName];
+        if (oldTile) {
+          uiStore.removeTile(oldName);
+          uiStore.addTile(
+            { id: newName, type: oldTile.type, props: { ...oldTile.props, sessionName: newName } },
+            { focus: true },
+          );
+        }
         if (state.session.name === oldName) {
           state.update('session.name', newName);
           setDocTitle(newName);
@@ -1512,12 +1514,11 @@
       uiStore,
     });
 
-    // Sync carousel card order when tabs are reordered via the shortcut bar
+    // Sync ui-store order when tabs are reordered via the legacy shortcut bar.
+    // Routes through ui-store so tile-host drives carousel.reorderCards.
     if (windowTabSet) {
       windowTabSet.subscribe(() => {
-        if (carousel.isActive()) {
-          carousel.reorderCards(windowTabSet.getTabs());
-        }
+        uiStore.reorder(windowTabSet.getTabs());
       });
     }
 
@@ -2196,7 +2197,8 @@
       let initial = loadFromStorage();
 
       // Legacy migration: if ui-store has nothing but the old carousel
-      // localStorage has tiles, migrate them.
+      // localStorage has tiles, migrate them. After migration, clear the
+      // old key so two persistence layers don't drift out of sync.
       if (!initial || Object.keys(initial.tiles).length === 0) {
         const carouselState = carousel.restore();
         if (carouselState?.tiles?.length) {
@@ -2217,6 +2219,8 @@
             order,
             focusedId: carouselState.focused || order[0] || null,
           };
+          // Migration complete — clear old key
+          try { localStorage.removeItem("katulong-carousel"); } catch {}
         }
       }
 

--- a/public/app.js
+++ b/public/app.js
@@ -1657,16 +1657,15 @@
       if (joystickEl) joystickEl.style.display = "";
     }
 
-    /** Create a file-browser tile at the active session's cwd, or focus
-     *  an existing file-browser tile if one is already open. */
+    /** Create a new file-browser tile at the active session's cwd.
+     *
+     *  Per the tile-clusters design (T1b), every click on the folder
+     *  button creates a fresh file-browser tile — no singleton reuse.
+     *  Two clicks from two different terminals produce two independent
+     *  browser tiles that can sit side-by-side in the carousel. The
+     *  previous "focus existing" shortcut was removed because it
+     *  conflicts with the multi-instance file-browser UX. */
     async function openFileBrowserTile() {
-      const existing = carousel.isActive()
-        ? carousel.findCard((tile) => tile.type === "file-browser")
-        : null;
-      if (existing) {
-        carousel.focusCard(existing);
-        return;
-      }
       const sessionName = state.session.name;
       let cwd = "";
       if (sessionName) {

--- a/public/app.js
+++ b/public/app.js
@@ -40,6 +40,9 @@
     import { createClusterTileFactory } from "/lib/tiles/cluster-tile.js";
     import { createFileBrowserTileFactory } from "/lib/tiles/file-browser-tile.js";
     import { dispatchNotification } from "/lib/notify.js";
+    import { createUiStore, loadFromStorage, EMPTY_STATE } from "/lib/ui-store.js";
+    import { initRenderers, isPersistable, getRenderer } from "/lib/tile-renderers/index.js";
+    import { createTileHost } from "/lib/tile-host.js";
 
     // --- Modal Manager ---
     const modals = new ModalRegistry();
@@ -367,6 +370,18 @@
     });
     const fileBrowserTileFactory = createFileBrowserTileFactory();
 
+    // ── Renderer registry + UI store ──────────────────────────────────
+    // Initialize the renderer registry with shared deps. This must happen
+    // before any tile mount — renderers wrap the existing tile factories.
+    initRenderers({
+      terminalPool,
+      createTerminalTile: (opts) => terminalTileFactory(opts),
+    });
+
+    // Single source of truth for tile UI state. Replaces the three-way
+    // carousel + windowTabSet + sessionStore synchronization.
+    const uiStore = createUiStore({ isPersistable });
+
     /**
      * Dispatcher for reconstructing tiles from serialized state (carousel
      * restore). Accepts the legacy `"dashboard"` type for forward-compat
@@ -427,15 +442,12 @@
         return;
       }
       const slots = created.map(s => ({ sessionName: s.name }));
-      const tile = clusterTileFactory({ slots, cells: count });
       const tileId = `cluster-${base}`;
-      if (!carousel.isActive()) {
-        carousel.activate([{ id: tileId, tile }], tileId);
-        wsConnection.connect();
-      } else {
-        carousel.addCard(tileId, tile, insertAtRightOfActive());
-        carousel.focusCard(tileId);
-      }
+      uiStore.addTile(
+        { id: tileId, type: "cluster", props: { slots, cells: count } },
+        { focus: true, insertAt: "afterFocus" },
+      );
+      wsConnection.connect();
     }
 
     /** Resolve the session name for a tile ID (works for terminal tiles). */
@@ -575,6 +587,81 @@
       },
     });
 
+    // ── Tile host — reactive bridge from ui-store → carousel ──────────
+    //
+    // Subscribes to ui-store state changes and translates them into
+    // carousel commands (activate, addCard, removeCard, focusCard,
+    // reorderCards). This replaces the imperative add/remove/focus calls
+    // that were scattered across routeToSession, restoreTile, and the
+    // boot sequence.
+    const tileHost = createTileHost({
+      store: uiStore,
+      carousel,
+      getRenderer,
+      buildCtx: (tileId, _tile) => ({
+        tileId,
+        sendWs(msg) {
+          const ws = state.connection.ws;
+          if (ws?.readyState === 1) ws.send(JSON.stringify(msg));
+        },
+        onWsMessage(_type, _handler) { return () => {}; },
+        setTitle(_title) {
+          // No-op: the renderer's setTitle dispatches UPDATE_PROPS to
+          // ui-store, which triggers <tile-tab-bar> re-render via its
+          // own subscription. No manual bar.render() needed.
+        },
+        setIcon(_icon) {},
+      }),
+      onFocusChange: (tileId, tileType) => {
+        // WS bookkeeping: only terminals need state.session.name, URL
+        // update, and WS switch/resize. Non-terminal tiles are no-ops.
+        if (tileType === "terminal") {
+          const sessionName = tileId; // terminal tile ids ARE session names
+          state.update("session.name", sessionName);
+          setDocTitle(sessionName);
+          const url = new URL(window.location);
+          url.searchParams.set("s", sessionName);
+          history.replaceState(null, "", url);
+
+          const ws = state.connection.ws;
+          const wsOpen = ws?.readyState === WebSocket.OPEN;
+          const entry = terminalPool.get(sessionName);
+          const buf = entry?.term?.buffer?.active;
+          const isEmpty = !buf || (buf.baseY === 0 && buf.cursorY === 0 && buf.cursorX === 0);
+          if (wsOpen && entry) {
+            if (isEmpty) {
+              ws.send(JSON.stringify({ type: "switch", session: sessionName, cols: entry.term.cols, rows: entry.term.rows }));
+            } else {
+              ws.send(JSON.stringify({ type: "resize", session: sessionName, cols: entry.term.cols, rows: entry.term.rows }));
+            }
+          } else if (isEmpty) {
+            wsConnection.enableReconnect();
+            wsConnection.connect();
+          }
+          syncCarouselSubscriptions();
+          _attachScrollButton();
+        }
+      },
+    });
+
+    // ── URL sync (reactive subscription) ────────────────────────────
+    // Keep ?s= in sync with the focused tile. Terminal tiles write their
+    // session name; non-terminal tiles clear ?s= so a stale terminal
+    // name doesn't override the persisted focusedId on the next refresh
+    // (the file-browser focus-loss bug — see tile-host init comment).
+    uiStore.subscribe((uiState) => {
+      const focused = uiState.tiles[uiState.focusedId];
+      const url = new URL(window.location);
+      if (focused?.type === "terminal") {
+        url.searchParams.set("s", focused.props.sessionName);
+      } else if (focused) {
+        url.searchParams.delete("s");
+      }
+      if (url.href !== window.location.href) {
+        history.replaceState(null, "", url);
+      }
+    });
+
     // ── Pinch-to-expose gesture ──────────────────────────────────────
     //
     // Step 1 of the tile-clusters design: pinch is the zoom verb.
@@ -664,29 +751,19 @@
       return idx >= 0 ? idx + 1 : undefined;
     }
 
-    /** Route a session through the carousel — activating it if needed
-     *  or focusing/adding a card if already active.
-     *  @param {string} name
-     *  @param {number} [insertAt] — insertion index for new cards (Chrome-style
-     *    "right of active"). Ignored when the card already exists. */
-    function routeToSession(name, insertAt) {
-      if (carousel.isActive()) {
-        // Check if a terminal tile for this session already exists
-        // Restrict match to terminal tiles: a cluster's sessionName getter
-        // aliases its first sub-tile, which would otherwise make this
-        // predicate falsely hit a cluster card when routing a real terminal.
-        const existing = carousel.findCard((tile) => tile.type === "terminal" && tile.sessionName === name);
-        if (!existing) {
-          const { id, tile } = makeTerminalTile(name);
-          carousel.addCard(id, tile, insertAt);
-        }
-        carousel.focusCard(existing || name);
+    /** Route a session through ui-store — adds the tile if absent, then
+     *  focuses it. tile-host picks up the state change and drives the
+     *  carousel. No direct carousel calls.
+     *  @param {string} name — session name (= tile id for terminals) */
+    function routeToSession(name) {
+      const uiState = uiStore.getState();
+      if (!uiState.tiles[name]) {
+        uiStore.addTile(
+          { id: name, type: "terminal", props: { sessionName: name } },
+          { focus: true, insertAt: "afterFocus" },
+        );
       } else {
-        const allNames = windowTabSet ? [...windowTabSet.getTabs()] : [];
-        if (!allNames.includes(name)) allNames.push(name);
-        const tiles = allNames.map(n => makeTerminalTile(n));
-        carousel.activate(tiles, name);
-        if (shortcutBarInstance) shortcutBarInstance.render(name);
+        uiStore.focusTile(name);
       }
     }
 
@@ -994,16 +1071,11 @@
         if (sidebar?.classList.contains("collapsed")) {
           setSidebarCollapsed(false);
         }
-        // Re-enable reconnect if we were in empty state
         wsConnection.enableReconnect();
-        // Insert right of the active card (Chrome-style) instead of at the end.
-        const insertAt = insertAtRightOfActive();
-        windowTabSet.addTab(data.name, insertAt);
-        routeToSession(data.name, insertAt);
-        // If carousel was just activated from empty state, reconnect WS
-        if (carousel.isActive()) {
-          wsConnection.connect();
-        }
+        // routeToSession dispatches ADD_TILE with insertAt: "afterFocus"
+        routeToSession(data.name);
+        windowTabSet.addTab(data.name);
+        wsConnection.connect();
       } catch (err) {
         console.error("Failed to create session:", err);
         showToast(`Failed to create session: ${err.message}`);
@@ -1569,6 +1641,7 @@
       sessionStore,
       windowTabSet,
       carousel,
+      uiStore,
     });
 
     // Sync carousel card order when tabs are reordered via the shortcut bar
@@ -1579,6 +1652,89 @@
         }
       });
     }
+
+    // ── <tile-tab-bar> event handlers ──────────────────────────────────
+    // The web component dispatches CustomEvents for actions that need
+    // host involvement (server API calls, WS cleanup). Tab focus and
+    // reorder go directly through ui-store inside the component.
+    bar.addEventListener("tab-add", () => {
+      // Delegate to the shortcut bar's + button menu
+      shortcutBarInstance.showAddMenu(bar.querySelector(".ipad-add-btn") || bar);
+    });
+
+    bar.addEventListener("tab-rename", (e) => {
+      const { id, oldName, newName } = e.detail;
+      // Terminal rename: update pool, notepad, carousel, server
+      const uiState = uiStore.getState();
+      const tile = uiState.tiles[id];
+      if (tile?.type === "terminal") {
+        if (carousel.isActive()) carousel.renameCard(oldName, newName);
+        terminalPool.rename(oldName, newName);
+        notepad.rename(oldName, newName);
+        windowTabSet.renameTab(oldName, newName);
+        invalidateSessions(sessionStore, newName);
+        // Update ui-store: remove old tile, add new one with new id
+        uiStore.removeTile(id);
+        uiStore.addTile(
+          { id: newName, type: "terminal", props: { sessionName: newName } },
+          { focus: uiState.focusedId === id },
+        );
+        if (state.session.name === oldName) {
+          state.update("session.name", newName);
+          setDocTitle(newName);
+        }
+      }
+    });
+
+    bar.addEventListener("tab-context-menu", (e) => {
+      const { id, type, anchorEl } = e.detail;
+      const isTerminalLike = !type || type === "terminal" || type === "cluster";
+
+      const items = [
+        { icon: "pencil-simple", label: "Rename", action: () => {
+          // Find the tab element and trigger rename inline
+          const tabEl = bar.querySelector(`.tab-bar-tab[data-session="${CSS.escape(id)}"]`);
+          if (tabEl) {
+            const tabBarEl = bar.querySelector("tile-tab-bar");
+            tabBarEl?._startRename(tabEl, id);
+          }
+        }},
+      ];
+      if (isTerminalLike) {
+        items.push({ icon: "eject", label: "Detach", action: async () => {
+          try { await api.delete(`/sessions/${encodeURIComponent(id)}?action=detach`); } catch (_) {}
+          uiStore.removeTile(id);
+          wsConnection.sendUnsubscribe(id);
+        }});
+        items.push({ icon: "x-circle", label: "Kill session", danger: true, action: async () => {
+          if (!confirm(`Kill session "${id}"?\n\nThis will terminate the tmux session and all its processes.`)) return;
+          try { await api.delete(`/sessions/${encodeURIComponent(id)}`); } catch (_) {}
+          uiStore.removeTile(id);
+          if (windowTabSet) windowTabSet.onSessionKilled(id);
+        }});
+      } else {
+        items.push({ icon: "x-circle", label: "Close", danger: true, action: () => {
+          uiStore.removeTile(id);
+        }});
+      }
+      if (isTerminalLike) {
+        items.push({ divider: true });
+        items.push({ icon: "arrow-square-out", label: "Open in new window", action: () => {
+          window.open(`${window.location.origin}?s=${encodeURIComponent(id)}`, "_blank");
+          uiStore.removeTile(id);
+        }});
+      }
+      // Use the shortcut bar's menu system
+      if (shortcutBarInstance?.showMenuFromHost) {
+        shortcutBarInstance.showMenuFromHost(items, anchorEl);
+      }
+    });
+
+    bar.addEventListener("tab-tear-off", (e) => {
+      const { id } = e.detail;
+      window.open(`${window.location.origin}?s=${encodeURIComponent(id)}`, "_blank");
+      uiStore.removeTile(id);
+    });
 
     // Re-render bar if pointer capability changes (e.g., external mouse connected)
     window.matchMedia("(pointer: fine)").addEventListener("change", () => {
@@ -1723,21 +1879,15 @@
           if (data.cwd) cwd = data.cwd;
         } catch {}
       }
-      const tile = fileBrowserTileFactory({ cwd, sessionName });
       const tileId = `file-browser-${Date.now().toString(36)}`;
-      if (!carousel.isActive()) {
-        carousel.activate([{ id: tileId, tile }], tileId);
-        wsConnection.connect();
-      } else {
-        carousel.addCard(tileId, tile, insertAtRightOfActive());
-        carousel.focusCard(tileId);
-      }
-      // Non-terminal tiles don't participate in windowTabSet, which is
-      // what normally triggers a shortcut-bar re-render. Without this
-      // explicit nudge, the new file-browser tile is invisible in the
-      // tab bar — no tab element, no right-click menu, nothing. The
-      // carousel has the card; the bar just hasn't learned about it.
-      if (shortcutBarInstance) shortcutBarInstance.render(state.session.name);
+      // Single dispatch — tile-host mounts via renderer, <tile-tab-bar>
+      // picks up the new tile via its ui-store subscription. No manual
+      // bar.render() or carousel.addCard().
+      uiStore.addTile(
+        { id: tileId, type: "file-browser", props: { cwd, sessionName } },
+        { focus: true, insertAt: "afterFocus" },
+      );
+      wsConnection.connect();
       if (isOverlayViewport()) setOverlaySidebar(false);
     }
 
@@ -2040,14 +2190,10 @@
     let bootReconcileDone = false;
 
     function removeDeadSession(name) {
-      // Carousel: terminal tile IDs are the (current) session name, and
-      // renameCard re-keys cardEls atomically — so getTile(name) is the
-      // canonical lookup and works for both renamed and freshly-created
-      // sessions. findCard by tile.sessionName was historically fragile
-      // because the field could lag behind a rename.
-      if (carousel.isActive()) {
-        const tile = carousel.getTile(name);
-        if (tile?.type === "terminal") carousel.removeCard(name);
+      // Remove from ui-store — tile-host will unmount and remove from carousel
+      const uiState = uiStore.getState();
+      if (uiState.tiles[name]?.type === "terminal") {
+        uiStore.removeTile(name);
       }
       // Tab set: remove + broadcast to other windows on this browser
       windowTabSet.onSessionKilled(name);
@@ -2083,29 +2229,21 @@
         if (serverSet.has(tab)) windowTabSet.confirmTab(tab);
       }
 
-      // Find dead terminal sessions: present locally, missing from the server,
-      // and not in the just-added grace period. Terminal tile IDs ARE the
-      // current session name (renameCard keeps them in sync), so iterate
-      // by tileId — tile.sessionName has historically been stale post-rename.
+      // Find dead terminal sessions: present in ui-store, missing from server,
+      // not in the just-added grace period. Non-terminal tiles (file browser,
+      // clusters) are skipped — they have no server-side session.
       const dead = new Set();
-      if (carousel.isActive()) {
-        for (const tileId of carousel.getCards()) {
-          const tile = carousel.getTile(tileId);
-          if (tile?.type !== "terminal") continue;
-          if (!serverSet.has(tileId) && !windowTabSet.isRecentlyAdded(tileId)) {
-            dead.add(tileId);
-          }
+      const uiState = uiStore.getState();
+      for (const [tileId, tile] of Object.entries(uiState.tiles)) {
+        if (tile.type !== "terminal") continue;
+        if (!serverSet.has(tileId) && !windowTabSet.isRecentlyAdded(tileId)) {
+          dead.add(tileId);
         }
       }
-      // Catch tab-set entries that have no carousel card. Shouldn't happen
-      // in steady state but tabs and cards can drift via races, and the URL
-      // session is added to the tab set before the carousel activates.
+      // Also check tab-set entries not in ui-store (race condition safety net)
       for (const tab of windowTabSet.getTabs()) {
         if (serverSet.has(tab) || windowTabSet.isRecentlyAdded(tab)) continue;
-        // Skip non-terminal carousel tiles (clusters) — they own their
-        // own slot lifecycle, and their tile IDs never appear in the
-        // server's session list.
-        const tile = carousel.isActive() ? carousel.getTile(tab) : null;
+        const tile = uiState.tiles[tab];
         if (tile && tile.type !== "terminal") continue;
         dead.add(tab);
       }
@@ -2163,126 +2301,144 @@
     sessionStore.subscribe(reconcileTilesAgainstServer);
 
     // --- Boot ---
-
-    // If no explicit ?s= param, resolve an existing session before connecting
-    // to avoid creating a throwaway "default" tmux session.
-    // If user explicitly closed all tabs, stay in empty state.
+    //
+    // One RESET dispatch. No setTimeout(500), no "carousel-already-active"
+    // merge path, no dual URL-vs-restore branches. The boot sequence:
+    //
+    //   1. Load persisted tile state from localStorage (ui-store).
+    //   2. Merge the ?s= URL hint (adds/focuses that terminal).
+    //   3. If no persisted state AND no URL hint, fetch /sessions to find
+    //      an existing session (avoids creating throwaway tmux sessions).
+    //   4. Dispatch RESET — tile-host subscribes and activates the carousel.
+    //   5. Connect WebSocket.
+    //
+    // The old boot had three entry points that each called carousel.activate
+    // separately, then a setTimeout(500) restore that merged persisted tiles
+    // with whatever the first activate set up. This collapsed into a single
+    // RESET because ui-store IS the persistence layer — loadFromStorage()
+    // returns the same state the old carousel.restore() + merge produced.
     const wasEmptyState = sessionStorage.getItem("katulong-empty-state");
     if (wasEmptyState) sessionStorage.removeItem("katulong-empty-state");
 
-    if (!explicitSession) {
-      fetch("/sessions").then(r => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        return r.json();
-      }).then(sessions => {
-        // Guard: if the user already picked a session while the fetch was in-flight, skip
-        if (state.connection.ws || state.session.name !== null) return;
-        // If user explicitly closed all tabs, don't auto-attach
-        if (wasEmptyState) return;
-        if (sessions.length > 0 && sessions[0].name) {
-          const name = sessions[0].name;
-          state.update('session.name', name);
-          setDocTitle(name);
-          const url = new URL(window.location);
-          url.searchParams.set("s", name);
-          history.replaceState(null, "", url);
-          const tabSessions = windowTabSet.getTabs();
-          const allNames = tabSessions.length > 0 ? [...tabSessions] : [name];
-          if (!allNames.includes(name)) allNames.unshift(name);
-          carousel.activate(allNames.map(n => makeTerminalTile(n)), name);
-          renderBar(name);
-          // Server already confirmed this session exists in the /sessions
-          // response above, so the grace period from addTab is harmless —
-          // confirmTab() will clear it on the next reconciler pass.
-          windowTabSet.addTab(name);
-          wsConnection.connect();
+    /** Build boot state from localStorage + URL hint + legacy migration. */
+    function buildBootState() {
+      // Start from persisted ui-store state
+      let initial = loadFromStorage();
+
+      // Legacy migration: if ui-store has nothing but the old carousel
+      // localStorage has tiles, migrate them.
+      if (!initial || Object.keys(initial.tiles).length === 0) {
+        const carouselState = carousel.restore();
+        if (carouselState?.tiles?.length) {
+          const tiles = {};
+          const order = [];
+          for (const t of carouselState.tiles) {
+            const type = t.type === "dashboard" ? "cluster" : t.type;
+            if (!getRenderer(type)) continue;
+            tiles[t.id] = { id: t.id, type, props: { ...t } };
+            delete tiles[t.id].props.id;
+            delete tiles[t.id].props.type;
+            delete tiles[t.id].props.cardWidth;
+            order.push(t.id);
+          }
+          initial = {
+            version: 1,
+            tiles,
+            order,
+            focusedId: carouselState.focused || order[0] || null,
+          };
         }
-        // If no sessions exist, stay empty — user can create one via session list
-      }).catch((err) => {
-        console.warn("Failed to fetch sessions on load:", err);
-        // Stay empty rather than creating a throwaway "default" session.
-        // User can create or pick a session via the sidebar.
-      });
-    } else {
-      // Explicit ?s= session — activate the carousel with the tab set
-      const tabSessions = windowTabSet.getTabs();
-      const allNames = tabSessions.length > 0 ? [...tabSessions] : [state.session.name];
-      if (state.session.name && !allNames.includes(state.session.name)) allNames.unshift(state.session.name);
-      carousel.activate(allNames.map(n => makeTerminalTile(n)), state.session.name);
-      renderBar(state.session.name);
-      wsConnection.connect();
-    }
-    loadShortcuts();
-    getTerm()?.focus();
+      }
 
-    // Restore carousel state from localStorage after a short delay.
-    //
-    // Two boot shapes to handle:
-    //   (a) No URL ?s= and nothing pre-activated — carousel is empty, so we
-    //       reconstruct the full persisted state via carousel.activate().
-    //   (b) URL ?s= pointed at an existing session, so app.js already
-    //       activated the carousel with that one terminal tile. In that
-    //       case we need to MERGE any persisted non-terminal tiles (e.g.
-    //       file browsers) that aren't already present — a plain activate()
-    //       would either be skipped or duplicate the terminal.
-    setTimeout(() => {
-      const carouselState = carousel.restore();
-      if (!carouselState || !carouselState.tiles?.length) return;
+      if (!initial) initial = { version: 1, tiles: {}, order: [], focusedId: null };
 
-      if (!carousel.isActive()) {
-        const tiles = [];
-        for (const t of carouselState.tiles) {
-          try {
-            const tile = restoreTile(t.type, t);
-            if (!tile) continue;
-            tiles.push({ id: t.id, tile, cardWidth: t.cardWidth });
-          } catch (err) {
-            console.warn(`[carousel] skipping tile ${t.id} (${t.type}):`, err.message);
+      // Merge ?s= URL hint. Only override focusedId when the URL
+      // introduced a NEW session — otherwise, the persisted focusedId
+      // wins. ?s= only tracks terminals, so it goes stale when the user
+      // focuses a non-terminal tile (file browser). Overriding
+      // unconditionally would lose that focus on every refresh.
+      if (explicitSession) {
+        if (!initial.tiles[explicitSession]) {
+          initial.tiles[explicitSession] = {
+            id: explicitSession,
+            type: "terminal",
+            props: { sessionName: explicitSession },
+          };
+          initial.order.push(explicitSession);
+          initial.focusedId = explicitSession;
+        }
+      }
+
+      // Merge windowTabSet sessions (legacy — ensures tabs from other windows
+      // appear even if they weren't in the persisted ui-store yet)
+      if (windowTabSet) {
+        for (const tab of windowTabSet.getTabs()) {
+          if (!initial.tiles[tab]) {
+            initial.tiles[tab] = {
+              id: tab, type: "terminal", props: { sessionName: tab },
+            };
+            initial.order.push(tab);
           }
         }
-        if (tiles.length > 0) {
-          carousel.activate(tiles, carouselState.focused);
-          if (windowTabSet) windowTabSet.reorderTabs(carousel.getCards());
-        }
-        return;
       }
 
-      // Carousel already active — append any persisted tiles not already
-      // present. Preserves whatever the URL-driven boot set up.
-      const existing = new Set(carousel.getCards());
-      for (const t of carouselState.tiles) {
-        if (existing.has(t.id)) continue;
-        try {
-          const tile = restoreTile(t.type, t);
-          if (!tile) continue;
-          carousel.addCard(t.id, tile);
-        } catch (err) {
-          console.warn(`[carousel] skipping tile ${t.id} (${t.type}):`, err.message);
-        }
+      return initial;
+    }
+
+    function bootFromState(bootState) {
+      if (Object.keys(bootState.tiles).length === 0) return;
+
+      // Set the terminal session for WS bookkeeping
+      const focused = bootState.tiles[bootState.focusedId];
+      if (focused?.type === "terminal") {
+        state.update("session.name", focused.props.sessionName);
+        setDocTitle(focused.props.sessionName);
       }
-      // Reorder the carousel to match the persisted order. Without this,
-      // addCard() appends newly-merged tiles to the end, so a pre-refresh
-      // layout of [fb, terminal] comes back as [terminal, fb] because the
-      // URL-driven boot inserts the terminal first.
-      carousel.reorderCards(carouselState.tiles.map(t => t.id));
-      if (windowTabSet) windowTabSet.reorderTabs(carousel.getCards());
-      // Restore focused tile if it's a non-terminal — the URL ?s= param
-      // always wins for terminals (URL is the canonical attachment point),
-      // but non-terminal tiles like the file browser have no URL analogue,
-      // so persisted focus is the only way to put them back in front.
-      const persistedFocus = carouselState.focused;
-      if (persistedFocus && carousel.getCards().includes(persistedFocus)) {
-        const focusedTile = carousel.getTile(persistedFocus);
-        if (focusedTile && focusedTile.type !== "terminal") {
-          carousel.focusCard(persistedFocus);
-        }
+
+      // Single dispatch — tile-host is already subscribed (init'd
+      // unconditionally above) and will pick up the state change.
+      uiStore.reset(bootState);
+      wsConnection.connect();
+    }
+
+    // Subscribe tile-host unconditionally BEFORE any boot path can
+    // dispatch tiles. This ensures the carousel is driven reactively
+    // from the store regardless of which boot branch fires — persisted
+    // state, server-fetched sessions, empty start, or delayed async.
+    // With an empty store, reconcile is a no-op; once tiles arrive
+    // (via RESET or ADD_TILE), the subscription picks them up.
+    tileHost.init();
+    renderBar(state.session.name || "");
+
+    if (!explicitSession && !wasEmptyState) {
+      // No URL hint — check for persisted tiles first, then fall back to
+      // fetching /sessions to find an existing session.
+      const bootState = buildBootState();
+      if (Object.keys(bootState.tiles).length > 0) {
+        bootFromState(bootState);
+      } else {
+        // No persisted tiles — ask the server for existing sessions
+        fetch("/sessions").then(r => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          return r.json();
+        }).then(sessions => {
+          if (state.connection.ws || state.session.name !== null) return;
+          if (sessions.length > 0 && sessions[0].name) {
+            const name = sessions[0].name;
+            bootState.tiles[name] = { id: name, type: "terminal", props: { sessionName: name } };
+            bootState.order.push(name);
+            bootState.focusedId = name;
+            bootFromState(bootState);
+          }
+        }).catch(err => {
+          console.warn("Failed to fetch sessions on load:", err);
+        });
       }
-      // Re-render the tab bar so non-terminal tiles merged in above pick
-      // up their tile-provided label/icon via getSessionList(). Without
-      // this, the initial bar render ran before restore and fell back to
-      // raw tile ids (e.g. `file-browser-mnrzz1`) as tab labels.
-      if (shortcutBarInstance) shortcutBarInstance.render(state.session.name);
-    }, 500);
+    } else if (!wasEmptyState) {
+      // Explicit ?s= — build and boot immediately
+      bootFromState(buildBootState());
+    }
+    // If wasEmptyState, stay empty — user explicitly closed all tabs.
 
     if ("serviceWorker" in navigator) {
       // Track whether a controller already exists when the page loads.

--- a/public/app.js
+++ b/public/app.js
@@ -391,23 +391,6 @@
     }
 
     /**
-     * Dispatcher for reconstructing tiles from serialized state (carousel
-     * restore). Accepts the legacy `"dashboard"` type for forward-compat
-     * with state saved before the rename.
-     */
-    function restoreTile(type, options = {}) {
-      if (type === "terminal") return terminalTileFactory(options);
-      if (type === "cluster" || type === "dashboard") return clusterTileFactory(options);
-      if (type === "file-browser") return fileBrowserTileFactory(options);
-      throw new Error(`Unknown tile type: "${type}"`);
-    }
-
-    /** Create a terminal tile for a session, using the session name as tile ID. */
-    function makeTerminalTile(sessionName) {
-      return { id: sessionName, tile: terminalTileFactory({ sessionName }) };
-    }
-
-    /**
      * Create a terminal cluster: a single card holding a 2x2 grid of new
      * tmux sessions, each its own PTY. Spawns sessions in parallel; on
      * partial failure, deletes the successfully created ones so the server
@@ -459,16 +442,9 @@
     }
 
     // --- Card Carousel (iPad/tablet) ---
-    // Tile types that opt out of carousel persistence. Keep in lockstep
-    // with `persistable: false` on the tile prototype — the carousel's
-    // save() path filters on the instance flag, but restore() only has
-    // the serialized type string to work with, so the type-side
-    // opt-out lives here at the host. Empty for now; Tier 2 replaces
-    // this with a polymorphic capability snapshot.
-    const NON_PERSISTABLE_TILE_TYPES = new Set();
     const carousel = createCardCarousel({
       container: document.getElementById("terminal-container"),
-      isTypePersistable: (type) => !NON_PERSISTABLE_TILE_TYPES.has(type),
+      isTypePersistable: isPersistable,
       createTileContext: (tileId, _tile) => ({
         tileId,
         sendWs(msg) {
@@ -518,27 +494,11 @@
     //
     // Subscribes to ui-store state changes and translates them into
     // carousel commands (activate, addCard, removeCard, focusCard,
-    // reorderCards). This replaces the imperative add/remove/focus calls
-    // that were scattered across routeToSession, restoreTile, and the
-    // boot sequence.
+    // reorderCards). All tile lifecycle now flows through one subscription.
     const tileHost = createTileHost({
       store: uiStore,
       carousel,
       getRenderer,
-      buildCtx: (tileId, _tile) => ({
-        tileId,
-        sendWs(msg) {
-          const ws = state.connection.ws;
-          if (ws?.readyState === 1) ws.send(JSON.stringify(msg));
-        },
-        onWsMessage(_type, _handler) { return () => {}; },
-        setTitle(_title) {
-          // No-op: the renderer's setTitle dispatches UPDATE_PROPS to
-          // ui-store, which triggers <tile-tab-bar> re-render via its
-          // own subscription. No manual bar.render() needed.
-        },
-        setIcon(_icon) {},
-      }),
       onFocusChange: (tileId, tileType) => {
         // Legacy shortcut bar — <tile-tab-bar> updates via store subscription
         if (shortcutBarInstance) shortcutBarInstance.setActiveTab(tileId);
@@ -660,21 +620,6 @@
         }
       }
       carousel.fitAll();
-    }
-
-    /** Compute the insertion index that places a new card immediately right
-     *  of the currently focused one (Chrome-style "new tab right of active").
-     *
-     *  Reads from `carousel.getCards()` when the carousel is active — that is
-     *  the visible order the user sees, and it can drift from `windowTabSet`
-     *  after drag-reorders or isolated removals. Falls back to the tab set
-     *  during empty-state boot, before the carousel has been activated.
-     *
-     *  Returns `undefined` (→ append to end) when there is no active anchor. */
-    function insertAtRightOfActive() {
-      const order = carousel.isActive() ? carousel.getCards() : windowTabSet.getTabs();
-      const idx = order.indexOf(state.session.name);
-      return idx >= 0 ? idx + 1 : undefined;
     }
 
     /** Route a session through ui-store — adds the tile if absent, then

--- a/public/index.html
+++ b/public/index.html
@@ -2101,10 +2101,11 @@
 
     /* --- File Browser --- */
     /* Formerly a fullscreen overlay (#file-browser); now hosted as a
-       file-browser tile. The component's internal styles (.file-browser
-       and descendants) remain — they target whatever container the
-       tile's mount(el) passes in. */
-    .file-browser { display: flex; flex-direction: column; height: 100%; width: 100%; background: var(--bg); color: var(--text); font-family: var(--font-mono); font-size: var(--text-sm); }
+       file-browser tile. The component owns a `.fb-root` child (created
+       in createFileBrowserComponent.mount) rather than stamping
+       `.file-browser` on its parent — that class collision is what
+       forced the extra wrapper div that T1b deleted. */
+    .fb-root { display: flex; flex-direction: column; height: 100%; width: 100%; background: var(--bg); color: var(--text); font-family: var(--font-mono); font-size: var(--text-sm); }
     .fb-toolbar { display: flex; align-items: center; gap: var(--space-sm); padding: var(--space-xs) var(--space-sm); border-bottom: 1px solid var(--border); flex-shrink: 0; background: var(--bg-surface); }
     .fb-toolbar-nav { display: flex; gap: 2px; }
     .fb-toolbar-actions { display: flex; gap: var(--space-xs); align-items: center; margin-left: auto; }

--- a/public/lib/card-carousel.js
+++ b/public/lib/card-carousel.js
@@ -38,6 +38,12 @@ export function createCardCarousel({
   let focusedId = null;
   const cardEls = new Map();  // tileId -> { wrapper, frontFace, backFace, tile, backTile, context, flipped, resizeHandles }
 
+  // View mode: "carousel" (default, horizontal strip) or "expose" (grid
+  // of all tiles, macOS-Expose-style). Switching between them morphs the
+  // same DOM elements via transform transitions — no teardown / rebuild.
+  // See docs/tile-clusters-design.md Step 1 for the mental model.
+  let mode = "carousel";
+
   // ── Persistence ──────────────────────────────────────────────────────
 
   function save() {
@@ -332,6 +338,7 @@ export function createCardCarousel({
 
   function positionCards(animate = true, focusedWidth) {
     if (!focusedId) return;
+    if (mode === "expose") { positionExpose(animate); return; }
     const focusedIdx = cards.indexOf(focusedId);
     if (focusedIdx === -1) return;
 
@@ -396,6 +403,118 @@ export function createCardCarousel({
     }
   }
 
+  // ── Exposé layout ────────────────────────────────────────────────────
+  //
+  // Grid-packs every card so all tiles are visible at once. Same DOM
+  // elements as carousel — we only change the target transform. Each
+  // `.carousel-card` is absolutely positioned with `left:50%` plus a
+  // negative `margin-left` that centers the card on the container's
+  // horizontal axis; its natural position is therefore the container
+  // center. Exposé positions are expressed as a translate *away from
+  // that center point* plus a uniform scale, which lets the existing
+  // `transition: transform` rule handle the morph with no layout change.
+  //
+  // This IS the FLIP technique's "play" phase. Full FLIP (measure
+  // first/last, invert-transform, transition to identity) is only
+  // necessary when layout flow actually changes between states.
+  // Katulong's carousel already positions via `transform` at all times,
+  // so the first and last DOM positions are identical — only the
+  // transform value changes. Swapping target transforms across a
+  // transition gives visually identical results to a full FLIP pass
+  // without the forced-reflow cost of getBoundingClientRect().
+  //
+  // Packing: simple row-major grid with ceil(sqrt(n)) columns. The
+  // existing tile chrome is reused as-is — tiles shrink proportionally
+  // via scale() rather than reflowing their contents, which sidesteps
+  // the "multiple terminal dimensions" trap called out in CLAUDE.md
+  // (PTYs only have one size; reflowing a TUI to a mini-cell and back
+  // would garble it). Since we only scale, tmux is never notified and
+  // the underlying terminal keeps its real dims. resize() is therefore
+  // deliberately NOT called on exposé entry/exit.
+  function computeExposeCells() {
+    const n = cards.length;
+    if (n === 0) return new Map();
+    const cw = container.offsetWidth || 800;
+    const ch = container.offsetHeight || 600;
+    const cols = Math.max(1, Math.ceil(Math.sqrt(n)));
+    const rows = Math.max(1, Math.ceil(n / cols));
+    // Pack more tightly than macOS Exposé (per design doc): small
+    // outer padding, small inter-cell gap.
+    const pad = 24;
+    const gap = 16;
+    const cellW = (cw - 2 * pad - (cols - 1) * gap) / cols;
+    const cellH = (ch - 2 * pad - (rows - 1) * gap) / rows;
+
+    const cells = new Map();
+    for (let i = 0; i < cards.length; i++) {
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      // Cell center relative to container top-left.
+      const cellCx = pad + col * (cellW + gap) + cellW / 2;
+      const cellCy = pad + row * (cellH + gap) + cellH / 2;
+      // Card natural center (before any transform) = container center
+      // horizontally + (top inset + height/2) vertically. We don't know
+      // the exact card rendered size without a measurement, but we
+      // only need the *delta* from natural center to target cell, so
+      // expressing the translate in viewport/container coords and
+      // letting the scale() shrink the chrome works regardless.
+      const dx = cellCx - cw / 2;
+      // Natural vertical center: card occupies top:var(--card-inset-top)
+      // to bottom:var(--card-inset-bottom), i.e. ~ch/2 in practice.
+      const dy = cellCy - ch / 2;
+
+      // Scale to fit: compare cell size to the card's natural size.
+      // We use cardWidthOf() for width and approximate natural height
+      // as (ch - insets). defaultCardGap has the inset values baked
+      // into CSS; reading offsetHeight here would force reflow, so
+      // approximate conservatively.
+      const naturalW = cardWidthOf(cards[i]);
+      const naturalH = Math.max(200, ch - 16); // matches --card-inset-*
+      const scale = Math.min(cellW / naturalW, cellH / naturalH, 1);
+
+      cells.set(cards[i], { dx, dy, scale });
+    }
+    return cells;
+  }
+
+  function positionExpose(animate = true) {
+    if (!defaultCardW) computeDefaultCardWidth();
+    const cells = computeExposeCells();
+
+    for (const [id, { wrapper }] of cardEls) {
+      const cell = cells.get(id);
+      if (!cell) continue;
+      if (!animate) wrapper.style.transition = "none";
+      wrapper.style.transform =
+        `translate(${cell.dx}px, ${cell.dy}px) scale(${cell.scale})`;
+      // In exposé every card must be visible — carousel hides cards
+      // more than 2 steps away from focus for perf, but that rule is
+      // nonsense at this zoom level.
+      wrapper.classList.remove("carousel-hidden");
+      wrapper.classList.toggle("focused", id === focusedId);
+      if (!animate) {
+        wrapper.offsetHeight;
+        requestAnimationFrame(() => { wrapper.style.transition = ""; });
+      }
+    }
+  }
+
+  /**
+   * Switch view mode. Same DOM elements morph between carousel and
+   * exposé layouts via their existing transform transition. The caller
+   * (pinch gesture controller) decides when to commit; this function
+   * is the cheap atomic switch.
+   */
+  function setMode(next) {
+    if (next !== "carousel" && next !== "expose") return;
+    if (mode === next) return;
+    mode = next;
+    container.dataset.mode = next;
+    positionCards(true);
+  }
+
+  function getMode() { return mode; }
+
   // ── Tile context builder ────────────────────────────────────────────
 
   /** Build a TileContext for a tile, including chrome and flip access. */
@@ -450,6 +569,7 @@ export function createCardCarousel({
     }
 
     container.dataset.carousel = "true";
+    container.dataset.mode = mode;
     positionCards(false);
     save();
 
@@ -480,6 +600,8 @@ export function createCardCarousel({
 
     // Remove card wrappers
     delete container.dataset.carousel;
+    delete container.dataset.mode;
+    mode = "carousel";
     for (const el of [...container.querySelectorAll(".carousel-card")]) {
       el.remove();
     }
@@ -767,5 +889,7 @@ export function createCardCarousel({
     setBackTile,
     flipCard,
     isFlipped,
+    setMode,
+    getMode,
   };
 }

--- a/public/lib/card-carousel.js
+++ b/public/lib/card-carousel.js
@@ -71,6 +71,14 @@ export function createCardCarousel({
   // See docs/tile-clusters-design.md Step 1 for the mental model.
   let mode = "carousel";
 
+  // Snapshot localStorage at construction, BEFORE anything can call save().
+  // The boot sequence in app.js activates a terminal tile from the ?s= URL
+  // param and only calls restore() later inside a setTimeout. That initial
+  // activate() fires save() with only the terminal, overwriting any
+  // previously persisted non-terminal tiles (e.g. file browsers). Capturing
+  // the raw state here preserves the pre-boot snapshot for restore().
+  let initialStoredState = null;
+
   // ── Persistence ──────────────────────────────────────────────────────
 
   function save() {
@@ -128,6 +136,7 @@ export function createCardCarousel({
         // works but looks like a bug.
         const persistedIds = new Set(serialized.map(s => s.id));
         const persistedFocus = persistedIds.has(focusedId) ? focusedId : null;
+        console.log("[carousel.save] " + JSON.stringify(serialized.map(s => ({id: s.id, type: s.type}))) + " focus=" + persistedFocus);
         localStorage.setItem(STORAGE_KEY, JSON.stringify({
           cards: serialized,
           focused: persistedFocus,
@@ -155,8 +164,16 @@ export function createCardCarousel({
     return null;
   }
 
+  // Capture the pre-boot snapshot immediately at construction, before any
+  // activate()/addCard() call can fire save() and clobber it.
+  initialStoredState = parseStoredState();
+  console.log("[carousel.construct] initialStoredState=" + JSON.stringify(initialStoredState?.cards?.map(c => ({id: c?.id, type: c?.type})) || null) + " rawLS=" + (localStorage.getItem(STORAGE_KEY) || "null").slice(0, 300));
+
   function restore() {
-    const state = parseStoredState();
+    // Use the snapshot captured at construction, not the live localStorage —
+    // see comment on `initialStoredState`. Falls back to parseStoredState()
+    // if the snapshot wasn't captured for any reason (defensive).
+    const state = initialStoredState || parseStoredState();
     if (!state) return null;
 
     // Truncate on read too. A user upgrading into this cap for the first
@@ -202,7 +219,9 @@ export function createCardCarousel({
     // manually clear their storage to stop seeing a phantom file
     // browser on every reload. Idempotent — runs every restore, drops
     // zero entries once the storage is clean.
+    console.log("[carousel.restore] raw " + JSON.stringify(rawCards.map(c => ({id: c?.id, type: c?.type}))));
     const tiles = rawCards.filter(c => isTypePersistable(c?.type));
+    console.log("[carousel.restore] after typefilter " + JSON.stringify(tiles.map(c => ({id: c?.id, type: c?.type}))));
     const focused = tiles.some(c => (typeof c === "string" ? c : c?.id) === state.focused)
       ? state.focused
       : null;

--- a/public/lib/card-carousel.js
+++ b/public/lib/card-carousel.js
@@ -517,7 +517,25 @@ export function createCardCarousel({
 
   // ── Tile context builder ────────────────────────────────────────────
 
-  /** Build a TileContext for a tile, including chrome and flip access. */
+  /** Build a TileContext for a tile, including chrome and faceStack access.
+   *
+   * `ctx.faceStack` is the tile-facing abstraction that replaced the
+   * previous `deps.carousel.{setBackTile,flipCard,isFlipped}` reach-around
+   * (see Tier 1 T1a, docs/tile-clusters-design.md). It exposes a minimal
+   * "this tile may have a secondary face" affordance:
+   *
+   *   setSecondary(tile)     — attach/replace the back-face tile
+   *   showSecondary(bool)    — flip to the secondary face (true) or primary (false)
+   *   isShowingSecondary()   — is the back face currently visible?
+   *
+   * Shaped deliberately to be additive for T2c (face-stack-of-N). Today
+   * there are only two faces (primary + secondary), so the API stays
+   * boolean; when N>2 lands, `setSecondary` will gain index-aware siblings
+   * without breaking existing callers. The terminal tile uses this to
+   * drive its auto-flip-on-idle behavior without ever touching
+   * deps.carousel — which kills the circular wiring that app.js used to
+   * plumb via a lazy getter.
+   */
   function buildTileContext(tileId, tile, entry) {
     const base = createTileContext ? createTileContext(tileId, tile) : { tileId };
     // Determine which chrome this tile is mounted in
@@ -525,6 +543,11 @@ export function createCardCarousel({
     return {
       ...base,
       flip: () => flipCard(tileId),
+      faceStack: {
+        setSecondary: (secondary) => setBackTile(tileId, secondary),
+        showSecondary: (show) => flipCard(tileId, show),
+        isShowingSecondary: () => isFlipped(tileId),
+      },
       get chrome() {
         // Return the chrome for whichever face this tile is on
         return isFront ? entry.frontChrome?.chrome : entry.backChrome?.chrome;
@@ -886,9 +909,6 @@ export function createCardCarousel({
     fitAll,
     save,
     restore,
-    setBackTile,
-    flipCard,
-    isFlipped,
     setMode,
     getMode,
   };

--- a/public/lib/card-carousel.js
+++ b/public/lib/card-carousel.js
@@ -136,7 +136,6 @@ export function createCardCarousel({
         // works but looks like a bug.
         const persistedIds = new Set(serialized.map(s => s.id));
         const persistedFocus = persistedIds.has(focusedId) ? focusedId : null;
-        console.log("[carousel.save] " + JSON.stringify(serialized.map(s => ({id: s.id, type: s.type}))) + " focus=" + persistedFocus);
         localStorage.setItem(STORAGE_KEY, JSON.stringify({
           cards: serialized,
           focused: persistedFocus,
@@ -167,8 +166,6 @@ export function createCardCarousel({
   // Capture the pre-boot snapshot immediately at construction, before any
   // activate()/addCard() call can fire save() and clobber it.
   initialStoredState = parseStoredState();
-  console.log("[carousel.construct] initialStoredState=" + JSON.stringify(initialStoredState?.cards?.map(c => ({id: c?.id, type: c?.type})) || null) + " rawLS=" + (localStorage.getItem(STORAGE_KEY) || "null").slice(0, 300));
-
   function restore() {
     // Use the snapshot captured at construction, not the live localStorage —
     // see comment on `initialStoredState`. Falls back to parseStoredState()
@@ -219,9 +216,7 @@ export function createCardCarousel({
     // manually clear their storage to stop seeing a phantom file
     // browser on every reload. Idempotent — runs every restore, drops
     // zero entries once the storage is clean.
-    console.log("[carousel.restore] raw " + JSON.stringify(rawCards.map(c => ({id: c?.id, type: c?.type}))));
     const tiles = rawCards.filter(c => isTypePersistable(c?.type));
-    console.log("[carousel.restore] after typefilter " + JSON.stringify(tiles.map(c => ({id: c?.id, type: c?.type}))));
     const focused = tiles.some(c => (typeof c === "string" ? c : c?.id) === state.focused)
       ? state.focused
       : null;

--- a/public/lib/card-carousel.js
+++ b/public/lib/card-carousel.js
@@ -26,12 +26,39 @@ const STORAGE_KEY = "katulong-carousel";
 // oldest-first on save, keeping the most recently focused cards.
 const MAX_PERSISTED_CARDS = 50;
 
+/**
+ * Is the given tile instance persistable across page reloads?
+ *
+ * Tile persistence is a *capability*, not a default. A tile opts out of
+ * persistence by setting `persistable: false` on its prototype. Today
+ * the file-browser tile is the only opt-out — it has no tmux-backed
+ * state, so "remember across reload" would just resurrect an empty
+ * pane for no reason. Terminal and cluster tiles omit the flag and
+ * default to persistable, preserving prior behavior.
+ *
+ * Tier 2 will generalize this to a richer capability snapshot emitted
+ * by the tile prototype; until then, a single boolean at the save /
+ * restore seam keeps the opt-out one-line per tile kind.
+ */
+function isTilePersistable(tile) {
+  return tile?.persistable !== false;
+}
+
 export function createCardCarousel({
   container,
   onFocusChange,
   onCardDismissed,
   onAllCardsDismissed,
   createTileContext,
+  /**
+   * Optional predicate for the *restore* path: given a tile type string
+   * from persisted JSON, should we rebuild it? Save() already filters
+   * non-persistable tiles from being written, but users upgrading from
+   * a buggy build may have stale entries in their localStorage. This
+   * hook lets the host (app.js) drop them on read so nobody has to
+   * manually clear their storage. Defaults to "yes, restore everything".
+   */
+  isTypePersistable = () => true,
 }) {
   let active = false;
   let cards = [];             // ordered tile IDs
@@ -48,22 +75,34 @@ export function createCardCarousel({
 
   function save() {
     try {
-      if (active && cards.length > 0) {
+      // Filter out non-persistable tiles (e.g. file-browser). Persistence
+      // is a capability the tile opts into by omitting `persistable:
+      // false`. Doing the filter at the top of save() — not inside the
+      // map — means the MAX_PERSISTED_CARDS cap below is computed over
+      // *persistable* cards, so a window full of ephemeral file-browser
+      // tiles can't push real terminal tabs out of the cap.
+      const persistableCards = cards.filter(id => {
+        const entry = cardEls.get(id);
+        return entry && isTilePersistable(entry.tile);
+      });
+      if (active && persistableCards.length > 0) {
         // Cap: if we're somehow above MAX_PERSISTED_CARDS, drop the oldest
         // entries (beginning of the array) and keep the most recent. The
         // focused card is promoted to the kept tail so user focus is never
         // the one thrown away. This is defensive — the UI shouldn't
         // normally mount this many cards, but phantom-leak bugs can push
         // past it, and the cap keeps one bad boot from cascading forever.
-        let toPersist = cards;
-        if (cards.length > MAX_PERSISTED_CARDS) {
-          const overflow = cards.length - MAX_PERSISTED_CARDS;
+        let toPersist = persistableCards;
+        if (toPersist.length > MAX_PERSISTED_CARDS) {
+          const overflow = toPersist.length - MAX_PERSISTED_CARDS;
           console.warn(
-            `[carousel] ${cards.length} cards exceeds persist cap ` +
+            `[carousel] ${toPersist.length} cards exceeds persist cap ` +
             `${MAX_PERSISTED_CARDS}; dropping ${overflow} oldest entries from storage`
           );
-          toPersist = cards.slice(-MAX_PERSISTED_CARDS);
-          if (focusedId && !toPersist.includes(focusedId) && cards.includes(focusedId)) {
+          toPersist = toPersist.slice(-MAX_PERSISTED_CARDS);
+          // Promote focused card to the kept tail only if it's itself
+          // persistable — otherwise we'd be writing a non-persistable id.
+          if (focusedId && !toPersist.includes(focusedId) && persistableCards.includes(focusedId)) {
             toPersist = [focusedId, ...toPersist.slice(0, -1)];
           }
         }
@@ -81,9 +120,17 @@ export function createCardCarousel({
           }
           return base;
         }).filter(Boolean);
+        // Only persist `focused` if it's actually in the serialized set.
+        // Focusing a non-persistable tile (e.g. a file browser) should
+        // not leave a dangling focused id pointing at nothing after
+        // reload — restore() would try to focus a tile it didn't
+        // rebuild and fall back to the first tile silently, which
+        // works but looks like a bug.
+        const persistedIds = new Set(serialized.map(s => s.id));
+        const persistedFocus = persistedIds.has(focusedId) ? focusedId : null;
         localStorage.setItem(STORAGE_KEY, JSON.stringify({
           cards: serialized,
-          focused: focusedId,
+          focused: persistedFocus,
         }));
       } else {
         localStorage.removeItem(STORAGE_KEY);
@@ -149,7 +196,17 @@ export function createCardCarousel({
       };
     }
 
-    return { tiles: rawCards, focused: state.focused };
+    // Storage migration: drop any entry whose tile type is known to be
+    // non-persistable. A previous (buggy) build wrote file-browser
+    // tiles into localStorage; users on that build shouldn't have to
+    // manually clear their storage to stop seeing a phantom file
+    // browser on every reload. Idempotent — runs every restore, drops
+    // zero entries once the storage is clean.
+    const tiles = rawCards.filter(c => isTypePersistable(c?.type));
+    const focused = tiles.some(c => (typeof c === "string" ? c : c?.id) === state.focused)
+      ? state.focused
+      : null;
+    return { tiles, focused };
   }
 
   /**

--- a/public/lib/card-carousel.js
+++ b/public/lib/card-carousel.js
@@ -543,6 +543,13 @@ export function createCardCarousel({
     return {
       ...base,
       flip: () => flipCard(tileId),
+      // Tile-initiated close. A tile calls this when it wants to be
+      // removed from its container (e.g. file-browser's own X button).
+      // Routes through removeCard so onCardDismissed fires and the
+      // windowTabSet / subscriptions stay consistent. Deferred via
+      // queueMicrotask so callers can finish their click handler
+      // before the DOM is torn out from under them.
+      requestClose: () => { queueMicrotask(() => removeCard(tileId)); },
       faceStack: {
         setSecondary: (secondary) => setBackTile(tileId, secondary),
         showSecondary: (show) => flipCard(tileId, show),

--- a/public/lib/file-browser/file-browser-component.js
+++ b/public/lib/file-browser/file-browser-component.js
@@ -295,12 +295,19 @@ export function createFileBrowserComponent(store, options = {}) {
       renderSingleColumn(colEl, columns[i], i);
     }
 
-    // Auto-scroll to the rightmost column when a new column was added
-    if (columns.length > prevColumnCount && columns.length > 0) {
-      const lastColEl = columnsEl.lastElementChild;
-      if (lastColEl) {
-        lastColEl.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "end" });
-      }
+    // Auto-scroll horizontally so the newly opened column is visible.
+    // Why rAF + direct scrollLeft instead of scrollIntoView: the last column
+    // has `flex: 1` (so a single-column browser fills the pane). When content
+    // overflows, scrollIntoView({inline:"end"}) considers the last column
+    // already "in view" because its right edge is flush with the container —
+    // nothing scrolls. Writing scrollLeft = scrollWidth after layout settles
+    // pins the deepest column to the right edge regardless of flex sizing.
+    // Runs on every render (not just count-change) so that drilling deeper
+    // via keyboard, or refreshing into a pre-selected deep path, also scrolls.
+    if (columns.length > 0) {
+      requestAnimationFrame(() => {
+        if (columnsEl) columnsEl.scrollLeft = columnsEl.scrollWidth;
+      });
     }
     prevColumnCount = columns.length;
   }

--- a/public/lib/file-browser/file-browser-component.js
+++ b/public/lib/file-browser/file-browser-component.js
@@ -68,9 +68,17 @@ export function createFileBrowserComponent(store, options = {}) {
   });
 
   function mount(el) {
-    container = el;
-    container.innerHTML = "";
-    container.className = "file-browser";
+    // The component owns a child element (.fb-root), not the parent
+    // element passed in. Previously mount() stamped `container.className
+    // = "file-browser"` on its host, forcing file-browser-tile.js to
+    // wrap it in an extra <div> so tile-chrome's `.tile-content` flex
+    // rules wouldn't get clobbered. Tier 1 T1b fixes that: we create
+    // and append our own root div here, and the tile mounts the
+    // component directly on its content element.
+    const root = document.createElement("div");
+    root.className = "fb-root";
+    el.appendChild(root);
+    container = root;
 
     container.innerHTML = `
       <div class="fb-toolbar">
@@ -363,6 +371,12 @@ export function createFileBrowserComponent(store, options = {}) {
     if (unsubscribe) unsubscribe();
     unsubscribe = null;
     contextMenu.close();
+    // Remove the .fb-root child we appended in mount(). The parent
+    // element belongs to the caller (tile-chrome) — we must not
+    // touch its className or its other children.
+    if (container && container.parentElement) {
+      container.parentElement.removeChild(container);
+    }
     container = null;
     columnsEl = null;
   }

--- a/public/lib/file-browser/file-browser-store.js
+++ b/public/lib/file-browser/file-browser-store.js
@@ -11,7 +11,7 @@ import { api } from "/lib/api-client.js";
 const initialState = {
   columns: [],         // [{ path, entries, selected, loading, error }]
   clipboard: null,     // { action: "copy"|"cut", items: [...paths] }
-  showHidden: localStorage.getItem("katulong-fb-show-hidden") !== "0",
+  showHidden: localStorage.getItem("katulong-fb-show-hidden") === "1",
 };
 
 const handlers = {

--- a/public/lib/pinch-gesture.js
+++ b/public/lib/pinch-gesture.js
@@ -1,0 +1,181 @@
+/**
+ * Pinch gesture detector — unified touch + trackpad.
+ *
+ * Emits a simple (scale, phase) stream so callers can drive a morph/zoom
+ * without caring about the input source. Two input sources are supported
+ * from day one because katulong is developed on a Mac mini (trackpad) and
+ * used on iPad / phone (touch):
+ *
+ *   - Touch / stylus: two active PointerEvents tracked by pointerId.
+ *     Scale = currentDistance / startDistance.
+ *   - Trackpad: macOS/Windows expose trackpad pinch as `wheel` events with
+ *     `ctrlKey` set (even when the Control key is not held — the browser
+ *     synthesizes it). Scale accumulates as `exp(-deltaY * k)` so a
+ *     continuous stream of small deltas produces a smooth multiplicative
+ *     scale. A short idle timeout closes the gesture.
+ *
+ * No external library. No DOM knowledge beyond attaching listeners to the
+ * target element — layout response is the caller's job.
+ *
+ * Phases:
+ *   - "start": first frame of a new gesture; scale === 1
+ *   - "move":  continuous updates; scale is current / initial
+ *   - "end":   gesture released; caller should commit or snap back.
+ *              The final scale value is passed so the caller can decide
+ *              whether it crossed a commit threshold.
+ *
+ * Deliberately NOT a general multi-touch handler. We do not rotate, we do
+ * not pan, we do not long-press. Step 1 only needs "is the user pinching,
+ * and by how much". Future gestures (two-finger swipe between clusters,
+ * three-finger, etc.) will live in their own modules so this one stays
+ * small and auditable.
+ */
+
+const WHEEL_SCALE_K = 0.01;       // sensitivity for trackpad pinch
+const WHEEL_IDLE_MS = 120;        // gap that ends a wheel gesture
+const MIN_ACTIVATION = 0.03;      // ignore sub-pixel jitter before "start"
+
+export function createPinchGesture({ target, onPinch }) {
+  if (!target || typeof onPinch !== "function") {
+    throw new Error("createPinchGesture: target and onPinch required");
+  }
+
+  // ── Touch state (two-pointer tracking) ────────────────────────────
+  const pointers = new Map(); // pointerId -> {x, y}
+  let touchStartDistance = 0;
+  let touchActive = false;
+  let touchActivated = false; // has scale crossed MIN_ACTIVATION?
+
+  function distance() {
+    const pts = [...pointers.values()];
+    if (pts.length < 2) return 0;
+    const dx = pts[0].x - pts[1].x;
+    const dy = pts[0].y - pts[1].y;
+    return Math.hypot(dx, dy);
+  }
+
+  function onPointerDown(e) {
+    // Only track primary pointers from touch or pen. Ignore mouse —
+    // trackpad pinch comes through the wheel path below, not pointer
+    // events, and a real mouse cannot two-finger pinch.
+    if (e.pointerType !== "touch" && e.pointerType !== "pen") return;
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+    if (pointers.size === 2 && !touchActive) {
+      touchActive = true;
+      touchActivated = false;
+      touchStartDistance = distance();
+    }
+  }
+
+  function onPointerMove(e) {
+    if (!pointers.has(e.pointerId)) return;
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (!touchActive || touchStartDistance === 0) return;
+
+    const d = distance();
+    if (d === 0) return;
+    const scale = d / touchStartDistance;
+
+    if (!touchActivated) {
+      if (Math.abs(scale - 1) < MIN_ACTIVATION) return;
+      touchActivated = true;
+      onPinch({ scale: 1, phase: "start" });
+      // Prevent native pinch-zoom / scroll from fighting us once we
+      // commit to handling the gesture. Doing this before activation
+      // would eat legitimate single-finger scrolls.
+      e.preventDefault();
+    }
+    e.preventDefault();
+    onPinch({ scale, phase: "move" });
+  }
+
+  function onPointerEndLike(e) {
+    const hadPointer = pointers.delete(e.pointerId);
+    if (!hadPointer) return;
+    if (touchActive && pointers.size < 2) {
+      // Gesture ends the moment we drop below two fingers, even if the
+      // other finger is still down.
+      if (touchActivated) {
+        const lastScale = touchStartDistance > 0
+          ? distance() / touchStartDistance
+          : 1;
+        onPinch({ scale: lastScale, phase: "end" });
+      }
+      touchActive = false;
+      touchActivated = false;
+      touchStartDistance = 0;
+    }
+  }
+
+  // ── Wheel state (trackpad pinch) ──────────────────────────────────
+  let wheelActive = false;
+  let wheelScale = 1;
+  let wheelIdleTimer = null;
+
+  function endWheel() {
+    if (!wheelActive) return;
+    const finalScale = wheelScale;
+    wheelActive = false;
+    wheelScale = 1;
+    wheelIdleTimer = null;
+    onPinch({ scale: finalScale, phase: "end" });
+  }
+
+  function onWheel(e) {
+    // Only trackpad pinch — ctrlKey is the cross-browser signal.
+    // Real Ctrl+wheel (page zoom) is what browsers emit here too, so
+    // this captures both: if the user actually Ctrl+scrolls on a mouse
+    // wheel we still treat it as a pinch, which is the desired verb.
+    if (!e.ctrlKey) return;
+    e.preventDefault();
+
+    if (!wheelActive) {
+      wheelActive = true;
+      wheelScale = 1;
+      onPinch({ scale: 1, phase: "start" });
+    }
+    // Multiplicative accumulation: each delta scales from the current
+    // value, so the gesture feels exponential (like native pinch)
+    // rather than linear. Negative deltaY = pinch out = zoom in.
+    wheelScale *= Math.exp(-e.deltaY * WHEEL_SCALE_K);
+    // Clamp so a runaway delta can't push scale to absurd values
+    // mid-gesture; the commit threshold is typically ~1.15 anyway.
+    wheelScale = Math.max(0.2, Math.min(5, wheelScale));
+    onPinch({ scale: wheelScale, phase: "move" });
+
+    if (wheelIdleTimer) clearTimeout(wheelIdleTimer);
+    wheelIdleTimer = setTimeout(endWheel, WHEEL_IDLE_MS);
+  }
+
+  // ── Attach / detach ───────────────────────────────────────────────
+  function attach() {
+    target.addEventListener("pointerdown", onPointerDown, { passive: true });
+    target.addEventListener("pointermove", onPointerMove, { passive: false });
+    target.addEventListener("pointerup", onPointerEndLike, { passive: true });
+    target.addEventListener("pointercancel", onPointerEndLike, { passive: true });
+    target.addEventListener("pointerleave", onPointerEndLike, { passive: true });
+    // wheel MUST be non-passive so preventDefault() actually stops
+    // browser page-zoom during trackpad pinch.
+    target.addEventListener("wheel", onWheel, { passive: false });
+  }
+
+  function detach() {
+    target.removeEventListener("pointerdown", onPointerDown);
+    target.removeEventListener("pointermove", onPointerMove);
+    target.removeEventListener("pointerup", onPointerEndLike);
+    target.removeEventListener("pointercancel", onPointerEndLike);
+    target.removeEventListener("pointerleave", onPointerEndLike);
+    target.removeEventListener("wheel", onWheel);
+    if (wheelIdleTimer) clearTimeout(wheelIdleTimer);
+    wheelIdleTimer = null;
+    pointers.clear();
+    touchActive = false;
+    touchActivated = false;
+    touchStartDistance = 0;
+    wheelActive = false;
+    wheelScale = 1;
+  }
+
+  return { attach, detach };
+}

--- a/public/lib/shortcut-bar.js
+++ b/public/lib/shortcut-bar.js
@@ -17,6 +17,7 @@ import { renderKeyIsland } from "/lib/key-island.js";
 import { renderDesktopTabs } from "/lib/shortcut-bar-desktop.js";
 import { renderIPadBar } from "/lib/shortcut-bar-ipad.js";
 import { renderPhoneBar } from "/lib/shortcut-bar-phone.js";
+import "/lib/tile-tab-bar.js"; // registers <tile-tab-bar> custom element
 
 const DRAG_OUT_THRESHOLD = 60; // px below bar to trigger tear-off (desktop)
 const DRAG_DEAD_ZONE = 5; // px before drag starts
@@ -54,6 +55,7 @@ export function createShortcutBar(options = {}) {
     sessionStore,
     windowTabSet,
     carousel,
+    uiStore,
   } = options;
 
   let currentSessionName = "";
@@ -1028,20 +1030,23 @@ export function createShortcutBar(options = {}) {
     container.classList.add("bar-ipad");
     document.body.dataset.platform = platform;
 
-    // Unified tab bar — all platforms use the same renderer
-    // with the card carousel layout.
-    const sessions = getSessionList();
-    // When the carousel is active, the highlighted tab must track the
-    // carousel's focused card id — which may be a non-terminal tile id
-    // like `file-browser-xxx`. Callers pass `state.session.name` (the
-    // terminal) for the active name, which would otherwise light up the
-    // wrong tab whenever a file browser is front-and-center.
-    const activeId = carousel?.isActive?.() ? (carousel.getFocusedCard?.() || sessionName) : sessionName;
-    console.log("[bar.render] sessionName=" + sessionName + " carouselActive=" + carousel?.isActive?.() + " focusedCard=" + carousel?.getFocusedCard?.() + " activeId=" + activeId);
-    _renderIPadBar(activeId, sessions);
-
-    // Adaptive tab truncation — fit tabs to available width
-    requestAnimationFrame(() => fitTabLabels());
+    // ── Tab strip ──────────────────────────────────────────────────
+    // When ui-store is wired, mount the declarative <tile-tab-bar> web
+    // component. It self-manages from the store — no getSessionList()
+    // shim, no activeId derivation, no fitTabLabels() call. One element,
+    // one source of truth.
+    //
+    // Legacy path (no uiStore): imperative iPad bar renderer.
+    if (uiStore) {
+      const tabBar = document.createElement("tile-tab-bar");
+      tabBar.store = uiStore;
+      container.appendChild(tabBar);
+    } else {
+      const sessions = getSessionList();
+      const activeId = carousel?.isActive?.() ? (carousel.getFocusedCard?.() || sessionName) : sessionName;
+      _renderIPadBar(activeId, sessions);
+      requestAnimationFrame(() => fitTabLabels());
+    }
 
     // Tool row — pinned keys + utility buttons, docked inside the bar
     renderKeyIsland({
@@ -1151,6 +1156,7 @@ export function createShortcutBar(options = {}) {
     renameTabEl,
     beginRename,
     showAddMenu,
+    showMenuFromHost: showMenu,
     setPortProxyEnabled(enabled) {
       portProxyEnabled = enabled;
       const btn = document.getElementById("bar-portfwd-btn");

--- a/public/lib/shortcut-bar.js
+++ b/public/lib/shortcut-bar.js
@@ -527,7 +527,16 @@ export function createShortcutBar(options = {}) {
       if (drag?.isTouch) return; // touch owns the gesture
 
       if (!started) {
-        if (name !== currentSessionName) {
+        // Compare against the carousel's focused tile id, not
+        // currentSessionName. When a non-terminal tile (e.g. file
+        // browser) is focused, currentSessionName still holds the
+        // backing terminal session, so clicking the terminal tab while
+        // the file browser is focused would short-circuit here and
+        // never switch. The carousel's focused card is the real
+        // "what's front-and-center" answer.
+        const focusedCardId = carousel?.isActive?.() ? carousel.getFocusedCard?.() : null;
+        const currentId = focusedCardId || currentSessionName;
+        if (name !== currentId) {
           if (onTabClick) onTabClick(name);
         }
         return;
@@ -754,6 +763,16 @@ export function createShortcutBar(options = {}) {
       if (windowTabSet) {
         windowTabSet.reorderTabs(names);
       }
+      // Also reorder the carousel directly. windowTabSet.reorderTabs filters
+      // out ids it doesn't persist (e.g. file-browser tiles are session-scoped
+      // — see commit b86275c), so the subscribe() bridge would drop them from
+      // the order it forwards to carousel.reorderCards, which then re-appends
+      // missing ids at the end — exactly the "snaps back" symptom. Reordering
+      // the carousel here with the full names array keeps non-persisted tiles
+      // in their dragged position. Matches the moveTab() pattern in app.js.
+      if (carousel?.isActive?.()) {
+        carousel.reorderCards(names);
+      }
     }
 
     // drag is null now — flush any deferred render
@@ -841,13 +860,23 @@ export function createShortcutBar(options = {}) {
       // teaching it the tile taxonomy.
       const tile = carousel?.getTile?.(n);
       if (tile) {
+        let label = n;
+        try {
+          if (typeof tile.getTitle === "function") {
+            const t = tile.getTitle();
+            if (t) label = t;
+          }
+        } catch (_) { /* tile getTitle threw — fall through to id */ }
         return {
           name: n,
-          label: typeof tile.getTitle === "function" ? tile.getTitle() : n,
+          label,
           icon: typeof tile.getIcon === "function" ? tile.getIcon() : null,
           tileType: tile.type || null,
         };
       }
+      // No tile registered — best-effort friendly label for known id
+      // prefixes so stale tab entries don't show raw tile ids.
+      if (n.startsWith("file-browser-")) return { name: n, label: "Files", icon: "folder" };
       return { name: n };
     }).filter(Boolean);
   }
@@ -1002,7 +1031,14 @@ export function createShortcutBar(options = {}) {
     // Unified tab bar — all platforms use the same renderer
     // with the card carousel layout.
     const sessions = getSessionList();
-    _renderIPadBar(sessionName, sessions);
+    // When the carousel is active, the highlighted tab must track the
+    // carousel's focused card id — which may be a non-terminal tile id
+    // like `file-browser-xxx`. Callers pass `state.session.name` (the
+    // terminal) for the active name, which would otherwise light up the
+    // wrong tab whenever a file browser is front-and-center.
+    const activeId = carousel?.isActive?.() ? (carousel.getFocusedCard?.() || sessionName) : sessionName;
+    console.log("[bar.render] sessionName=" + sessionName + " carouselActive=" + carousel?.isActive?.() + " focusedCard=" + carousel?.getFocusedCard?.() + " activeId=" + activeId);
+    _renderIPadBar(activeId, sessions);
 
     // Adaptive tab truncation — fit tabs to available width
     requestAnimationFrame(() => fitTabLabels());

--- a/public/lib/shortcut-bar.js
+++ b/public/lib/shortcut-bar.js
@@ -771,13 +771,15 @@ export function createShortcutBar(options = {}) {
     tab.setAttribute("aria-label", `Session: ${s.name}`);
 
     const iconEl = document.createElement("i");
-    iconEl.className = `ph ph-${iconForSession(s.name)}`;
+    // Non-terminal tiles provide their own icon via getSessionList shim.
+    iconEl.className = `ph ph-${s.icon || iconForSession(s.name)}`;
     tab.appendChild(iconEl);
 
     const nameSpan = document.createElement("span");
     nameSpan.className = "tab-label";
-    nameSpan.textContent = s.name;
-    nameSpan.dataset.fullName = s.name;
+    const displayLabel = s.label || s.name;
+    nameSpan.textContent = displayLabel;
+    nameSpan.dataset.fullName = displayLabel;
     tab.appendChild(nameSpan);
 
     // Double-click to rename
@@ -829,7 +831,25 @@ export function createShortcutBar(options = {}) {
     // Carousel is the source of truth for visual order when active
     const tabNames = carousel?.isActive() ? carousel.getCards() : windowTabSet.getTabs();
     const sessionMap = new Map(allSessions.map(s => [s.name, s]));
-    return tabNames.map(n => sessionMap.get(n) || { name: n }).filter(Boolean);
+    return tabNames.map(n => {
+      const existing = sessionMap.get(n);
+      if (existing) return existing;
+      // Non-terminal tile (e.g. file-browser): synthesize a session-like
+      // entry from the tile's own getTitle/getIcon. The tab bar doesn't
+      // know about tile types; branding a tile-specific label/icon via
+      // this shim keeps the unified tab render path working without
+      // teaching it the tile taxonomy.
+      const tile = carousel?.getTile?.(n);
+      if (tile) {
+        return {
+          name: n,
+          label: typeof tile.getTitle === "function" ? tile.getTitle() : n,
+          icon: typeof tile.getIcon === "function" ? tile.getIcon() : null,
+          tileType: tile.type || null,
+        };
+      }
+      return { name: n };
+    }).filter(Boolean);
   }
 
   function _renderIPadBar(sessionName, sessions) {

--- a/public/lib/shortcut-bar.js
+++ b/public/lib/shortcut-bar.js
@@ -269,37 +269,65 @@ export function createShortcutBar(options = {}) {
 
   /**
    * Show right-click context menu on a tab
+   *
+   * Note: in carousel mode, `sessionName` here is actually the tile ID,
+   * which for terminal tiles happens to equal the session name but for
+   * file-browser / cluster / future tile kinds does not. The tab bar
+   * still treats every tab uniformly, so we branch on the tile's `type`
+   * (looked up via the carousel) to decide which actions are meaningful.
+   * Tier 2 will replace this with a polymorphic onLayoutChange snapshot
+   * from the carousel; until then this is the surgical fix that keeps
+   * file-browser tiles closable without regressing terminal tiles.
    */
   function showTabContextMenu(e, sessionName) {
     e.preventDefault();
     const tab = e.currentTarget;
+    const tile = carousel?.getTile?.(sessionName);
+    const isTerminalLike = !tile || tile.type === "terminal" || tile.type === "cluster";
     const items = [
       {
         icon: "pencil-simple",
         label: "Rename",
         action: () => startTabRename(tab, sessionName)
       },
-      {
+    ];
+    if (isTerminalLike) {
+      items.push({
         icon: "eject",
         label: "Detach",
         action: () => detachTab(sessionName)
-      },
-      {
+      });
+      items.push({
         icon: "x-circle",
         label: "Kill session",
         danger: true,
         action: () => killTab(sessionName)
-      },
-      { divider: true },
-      {
+      });
+    } else {
+      // Non-terminal tiles (file browser, etc.) have no tmux session to
+      // detach from or kill. Close is the only meaningful destructive
+      // action — route it through closeTab so the carousel removes the
+      // card and onCardDismissed fires normally. Hitting the REST
+      // /sessions/:id endpoints with a tile ID would 404 and leave the
+      // tile stuck on screen (this was the original bug).
+      items.push({
+        icon: "x-circle",
+        label: "Close",
+        danger: true,
+        action: () => closeTab(sessionName)
+      });
+    }
+    if (isTerminalLike) {
+      items.push({ divider: true });
+      items.push({
         icon: "arrow-square-out",
         label: "Open in new window",
         action: () => {
           openInNewWindow(sessionName);
           closeTab(sessionName);
         }
-      }
-    ];
+      });
+    }
     showMenu(items, tab);
   }
 

--- a/public/lib/tile-host.js
+++ b/public/lib/tile-host.js
@@ -1,0 +1,208 @@
+/**
+ * Tile Host — reactive bridge between ui-store and card-carousel.
+ *
+ * Subscribes to the ui-store and translates state changes into carousel
+ * commands: mount new tiles, unmount removed ones, reorder, and shift
+ * focus. The carousel keeps its visual presentation (gestures, animations,
+ * expose mode) — tile-host just drives it declaratively from state.
+ *
+ * This replaces the imperative activate/addCard/removeCard/focusCard
+ * calls scattered across app.js, shortcut-bar.js, and the restore path.
+ * All tile lifecycle now flows through one subscription.
+ *
+ * Design: docs/tile-state-rewrite.md, Step 3.
+ */
+
+/**
+ * Create a tile host.
+ *
+ * @param {object} opts
+ * @param {object} opts.store — ui-store instance (getState, subscribe, dispatch)
+ * @param {object} opts.carousel — card-carousel instance
+ * @param {function} opts.getRenderer — (type) → renderer object (from tile-renderers registry)
+ * @param {function} [opts.onFocusChange] — called after carousel focus settles,
+ *   with (tileId, tileType). App.js uses this for WS subscription switching.
+ */
+export function createTileHost({ store, carousel, getRenderer, onFocusChange }) {
+  // Map<tileId, { unmount, focus, blur, resize, tile }>
+  const handles = new Map();
+  let prevState = null;
+  let unsubscribe = null;
+  // Guard against re-entrant subscription notifications. When tile-host
+  // dispatches UPDATE_PROPS (e.g. from a file-browser cwd change routed
+  // through the renderer's setTitle shim), the store fires subscribers
+  // synchronously. Without this guard, reconcile() would re-enter itself,
+  // see a half-updated prevState, and double-mount or double-unmount.
+  let reconciling = false;
+
+  function reconcile(state) {
+    if (reconciling) return;
+    reconciling = true;
+    try {
+      _reconcile(state);
+    } finally {
+      reconciling = false;
+    }
+  }
+
+  function _reconcile(state) {
+    const prev = prevState || { tiles: {}, order: [], focusedId: null };
+    prevState = state;
+
+    // ── Diff tiles ─────────────────────────────────────────────────
+    const prevIds = new Set(Object.keys(prev.tiles));
+    const nextIds = new Set(Object.keys(state.tiles));
+
+    // Removed tiles
+    for (const id of prevIds) {
+      if (!nextIds.has(id)) {
+        const handle = handles.get(id);
+        if (handle) {
+          // Let carousel handle DOM teardown (wrapper removal, chrome
+          // destroy, resize handles). We just need to tell it.
+          carousel.removeCard(id);
+          handles.delete(id);
+        }
+      }
+    }
+
+    // Added tiles — must activate carousel first if it's not active
+    const added = [];
+    for (const id of state.order) {
+      if (!prevIds.has(id) && nextIds.has(id)) {
+        added.push(id);
+      }
+    }
+
+    if (added.length > 0 && !carousel.isActive()) {
+      // First tiles ever — activate the carousel with all current tiles
+      const tilesToActivate = state.order.map(id => {
+        const tileDesc = state.tiles[id];
+        const renderer = getRenderer(tileDesc.type);
+        if (!renderer) return null;
+        // Create a thin tile adapter that carousel can mount
+        const adapter = _createAdapter(id, tileDesc, renderer, store.dispatch);
+        return { id, tile: adapter };
+      }).filter(Boolean);
+
+      carousel.activate(tilesToActivate, state.focusedId);
+
+      // Stash handles from the adapters that carousel just mounted
+      for (const { id, tile: adapter } of tilesToActivate) {
+        if (adapter._handle) handles.set(id, adapter._handle);
+      }
+    } else {
+      // Carousel already active — add new tiles individually
+      for (const id of added) {
+        const tileDesc = state.tiles[id];
+        const renderer = getRenderer(tileDesc.type);
+        if (!renderer) continue;
+        const adapter = _createAdapter(id, tileDesc, renderer, store.dispatch);
+        // Insert at the correct position in the carousel
+        const position = state.order.indexOf(id);
+        carousel.addCard(id, adapter, position >= 0 ? position : undefined);
+        if (adapter._handle) handles.set(id, adapter._handle);
+      }
+    }
+
+    // ── Reorder ────────────────────────────────────────────────────
+    // Only call reorder if the order actually changed and we didn't just
+    // activate (activate already sets the order).
+    if (added.length === 0 || carousel.isActive()) {
+      const currentCards = carousel.getCards();
+      if (!arraysEqual(currentCards, state.order)) {
+        carousel.reorderCards(state.order);
+      }
+    }
+
+    // ── Focus ──────────────────────────────────────────────────────
+    if (state.focusedId && state.focusedId !== carousel.getFocusedCard()) {
+      carousel.focusCard(state.focusedId);
+    }
+
+    // Notify app.js of focus change so it can do WS bookkeeping
+    if (state.focusedId !== prev.focusedId && onFocusChange) {
+      const tile = state.tiles[state.focusedId];
+      onFocusChange(state.focusedId, tile?.type || null);
+    }
+  }
+
+  /**
+   * Create a tile adapter that bridges the renderer interface to the
+   * carousel's TilePrototype duck-type expectations.
+   *
+   * The carousel calls tile.mount(el, ctx), tile.unmount(), tile.focus(),
+   * etc. on TilePrototype objects. The adapter implements this interface
+   * and delegates to the renderer's mount() handle internally.
+   */
+  function _createAdapter(id, tileDesc, renderer, dispatch) {
+    let handle = null;
+    const adapter = {
+      type: tileDesc.type,
+      // The carousel reads persistable on save — route through renderer
+      get persistable() { return renderer.describe(tileDesc.props).persistable !== false; },
+      get sessionName() {
+        // Terminal and cluster tiles need sessionName for WS bookkeeping
+        return tileDesc.props.sessionName || id;
+      },
+      setSessionName(newName) {
+        // Carousel rename — update the underlying tile handle if it exists
+        handle?.tile?.setSessionName?.(newName);
+      },
+      mount(el, ctx) {
+        handle = renderer.mount(el, { id, props: tileDesc.props, dispatch, ctx });
+        adapter._handle = handle;
+      },
+      unmount() {
+        handle?.unmount();
+        handle = null;
+      },
+      focus() { handle?.focus(); },
+      blur() { handle?.blur(); },
+      resize() { handle?.resize(); },
+      getTitle() { return renderer.describe(tileDesc.props).title; },
+      getIcon() { return renderer.describe(tileDesc.props).icon; },
+      serialize() {
+        return { type: tileDesc.type, ...tileDesc.props };
+      },
+      // For cluster sub-tiles
+      getSubTiles() { return handle?.tile?.getSubTiles?.() || []; },
+      // Stash for tile-host to grab after carousel.activate mounts it
+      _handle: null,
+    };
+    return adapter;
+  }
+
+  function init() {
+    // Leave prevState as null so the first reconcile sees an empty
+    // "previous" state and treats every tile in the store as "added".
+    // Without this, a pre-populated store (e.g. from loadFromStorage +
+    // RESET before init) would match prev === next, nothing would mount,
+    // and the carousel would stay empty after a page refresh.
+    reconcile(store.getState());
+    unsubscribe = store.subscribe((state) => {
+      reconcile(state);
+    });
+  }
+
+  function destroy() {
+    if (unsubscribe) { unsubscribe(); unsubscribe = null; }
+    handles.clear();
+    prevState = null;
+  }
+
+  /** Get the renderer handle for a tile (for WS bookkeeping, sub-tile access). */
+  function getHandle(id) {
+    return handles.get(id) || null;
+  }
+
+  return { init, destroy, getHandle };
+}
+
+function arraysEqual(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/public/lib/tile-host.js
+++ b/public/lib/tile-host.js
@@ -23,7 +23,7 @@
  * @param {function} [opts.onFocusChange] — called after carousel focus settles,
  *   with (tileId, tileType). App.js uses this for WS subscription switching.
  */
-export function createTileHost({ store, carousel, getRenderer, onFocusChange }) {
+export function createTileHost({ store, carousel, getRenderer, onFocusChange, onTileRemoved }) {
   // Map<tileId, { unmount, focus, blur, resize, tile }>
   const handles = new Map();
   let prevState = null;
@@ -58,6 +58,9 @@ export function createTileHost({ store, carousel, getRenderer, onFocusChange }) 
       if (!nextIds.has(id)) {
         const handle = handles.get(id);
         if (handle) {
+          // Notify host before teardown so it can do cleanup (WS
+          // unsubscribe, tab-set removal) while the handle is still live.
+          if (onTileRemoved) onTileRemoved(id, handle);
           // Let carousel handle DOM teardown (wrapper removal, chrome
           // destroy, resize handles). We just need to tell it.
           carousel.removeCard(id);

--- a/public/lib/tile-renderers/cluster.js
+++ b/public/lib/tile-renderers/cluster.js
@@ -24,6 +24,10 @@ export const clusterRenderer = {
       title: props.title || "Terminal Cluster",
       icon: "squares-four",
       persistable: true,
+      session: null,
+      updatesUrl: false,
+      renameable: false,
+      handlesDnd: false,
     };
   },
 
@@ -45,6 +49,11 @@ export const clusterRenderer = {
       focus()   { tile.focus(); },
       blur()    { tile.blur(); },
       resize()  { tile.resize(); },
+      getSessions() {
+        return tile.getSubTiles()
+          .map(({ tile: subTile }) => subTile?.sessionName)
+          .filter(Boolean);
+      },
       tile,
     };
   },

--- a/public/lib/tile-renderers/cluster.js
+++ b/public/lib/tile-renderers/cluster.js
@@ -1,0 +1,51 @@
+/**
+ * Cluster renderer — wraps createClusterTileFactory.
+ *
+ * Clusters are compound tiles: a grid of sub-terminal-tiles. The
+ * renderer delegates entirely to the existing factory. describe() is
+ * pure; mount() returns the standard handle plus the tile escape hatch
+ * for getSubTiles() access.
+ */
+
+import { createClusterTileFactory } from "../tiles/cluster-tile.js";
+
+let factory = null;
+
+export const clusterRenderer = {
+  type: "cluster",
+
+  /** Inject deps — needs createTerminalTile (the raw factory, not renderer). */
+  init(deps) {
+    factory = createClusterTileFactory(deps);
+  },
+
+  describe(props) {
+    return {
+      title: props.title || "Terminal Cluster",
+      icon: "squares-four",
+      persistable: true,
+    };
+  },
+
+  mount(el, { id, props, dispatch, ctx }) {
+    if (!factory) throw new Error("clusterRenderer.init() not called");
+    const tile = factory({
+      cols: props.cols,
+      rows: props.rows,
+      cells: props.cells,
+      maxCellWidth: props.maxCellWidth,
+      gap: props.gap,
+      title: props.title,
+      slots: props.slots || [],
+    });
+    tile.mount(el, ctx);
+
+    return {
+      unmount() { tile.unmount(); },
+      focus()   { tile.focus(); },
+      blur()    { tile.blur(); },
+      resize()  { tile.resize(); },
+      tile,
+    };
+  },
+};

--- a/public/lib/tile-renderers/file-browser.js
+++ b/public/lib/tile-renderers/file-browser.js
@@ -1,0 +1,57 @@
+/**
+ * File-browser renderer — wraps createFileBrowserTileFactory.
+ *
+ * The key difference from the old tile: when cwd changes, the renderer
+ * dispatches UPDATE_PROPS into ui-store instead of calling ctx.setTitle.
+ * The tab bar re-derives the title from describe(newProps) on the next
+ * state change — no push-based notification chain.
+ */
+
+import { createFileBrowserTileFactory } from "../tiles/file-browser-tile.js";
+
+let factory = null;
+
+export const fileBrowserRenderer = {
+  type: "file-browser",
+
+  init(_deps) {
+    factory = createFileBrowserTileFactory(_deps);
+  },
+
+  describe(props) {
+    const cwd = typeof props.cwd === "string" ? props.cwd : "";
+    if (!cwd || cwd === "/") return { title: "Files", icon: "folder", persistable: true };
+    const segments = cwd.split("/").filter(Boolean);
+    return {
+      title: segments.length > 0 ? segments[segments.length - 1] : "Files",
+      icon: "folder",
+      persistable: true,
+    };
+  },
+
+  mount(el, { id, props, dispatch, ctx }) {
+    if (!factory) throw new Error("fileBrowserRenderer.init() not called");
+    const tile = factory({ cwd: props.cwd || "", sessionName: props.sessionName });
+    tile.mount(el, {
+      ...ctx,
+      // Intercept setTitle — translate into ui-store dispatch so the
+      // tab bar picks it up reactively instead of imperatively.
+      setTitle(_title) {
+        // The fb tile calls setTitle with the folder name, but we want
+        // the full cwd in props so describe() can derive the title.
+        dispatch({ type: "ui/UPDATE_PROPS", id, patch: { cwd: tile.cwd } });
+      },
+      setIcon(icon) {
+        dispatch({ type: "ui/UPDATE_PROPS", id, patch: { icon } });
+      },
+    });
+
+    return {
+      unmount() { tile.unmount(); },
+      focus()   { tile.focus(); },
+      blur()    { tile.blur(); },
+      resize()  { tile.resize(); },
+      tile,
+    };
+  },
+};

--- a/public/lib/tile-renderers/file-browser.js
+++ b/public/lib/tile-renderers/file-browser.js
@@ -20,12 +20,19 @@ export const fileBrowserRenderer = {
 
   describe(props) {
     const cwd = typeof props.cwd === "string" ? props.cwd : "";
-    if (!cwd || cwd === "/") return { title: "Files", icon: "folder", persistable: true };
+    if (!cwd || cwd === "/") return {
+      title: "Files", icon: "folder", persistable: true,
+      session: null, updatesUrl: false, renameable: false, handlesDnd: true,
+    };
     const segments = cwd.split("/").filter(Boolean);
     return {
       title: segments.length > 0 ? segments[segments.length - 1] : "Files",
       icon: "folder",
       persistable: true,
+      session: null,
+      updatesUrl: false,
+      renameable: false,
+      handlesDnd: true,
     };
   },
 
@@ -51,6 +58,7 @@ export const fileBrowserRenderer = {
       focus()   { tile.focus(); },
       blur()    { tile.blur(); },
       resize()  { tile.resize(); },
+      getSessions() { return []; },
       tile,
     };
   },

--- a/public/lib/tile-renderers/index.js
+++ b/public/lib/tile-renderers/index.js
@@ -1,0 +1,49 @@
+/**
+ * Tile Renderer Registry
+ *
+ * Central registry mapping tile type strings to renderer objects.
+ * Each renderer exposes:
+ *   - describe(props) → { title, icon, persistable }   (pure)
+ *   - mount(el, api)  → { unmount, focus, blur, resize, tile }
+ *   - init(deps)      — one-time dep injection at startup
+ *
+ * The registry itself is a plain Map. Renderers self-register at import
+ * time via registerRenderer(), or can be bulk-registered at boot.
+ */
+
+import { terminalRenderer } from "./terminal.js";
+import { fileBrowserRenderer } from "./file-browser.js";
+import { clusterRenderer } from "./cluster.js";
+
+const renderers = new Map();
+
+export function registerRenderer(renderer) {
+  if (!renderer?.type) throw new Error("renderer must have a .type");
+  renderers.set(renderer.type, renderer);
+}
+
+export function getRenderer(type) {
+  return renderers.get(type) || null;
+}
+
+/** Does this tile type persist across reloads? */
+export function isPersistable(type) {
+  const r = renderers.get(type);
+  if (!r) return false;
+  // Ask the renderer with empty props — persistable is type-level, not
+  // instance-level (a terminal is always persistable regardless of which
+  // session it wraps).
+  return r.describe({}).persistable === true;
+}
+
+/** Initialize all built-in renderers with their deps. */
+export function initRenderers({ terminalPool, createTerminalTile }) {
+  terminalRenderer.init({ terminalPool });
+  fileBrowserRenderer.init({});
+  clusterRenderer.init({ createTerminalTile });
+}
+
+// Register built-in renderers
+registerRenderer(terminalRenderer);
+registerRenderer(fileBrowserRenderer);
+registerRenderer(clusterRenderer);

--- a/public/lib/tile-renderers/terminal.js
+++ b/public/lib/tile-renderers/terminal.js
@@ -28,6 +28,11 @@ export const terminalRenderer = {
       title: props.sessionName || "terminal",
       icon: "terminal-window",
       persistable: true,
+      // Capabilities — tile-host uses these instead of type checks
+      session: props.sessionName || null,
+      updatesUrl: true,
+      renameable: true,
+      handlesDnd: false,
     };
   },
 
@@ -50,6 +55,7 @@ export const terminalRenderer = {
       focus()   { tile.focus(); },
       blur()    { tile.blur(); },
       resize()  { tile.resize(); },
+      getSessions() { return [props.sessionName].filter(Boolean); },
       // Escape hatch for carousel rename / sub-tile queries
       tile,
     };

--- a/public/lib/tile-renderers/terminal.js
+++ b/public/lib/tile-renderers/terminal.js
@@ -1,0 +1,57 @@
+/**
+ * Terminal renderer — wraps createTerminalTileFactory as a renderer.
+ *
+ * describe(props) is pure: props → { title, icon, persistable }.
+ * mount(el, api) delegates to the existing tile factory and returns
+ * a handle { unmount, focus, blur, resize, tile }.
+ *
+ * The `tile` escape hatch exposes the underlying TilePrototype for
+ * carousel features that still need it (renameCard, getSubTiles on
+ * clusters). Once all carousel methods go through tile-host, this
+ * can be removed.
+ */
+
+import { createTerminalTileFactory } from "../tiles/terminal-tile.js";
+
+let factory = null;
+
+export const terminalRenderer = {
+  type: "terminal",
+
+  /** Inject deps once at startup. */
+  init(deps) {
+    factory = createTerminalTileFactory(deps);
+  },
+
+  describe(props) {
+    return {
+      title: props.sessionName || "terminal",
+      icon: "terminal-window",
+      persistable: true,
+    };
+  },
+
+  mount(el, { id, props, dispatch, ctx }) {
+    if (!factory) throw new Error("terminalRenderer.init() not called");
+    const tile = factory({ sessionName: props.sessionName });
+    tile.mount(el, {
+      ...ctx,
+      // When the tile pushes title/icon changes, reflect into ui-store
+      setTitle(title) {
+        dispatch({ type: "ui/UPDATE_PROPS", id, patch: { title } });
+      },
+      setIcon(icon) {
+        dispatch({ type: "ui/UPDATE_PROPS", id, patch: { icon } });
+      },
+    });
+
+    return {
+      unmount() { tile.unmount(); },
+      focus()   { tile.focus(); },
+      blur()    { tile.blur(); },
+      resize()  { tile.resize(); },
+      // Escape hatch for carousel rename / sub-tile queries
+      tile,
+    };
+  },
+};

--- a/public/lib/tile-tab-bar.js
+++ b/public/lib/tile-tab-bar.js
@@ -1,0 +1,564 @@
+/**
+ * <tile-tab-bar> — Declarative tab bar driven by ui-store.
+ *
+ * Replaces the imperative getSessionList() → createTabEl() → render()
+ * pipeline in shortcut-bar.js. The component subscribes to the ui-store,
+ * derives its tab list from state.order + state.tiles via renderer
+ * describe(), and dispatches actions (FOCUS_TILE, REORDER, REMOVE_TILE)
+ * back into the store. No dual paths, no legacy shims.
+ *
+ * Platform support: desktop (mouse drag, dblclick rename, contextmenu),
+ * tablet (touch drag, long-press context menu, double-tap rename),
+ * phone (same layout, CSS handles sizing).
+ *
+ * Usage:
+ *   const bar = document.createElement("tile-tab-bar");
+ *   bar.store = uiStore;
+ *   bar.addEventListener("tab-close", e => { ... });
+ *   bar.addEventListener("tab-add", e => { ... });
+ *   container.appendChild(bar);
+ */
+
+import { getRenderer } from "/lib/tile-renderers/index.js";
+import { detectPlatform } from "/lib/platform.js";
+
+// ── Constants ──────────────────────────────────────────────────────────
+const DRAG_DEAD_ZONE = 5;
+const LONG_PRESS_MS = 300;
+const DRAG_OUT_THRESHOLD = 60;
+const DOUBLE_TAP_MS = 300;
+
+// ── Pure derivation ────────────────────────────────────────────────────
+
+/** state → tab descriptors (pure function, no side effects) */
+function deriveTabs(state) {
+  if (!state?.order) return [];
+  return state.order.map(id => {
+    const tile = state.tiles[id];
+    if (!tile) return null;
+    const renderer = getRenderer(tile.type);
+    const desc = renderer ? renderer.describe(tile.props) : { title: id, icon: null };
+    return {
+      id,
+      type: tile.type,
+      title: desc.title || id,
+      icon: desc.icon || "terminal-window",
+      active: id === state.focusedId,
+    };
+  }).filter(Boolean);
+}
+
+// ── Web Component ──────────────────────────────────────────────────────
+
+class TileTabBar extends HTMLElement {
+  constructor() {
+    super();
+    this._store = null;
+    this._unsubscribe = null;
+    this._tabs = [];
+    this._drag = null;
+    this._touchActive = false;
+    this._lastTapId = null;
+    this._lastTapTime = 0;
+    this._platform = detectPlatform();
+    this._rafId = null;
+    this._renaming = false;
+  }
+
+  // ── Properties ─────────────────────────────────────────────────────
+
+  set store(s) {
+    if (this._store === s) return;
+    this._unsubscribe?.();
+    this._store = s;
+    if (s && this.isConnected) this._subscribe();
+  }
+
+  get store() { return this._store; }
+
+  // ── Lifecycle ──────────────────────────────────────────────────────
+
+  connectedCallback() {
+    this.classList.add("tile-tab-bar");
+    if (this._store) this._subscribe();
+  }
+
+  disconnectedCallback() {
+    this._unsubscribe?.();
+    this._unsubscribe = null;
+    if (this._rafId) { cancelAnimationFrame(this._rafId); this._rafId = null; }
+  }
+
+  _subscribe() {
+    // Render immediately from current state
+    this._renderFromState(this._store.getState());
+    // Then subscribe for updates
+    this._unsubscribe = this._store.subscribe(() => {
+      if (this._renaming) return;
+      if (this._drag) return; // defer during drag
+      if (this._rafId) return; // coalesce
+      this._rafId = requestAnimationFrame(() => {
+        this._rafId = null;
+        this._renderFromState(this._store.getState());
+      });
+    });
+  }
+
+  // ── Rendering (state → DOM) ────────────────────────────────────────
+
+  _renderFromState(state) {
+    this._tabs = deriveTabs(state);
+    this._render();
+  }
+
+  _render() {
+    // Preserve any active rename input
+    const activeRename = this.querySelector("input.tab-rename-input");
+    const renamingId = activeRename?.closest(".tab-bar-tab")?.dataset.session;
+
+    this.innerHTML = "";
+
+    // Add button
+    const addBtn = document.createElement("button");
+    addBtn.className = "ipad-add-btn";
+    addBtn.tabIndex = -1;
+    addBtn.setAttribute("aria-label", "New session");
+    addBtn.innerHTML = '<i class="ph ph-plus-circle"></i>';
+    addBtn.addEventListener("click", () => {
+      this.dispatchEvent(new CustomEvent("tab-add", { bubbles: true }));
+    });
+
+    // Tab row container
+    const tabRow = document.createElement("div");
+    tabRow.className = "bar-tab-row";
+    tabRow.appendChild(addBtn);
+
+    // Scrollable tab area
+    const tabArea = document.createElement("div");
+    tabArea.className = "tab-scroll-area";
+
+    for (const tab of this._tabs) {
+      if (renamingId === tab.id) {
+        // Re-insert preserved rename input
+        const el = this._createTabEl(tab);
+        const label = el.querySelector(".tab-label");
+        if (label && activeRename) label.replaceWith(activeRename);
+        tabArea.appendChild(el);
+      } else {
+        tabArea.appendChild(this._createTabEl(tab));
+      }
+    }
+
+    tabRow.appendChild(tabArea);
+    this.appendChild(tabRow);
+
+    // Fit labels after DOM is in place
+    requestAnimationFrame(() => this._fitLabels());
+  }
+
+  // ── Tab element factory ────────────────────────────────────────────
+
+  _createTabEl(tab) {
+    const el = document.createElement("button");
+    el.className = "tab-bar-tab" + (tab.active ? " active" : "");
+    el.tabIndex = -1;
+    el.dataset.session = tab.id;
+    el.dataset.type = tab.type;
+    el.setAttribute("aria-label", `Tile: ${tab.title}`);
+
+    const icon = document.createElement("i");
+    icon.className = `ph ph-${tab.icon}`;
+    el.appendChild(icon);
+
+    const label = document.createElement("span");
+    label.className = "tab-label";
+    label.textContent = tab.title;
+    label.dataset.fullName = tab.title;
+    el.appendChild(label);
+
+    // ── Event handlers ─────────────────────────────────────────────
+    el.addEventListener("dblclick", (e) => {
+      e.preventDefault();
+      this._startRename(el, tab.id);
+    });
+
+    el.addEventListener("contextmenu", (e) => {
+      if (this._drag) { e.preventDefault(); return; }
+      this._showContextMenu(e, tab);
+    });
+
+    el.addEventListener("mousedown", (e) => this._onMouseDown(e, el, tab.id));
+    el.addEventListener("touchstart", (e) => this._onTouchStart(e, el, tab.id), { passive: false });
+
+    return el;
+  }
+
+  // ── Click / focus ──────────────────────────────────────────────────
+
+  _focusTile(id) {
+    if (!this._store) return;
+    const state = this._store.getState();
+    if (state.focusedId !== id) this._store.focusTile(id);
+  }
+
+  // ── Mouse drag ─────────────────────────────────────────────────────
+
+  _onMouseDown(e, tab, id) {
+    if (e.button !== 0 || e.target.closest(".tab-close")) return;
+    if (this._touchActive || this._drag) return;
+
+    const startX = e.clientX;
+    const startY = e.clientY;
+    let started = false;
+
+    const onMove = (me) => {
+      if (this._drag?.isTouch) return;
+      me.preventDefault();
+      const dx = me.clientX - startX;
+      const dy = me.clientY - startY;
+      if (!started) {
+        if (Math.abs(dx) < DRAG_DEAD_ZONE && Math.abs(dy) < DRAG_DEAD_ZONE) return;
+        started = true;
+        this._beginDrag(tab, id, startX);
+      }
+      this._updateDrag(me.clientX, me.clientY);
+    };
+
+    const onUp = () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      if (this._drag?.isTouch) return;
+      if (!started) {
+        this._focusTile(id);
+        return;
+      }
+      this._endDrag();
+    };
+
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  }
+
+  // ── Touch drag ─────────────────────────────────────────────────────
+
+  _onTouchStart(e, tab, id) {
+    if (e.target.closest(".tab-close")) return;
+    const touch = e.touches[0];
+    const startX = touch.clientX;
+    e.preventDefault();
+    this._touchActive = true;
+    let started = false;
+    let longPressed = false;
+
+    const longPressTimer = setTimeout(() => {
+      longPressed = true;
+      tab.classList.add("tab-long-press");
+    }, LONG_PRESS_MS);
+
+    const onMove = (te) => {
+      const t = te.touches[0];
+      const dx = t.clientX - startX;
+      if (!longPressed && Math.abs(dx) > DRAG_DEAD_ZONE) clearTimeout(longPressTimer);
+      if (!started) {
+        if (Math.abs(dx) < DRAG_DEAD_ZONE) return;
+        started = true;
+        clearTimeout(longPressTimer);
+        this._beginDrag(tab, id, startX, true);
+      }
+      te.preventDefault();
+      this._updateDrag(t.clientX, t.clientY);
+    };
+
+    const onEnd = () => {
+      clearTimeout(longPressTimer);
+      setTimeout(() => { this._touchActive = false; }, 50);
+      tab.classList.remove("tab-long-press");
+      document.removeEventListener("touchmove", onMove);
+      document.removeEventListener("touchend", onEnd);
+      document.removeEventListener("touchcancel", onEnd);
+      if (started) {
+        this._endDrag();
+      } else if (longPressed) {
+        const tabDesc = this._tabs.find(t => t.id === id);
+        if (tabDesc) this._showContextMenu({ preventDefault() {}, currentTarget: tab }, tabDesc);
+      } else {
+        const now = Date.now();
+        if (this._lastTapId === id && now - this._lastTapTime < DOUBLE_TAP_MS) {
+          this._lastTapId = null;
+          this._lastTapTime = 0;
+          this._startRename(tab, id);
+        } else {
+          this._lastTapId = id;
+          this._lastTapTime = now;
+          this._focusTile(id);
+        }
+      }
+    };
+
+    document.addEventListener("touchmove", onMove, { passive: false });
+    document.addEventListener("touchend", onEnd);
+    document.addEventListener("touchcancel", onEnd);
+  }
+
+  // ── Drag reorder (shared mouse/touch) ──────────────────────────────
+
+  _beginDrag(tab, id, startX, isTouch = false) {
+    const tabArea = this.querySelector(".tab-scroll-area");
+    if (!tabArea) return;
+
+    const tabs = [...tabArea.querySelectorAll(".tab-bar-tab")];
+    const dragIndex = tabs.indexOf(tab);
+    if (dragIndex === -1) return;
+
+    // Cache tab rects for swap calculation
+    const rects = tabs.map(t => t.getBoundingClientRect());
+    const tabRect = rects[dragIndex];
+
+    // Create ghost
+    const ghost = tab.cloneNode(true);
+    ghost.className = "tab-bar-tab tab-ghost";
+    ghost.style.cssText = `
+      position: fixed; z-index: 9999; pointer-events: none;
+      top: ${tabRect.top}px; left: ${tabRect.left}px;
+      width: ${tabRect.width}px; height: ${tabRect.height}px;
+      opacity: 0.85;
+    `;
+    document.body.appendChild(ghost);
+    tab.classList.add("tab-dragging");
+
+    this._drag = {
+      id, tab, tabs, rects, ghost, startX, isTouch,
+      dragIndex, currentIndex: dragIndex, tornOff: false,
+    };
+  }
+
+  _updateDrag(clientX, clientY) {
+    const d = this._drag;
+    if (!d) return;
+
+    const dx = clientX - d.startX;
+    d.ghost.style.transform = `translateX(${dx}px)`;
+
+    // Tear-off detection (desktop only)
+    const tabRect = d.rects[d.dragIndex];
+    if (!d.isTouch && clientY > tabRect.bottom + DRAG_OUT_THRESHOLD) {
+      d.tornOff = true;
+      d.ghost.classList.add("tab-torn-off");
+    } else {
+      d.tornOff = false;
+      d.ghost.classList.remove("tab-torn-off");
+    }
+
+    // Swap detection
+    const ghostCenter = d.rects[d.dragIndex].left + d.rects[d.dragIndex].width / 2 + dx;
+    let newIndex = d.currentIndex;
+    for (let i = 0; i < d.rects.length; i++) {
+      const r = d.rects[i];
+      if (ghostCenter >= r.left && ghostCenter <= r.right) {
+        newIndex = i;
+        break;
+      }
+    }
+
+    if (newIndex !== d.currentIndex) {
+      d.currentIndex = newIndex;
+      // Visual hint: shift tabs
+      for (let i = 0; i < d.tabs.length; i++) {
+        if (i === d.dragIndex) continue;
+        const shift = (i >= Math.min(d.dragIndex, newIndex) && i <= Math.max(d.dragIndex, newIndex))
+          ? (newIndex > d.dragIndex ? -d.rects[d.dragIndex].width : d.rects[d.dragIndex].width)
+          : 0;
+        d.tabs[i].style.transition = "transform 150ms ease";
+        d.tabs[i].style.transform = shift ? `translateX(${shift}px)` : "";
+      }
+    }
+  }
+
+  _endDrag() {
+    const d = this._drag;
+    if (!d) return;
+    this._cleanupDrag();
+
+    if (d.tornOff) {
+      this.dispatchEvent(new CustomEvent("tab-tear-off", {
+        bubbles: true, detail: { id: d.id },
+      }));
+      return;
+    }
+
+    if (d.currentIndex !== d.dragIndex) {
+      const ids = d.tabs.map(t => t.dataset.session);
+      const [moved] = ids.splice(d.dragIndex, 1);
+      ids.splice(d.currentIndex, 0, moved);
+      // Single dispatch — ui-store is source of truth
+      if (this._store) this._store.reorder(ids);
+    }
+  }
+
+  _cleanupDrag() {
+    if (!this._drag) return;
+    if (this._drag.ghost) this._drag.ghost.remove();
+    if (this._drag.tab) this._drag.tab.classList.remove("tab-dragging");
+    if (this._drag.tabs) {
+      for (const t of this._drag.tabs) {
+        t.style.transition = "";
+        t.style.transform = "";
+      }
+    }
+    this._drag = null;
+    // Flush deferred render
+    if (this._store) this._renderFromState(this._store.getState());
+  }
+
+  // ── Context menu ───────────────────────────────────────────────────
+
+  _showContextMenu(e, tab) {
+    e.preventDefault();
+    this.dispatchEvent(new CustomEvent("tab-context-menu", {
+      bubbles: true,
+      detail: {
+        id: tab.id,
+        type: tab.type,
+        title: tab.title,
+        x: e.clientX || 0,
+        y: e.clientY || 0,
+        anchorEl: e.currentTarget,
+      },
+    }));
+  }
+
+  // ── Inline rename ──────────────────────────────────────────────────
+
+  _startRename(tabEl, id) {
+    const label = tabEl.querySelector(".tab-label");
+    if (!label) return;
+
+    this._renaming = true;
+    const currentName = label.dataset.fullName || label.textContent;
+    const input = document.createElement("input");
+    input.type = "text";
+    input.className = "tab-rename-input";
+    input.value = currentName;
+    input.style.cssText = `
+      background: transparent; border: none; outline: none;
+      color: inherit; font: inherit; width: 100%;
+      padding: 0; margin: 0;
+    `;
+    label.replaceWith(input);
+    input.focus();
+    input.select();
+
+    let committed = false;
+    const commit = () => {
+      if (committed) return;
+      committed = true;
+      this._renaming = false;
+      const newName = input.value.trim();
+      if (newName && newName !== currentName) {
+        this.dispatchEvent(new CustomEvent("tab-rename", {
+          bubbles: true,
+          detail: { id, oldName: currentName, newName },
+        }));
+      }
+      // Re-render to reset the label
+      if (this._store) this._renderFromState(this._store.getState());
+    };
+
+    const revert = () => {
+      committed = true;
+      this._renaming = false;
+      if (this._store) this._renderFromState(this._store.getState());
+    };
+
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") { e.preventDefault(); commit(); }
+      if (e.key === "Escape") { e.preventDefault(); revert(); }
+      e.stopPropagation();
+    });
+    input.addEventListener("blur", () => { if (input.isConnected) commit(); });
+    input.addEventListener("mousedown", (e) => e.stopPropagation());
+  }
+
+  // ── Tab label truncation ───────────────────────────────────────────
+
+  _fitLabels() {
+    const tabArea = this.querySelector(".tab-scroll-area");
+    if (!tabArea) return;
+    const tabs = [...tabArea.querySelectorAll(".tab-bar-tab")];
+    if (tabs.length === 0) return;
+
+    const areaWidth = tabArea.clientWidth;
+    const gap = parseFloat(getComputedStyle(tabArea).gap) || 0;
+    const totalGap = gap * (tabs.length - 1);
+    const availPerTab = Math.floor((areaWidth - totalGap) / tabs.length);
+
+    // Canvas-based text measurement (no reflow)
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+
+    for (const tab of tabs) {
+      const label = tab.querySelector(".tab-label");
+      if (!label) continue;
+
+      const fullName = label.dataset.fullName || label.textContent;
+      const computedFont = getComputedStyle(label).font;
+      ctx.font = computedFont;
+
+      const padLeft = parseFloat(getComputedStyle(tab).paddingLeft) || 0;
+      const padRight = parseFloat(getComputedStyle(tab).paddingRight) || 0;
+      const icon = tab.querySelector("i.ph");
+      const iconWidth = icon ? (icon.offsetWidth + 6) : 0;
+      const chrome = padLeft + padRight;
+      const textBudget = availPerTab - chrome - iconWidth;
+
+      const fullWidth = ctx.measureText(fullName).width;
+      if (fullWidth <= textBudget) {
+        label.textContent = fullName;
+        continue;
+      }
+
+      // Middle-ellipsis truncation
+      const ellipsis = "\u2026";
+      const ellipsisW = ctx.measureText(ellipsis).width;
+      const startBudget = (textBudget - ellipsisW) * 0.6;
+      const endBudget = (textBudget - ellipsisW) * 0.4;
+
+      const measure = (ch) => ctx.measureText(ch).width;
+      let startLen = 0, startW = 0;
+      for (let i = 0; i < fullName.length; i++) {
+        const w = measure(fullName[i]);
+        if (startW + w > startBudget) break;
+        startW += w;
+        startLen = i + 1;
+      }
+
+      let endLen = 0, endW = 0;
+      for (let i = fullName.length - 1; i >= startLen; i--) {
+        const w = measure(fullName[i]);
+        if (endW + w > endBudget) break;
+        endW += w;
+        endLen++;
+      }
+
+      if (startLen > 0 && endLen > 0) {
+        label.textContent = fullName.slice(0, startLen) + ellipsis + fullName.slice(-endLen);
+      } else if (startLen > 0) {
+        label.textContent = fullName.slice(0, startLen) + ellipsis;
+      } else {
+        label.textContent = fullName[0] || "";
+      }
+    }
+  }
+}
+
+// Register the component
+customElements.define("tile-tab-bar", TileTabBar);
+
+// Re-fit on window resize
+window.addEventListener("resize", () => {
+  for (const bar of document.querySelectorAll("tile-tab-bar")) {
+    bar._fitLabels();
+  }
+});
+
+export { TileTabBar, deriveTabs };

--- a/public/lib/tiles/dashboard-back-tile.js
+++ b/public/lib/tiles/dashboard-back-tile.js
@@ -3,11 +3,10 @@
  *
  * Back-face tile for terminal cards. Shows agent status, run duration,
  * task assignment, process info, quick actions, and a compact event
- * timeline. Designed to be mounted via carousel.setBackTile().
- *
- * Usage:
- *   const back = createDashboardBackTile({ sessionName: "katulong--dev" });
- *   carousel.setBackTile(tileId, back);
+ * timeline. Mounted as the secondary face via ctx.faceStack.setSecondary()
+ * from terminal-tile.js. (Pre-Tier-1 it was mounted via
+ * carousel.setBackTile — that API no longer exists on the public
+ * carousel surface; the container exposes `ctx.faceStack` instead.)
  */
 
 import { api } from "../api-client.js";

--- a/public/lib/tiles/file-browser-tile.js
+++ b/public/lib/tiles/file-browser-tile.js
@@ -42,20 +42,19 @@ export function createFileBrowserTileFactory(_deps = {}) {
 
       mount(el, _ctx) {
         container = el;
-        // Wrap in an inner div because createFileBrowserComponent's
-        // mount() overwrites container.className = "file-browser",
-        // which would clobber tile-chrome's `.tile-content` flex rules
-        // if given the raw contentEl directly.
-        const inner = document.createElement("div");
-        inner.style.cssText = "flex:1; min-height:0; display:flex;";
-        el.appendChild(inner);
+        // Mount the component directly onto the tile-chrome content
+        // element. Previously a wrapper <div> existed to protect
+        // tile-chrome's `.tile-content` flex rules from
+        // createFileBrowserComponent clobbering `container.className =
+        // "file-browser"`. Tier 1 T1b fixed the component to own a
+        // `.fb-root` child, so the wrapper is no longer needed.
         component = createFileBrowserComponent(store, {
           // Overlay had an onClose that called toggleFileBrowser. As a
           // tile there is no overlay to close — the carousel handles
           // tile removal via its close button.
           onClose: () => {},
         });
-        component.mount(inner);
+        component.mount(el);
         loadRoot(store, currentCwd);
         mounted = true;
       },

--- a/public/lib/tiles/file-browser-tile.js
+++ b/public/lib/tiles/file-browser-tile.js
@@ -14,7 +14,7 @@
  * existing tile-chrome primitive.
  */
 
-import { createFileBrowserStore, loadRoot } from "../file-browser/file-browser-store.js";
+import { createFileBrowserStore, loadRoot, getDeepestPath } from "../file-browser/file-browser-store.js";
 import { createFileBrowserComponent } from "../file-browser/file-browser-component.js";
 
 /**
@@ -29,6 +29,7 @@ export function createFileBrowserTileFactory(_deps = {}) {
     let container = null;
     let mounted = false;
     let component = null;
+    let unsubscribeStore = null;
     // Each tile has its own store — mirroring per-tile independence of
     // terminal tiles. Sharing one global store across multiple browser
     // tiles would couple their navigation state and break serialize().
@@ -37,13 +38,13 @@ export function createFileBrowserTileFactory(_deps = {}) {
     const tile = {
       type: "file-browser",
 
-      // File browsers have no server-backed state, so "persist across
-      // reload" would resurrect an empty tile for no reason. Opt out of
-      // carousel persistence via this capability flag — the carousel's
-      // save() filters on it. Tier 2 will fold this into a broader
-      // capability snapshot; for now a single boolean keeps the opt-out
-      // one line per tile kind. See docs/tile-clusters-design.md.
-      persistable: false,
+      // File-browser tiles persist across reload. Earlier (commit b86275c)
+      // they were marked non-persistable out of a concern that resurrecting
+      // them would produce "empty phantom" tiles — but that was only true
+      // before serialize() captured `cwd`. With cwd in the snapshot and
+      // restoreTile() in app.js rebuilding the factory at that cwd, the
+      // restored tile lands in the same directory the user left it.
+      persistable: true,
 
       get sessionName() { return sessionName; },
       get cwd() { return currentCwd; },
@@ -68,11 +69,22 @@ export function createFileBrowserTileFactory(_deps = {}) {
         });
         component.mount(el);
         loadRoot(store, currentCwd);
+        // Track the deepest navigated path as the tile's "current" path
+        // so the tab label follows the user's folder navigation. Notify
+        // the host (carousel/tab bar) via ctx.setTitle whenever it moves.
+        unsubscribeStore = store.subscribe(() => {
+          const deepest = getDeepestPath(store.getState());
+          if (deepest && deepest !== currentCwd) {
+            currentCwd = deepest;
+            ctx?.setTitle?.(tile.getTitle());
+          }
+        });
         mounted = true;
       },
 
       unmount() {
         if (!mounted) return;
+        if (unsubscribeStore) { unsubscribeStore(); unsubscribeStore = null; }
         component?.unmount?.();
         component = null;
         if (container) container.innerHTML = "";
@@ -93,8 +105,9 @@ export function createFileBrowserTileFactory(_deps = {}) {
       },
 
       getTitle() {
-        if (!currentCwd || currentCwd === "/") return "Files";
-        const segments = currentCwd.split("/").filter(Boolean);
+        const cwd = typeof currentCwd === "string" ? currentCwd : "";
+        if (!cwd || cwd === "/") return "Files";
+        const segments = cwd.split("/").filter(Boolean);
         return segments.length > 0 ? segments[segments.length - 1] : "Files";
       },
 

--- a/public/lib/tiles/file-browser-tile.js
+++ b/public/lib/tiles/file-browser-tile.js
@@ -37,6 +37,14 @@ export function createFileBrowserTileFactory(_deps = {}) {
     const tile = {
       type: "file-browser",
 
+      // File browsers have no server-backed state, so "persist across
+      // reload" would resurrect an empty tile for no reason. Opt out of
+      // carousel persistence via this capability flag — the carousel's
+      // save() filters on it. Tier 2 will fold this into a broader
+      // capability snapshot; for now a single boolean keeps the opt-out
+      // one line per tile kind. See docs/tile-clusters-design.md.
+      persistable: false,
+
       get sessionName() { return sessionName; },
       get cwd() { return currentCwd; },
 

--- a/public/lib/tiles/file-browser-tile.js
+++ b/public/lib/tiles/file-browser-tile.js
@@ -40,7 +40,7 @@ export function createFileBrowserTileFactory(_deps = {}) {
       get sessionName() { return sessionName; },
       get cwd() { return currentCwd; },
 
-      mount(el, _ctx) {
+      mount(el, ctx) {
         container = el;
         // Mount the component directly onto the tile-chrome content
         // element. Previously a wrapper <div> existed to protect
@@ -49,10 +49,14 @@ export function createFileBrowserTileFactory(_deps = {}) {
         // "file-browser"`. Tier 1 T1b fixed the component to own a
         // `.fb-root` child, so the wrapper is no longer needed.
         component = createFileBrowserComponent(store, {
-          // Overlay had an onClose that called toggleFileBrowser. As a
-          // tile there is no overlay to close — the carousel handles
-          // tile removal via its close button.
-          onClose: () => {},
+          // The file-browser component draws its own X button in its
+          // header. When hosted as a tile, that X must remove this
+          // tile from its container. Route through ctx.requestClose
+          // (carousel-provided) so onCardDismissed fires and the
+          // tab set / subscriptions stay consistent. Falls back to a
+          // no-op if the container does not supply requestClose (e.g.
+          // a future non-carousel host) so the tile never throws.
+          onClose: () => { ctx?.requestClose?.(); },
         });
         component.mount(el);
         loadRoot(store, currentCwd);

--- a/public/lib/tiles/terminal-tile.js
+++ b/public/lib/tiles/terminal-tile.js
@@ -16,8 +16,14 @@ import { createSessionStatusWatcher } from "../session-status-watcher.js";
  *
  * @param {object} deps
  * @param {object} deps.terminalPool — the terminal pool instance
- * @param {object} [deps.carousel] — carousel instance (for setBackTile)
  * @returns {(options: { sessionName: string }) => TilePrototype}
+ *
+ * Note: this factory intentionally does NOT receive the carousel. The
+ * previous `a carousel dep` lazy-getter (removed in Tier 1 T1a) was a
+ * confession of circular wiring — the carousel creates the tile, then
+ * the tile reached back up into the carousel to register a back face.
+ * The replacement is `ctx.faceStack`, which the container (carousel)
+ * hands to the tile at mount time. See docs/tile-clusters-design.md.
  */
 export function createTerminalTileFactory(deps) {
   const { terminalPool } = deps;
@@ -68,11 +74,16 @@ export function createTerminalTileFactory(deps) {
         // its own interval. See public/lib/session-status-watcher.js.
         watcher = createSessionStatusWatcher({ sessionName: currentSessionName });
 
-        // ── Register dashboard back-face ───────────────────────────
-        const carousel = deps.carousel;
-        if (carousel) {
+        // ── Register dashboard back-face via faceStack ─────────────
+        // `ctx.faceStack` is the container-provided affordance that
+        // replaced `a carousel dep.setBackTile` in Tier 1 T1a. The tile
+        // doesn't know or care whether the container is a carousel, an
+        // exposé pack, or a Level 2 mini-strip — it just says "here's
+        // my secondary face, show it when I tell you to".
+        const faceStack = ctx?.faceStack;
+        if (faceStack) {
           backTile = createDashboardBackTile({ sessionName: currentSessionName, watcher });
-          carousel.setBackTile(currentSessionName, backTile);
+          faceStack.setSecondary(backTile);
         }
 
         // ── Auto-flip on child process exit ────────────────────────
@@ -81,22 +92,28 @@ export function createTerminalTileFactory(deps) {
         // if still idle. The debounce absorbs brief pauses between
         // commands. The watcher's own destroyed guard covers the fetch
         // side; the `destroyed` flag here covers the setTimeout side.
+        //
+        // The `destroyed` guard remains load-bearing even though the
+        // tile now owns its affordance cleanly: the 1.5s debounce and
+        // the re-poll inside it are both async hops that can land
+        // after unmount(). Removing the guard would let a late
+        // setTimeout flip a stale faceStack reference.
         watcherUnsubscribe = watcher.subscribe((event) => {
           if (destroyed) return;
           if (!event.transitions?.idle) return;
-          if (!carousel || carousel.isFlipped(currentSessionName)) return;
+          if (!faceStack || faceStack.isShowingSecondary()) return;
           if (autoFlipTimer) clearTimeout(autoFlipTimer);
           autoFlipTimer = setTimeout(() => {
             if (destroyed) return;
-            if (carousel.isFlipped(currentSessionName)) return;
+            if (faceStack.isShowingSecondary()) return;
             // Re-check via an immediate poll so we don't flip on a
             // momentary pause between commands. If that poll reports
             // child processes are back, the flip is cancelled.
             watcher.poll().then(() => {
               if (destroyed) return;
-              if (carousel.isFlipped(currentSessionName)) return;
+              if (faceStack.isShowingSecondary()) return;
               if (backTile?.addEvent) backTile.addEvent("Agent work completed");
-              carousel.flipCard(currentSessionName, true);
+              faceStack.showSecondary(true);
             }).catch(() => {});
           }, 1500);
         });

--- a/public/lib/ui-store.js
+++ b/public/lib/ui-store.js
@@ -1,0 +1,220 @@
+/**
+ * UI Store — single source of truth for tile UI state
+ *
+ * See docs/tile-state-rewrite.md for the "why". Summary: previously
+ * tile state was spread across the carousel, windowTabSet, and
+ * sessionStore, each mutated at every call site. This collapses it
+ * into one reducer-driven atom. Tab bar and carousel both derive from
+ * it; persistence and URL sync are reactive subscriptions.
+ *
+ * State shape:
+ *   {
+ *     version: 1,
+ *     tiles:     { [id]: { id, type, props } },
+ *     order:     [id, id, ...],   // left → right, permutation of tiles keys
+ *     focusedId: id | null,
+ *   }
+ *
+ * Invariants (enforced by the reducer):
+ *   - order is a permutation of Object.keys(tiles)
+ *   - focusedId is null or a key of tiles
+ *   - ids are unique (tiles is a map, not a list)
+ *   - every mutation returns a new state object (structural sharing)
+ */
+
+import { createStore } from "/lib/store.js";
+
+const STORAGE_KEY = "katulong-ui-v1";
+const VERSION = 1;
+
+export const EMPTY_STATE = Object.freeze({
+  version: VERSION,
+  tiles: Object.freeze({}),
+  order: Object.freeze([]),
+  focusedId: null,
+});
+
+// ─── Action types ────────────────────────────────────────────────────
+export const ADD_TILE     = "ui/ADD_TILE";
+export const REMOVE_TILE  = "ui/REMOVE_TILE";
+export const REORDER      = "ui/REORDER";
+export const FOCUS_TILE   = "ui/FOCUS_TILE";
+export const UPDATE_PROPS = "ui/UPDATE_PROPS";
+export const RESET        = "ui/RESET";
+
+// ─── Reducer ─────────────────────────────────────────────────────────
+function reducer(state = EMPTY_STATE, action) {
+  switch (action.type) {
+    case ADD_TILE: {
+      const { tile, focus = false, insertAt = "end" } = action;
+      if (!tile || !tile.id || !tile.type) return state;
+      if (state.tiles[tile.id]) {
+        // Already present — optionally focus, but don't duplicate.
+        return focus ? { ...state, focusedId: tile.id } : state;
+      }
+      const newTile = { id: tile.id, type: tile.type, props: { ...(tile.props || {}) } };
+      const newTiles = { ...state.tiles, [tile.id]: newTile };
+      let newOrder;
+      if (insertAt === "afterFocus" && state.focusedId) {
+        const idx = state.order.indexOf(state.focusedId);
+        newOrder = [...state.order.slice(0, idx + 1), tile.id, ...state.order.slice(idx + 1)];
+      } else {
+        newOrder = [...state.order, tile.id];
+      }
+      return {
+        ...state,
+        tiles: newTiles,
+        order: newOrder,
+        focusedId: focus ? tile.id : state.focusedId,
+      };
+    }
+
+    case REMOVE_TILE: {
+      const { id } = action;
+      if (!state.tiles[id]) return state;
+      const { [id]: _removed, ...restTiles } = state.tiles;
+      const newOrder = state.order.filter(x => x !== id);
+      let focusedId = state.focusedId;
+      if (focusedId === id) {
+        // Focus the neighbor to the right (or left if we removed the
+        // last card). Matches carousel's "focus right neighbor on
+        // close" behavior without needing the host to reimplement it.
+        const removedIdx = state.order.indexOf(id);
+        focusedId = newOrder[removedIdx] || newOrder[removedIdx - 1] || null;
+      }
+      return { ...state, tiles: restTiles, order: newOrder, focusedId };
+    }
+
+    case REORDER: {
+      const { order } = action;
+      if (!Array.isArray(order)) return state;
+      // Defend against drops that omit ids or smuggle unknowns — fold
+      // in any missing tiles at the end so state never desyncs from
+      // `tiles`. Unknown ids are dropped.
+      const known = new Set(Object.keys(state.tiles));
+      const cleaned = order.filter(id => known.has(id));
+      const seen = new Set(cleaned);
+      for (const id of state.order) {
+        if (!seen.has(id)) cleaned.push(id);
+      }
+      // No-op if identical
+      if (cleaned.length === state.order.length && cleaned.every((id, i) => id === state.order[i])) {
+        return state;
+      }
+      return { ...state, order: cleaned };
+    }
+
+    case FOCUS_TILE: {
+      const { id } = action;
+      if (id !== null && !state.tiles[id]) return state;
+      if (state.focusedId === id) return state;
+      return { ...state, focusedId: id };
+    }
+
+    case UPDATE_PROPS: {
+      const { id, patch } = action;
+      const existing = state.tiles[id];
+      if (!existing || !patch) return state;
+      // Shallow-merge patch into props. Bail if nothing actually
+      // changed — subscribers shouldn't fire on no-op UPDATE_PROPS.
+      let changed = false;
+      for (const k of Object.keys(patch)) {
+        if (existing.props[k] !== patch[k]) { changed = true; break; }
+      }
+      if (!changed) return state;
+      const newTile = { ...existing, props: { ...existing.props, ...patch } };
+      return { ...state, tiles: { ...state.tiles, [id]: newTile } };
+    }
+
+    case RESET: {
+      const { state: next } = action;
+      return normalize(next);
+    }
+
+    default:
+      return state;
+  }
+}
+
+/** Coerce an arbitrary object into a valid ui-store state. */
+export function normalize(raw) {
+  if (!raw || typeof raw !== "object") return EMPTY_STATE;
+  const tiles = {};
+  if (raw.tiles && typeof raw.tiles === "object") {
+    for (const [id, t] of Object.entries(raw.tiles)) {
+      if (t && typeof t.type === "string") {
+        tiles[id] = { id, type: t.type, props: { ...(t.props || {}) } };
+      }
+    }
+  }
+  const known = new Set(Object.keys(tiles));
+  const order = Array.isArray(raw.order) ? raw.order.filter(id => known.has(id)) : [];
+  // Append any tiles that exist but weren't in order (corrupt save)
+  for (const id of known) {
+    if (!order.includes(id)) order.push(id);
+  }
+  const focusedId = raw.focusedId && known.has(raw.focusedId) ? raw.focusedId : (order[0] || null);
+  return { version: VERSION, tiles, order, focusedId };
+}
+
+// ─── Persistence ─────────────────────────────────────────────────────
+/**
+ * Serialize state for localStorage. Accepts an `isPersistable(type)`
+ * predicate supplied by the host so this module never needs to know
+ * about renderer internals.
+ */
+export function serialize(state, isPersistable = () => true) {
+  const tiles = {};
+  for (const [id, t] of Object.entries(state.tiles)) {
+    if (isPersistable(t.type)) tiles[id] = t;
+  }
+  const known = new Set(Object.keys(tiles));
+  const order = state.order.filter(id => known.has(id));
+  const focusedId = state.focusedId && known.has(state.focusedId) ? state.focusedId : (order[0] || null);
+  return { version: VERSION, tiles, order, focusedId };
+}
+
+export function loadFromStorage() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || parsed.version !== VERSION) return null;
+    return normalize(parsed);
+  } catch (_) {
+    return null;
+  }
+}
+
+export function saveToStorage(state, isPersistable) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(serialize(state, isPersistable)));
+  } catch (_) { /* quota exceeded, etc. — silently skip */ }
+}
+
+// ─── Store factory ───────────────────────────────────────────────────
+/**
+ * Create a UI store. Pass `isPersistable(type)` so persistence can
+ * filter non-persistable tile types without this module importing
+ * the renderer registry.
+ */
+export function createUiStore({ initialState = EMPTY_STATE, isPersistable = () => true, debug = false } = {}) {
+  const store = createStore(normalize(initialState), reducer, { debug });
+
+  // Persist on every change. Cheap: JSON.stringify of a small object.
+  store.subscribe((state) => saveToStorage(state, isPersistable));
+
+  return {
+    getState: store.getState,
+    subscribe: store.subscribe,
+    dispatch:  store.dispatch,
+    // Convenience action creators — call sites read more like a
+    // command API than raw dispatches, and typos throw at the source.
+    addTile:     (tile, opts = {}) => store.dispatch({ type: ADD_TILE, tile, ...opts }),
+    removeTile:  (id)              => store.dispatch({ type: REMOVE_TILE, id }),
+    reorder:     (order)           => store.dispatch({ type: REORDER, order }),
+    focusTile:   (id)              => store.dispatch({ type: FOCUS_TILE, id }),
+    updateProps: (id, patch)       => store.dispatch({ type: UPDATE_PROPS, id, patch }),
+    reset:       (state)           => store.dispatch({ type: RESET, state }),
+  };
+}

--- a/public/lib/ui-store.js
+++ b/public/lib/ui-store.js
@@ -10,19 +10,25 @@
  * State shape:
  *   {
  *     version: 1,
- *     tiles:     { [id]: { id, type, props } },
- *     order:     [id, id, ...],   // left → right, permutation of tiles keys
+ *     tiles:     { [id]: { id, type, props, x } },  // x = horizontal position
+ *     order:     [id, id, ...],   // derived: tiles sorted by x
  *     focusedId: id | null,
  *   }
  *
+ * Position is a property of the tile itself (the `x` field) rather than
+ * a separate array.  Today x is a 1-D integer; the clusters design
+ * (docs/tile-clusters-design.md) will extend this to (cluster, x, y).
+ * `state.order` is kept as a derived convenience so consumers that just
+ * need "left-to-right list of ids" don't change.
+ *
  * Invariants (enforced by the reducer):
- *   - order is a permutation of Object.keys(tiles)
+ *   - order is derived from tiles sorted by x
  *   - focusedId is null or a key of tiles
  *   - ids are unique (tiles is a map, not a list)
  *   - every mutation returns a new state object (structural sharing)
  */
 
-import { createStore } from "/lib/store.js";
+import { createStore } from "./store.js";
 
 const STORAGE_KEY = "katulong-ui-v1";
 const VERSION = 1;
@@ -33,6 +39,23 @@ export const EMPTY_STATE = Object.freeze({
   order: Object.freeze([]),
   focusedId: null,
 });
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+/** Derive the order array from tiles by sorting on x. */
+function deriveOrder(tiles) {
+  return Object.values(tiles)
+    .sort((a, b) => a.x - b.x)
+    .map(t => t.id);
+}
+
+/** One past the highest x coordinate (or 0 if no tiles). */
+function nextX(tiles) {
+  let max = -1;
+  for (const t of Object.values(tiles)) {
+    if (typeof t.x === "number" && t.x > max) max = t.x;
+  }
+  return max + 1;
+}
 
 // ─── Action types ────────────────────────────────────────────────────
 export const ADD_TILE     = "ui/ADD_TILE";
@@ -53,18 +76,24 @@ function reducer(state = EMPTY_STATE, action) {
         return focus ? { ...state, focusedId: tile.id } : state;
       }
       const newTile = { id: tile.id, type: tile.type, props: { ...(tile.props || {}) } };
-      const newTiles = { ...state.tiles, [tile.id]: newTile };
-      let newOrder;
+      let newTiles;
       if (insertAt === "afterFocus" && state.focusedId) {
-        const idx = state.order.indexOf(state.focusedId);
-        newOrder = [...state.order.slice(0, idx + 1), tile.id, ...state.order.slice(idx + 1)];
+        const insertX = state.tiles[state.focusedId].x + 1;
+        newTile.x = insertX;
+        // Shift tiles at or past the insertion point to make room
+        newTiles = {};
+        for (const [id, t] of Object.entries(state.tiles)) {
+          newTiles[id] = t.x >= insertX ? { ...t, x: t.x + 1 } : t;
+        }
+        newTiles[tile.id] = newTile;
       } else {
-        newOrder = [...state.order, tile.id];
+        newTile.x = nextX(state.tiles);
+        newTiles = { ...state.tiles, [tile.id]: newTile };
       }
       return {
         ...state,
         tiles: newTiles,
-        order: newOrder,
+        order: deriveOrder(newTiles),
         focusedId: focus ? tile.id : state.focusedId,
       };
     }
@@ -73,7 +102,7 @@ function reducer(state = EMPTY_STATE, action) {
       const { id } = action;
       if (!state.tiles[id]) return state;
       const { [id]: _removed, ...restTiles } = state.tiles;
-      const newOrder = state.order.filter(x => x !== id);
+      const newOrder = deriveOrder(restTiles);
       let focusedId = state.focusedId;
       if (focusedId === id) {
         // Focus the neighbor to the right (or left if we removed the
@@ -101,7 +130,14 @@ function reducer(state = EMPTY_STATE, action) {
       if (cleaned.length === state.order.length && cleaned.every((id, i) => id === state.order[i])) {
         return state;
       }
-      return { ...state, order: cleaned };
+      // Reassign x coordinates from the new order
+      const newTiles = { ...state.tiles };
+      cleaned.forEach((id, i) => {
+        if (newTiles[id].x !== i) {
+          newTiles[id] = { ...newTiles[id], x: i };
+        }
+      });
+      return { ...state, tiles: newTiles, order: cleaned };
     }
 
     case FOCUS_TILE: {
@@ -136,7 +172,9 @@ function reducer(state = EMPTY_STATE, action) {
   }
 }
 
-/** Coerce an arbitrary object into a valid ui-store state. */
+/** Coerce an arbitrary object into a valid ui-store state.
+ *  Handles migration: tiles may or may not carry `x`. When absent,
+ *  position is backfilled from raw.order (the old persistence format). */
 export function normalize(raw) {
   if (!raw || typeof raw !== "object") return EMPTY_STATE;
   const tiles = {};
@@ -144,16 +182,23 @@ export function normalize(raw) {
     for (const [id, t] of Object.entries(raw.tiles)) {
       if (t && typeof t.type === "string") {
         tiles[id] = { id, type: t.type, props: { ...(t.props || {}) } };
+        if (typeof t.x === "number") tiles[id].x = t.x;
       }
     }
   }
-  const known = new Set(Object.keys(tiles));
-  const order = Array.isArray(raw.order) ? raw.order.filter(id => known.has(id)) : [];
-  // Append any tiles that exist but weren't in order (corrupt save)
-  for (const id of known) {
-    if (!order.includes(id)) order.push(id);
+  // Backfill x for tiles that lack it (old format or manual state).
+  const needsX = Object.keys(tiles).filter(id => typeof tiles[id].x !== "number");
+  if (needsX.length > 0) {
+    let pos = nextX(tiles); // start after highest existing x (0 if none)
+    const orderHint = Array.isArray(raw.order) ? raw.order : [];
+    const pending = new Set(needsX);
+    for (const id of orderHint) {
+      if (pending.has(id)) { tiles[id].x = pos++; pending.delete(id); }
+    }
+    for (const id of pending) { tiles[id].x = pos++; }
   }
-  const focusedId = raw.focusedId && known.has(raw.focusedId) ? raw.focusedId : (order[0] || null);
+  const order = deriveOrder(tiles);
+  const focusedId = raw.focusedId && tiles[raw.focusedId] ? raw.focusedId : (order[0] || null);
   return { version: VERSION, tiles, order, focusedId };
 }
 
@@ -168,9 +213,11 @@ export function serialize(state, isPersistable = () => true) {
   for (const [id, t] of Object.entries(state.tiles)) {
     if (isPersistable(t.type)) tiles[id] = t;
   }
-  const known = new Set(Object.keys(tiles));
-  const order = state.order.filter(id => known.has(id));
-  const focusedId = state.focusedId && known.has(state.focusedId) ? state.focusedId : (order[0] || null);
+  // Derive order from the persisted tiles' x coordinates. The order
+  // field is redundant (x is authoritative) but included for backward
+  // compat if the user ever rolls back to a pre-coordinate build.
+  const order = deriveOrder(tiles);
+  const focusedId = state.focusedId && tiles[state.focusedId] ? state.focusedId : (order[0] || null);
   return { version: VERSION, tiles, order, focusedId };
 }
 

--- a/test/auto-flip.test.js
+++ b/test/auto-flip.test.js
@@ -10,8 +10,10 @@
  * This test pins the behavior so that Phase 1.2 (consolidate status
  * polling into a single SessionStatusWatcher) does not regress it.
  *
- * The test uses mock timers + a mock fetch + mock carousel, not real
- * tmux or real network.
+ * The test uses mock timers + a mock fetch + a mock ctx.faceStack, not
+ * real tmux or real network. As of Tier 1 T1a the terminal tile no
+ * longer reaches into `deps.carousel` — it drives the flip through the
+ * container-provided `ctx.faceStack` affordance.
  */
 
 import { describe, it, beforeEach, afterEach, mock } from 'node:test';
@@ -84,13 +86,12 @@ function createMockTerminalPool() {
   };
 }
 
-function createMockCarousel() {
-  const flipped = new Set();
+function createMockFaceStack() {
+  let showing = false;
   return {
-    flipCard: mock.fn((name, _isFlipped) => { flipped.add(name); }),
-    isFlipped: (name) => flipped.has(name),
-    setBackTile: mock.fn(),
-    _flipped: flipped,
+    showSecondary: mock.fn((show) => { showing = !!show; }),
+    isShowingSecondary: () => showing,
+    setSecondary: mock.fn(),
   };
 }
 
@@ -115,7 +116,7 @@ function makeFetchScript(statuses) {
 describe('terminal-tile auto-flip on idle', () => {
   let createTerminalTileFactory;
   let terminalPool;
-  let carousel;
+  let faceStack;
   let originalFetch;
   let timers;
 
@@ -123,7 +124,7 @@ describe('terminal-tile auto-flip on idle', () => {
     setupGlobals();
     createTerminalTileFactory = await importTerminalTile();
     terminalPool = createMockTerminalPool();
-    carousel = createMockCarousel();
+    faceStack = createMockFaceStack();
     originalFetch = globalThis.fetch;
     timers = mock.timers;
     timers.enable({ apis: ['setInterval', 'setTimeout'] });
@@ -143,11 +144,11 @@ describe('terminal-tile auto-flip on idle', () => {
       { alive: true, hasChildProcesses: false, childCount: 0 },
     ]);
 
-    const factory = createTerminalTileFactory({ terminalPool, carousel });
+    const factory = createTerminalTileFactory({ terminalPool });
     const tile = factory({ sessionName: "dev" });
     const container = createMockElement("div");
 
-    tile.mount(container, { flip: () => {} });
+    tile.mount(container, { flip: () => {}, faceStack });
 
     // Tick the 5s status poll interval to trigger first poll (active)
     timers.tick(5000);
@@ -163,11 +164,10 @@ describe('terminal-tile auto-flip on idle', () => {
     await flush();
 
     assert.ok(
-      carousel.flipCard.mock.callCount() >= 1,
-      `expected flipCard to be called at least once after idle transition, got ${carousel.flipCard.mock.callCount()}`,
+      faceStack.showSecondary.mock.callCount() >= 1,
+      `expected showSecondary to be called at least once after idle transition, got ${faceStack.showSecondary.mock.callCount()}`,
     );
-    assert.strictEqual(carousel.flipCard.mock.calls[0].arguments[0], "dev");
-    assert.strictEqual(carousel.flipCard.mock.calls[0].arguments[1], true);
+    assert.strictEqual(faceStack.showSecondary.mock.calls[0].arguments[0], true);
   });
 
   it('does not flip when the tile has been unmounted before debounce fires', async () => {
@@ -177,11 +177,11 @@ describe('terminal-tile auto-flip on idle', () => {
       { alive: true, hasChildProcesses: false, childCount: 0 },
     ]);
 
-    const factory = createTerminalTileFactory({ terminalPool, carousel });
+    const factory = createTerminalTileFactory({ terminalPool });
     const tile = factory({ sessionName: "dev" });
     const container = createMockElement("div");
 
-    tile.mount(container, { flip: () => {} });
+    tile.mount(container, { flip: () => {}, faceStack });
     timers.tick(5000);
     await flush();
     timers.tick(5000);
@@ -194,9 +194,9 @@ describe('terminal-tile auto-flip on idle', () => {
     await flush();
 
     assert.strictEqual(
-      carousel.flipCard.mock.callCount(),
+      faceStack.showSecondary.mock.callCount(),
       0,
-      'destroyed tile must not call carousel.flipCard',
+      'destroyed tile must not call faceStack.showSecondary',
     );
   });
 
@@ -206,11 +206,11 @@ describe('terminal-tile auto-flip on idle', () => {
       { alive: true, hasChildProcesses: true, childCount: 2 },
     ]);
 
-    const factory = createTerminalTileFactory({ terminalPool, carousel });
+    const factory = createTerminalTileFactory({ terminalPool });
     const tile = factory({ sessionName: "dev" });
     const container = createMockElement("div");
 
-    tile.mount(container, { flip: () => {} });
+    tile.mount(container, { flip: () => {}, faceStack });
     timers.tick(5000);
     await flush();
     timers.tick(5000);
@@ -218,6 +218,6 @@ describe('terminal-tile auto-flip on idle', () => {
     timers.tick(2000);
     await flush();
 
-    assert.strictEqual(carousel.flipCard.mock.callCount(), 0);
+    assert.strictEqual(faceStack.showSecondary.mock.callCount(), 0);
   });
 });

--- a/test/e2e/file-browser.e2e.js
+++ b/test/e2e/file-browser.e2e.js
@@ -1,229 +1,159 @@
+/**
+ * File Browser tile E2E
+ *
+ * The file-browser is a first-class tile (PR #533). These tests are the
+ * regression contracts for the three reported user-visible bugs:
+ *
+ *   P1/P2 — no phantom file-browser tile on fresh load or after reload
+ *   P3/P4/P5/P6 — tab context menu + close paths on the file-browser tile
+ *   P7 — terminal tab context menu is unchanged (regression guard)
+ *   P8 — file-browser tile fills the carousel cell like a terminal tile
+ *
+ * The previous version of this file targeted the retired #file-browser
+ * overlay (selectors like `.fb-hidden`, aria-label="Close file browser").
+ * Those no longer exist — the file browser is now hosted inside a
+ * carousel card via tile-chrome.
+ */
 import { test, expect } from "@playwright/test";
-import { waitForAppReady, waitForShellReady } from "./helpers.js";
+import { setupTest, cleanupSession, waitForAppReady } from "./helpers.js";
 
-test.describe("File Browser", () => {
+const FB_TILE_SELECTOR = '.carousel-card:has(.fb-root)';
+const TERMINAL_TILE_SELECTOR = '.carousel-card:has(.terminal-pane)';
+async function openFileBrowser(page) {
+  // Desktop: sidebar is hidden, so use the tab-bar "+" add menu which
+  // exposes a "New Files" item built from tileTypes.
+  await page.click(".ipad-add-btn");
+  const menu = page.locator(".tab-context-menu, .dropdown-menu, [role=menu]").last();
+  await menu.getByText(/New Files/i).click();
+  await page.waitForSelector(".fb-miller-col", { timeout: 5000 });
+}
+
+test.describe("File Browser tile", () => {
   let sessionName;
 
-  test.beforeEach(async ({ page }, testInfo) => {
-    sessionName = `fb-${testInfo.testId}-${Date.now()}`;
-    await page.goto(`/?s=${encodeURIComponent(sessionName)}`);
-    await waitForAppReady(page);
-    await page.locator(".xterm-helper-textarea").focus();
-  });
-
   test.afterEach(async ({ page }) => {
-    await page.evaluate(
-      (n) => fetch(`/sessions/${encodeURIComponent(n)}`, { method: "DELETE" }),
-      sessionName,
+    await cleanupSession(page, sessionName);
+    sessionName = null;
+  });
+
+  test("P1: fresh load (clean storage) has no file-browser tile", async ({ page, context }, testInfo) => {
+    // Clear storage on a blank page first, then navigate.
+    await page.goto("/");
+    await page.evaluate(() => { localStorage.clear(); sessionStorage.clear(); });
+    sessionName = await setupTest({ page, context, testInfo });
+    // After app is ready, there must be zero file-browser tiles.
+    const count = await page.locator(FB_TILE_SELECTOR).count();
+    expect(count).toBe(0);
+  });
+
+  test("P2: open file browser → reload → no file-browser tile restored", async ({ page, context }, testInfo) => {
+    await page.goto("/");
+    await page.evaluate(() => { localStorage.clear(); sessionStorage.clear(); });
+    sessionName = await setupTest({ page, context, testInfo });
+
+    await openFileBrowser(page);
+    await expect(page.locator(FB_TILE_SELECTOR)).toHaveCount(1);
+
+    // Dump what we persisted so failures show the stored shape.
+    const stored = await page.evaluate(() =>
+      localStorage.getItem("katulong.carousel.v1") || localStorage.getItem("katulong-carousel") || null
     );
+    // eslint-disable-next-line no-console
+    console.log("[P2] stored carousel state:", stored);
+
+    await page.reload();
+    await waitForAppReady(page);
+
+    const count = await page.locator(FB_TILE_SELECTOR).count();
+    expect(count).toBe(0);
   });
 
-  test("File browser button is visible in shortcut bar", async ({ page }) => {
-    const filesBtn = page.locator('button[aria-label="Open file browser"]').first();
-    await expect(filesBtn).toBeVisible();
-  });
+  test("P3: right-click FB tab → only Close, no Detach/Kill/Open-in-new-window", async ({ page, context }, testInfo) => {
+    sessionName = await setupTest({ page, context, testInfo });
+    await openFileBrowser(page);
 
-  test("Opens file browser and shows columns", async ({ page }) => {
-    // Click the file browser button in the shortcut bar
-    await page.locator('button[aria-label="Open file browser"]').first().click();
+    // The FB tab's data-session is the tile id (`file-browser-*`).
+    const fbTileId = await page.locator(FB_TILE_SELECTOR).getAttribute("data-tile-id");
+    expect(fbTileId).toMatch(/^file-browser-/);
 
-    // File browser should be visible
-    const fb = page.locator("#file-browser");
-    await expect(fb).toHaveClass(/active/);
+    const tab = page.locator(`.tab-bar-tab[data-session="${fbTileId}"]`);
+    await expect(tab).toBeVisible();
+    await tab.click({ button: "right" });
 
-    // Terminal should be hidden
-    const termContainer = page.locator("#terminal-container");
-    await expect(termContainer).toHaveClass(/fb-hidden/);
-
-    // Should have at least one column with entries
-    await page.waitForSelector(".fb-miller-col", { timeout: 5000 });
-    const columns = page.locator(".fb-miller-col");
-    await expect(columns.first()).toBeVisible();
-
-    // Should have rows in the first column
-    const rows = page.locator(".fb-miller-row");
-    const count = await rows.count();
-    expect(count).toBeGreaterThan(0);
-  });
-
-  test("Clicking a folder drills into it", async ({ page }) => {
-    await page.locator('button[aria-label="Open file browser"]').first().click();
-    await page.waitForSelector(".fb-miller-col", { timeout: 5000 });
-
-    // Find and click a directory row
-    const dirRow = page.locator('.fb-miller-row[data-type="directory"]').first();
-    await expect(dirRow).toBeVisible();
-    const dirName = await dirRow.getAttribute("data-name");
-    await dirRow.click();
-
-    // Should now have a second column
-    await page.waitForSelector(".fb-miller-col:nth-child(2)", { timeout: 5000 });
-    const columns = page.locator(".fb-miller-col");
-    const colCount = await columns.count();
-    expect(colCount).toBeGreaterThanOrEqual(2);
-
-    // The clicked row should be selected (highlighted)
-    await expect(dirRow).toHaveClass(/fb-miller-selected/);
-  });
-
-  test("Folders show chevron indicator", async ({ page }) => {
-    await page.locator('button[aria-label="Open file browser"]').first().click();
-    await page.waitForSelector(".fb-miller-col", { timeout: 5000 });
-
-    // Directories should have a chevron
-    const dirRow = page.locator('.fb-miller-row[data-type="directory"]').first();
-    if (await dirRow.count() > 0) {
-      const chevron = dirRow.locator(".fb-miller-chevron");
-      await expect(chevron).toBeVisible();
-    }
-
-    // Files should NOT have a chevron
-    const fileRow = page.locator('.fb-miller-row[data-type="file"]').first();
-    if (await fileRow.count() > 0) {
-      const chevron = fileRow.locator(".fb-miller-chevron");
-      await expect(chevron).toHaveCount(0);
-    }
-  });
-
-  test("Close button returns to terminal", async ({ page }) => {
-    await page.locator('button[aria-label="Open file browser"]').first().click();
-    await page.waitForSelector(".fb-miller-col", { timeout: 5000 });
-
-    // Click close button
-    await page.locator('button[aria-label="Close file browser"]').click();
-
-    // File browser should be hidden
-    const fb = page.locator("#file-browser");
-    await expect(fb).not.toHaveClass(/active/);
-
-    // Terminal should be visible again
-    const termContainer = page.locator("#terminal-container");
-    await expect(termContainer).not.toHaveClass(/fb-hidden/);
-  });
-
-  test("Terminal session survives file browser toggle", async ({ page }) => {
-    // Type something in the terminal first
-    const marker = `fb_survive_${Date.now()}`;
-    await page.keyboard.type(`echo ${marker}`);
-    await page.keyboard.press("Enter");
-    await expect(page.locator(".xterm-rows")).toContainText(marker);
-
-    // Open file browser
-    await page.locator('button[aria-label="Open file browser"]').first().click();
-    await page.waitForSelector(".fb-miller-col", { timeout: 5000 });
-
-    // Browse around - click a folder
-    const dirRow = page.locator('.fb-miller-row[data-type="directory"]').first();
-    if (await dirRow.count() > 0) {
-      await dirRow.click();
-      await page.waitForSelector(".fb-miller-col:nth-child(2)", { timeout: 5000 });
-    }
-
-    // Close file browser, return to terminal
-    await page.locator('button[aria-label="Close file browser"]').click();
-    await expect(page.locator("#terminal-container")).not.toHaveClass(/fb-hidden/);
-
-    // Terminal should still work — type another command
-    await page.locator(".xterm-helper-textarea").focus();
-    const marker2 = `fb_after_${Date.now()}`;
-    await page.keyboard.type(`echo ${marker2}`);
-    await page.keyboard.press("Enter");
-    await expect(page.locator(".xterm-rows")).toContainText(marker2, { timeout: 10000 });
-  });
-
-  test("Breadcrumb shows current path", async ({ page }) => {
-    await page.locator('button[aria-label="Open file browser"]').first().click();
-    await page.waitForSelector(".fb-miller-col", { timeout: 5000 });
-
-    // Breadcrumb should show at least "/"
-    const breadcrumb = page.locator(".fb-breadcrumb");
-    await expect(breadcrumb).toContainText("/");
-  });
-
-  test("Back button removes last column", async ({ page }) => {
-    await page.locator('button[aria-label="Open file browser"]').first().click();
-    await page.waitForSelector(".fb-miller-col", { timeout: 5000 });
-
-    // Drill into a folder
-    const dirRow = page.locator('.fb-miller-row[data-type="directory"]').first();
-    if (await dirRow.count() === 0) {
-      test.skip();
-      return;
-    }
-    await dirRow.click();
-    await page.waitForSelector(".fb-miller-col:nth-child(2)", { timeout: 5000 });
-
-    const colsBefore = await page.locator(".fb-miller-col").count();
-
-    // Click back
-    await page.locator('button[aria-label="Go back"]').click();
-
-    // Should have one fewer column
-    const colsAfter = await page.locator(".fb-miller-col").count();
-    expect(colsAfter).toBeLessThan(colsBefore);
-  });
-
-  test("Status bar shows item count", async ({ page }) => {
-    await page.locator('button[aria-label="Open file browser"]').first().click();
-    await page.waitForSelector(".fb-miller-col", { timeout: 5000 });
-
-    const status = page.locator(".fb-status");
-    await expect(status).toContainText("item");
-  });
-
-  test("Context menu appears on right-click", async ({ page }) => {
-    await page.locator('button[aria-label="Open file browser"]').first().click();
-    await page.waitForSelector(".fb-miller-row", { timeout: 5000 });
-
-    // Right-click on a row
-    const row = page.locator(".fb-miller-row").first();
-    await row.click({ button: "right" });
-
-    // Context menu should appear
-    const menu = page.locator(".fb-context-menu");
+    const menu = page.locator(".tab-context-menu");
     await expect(menu).toBeVisible();
+    const labels = await menu.locator(".menu-item, .context-menu-item, [role=menuitem], button, div").allTextContents();
+    const joined = labels.join(" | ").toLowerCase();
 
-    // Click elsewhere to dismiss
-    await page.locator(".fb-columns").click({ position: { x: 5, y: 5 } });
-    await expect(menu).not.toBeVisible();
+    expect(joined).toContain("close");
+    expect(joined).not.toContain("detach");
+    expect(joined).not.toContain("kill session");
+    expect(joined).not.toContain("open in new window");
   });
 
-  test("File browser API returns directory listing", async ({ page }) => {
-    const response = await page.evaluate(() =>
-      fetch("/api/files").then(r => r.json())
-    );
-    expect(response.path).toBeTruthy();
-    expect(Array.isArray(response.entries)).toBe(true);
-    expect(response.entries.length).toBeGreaterThan(0);
-    // Each entry should have required fields
-    const entry = response.entries[0];
-    expect(entry.name).toBeTruthy();
-    expect(["file", "directory"]).toContain(entry.type);
-    expect(entry.kind).toBeTruthy();
+  test("P4: clicking Close in FB tab context menu removes the tile", async ({ page, context }, testInfo) => {
+    sessionName = await setupTest({ page, context, testInfo });
+    await openFileBrowser(page);
+
+    const fbTileId = await page.locator(FB_TILE_SELECTOR).getAttribute("data-tile-id");
+    const tab = page.locator(`.tab-bar-tab[data-session="${fbTileId}"]`);
+    await tab.click({ button: "right" });
+
+    const menu = page.locator(".tab-context-menu");
+    await expect(menu).toBeVisible();
+    // Click the item whose text contains "Close"
+    await menu.getByText(/^Close$/i).first().click();
+
+    await expect(page.locator(FB_TILE_SELECTOR)).toHaveCount(0);
   });
 
-  test("File browser API rejects path traversal", async ({ page }) => {
-    const response = await page.evaluate(() =>
-      fetch("/api/files?path=/etc/../etc/passwd").then(r => ({ status: r.status }))
-    );
-    expect(response.status).toBe(400);
+  test("P5: component header X removes the tile", async ({ page, context }, testInfo) => {
+    sessionName = await setupTest({ page, context, testInfo });
+    await openFileBrowser(page);
+
+    const tile = page.locator(FB_TILE_SELECTOR);
+    await expect(tile).toHaveCount(1);
+
+    // The file-browser component has its own close button in the header.
+    // Prefer any button with an aria-label starting with "Close".
+    const closeBtn = tile.locator('button[aria-label*="Close" i]').first();
+    await closeBtn.click();
+
+    await expect(page.locator(FB_TILE_SELECTOR)).toHaveCount(0);
   });
 
-  test("Global drop overlay does not appear when file browser is active", async ({ page }) => {
-    await page.locator('button[aria-label="Open file browser"]').first().click();
-    await page.waitForSelector(".fb-miller-col", { timeout: 5000 });
+  test("P6: two clicks on files button → two independent tiles", async ({ page, context }, testInfo) => {
+    sessionName = await setupTest({ page, context, testInfo });
+    await openFileBrowser(page);
+    await openFileBrowser(page);
+    await expect(page.locator(FB_TILE_SELECTOR)).toHaveCount(2);
+  });
 
-    // Simulate dragenter on the page
-    await page.evaluate(() => {
-      const event = new DragEvent("dragenter", {
-        bubbles: true,
-        dataTransfer: new DataTransfer(),
-      });
-      document.querySelector(".fb-columns").dispatchEvent(event);
-    });
+  test("P7: terminal tab context menu still has Detach and Kill session", async ({ page, context }, testInfo) => {
+    sessionName = await setupTest({ page, context, testInfo });
+    const tab = page.locator(`.tab-bar-tab[data-session="${sessionName}"]`);
+    await expect(tab).toBeVisible();
+    await tab.click({ button: "right" });
+    const menu = page.locator(".tab-context-menu");
+    await expect(menu).toBeVisible();
+    const text = (await menu.allTextContents()).join(" ").toLowerCase();
+    expect(text).toContain("detach");
+    expect(text).toContain("kill session");
+  });
 
-    // The global "Drop image here" overlay should NOT be visible
-    const dropOverlay = page.locator("#drop-overlay");
-    await expect(dropOverlay).not.toHaveClass(/visible/);
+  test("P8: FB tile width matches terminal tile width", async ({ page, context }, testInfo) => {
+    sessionName = await setupTest({ page, context, testInfo });
+
+    const termBox = await page.locator(TERMINAL_TILE_SELECTOR).first().boundingBox();
+    expect(termBox).not.toBeNull();
+
+    await openFileBrowser(page);
+    const fbBox = await page.locator(FB_TILE_SELECTOR).first().boundingBox();
+    expect(fbBox).not.toBeNull();
+
+    // Same layout slot → widths within 2px.
+    expect(Math.abs(fbBox.width - termBox.width)).toBeLessThan(2);
+    // And the FB tile should be meaningfully wide (>300px), not a narrow side panel.
+    expect(fbBox.width).toBeGreaterThan(300);
   });
 });

--- a/test/file-browser-tile-persist.test.js
+++ b/test/file-browser-tile-persist.test.js
@@ -1,0 +1,229 @@
+/**
+ * file-browser tile: persistence opt-out + close path integration
+ *
+ * These tests pin two regressions the carousel used to have:
+ *
+ *  1. File-browser tiles (which have no tmux-backed state) must not be
+ *     written to the carousel's localStorage persistence — they are
+ *     session-scoped. Reload should forget them.
+ *
+ *  2. The `ctx.requestClose()` wiring landed in a4d8048 must actually
+ *     result in the tile being removed from the carousel when called
+ *     from any code path (X button, tab-bar context menu, etc.).
+ *
+ * Both are asserted here at the carousel seam so the capability check
+ * is exercised end-to-end with the real card-carousel module (not the
+ * file-browser tile in isolation, which was already tested).
+ */
+
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert";
+
+// ── Minimal DOM shims (mirror card-carousel.test.js) ───────────────────
+
+function createMockElement(tag) {
+  const styles = {};
+  const classes = new Set();
+  const children = [];
+  const listeners = {};
+  const styleTarget = {
+    setProperty: (k, v) => { styles[k] = v; },
+    removeProperty: (k) => { delete styles[k]; },
+  };
+  const el = {
+    tagName: (tag || "DIV").toUpperCase(),
+    style: new Proxy(styleTarget, {
+      set: (_t, k, v) => { styles[k] = v; return true; },
+      get: (t, k) => (k in t ? t[k] : (styles[k] || "")),
+    }),
+    classList: {
+      add: (...c) => c.forEach(x => classes.add(x)),
+      remove: (...c) => c.forEach(x => classes.delete(x)),
+      toggle: (c, f) => f !== undefined ? (f ? classes.add(c) : classes.delete(c)) : (classes.has(c) ? classes.delete(c) : classes.add(c)),
+      contains: (c) => classes.has(c),
+    },
+    className: "",
+    dataset: {},
+    appendChild: (child) => { children.push(child); child.parentElement = el; return child; },
+    insertBefore: (child, ref) => {
+      child.parentElement = el;
+      const idx = ref ? children.indexOf(ref) : children.length;
+      if (idx === -1) children.push(child); else children.splice(idx, 0, child);
+      return child;
+    },
+    remove: () => { el.parentElement = null; },
+    addEventListener: (type, fn) => { (listeners[type] = listeners[type] || []).push(fn); },
+    removeEventListener: (type, fn) => { if (listeners[type]) listeners[type] = listeners[type].filter(f => f !== fn); },
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    get firstChild() { return children[0] || null; },
+    get nextSibling() { return null; },
+    get previousElementSibling() { return null; },
+    get nextElementSibling() { return null; },
+    get parentElement() { return el._parentElement || null; },
+    set parentElement(v) { el._parentElement = v; },
+    get innerHTML() { return ""; },
+    set innerHTML(v) { children.length = 0; },
+    focus: () => {},
+    blur: () => {},
+    select: () => {},
+    setAttribute: (k, v) => { el[`_attr_${k}`] = v; },
+    getAttribute: (k) => el[`_attr_${k}`] || null,
+    scrollIntoView: () => {},
+    getBoundingClientRect: () => ({ left: 0, top: 0, width: 100, height: 100 }),
+    get offsetHeight() { return 100; },
+    get offsetWidth() { return 800; },
+    _classes: classes,
+    _styles: styles,
+    _children: children,
+    _listeners: listeners,
+  };
+  return el;
+}
+
+function setupGlobals() {
+  Object.defineProperty(globalThis, "navigator", {
+    value: { maxTouchPoints: 0, userAgent: "" },
+    writable: true, configurable: true,
+  });
+  globalThis.window = globalThis.window || globalThis;
+  globalThis.window.innerWidth = 1024;
+  if (!globalThis.window.addEventListener) globalThis.window.addEventListener = () => {};
+  globalThis.window.matchMedia = () => ({ matches: false, addEventListener: () => {} });
+  globalThis.screen = { orientation: { type: "landscape-primary", addEventListener: () => {} }, width: 1024, height: 768 };
+  globalThis.document = globalThis.document || {};
+  globalThis.document.createElement = (tag) => createMockElement(tag);
+  globalThis.document.getElementById = () => null;
+  globalThis.document.querySelector = () => null;
+  globalThis.requestAnimationFrame = (fn) => fn();
+  globalThis.getComputedStyle = () => ({ getPropertyValue: () => "" });
+  const storage = {};
+  globalThis.__storage = storage;
+  globalThis.localStorage = {
+    getItem: (k) => storage[k] ?? null,
+    setItem: (k, v) => { storage[k] = String(v); },
+    removeItem: (k) => { delete storage[k]; },
+  };
+}
+
+function makeMockTile(type, id) {
+  return {
+    type,
+    get sessionName() { return id; },
+    mount: mock.fn(),
+    unmount: mock.fn(),
+    focus: mock.fn(),
+    blur: mock.fn(),
+    resize: mock.fn(),
+    getTitle: () => id,
+    getIcon: () => "x",
+    serialize: () => ({ type, sessionName: id }),
+  };
+}
+
+function makePersistableFalseTile(type, id) {
+  const t = makeMockTile(type, id);
+  t.persistable = false;
+  return t;
+}
+
+async function importCarousel() {
+  const url = new URL("../public/lib/card-carousel.js", import.meta.url);
+  const mod = await import(url.href + "?t=" + Date.now() + Math.random());
+  return mod;
+}
+
+describe("file-browser tile — persistence opt-out", () => {
+  let createCardCarousel;
+  let onCardDismissed;
+  let container;
+  let carousel;
+
+  beforeEach(async () => {
+    setupGlobals();
+    ({ createCardCarousel } = await importCarousel());
+    container = createMockElement("div");
+    onCardDismissed = mock.fn();
+    carousel = createCardCarousel({
+      container,
+      onCardDismissed,
+      onAllCardsDismissed: mock.fn(),
+      isTypePersistable: (type) => type !== "file-browser",
+    });
+  });
+
+  it("save() skips tiles with persistable: false", () => {
+    const term = makeMockTile("terminal", "t1");
+    const fb = makePersistableFalseTile("file-browser", "file-browser-abc");
+    carousel.activate([{ id: "t1", tile: term }, { id: "file-browser-abc", tile: fb }], "t1");
+    const raw = globalThis.localStorage.getItem("katulong-carousel");
+    assert.ok(raw, "carousel persisted something");
+    const parsed = JSON.parse(raw);
+    const ids = parsed.cards.map(c => c.id);
+    assert.deepStrictEqual(ids, ["t1"], "file-browser tile should not be persisted");
+  });
+
+  it("save() omits persistence entirely if all tiles are non-persistable", () => {
+    const fb = makePersistableFalseTile("file-browser", "file-browser-abc");
+    carousel.activate([{ id: "file-browser-abc", tile: fb }], "file-browser-abc");
+    const raw = globalThis.localStorage.getItem("katulong-carousel");
+    // Either absent or an empty cards array — both mean "nothing to restore"
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      assert.deepStrictEqual(parsed.cards, []);
+    }
+  });
+
+  it("restore() drops legacy persisted file-browser entries (storage migration)", () => {
+    // Simulate a user whose localStorage was written by the buggy version
+    globalThis.localStorage.setItem("katulong-carousel", JSON.stringify({
+      cards: [
+        { id: "t1", type: "terminal", sessionName: "t1" },
+        { id: "file-browser-legacy", type: "file-browser", cwd: "/tmp" },
+      ],
+      focused: "file-browser-legacy",
+    }));
+    const state = carousel.restore();
+    assert.ok(state, "restore returns state");
+    const ids = state.tiles.map(t => t.id);
+    assert.deepStrictEqual(ids, ["t1"], "legacy file-browser entry dropped on restore");
+  });
+});
+
+describe("file-browser tile — ctx.requestClose removes the card", () => {
+  let createCardCarousel;
+  let onCardDismissed;
+  let carousel;
+
+  beforeEach(async () => {
+    setupGlobals();
+    ({ createCardCarousel } = await importCarousel());
+    onCardDismissed = mock.fn();
+    carousel = createCardCarousel({
+      container: createMockElement("div"),
+      onCardDismissed,
+      onAllCardsDismissed: mock.fn(),
+      isTypePersistable: (type) => type !== "file-browser",
+    });
+  });
+
+  it("ctx.requestClose() removes the card and fires onCardDismissed", async () => {
+    let capturedCtx = null;
+    const fb = makePersistableFalseTile("file-browser", "file-browser-abc");
+    fb.mount = mock.fn((_el, ctx) => { capturedCtx = ctx; });
+    const term = makeMockTile("terminal", "t1");
+    carousel.activate(
+      [{ id: "t1", tile: term }, { id: "file-browser-abc", tile: fb }],
+      "file-browser-abc",
+    );
+    assert.ok(capturedCtx, "mount was called with a ctx");
+    assert.strictEqual(typeof capturedCtx.requestClose, "function");
+    capturedCtx.requestClose();
+    // requestClose defers via queueMicrotask — flush it
+    await new Promise(r => queueMicrotask(r));
+    assert.deepStrictEqual(carousel.getCards(), ["t1"]);
+    assert.strictEqual(fb.unmount.mock.callCount(), 1);
+    assert.strictEqual(onCardDismissed.mock.callCount(), 1);
+    assert.strictEqual(onCardDismissed.mock.calls[0].arguments[0], "file-browser-abc");
+  });
+});

--- a/test/file-browser-tile.test.js
+++ b/test/file-browser-tile.test.js
@@ -78,6 +78,29 @@ describe("file-browser-tile", () => {
     assert.equal(restored.getIcon(), "folder");
   });
 
+  it("component onClose routes through ctx.requestClose", () => {
+    createComponentCalls.length = 0;
+    const factory = createFileBrowserTileFactory();
+    const tile = factory({ cwd: "/tmp/x", sessionName: "s" });
+    const requestClose = mock.fn();
+    tile.mount(makeEl(), { requestClose });
+    // Grab the onClose the tile wired into the component and invoke it.
+    const { opts } = createComponentCalls[createComponentCalls.length - 1];
+    assert.equal(typeof opts.onClose, "function");
+    opts.onClose();
+    assert.equal(requestClose.mock.callCount(), 1);
+  });
+
+  it("component onClose is a no-op when ctx has no requestClose", () => {
+    createComponentCalls.length = 0;
+    const factory = createFileBrowserTileFactory();
+    const tile = factory({ cwd: "/tmp/x", sessionName: "s" });
+    tile.mount(makeEl(), {}); // no requestClose
+    const { opts } = createComponentCalls[createComponentCalls.length - 1];
+    // Must not throw — falls back to a no-op when host doesn't supply it.
+    assert.doesNotThrow(() => opts.onClose());
+  });
+
   it("mount creates the component and loadRoots the constructor cwd", () => {
     loadRootCalls.length = 0;
     createComponentCalls.length = 0;

--- a/test/tile-host.test.js
+++ b/test/tile-host.test.js
@@ -1,0 +1,406 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert";
+
+// tile-host has zero imports now (getRenderer is injected), so the
+// file:// URL import works without a custom Node loader.
+const { createTileHost } = await import(
+  new URL("../public/lib/tile-host.js", import.meta.url).href
+);
+
+// ── Minimal store ──────────────────────────────────────────────────────
+// Just enough to drive tile-host: getState, subscribe, dispatch.
+function createTestStore(initial = { tiles: {}, order: [], focusedId: null }) {
+  let state = { ...initial };
+  const subs = new Set();
+
+  function notify() { subs.forEach(fn => fn(state)); }
+
+  return {
+    getState: () => state,
+    subscribe(fn) { subs.add(fn); return () => subs.delete(fn); },
+    dispatch(action) { /* not used by tile-host */ },
+    // Test helpers — mutate state and notify subscribers
+    setState(next) { state = next; notify(); },
+    addTile(id, type, props, focus) {
+      state = {
+        ...state,
+        tiles: { ...state.tiles, [id]: { id, type, props } },
+        order: [...state.order, id],
+        focusedId: focus ? id : state.focusedId,
+      };
+      notify();
+    },
+    removeTile(id) {
+      const { [id]: _, ...rest } = state.tiles;
+      state = {
+        ...state,
+        tiles: rest,
+        order: state.order.filter(x => x !== id),
+        focusedId: state.focusedId === id ? (state.order.filter(x => x !== id)[0] || null) : state.focusedId,
+      };
+      notify();
+    },
+    focusTile(id) {
+      state = { ...state, focusedId: id };
+      notify();
+    },
+    reorder(order) {
+      state = { ...state, order };
+      notify();
+    },
+  };
+}
+
+// ── Fake renderer ──────────────────────────────────────────────────────
+function createFakeRenderer() {
+  const mounts = [];
+  return {
+    mounts,
+    getRenderer(type) {
+      if (type !== "terminal") return null;
+      return {
+        type: "terminal",
+        describe(props) {
+          return { title: props.sessionName || "terminal", icon: "t", persistable: true };
+        },
+        mount(_el, { id, props }) {
+          const entry = { id, mounted: true };
+          mounts.push(entry);
+          return {
+            unmount() { entry.mounted = false; },
+            focus() {},
+            blur() {},
+            resize() {},
+            tile: { sessionName: props.sessionName || id },
+          };
+        },
+      };
+    },
+  };
+}
+
+// ── Mock carousel ──────────────────────────────────────────────────────
+function createMockCarousel() {
+  let active = false;
+  let cards = [];
+  let focusedId = null;
+  const log = [];
+
+  return {
+    log,
+    isActive: () => active,
+    getCards: () => [...cards],
+    getFocusedCard: () => focusedId,
+
+    activate(tiles, focused) {
+      log.push({ op: "activate", ids: tiles.map(t => t.id), focused });
+      active = true;
+      cards = tiles.map(t => t.id);
+      focusedId = focused || cards[0] || null;
+      for (const { tile } of tiles) tile.mount({}, {});
+    },
+
+    addCard(id, tile, position) {
+      log.push({ op: "addCard", id, position });
+      if (!active) return;
+      if (cards.includes(id)) return;
+      if (typeof position === "number") cards.splice(position, 0, id);
+      else cards.push(id);
+      tile.mount({}, {});
+    },
+
+    removeCard(id) {
+      log.push({ op: "removeCard", id });
+      cards = cards.filter(c => c !== id);
+      if (focusedId === id) focusedId = cards[0] || null;
+    },
+
+    focusCard(id) {
+      log.push({ op: "focusCard", id });
+      focusedId = id;
+    },
+
+    reorderCards(order) {
+      log.push({ op: "reorderCards", order: [...order] });
+      cards = [...order];
+    },
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("tile-host", () => {
+  let store, carousel, renderer, host;
+
+  beforeEach(() => {
+    store = createTestStore();
+    carousel = createMockCarousel();
+    renderer = createFakeRenderer();
+  });
+
+  function createHost(opts = {}) {
+    host = createTileHost({
+      store,
+      carousel,
+      getRenderer: renderer.getRenderer,
+      onFocusChange: opts.onFocusChange || (() => {}),
+    });
+    return host;
+  }
+
+  // ── BUG: refresh — store pre-populated before init ─────────────────
+  describe("init with pre-populated store (refresh path)", () => {
+    it("activates carousel with all tiles from store", () => {
+      store.setState({
+        tiles: {
+          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
+          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+        },
+        order: ["s1", "s2"],
+        focusedId: "s1",
+      });
+
+      createHost();
+      host.init();
+
+      const op = carousel.log.find(l => l.op === "activate");
+      assert.ok(op, "carousel.activate must be called");
+      assert.deepStrictEqual(op.ids, ["s1", "s2"]);
+      assert.strictEqual(op.focused, "s1");
+    });
+
+    it("mounts every tile via the renderer", () => {
+      store.setState({
+        tiles: {
+          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
+        },
+        order: ["s1"],
+        focusedId: "s1",
+      });
+
+      createHost();
+      host.init();
+
+      assert.strictEqual(renderer.mounts.length, 1);
+      assert.strictEqual(renderer.mounts[0].id, "s1");
+      assert.strictEqual(renderer.mounts[0].mounted, true);
+    });
+  });
+
+  // ── BUG: add tile from empty — tab shows but tile doesn't ──────────
+  describe("add tile to empty store after init", () => {
+    it("activates carousel when first tile is added", () => {
+      createHost();
+      host.init();
+
+      assert.strictEqual(carousel.isActive(), false);
+      assert.strictEqual(carousel.log.length, 0);
+
+      store.addTile("s1", "terminal", { sessionName: "s1" }, true);
+
+      const op = carousel.log.find(l => l.op === "activate");
+      assert.ok(op, "carousel.activate must fire on first tile add");
+      assert.deepStrictEqual(op.ids, ["s1"]);
+      assert.strictEqual(renderer.mounts.length, 1);
+    });
+
+    it("uses addCard for subsequent tiles", () => {
+      createHost();
+      host.init();
+
+      store.addTile("s1", "terminal", { sessionName: "s1" }, true);
+      store.addTile("s2", "terminal", { sessionName: "s2" }, true);
+
+      const addOps = carousel.log.filter(l => l.op === "addCard");
+      assert.strictEqual(addOps.length, 1, "second tile should use addCard");
+      assert.strictEqual(addOps[0].id, "s2");
+      assert.strictEqual(renderer.mounts.length, 2);
+    });
+
+    it("inserts new tile at the correct position from state.order", () => {
+      // Simulate afterFocus: store already has [s1, s2], focus on s1.
+      // A new tile 'fb' is inserted at index 1 (right of s1).
+      createHost();
+      host.init();
+
+      store.addTile("s1", "terminal", { sessionName: "s1" }, true);
+      store.addTile("s2", "terminal", { sessionName: "s2" }, false);
+
+      // Now insert fb between s1 and s2 (afterFocus on s1)
+      const s = store.getState();
+      store.setState({
+        ...s,
+        tiles: { ...s.tiles, fb: { id: "fb", type: "terminal", props: { sessionName: "fb" } } },
+        order: ["s1", "fb", "s2"],
+        focusedId: "fb",
+      });
+
+      const addOps = carousel.log.filter(l => l.op === "addCard");
+      const fbOp = addOps.find(l => l.id === "fb");
+      assert.ok(fbOp, "addCard must be called for fb");
+      assert.strictEqual(fbOp.position, 1, "fb must be inserted at index 1 (right of s1)");
+
+      // Carousel order should reflect the store order
+      assert.deepStrictEqual(carousel.getCards(), ["s1", "fb", "s2"]);
+    });
+  });
+
+  // ── Remove ─────────────────────────────────────────────────────────
+  describe("remove tile", () => {
+    it("calls carousel.removeCard", () => {
+      store.setState({
+        tiles: {
+          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
+          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+        },
+        order: ["s1", "s2"],
+        focusedId: "s1",
+      });
+
+      createHost();
+      host.init();
+
+      store.removeTile("s2");
+
+      const op = carousel.log.find(l => l.op === "removeCard");
+      assert.ok(op, "carousel.removeCard must be called");
+      assert.strictEqual(op.id, "s2");
+    });
+
+    it("unmounts the renderer handle", () => {
+      store.setState({
+        tiles: {
+          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
+        },
+        order: ["s1"],
+        focusedId: "s1",
+      });
+
+      createHost();
+      host.init();
+
+      assert.strictEqual(renderer.mounts[0].mounted, true);
+
+      store.removeTile("s1");
+      // removeCard is called — the carousel is responsible for
+      // calling adapter.unmount(), which the real carousel does.
+      // Our mock doesn't, but the handle tracking should clear.
+      assert.strictEqual(host.getHandle("s1"), null);
+    });
+  });
+
+  // ── Focus ──────────────────────────────────────────────────────────
+  describe("focus change", () => {
+    it("calls carousel.focusCard", () => {
+      store.setState({
+        tiles: {
+          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
+          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+        },
+        order: ["s1", "s2"],
+        focusedId: "s1",
+      });
+
+      createHost();
+      host.init();
+
+      store.focusTile("s2");
+
+      const ops = carousel.log.filter(l => l.op === "focusCard");
+      const last = ops[ops.length - 1];
+      assert.ok(last);
+      assert.strictEqual(last.id, "s2");
+    });
+
+    it("fires onFocusChange with tile type", () => {
+      const changes = [];
+      store.setState({
+        tiles: {
+          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
+          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+        },
+        order: ["s1", "s2"],
+        focusedId: "s1",
+      });
+
+      createHost({ onFocusChange: (id, type) => changes.push({ id, type }) });
+      host.init();
+
+      // init fires for initial focus (prev null → s1)
+      assert.strictEqual(changes.length, 1);
+      assert.strictEqual(changes[0].id, "s1");
+
+      store.focusTile("s2");
+      assert.strictEqual(changes.length, 2);
+      assert.deepStrictEqual(changes[1], { id: "s2", type: "terminal" });
+    });
+  });
+
+  // ── Reorder ────────────────────────────────────────────────────────
+  describe("reorder", () => {
+    it("calls carousel.reorderCards", () => {
+      store.setState({
+        tiles: {
+          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
+          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+        },
+        order: ["s1", "s2"],
+        focusedId: "s1",
+      });
+
+      createHost();
+      host.init();
+
+      store.reorder(["s2", "s1"]);
+
+      const ops = carousel.log.filter(l => l.op === "reorderCards");
+      assert.ok(ops.length > 0);
+      assert.deepStrictEqual(ops[ops.length - 1].order, ["s2", "s1"]);
+    });
+  });
+
+  // ── Destroy ────────────────────────────────────────────────────────
+  describe("destroy", () => {
+    it("stops reacting to store changes", () => {
+      createHost();
+      host.init();
+
+      store.addTile("s1", "terminal", { sessionName: "s1" }, true);
+      const before = carousel.log.length;
+
+      host.destroy();
+
+      store.addTile("s2", "terminal", { sessionName: "s2" }, true);
+      assert.strictEqual(carousel.log.length, before, "no carousel calls after destroy");
+    });
+  });
+
+  // ── Re-entrancy guard ──────────────────────────────────────────────
+  describe("re-entrancy", () => {
+    it("does not double-mount when onFocusChange triggers a dispatch", () => {
+      // Simulate what happens when a renderer dispatches UPDATE_PROPS
+      // from inside the focus callback — the store fires subscribers
+      // synchronously, which would re-enter reconcile without the guard.
+      createHost({
+        onFocusChange: (id) => {
+          const s = store.getState();
+          if (s.tiles[id]) {
+            // Mutate state from inside the callback
+            store.setState({
+              ...s,
+              tiles: {
+                ...s.tiles,
+                [id]: { ...s.tiles[id], props: { ...s.tiles[id].props, touched: true } },
+              },
+            });
+          }
+        },
+      });
+      host.init();
+
+      store.addTile("s1", "terminal", { sessionName: "s1" }, true);
+
+      assert.strictEqual(renderer.mounts.length, 1, "exactly one mount, not two");
+    });
+  });
+});

--- a/test/tile-host.test.js
+++ b/test/tile-host.test.js
@@ -61,7 +61,11 @@ function createFakeRenderer() {
       return {
         type: "terminal",
         describe(props) {
-          return { title: props.sessionName || "terminal", icon: "t", persistable: true };
+          return {
+            title: props.sessionName || "terminal", icon: "t", persistable: true,
+            session: props.sessionName || null, updatesUrl: true,
+            renameable: true, handlesDnd: false,
+          };
         },
         mount(_el, { id, props }) {
           const entry = { id, mounted: true };
@@ -71,6 +75,7 @@ function createFakeRenderer() {
             focus() {},
             blur() {},
             resize() {},
+            getSessions() { return [props.sessionName].filter(Boolean); },
             tile: { sessionName: props.sessionName || id },
           };
         },
@@ -401,6 +406,64 @@ describe("tile-host", () => {
       store.addTile("s1", "terminal", { sessionName: "s1" }, true);
 
       assert.strictEqual(renderer.mounts.length, 1, "exactly one mount, not two");
+    });
+  });
+
+  // ── onTileRemoved callback ────────────────────────────────────────
+  describe("onTileRemoved", () => {
+    it("fires with tile id and handle when a tile is removed", () => {
+      const removed = [];
+      store.setState({
+        tiles: {
+          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
+          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+        },
+        order: ["s1", "s2"],
+        focusedId: "s1",
+      });
+
+      host = createTileHost({
+        store,
+        carousel,
+        getRenderer: renderer.getRenderer,
+        onFocusChange: () => {},
+        onTileRemoved: (id, handle) => removed.push({ id, sessions: handle.getSessions?.() }),
+      });
+      host.init();
+
+      store.removeTile("s2");
+
+      assert.strictEqual(removed.length, 1);
+      assert.strictEqual(removed[0].id, "s2");
+      assert.deepStrictEqual(removed[0].sessions, ["s2"]);
+    });
+
+    it("fires for each tile on bulk removal (RESET to empty)", () => {
+      const removed = [];
+      store.setState({
+        tiles: {
+          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
+          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+        },
+        order: ["s1", "s2"],
+        focusedId: "s1",
+      });
+
+      host = createTileHost({
+        store,
+        carousel,
+        getRenderer: renderer.getRenderer,
+        onFocusChange: () => {},
+        onTileRemoved: (id, handle) => removed.push({ id, sessions: handle.getSessions?.() }),
+      });
+      host.init();
+
+      // Simulate RESET to empty state
+      store.setState({ tiles: {}, order: [], focusedId: null });
+
+      assert.strictEqual(removed.length, 2, "onTileRemoved fires for each tile");
+      const ids = removed.map(r => r.id).sort();
+      assert.deepStrictEqual(ids, ["s1", "s2"]);
     });
   });
 });

--- a/test/ui-store.test.js
+++ b/test/ui-store.test.js
@@ -1,0 +1,386 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const { normalize, serialize, EMPTY_STATE } = await import(
+  new URL("../public/lib/ui-store.js", import.meta.url).href
+);
+
+// ── normalize ───────────────────────────────────────────────────────
+
+describe("normalize", () => {
+  it("returns EMPTY_STATE for null/undefined", () => {
+    assert.deepStrictEqual(normalize(null), EMPTY_STATE);
+    assert.deepStrictEqual(normalize(undefined), EMPTY_STATE);
+    assert.deepStrictEqual(normalize(42), EMPTY_STATE);
+  });
+
+  it("assigns x from order array when tiles lack x (migration)", () => {
+    const raw = {
+      version: 1,
+      tiles: {
+        a: { id: "a", type: "terminal", props: {} },
+        b: { id: "b", type: "terminal", props: {} },
+        c: { id: "c", type: "terminal", props: {} },
+      },
+      order: ["b", "a", "c"],
+      focusedId: "a",
+    };
+    const result = normalize(raw);
+    assert.strictEqual(result.tiles.b.x, 0);
+    assert.strictEqual(result.tiles.a.x, 1);
+    assert.strictEqual(result.tiles.c.x, 2);
+    assert.deepStrictEqual(result.order, ["b", "a", "c"]);
+    assert.strictEqual(result.focusedId, "a");
+  });
+
+  it("preserves x when tiles already have it", () => {
+    const raw = {
+      version: 1,
+      tiles: {
+        a: { id: "a", type: "terminal", props: {}, x: 5 },
+        b: { id: "b", type: "terminal", props: {}, x: 2 },
+      },
+      focusedId: "a",
+    };
+    const result = normalize(raw);
+    assert.strictEqual(result.tiles.a.x, 5);
+    assert.strictEqual(result.tiles.b.x, 2);
+    assert.deepStrictEqual(result.order, ["b", "a"]);
+  });
+
+  it("backfills missing tiles not in order array (corrupt save)", () => {
+    const raw = {
+      version: 1,
+      tiles: {
+        a: { id: "a", type: "terminal", props: {} },
+        b: { id: "b", type: "terminal", props: {} },
+        orphan: { id: "orphan", type: "terminal", props: {} },
+      },
+      order: ["a", "b"], // orphan missing from order
+      focusedId: "a",
+    };
+    const result = normalize(raw);
+    assert.strictEqual(result.tiles.a.x, 0);
+    assert.strictEqual(result.tiles.b.x, 1);
+    assert.strictEqual(result.tiles.orphan.x, 2);
+    assert.deepStrictEqual(result.order, ["a", "b", "orphan"]);
+  });
+
+  it("defaults focusedId to first tile when missing", () => {
+    const raw = {
+      tiles: { z: { id: "z", type: "terminal", props: {}, x: 0 } },
+    };
+    const result = normalize(raw);
+    assert.strictEqual(result.focusedId, "z");
+  });
+
+  it("rejects tiles with invalid type", () => {
+    const raw = {
+      tiles: {
+        good: { id: "good", type: "terminal", props: {} },
+        bad: { id: "bad", props: {} }, // no type
+      },
+      order: ["good", "bad"],
+    };
+    const result = normalize(raw);
+    assert.ok(result.tiles.good);
+    assert.ok(!result.tiles.bad);
+    assert.deepStrictEqual(result.order, ["good"]);
+  });
+});
+
+// ── reducer (via createUiStore) ─────────────────────────────────────
+
+// createUiStore calls normalize on initialState and wraps the reducer.
+// We test through it to exercise the real dispatch path.
+
+// Stub localStorage — ui-store calls saveToStorage on every change
+const _storage = {};
+globalThis.localStorage = {
+  getItem: (k) => _storage[k] ?? null,
+  setItem: (k, v) => { _storage[k] = v; },
+  removeItem: (k) => { delete _storage[k]; },
+};
+
+const { createUiStore } = await import(
+  new URL("../public/lib/ui-store.js", import.meta.url).href
+);
+
+function makeStore(initial) {
+  return createUiStore({ initialState: initial });
+}
+
+describe("ADD_TILE", () => {
+  it("assigns x = 0 to the first tile", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    const s = store.getState();
+    assert.strictEqual(s.tiles.a.x, 0);
+    assert.deepStrictEqual(s.order, ["a"]);
+  });
+
+  it("appends at end by default (x = nextX)", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.addTile({ id: "b", type: "terminal", props: {} });
+    store.addTile({ id: "c", type: "terminal", props: {} });
+    const s = store.getState();
+    assert.strictEqual(s.tiles.a.x, 0);
+    assert.strictEqual(s.tiles.b.x, 1);
+    assert.strictEqual(s.tiles.c.x, 2);
+    assert.deepStrictEqual(s.order, ["a", "b", "c"]);
+  });
+
+  it("inserts afterFocus — shifts tiles to the right", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} }, { focus: true });
+    store.addTile({ id: "b", type: "terminal", props: {} });
+    // Focus is on "a" (x=0). Insert "mid" after focus.
+    store.addTile({ id: "mid", type: "terminal", props: {} }, { insertAt: "afterFocus" });
+    const s = store.getState();
+    assert.strictEqual(s.tiles.a.x, 0);
+    assert.strictEqual(s.tiles.mid.x, 1);
+    assert.strictEqual(s.tiles.b.x, 2); // shifted from 1 → 2
+    assert.deepStrictEqual(s.order, ["a", "mid", "b"]);
+  });
+
+  it("does not duplicate — optionally focuses existing tile", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.addTile({ id: "b", type: "terminal", props: {} }, { focus: true });
+    // Try to add "a" again with focus
+    store.addTile({ id: "a", type: "terminal", props: {} }, { focus: true });
+    const s = store.getState();
+    assert.strictEqual(Object.keys(s.tiles).length, 2);
+    assert.strictEqual(s.focusedId, "a");
+  });
+});
+
+describe("REMOVE_TILE", () => {
+  it("removes tile and derives new order", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.addTile({ id: "b", type: "terminal", props: {} });
+    store.addTile({ id: "c", type: "terminal", props: {} });
+    store.removeTile("b");
+    const s = store.getState();
+    assert.ok(!s.tiles.b);
+    assert.deepStrictEqual(s.order, ["a", "c"]);
+  });
+
+  it("focuses right neighbor when removing focused tile", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.addTile({ id: "b", type: "terminal", props: {} }, { focus: true });
+    store.addTile({ id: "c", type: "terminal", props: {} });
+    // b is focused, remove it — should focus c (right neighbor)
+    store.removeTile("b");
+    assert.strictEqual(store.getState().focusedId, "c");
+  });
+
+  it("focuses left neighbor when removing last tile", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.addTile({ id: "b", type: "terminal", props: {} });
+    store.focusTile("b");
+    store.removeTile("b");
+    assert.strictEqual(store.getState().focusedId, "a");
+  });
+
+  it("sets focusedId to null when removing the only tile", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} }, { focus: true });
+    store.removeTile("a");
+    assert.strictEqual(store.getState().focusedId, null);
+    assert.deepStrictEqual(store.getState().order, []);
+  });
+
+  it("no-ops for unknown id", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    const before = store.getState();
+    store.removeTile("nope");
+    assert.strictEqual(store.getState(), before);
+  });
+});
+
+describe("REORDER", () => {
+  it("reassigns x coordinates to match new order", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.addTile({ id: "b", type: "terminal", props: {} });
+    store.addTile({ id: "c", type: "terminal", props: {} });
+    store.reorder(["c", "a", "b"]);
+    const s = store.getState();
+    assert.strictEqual(s.tiles.c.x, 0);
+    assert.strictEqual(s.tiles.a.x, 1);
+    assert.strictEqual(s.tiles.b.x, 2);
+    assert.deepStrictEqual(s.order, ["c", "a", "b"]);
+  });
+
+  it("no-ops when order is unchanged", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.addTile({ id: "b", type: "terminal", props: {} });
+    const before = store.getState();
+    store.reorder(["a", "b"]);
+    assert.strictEqual(store.getState(), before);
+  });
+
+  it("appends missing tiles at the end", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.addTile({ id: "b", type: "terminal", props: {} });
+    store.addTile({ id: "c", type: "terminal", props: {} });
+    // Only specify a,c — b should be appended
+    store.reorder(["a", "c"]);
+    const s = store.getState();
+    assert.deepStrictEqual(s.order, ["a", "c", "b"]);
+    assert.strictEqual(s.tiles.a.x, 0);
+    assert.strictEqual(s.tiles.c.x, 1);
+    assert.strictEqual(s.tiles.b.x, 2);
+  });
+
+  it("drops unknown ids", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.reorder(["ghost", "a"]);
+    assert.deepStrictEqual(store.getState().order, ["a"]);
+  });
+});
+
+describe("FOCUS_TILE", () => {
+  it("changes focusedId", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} }, { focus: true });
+    store.addTile({ id: "b", type: "terminal", props: {} });
+    store.focusTile("b");
+    assert.strictEqual(store.getState().focusedId, "b");
+  });
+
+  it("no-ops when already focused", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} }, { focus: true });
+    const before = store.getState();
+    store.focusTile("a");
+    assert.strictEqual(store.getState(), before);
+  });
+
+  it("ignores unknown id", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} }, { focus: true });
+    const before = store.getState();
+    store.focusTile("ghost");
+    assert.strictEqual(store.getState(), before);
+  });
+});
+
+describe("UPDATE_PROPS", () => {
+  it("shallow-merges patch into props, preserves x", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: { sessionName: "s1" } });
+    store.updateProps("a", { title: "hello" });
+    const t = store.getState().tiles.a;
+    assert.strictEqual(t.props.sessionName, "s1");
+    assert.strictEqual(t.props.title, "hello");
+    assert.strictEqual(t.x, 0); // x preserved
+  });
+
+  it("no-ops when patch values are identical", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: { sessionName: "s1" } });
+    const before = store.getState();
+    store.updateProps("a", { sessionName: "s1" });
+    assert.strictEqual(store.getState(), before);
+  });
+});
+
+describe("RESET", () => {
+  it("normalizes the provided state (backfills x from order)", () => {
+    const store = makeStore();
+    store.reset({
+      tiles: {
+        x: { id: "x", type: "terminal", props: {} },
+        y: { id: "y", type: "terminal", props: {} },
+      },
+      order: ["y", "x"],
+      focusedId: "y",
+    });
+    const s = store.getState();
+    assert.strictEqual(s.tiles.y.x, 0);
+    assert.strictEqual(s.tiles.x.x, 1);
+    assert.deepStrictEqual(s.order, ["y", "x"]);
+    assert.strictEqual(s.focusedId, "y");
+  });
+
+  it("preserves x when tiles already have it", () => {
+    const store = makeStore();
+    store.reset({
+      tiles: {
+        a: { id: "a", type: "terminal", props: {}, x: 10 },
+        b: { id: "b", type: "terminal", props: {}, x: 3 },
+      },
+      focusedId: "b",
+    });
+    const s = store.getState();
+    assert.strictEqual(s.tiles.a.x, 10);
+    assert.strictEqual(s.tiles.b.x, 3);
+    assert.deepStrictEqual(s.order, ["b", "a"]);
+  });
+});
+
+describe("serialize", () => {
+  it("includes x on tiles and derives order", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.addTile({ id: "b", type: "terminal", props: {} });
+    const out = serialize(store.getState());
+    assert.strictEqual(out.tiles.a.x, 0);
+    assert.strictEqual(out.tiles.b.x, 1);
+    assert.deepStrictEqual(out.order, ["a", "b"]);
+  });
+
+  it("filters non-persistable tiles", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.addTile({ id: "b", type: "ephemeral", props: {} });
+    const out = serialize(store.getState(), (type) => type === "terminal");
+    assert.ok(out.tiles.a);
+    assert.ok(!out.tiles.b);
+    assert.deepStrictEqual(out.order, ["a"]);
+  });
+});
+
+describe("round-trip: serialize → normalize", () => {
+  it("serialize output normalizes back to equivalent state", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: { sessionName: "a" } }, { focus: true });
+    store.addTile({ id: "b", type: "terminal", props: { sessionName: "b" } });
+    store.addTile({ id: "c", type: "terminal", props: { sessionName: "c" } }, { insertAt: "afterFocus" });
+    const serialized = serialize(store.getState());
+    const restored = normalize(serialized);
+    assert.deepStrictEqual(restored.order, store.getState().order);
+    assert.strictEqual(restored.focusedId, store.getState().focusedId);
+    for (const id of restored.order) {
+      assert.strictEqual(restored.tiles[id].x, store.getState().tiles[id].x);
+    }
+  });
+
+  it("old format (no x) round-trips through normalize correctly", () => {
+    // Simulate what loadFromStorage returns for pre-coordinate persistence
+    const oldFormat = {
+      version: 1,
+      tiles: {
+        s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
+        s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+      },
+      order: ["s2", "s1"],
+      focusedId: "s2",
+    };
+    const restored = normalize(oldFormat);
+    assert.deepStrictEqual(restored.order, ["s2", "s1"]);
+    assert.strictEqual(restored.tiles.s2.x, 0);
+    assert.strictEqual(restored.tiles.s1.x, 1);
+    assert.strictEqual(restored.focusedId, "s2");
+  });
+});


### PR DESCRIPTION
## Summary

Rewrites katulong's tile UI from an imperative 3-source-of-truth architecture (carousel + windowTabSet + sessionStore) into a single reducer-driven state atom. This is the foundation for the tile-clusters design (virtual desktops, columns, drag-to-stack).

- **ui-store.js** — reducer-driven state atom: tiles, position (x coordinate), focus. Single source of truth replaces carousel state + windowTabSet + sessionStore. Backward-compatible persistence migration.
- **Renderer registry** — `terminal.js`, `file-browser.js`, `cluster.js` wrap existing tile factories with a `describe(props) → capabilities` + `mount(el, api) → handle` interface. Capabilities (`session`, `updatesUrl`, `renameable`, `handlesDnd`) replace all ~20 `if (type === "terminal")` branches.
- **tile-host.js** — subscribes to ui-store, diffs prev vs next tiles, mounts/unmounts via renderers, drives carousel reactively. Re-entrancy guard prevents double-mounts from synchronous dispatch cycles.
- **tile-tab-bar.js** — derives tab list purely from ui-store state via `describe()`. Drag reorder dispatches to ui-store.
- **app.js boot** — single `RESET` dispatch replaces the old setTimeout/merge/carousel-already-active paths. `onFocusChange` and `onCardDismissed` are one-liners that dispatch to ui-store.
- **Coordinate-based position** — tiles carry `x` (integer position) instead of a separate `order[]` array. `state.order` is derived (sorted by `x`) for backward compat. Prepares the data model for `(cluster, x, y)`.

Also includes pinch-to-expose gesture and file-browser-as-a-tile from the earlier commits on this branch.

## Test plan

- [x] 14 tile-host tests (init, add, remove, focus, reorder, destroy, re-entrancy, onTileRemoved)
- [x] 30 ui-store tests (all reducer actions, normalize migration, serialize round-trip)
- [x] Full unit + integration suite passes (pre-push)
- [x] Smoke E2E passes
- [x] Staged on https://feat-pinch-expose-morph.felixflor.es — terminal tiles work, tab bar renders, drag reorder works, persistence survives refresh
- [ ] Known issue: file browser tile shows infinite spinner — orthogonal to this PR, will fix on separate branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)