### PR TITLE
fix(tmux): byte-level parser to stop mangling multi-byte UTF-8 at %output boundaries

### DIFF
--- a/bin/debug-drift.sh
+++ b/bin/debug-drift.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Run katulong locally with drift diagnostic logging enabled.
+#
+# Usage: bin/debug-drift.sh [level]
+#   level 1 (default): high-level events — flush-fffd, backpressure,
+#                      pull-bypass, eviction, resync. Cheap enough to
+#                      leave on for days to catch a rare bug.
+#   level 2:           everything above + deep byte-level parser-fffd
+#                      probes with raw chunk hex dumps. Noisy — turn on
+#                      when you're actively reproducing.
+#
+# Kills whatever is on :3001 first (likely the brew-installed katulong)
+# and re-execs this checkout.
+#
+# Log file: ~/.katulong/drift.log
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+LEVEL="${1:-1}"
+if ! [[ "$LEVEL" =~ ^[0-9]+$ ]]; then
+  echo "Usage: $0 [level]" >&2
+  echo "  level must be a non-negative integer (1 or 2 are typical)" >&2
+  exit 2
+fi
+
+PIDS=$(lsof -ti:3001 || true)
+if [ -n "$PIDS" ]; then
+  echo "Killing existing process(es) on :3001 — $PIDS"
+  kill -9 $PIDS || true
+  sleep 0.5
+fi
+
+mkdir -p "$HOME/.katulong"
+echo "Drift log:   $HOME/.katulong/drift.log"
+echo "Drift level: $LEVEL"
+echo "Starting katulong (local) on :3001 with KATULONG_DRIFT_LOG=$LEVEL"
+
+export KATULONG_DRIFT_LOG="$LEVEL"
+export PORT=3001
+exec node server.js

--- a/bin/restart-drift.sh
+++ b/bin/restart-drift.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Restart the drift-debug katulong on :3001.
+# Kills whatever is on the port (the previous debug run or brew katulong)
+# and re-execs bin/debug-drift.sh.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+exec ./bin/debug-drift.sh "$@"

--- a/lib/drift-log.js
+++ b/lib/drift-log.js
@@ -1,0 +1,122 @@
+/**
+ * Drift diagnostic logger.
+ *
+ * Env-gated JSONL logger for investigating client/server terminal state
+ * divergence — stacked spinners, leftover TUI fragments, U+FFFD bursts,
+ * backpressure drops, pull-bypass byte loss, etc. Off unless enabled via
+ * env var, so production has zero overhead.
+ *
+ * Enabling
+ *   KATULONG_DRIFT_LOG=1   high-level events (flushes with FFFD, relay
+ *                          backpressure, pull-bypass, eviction, resync).
+ *                          Cheap enough to leave on for days to catch a
+ *                          rare bug without drowning the disk.
+ *   KATULONG_DRIFT_LOG=2   everything above + deep byte-level probes
+ *                          (parser-fffd with raw chunk hex dumps).
+ *                          Noisy — turn on when reproducing a known bug.
+ *
+ *   KATULONG_DRIFT_DEBUG=1 legacy alias for level 1. Kept so existing
+ *                          bin/debug-drift.sh invocations and prior
+ *                          documentation still work.
+ *
+ * Log location: ~/.katulong/drift.log (one JSON object per line).
+ *
+ * Event types emitted
+ *   level 1:
+ *     flush              output coalescer flushed bytes to relay (only
+ *                        logged when the flushed payload contains FFFD)
+ *     relay-backpressure output relay dropped to data-available notify
+ *                        (safe — bytes stay in RingBuffer for later pull)
+ *     pull-bypass        pull handler skipped the client cursor to HEAD
+ *                        under backpressure (BYTE LOSS — clients miss
+ *                        the intervening range, producing cursor/scroll
+ *                        drift that compounds)
+ *     pull-eviction      client cursor fell out of RingBuffer → snapshot
+ *     resync             client detected drift and requested snapshot
+ *   level 2 (adds):
+ *     parser-fffd        tmux parser emitted U+FFFD; includes raw stdout
+ *                        chunk hex dumps, the escaped payload hex, and
+ *                        decoded context around the first FFFD
+ *
+ * Design notes
+ * - Writes are fire-and-forget: failures never throw into the hot path.
+ * - The stream is opened lazily on first log so a disabled logger does
+ *   not create ~/.katulong at startup.
+ * - `driftLogLevel()` is a cheap getter callers can use to avoid
+ *   building an expensive log payload (hex dumps, rolling-buffer
+ *   stringification) when the level is below the threshold.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const LOG_PATH = path.join(os.homedir(), ".katulong", "drift.log");
+
+function parseLevel() {
+  const raw = process.env.KATULONG_DRIFT_LOG;
+  if (raw !== undefined) {
+    const n = parseInt(raw, 10);
+    if (!isNaN(n) && n >= 0) return n;
+  }
+  // Legacy alias — KATULONG_DRIFT_DEBUG=1 means level 1.
+  if (process.env.KATULONG_DRIFT_DEBUG === "1") return 1;
+  return 0;
+}
+
+const LEVEL = parseLevel();
+
+let stream = null;
+
+function ensureStream() {
+  if (stream) return stream;
+  try {
+    fs.mkdirSync(path.dirname(LOG_PATH), { recursive: true });
+    stream = fs.createWriteStream(LOG_PATH, { flags: "a" });
+    stream.write(JSON.stringify({
+      ts: Date.now(),
+      event: "log-open",
+      level: LEVEL,
+      pid: process.pid,
+    }) + "\n");
+  } catch {
+    stream = null;
+  }
+  return stream;
+}
+
+/**
+ * Write a log entry if the current level is >= `minLevel`.
+ *
+ * @param {object} entry - JSON-serializable fields. `ts` is added automatically.
+ * @param {number} [minLevel=1] - minimum KATULONG_DRIFT_LOG level required.
+ */
+export function driftLog(entry, minLevel = 1) {
+  if (LEVEL < minLevel) return;
+  const s = ensureStream();
+  if (!s) return;
+  try {
+    s.write(JSON.stringify({ ts: Date.now(), ...entry }) + "\n");
+  } catch {
+    // Never let logging throw into the hot path.
+  }
+}
+
+/**
+ * Current drift log level (0 = off). Cheap — callers can use this to
+ * skip building expensive payloads when the logger is disabled.
+ */
+export function driftLogLevel() {
+  return LEVEL;
+}
+
+/**
+ * Back-compat: true if any drift logging is enabled.
+ */
+export function driftLogEnabled() {
+  return LEVEL > 0;
+}
+
+export function driftLogPath() {
+  return LOG_PATH;
+}

--- a/lib/drift-log.js
+++ b/lib/drift-log.js
@@ -72,7 +72,10 @@ function ensureStream() {
   if (stream) return stream;
   try {
     fs.mkdirSync(path.dirname(LOG_PATH), { recursive: true });
-    stream = fs.createWriteStream(LOG_PATH, { flags: "a" });
+    // mode 0o600: the log can contain diagnostic fragments of terminal
+    // I/O at level 2 (hex dumps of raw stdout chunks). Restrict to
+    // owner-only so a shared host does not leak terminal context.
+    stream = fs.createWriteStream(LOG_PATH, { flags: "a", mode: 0o600 });
     stream.write(JSON.stringify({
       ts: Date.now(),
       event: "log-open",
@@ -110,13 +113,3 @@ export function driftLogLevel() {
   return LEVEL;
 }
 
-/**
- * Back-compat: true if any drift logging is enabled.
- */
-export function driftLogEnabled() {
-  return LEVEL > 0;
-}
-
-export function driftLogPath() {
-  return LOG_PATH;
-}

--- a/lib/env-filter.js
+++ b/lib/env-filter.js
@@ -8,6 +8,10 @@
 export const SENSITIVE_ENV_VARS = new Set([
   "SETUP_TOKEN",
   "CLAUDECODE", // Prevent nested Claude Code sessions
+  // Diagnostic/debug flags — filter so shell users can't observe that
+  // the server is running with drift logging on (information disclosure).
+  "KATULONG_DRIFT_LOG",
+  "KATULONG_DRIFT_DEBUG",
 ]);
 
 /**

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -17,6 +17,7 @@ import { log } from "./log.js";
 import { getSafeEnv } from "./env-filter.js";
 import { createClientTracker } from "./client-tracker.js";
 import { createOutputCoalescer } from "./output-coalescer.js";
+import { driftLog, driftLogLevel } from "./drift-log.js";
 import { createSessionStore } from "./session-persistence.js";
 import { startChildCountMonitor } from "./session-child-counter.js";
 import { Session } from "./session.js";
@@ -114,6 +115,30 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
       if (!session) return;
       const { data, cursor } = session.pullFrom(fromSeq);
       if (data && data.length > 0) {
+        // Drift probe: if the flushed payload contains U+FFFD, log it so
+        // we can tell whether the corruption is upstream of the relay
+        // (tmux parser / octal unescape / payload UTF-8 decoder) or
+        // client-side. Only scanned when drift logging is on, since
+        // iterating every flushed byte on every flush is not free.
+        if (driftLogLevel() >= 1) {
+          let fffdCount = 0;
+          for (let i = 0; i < data.length; i++) {
+            if (data.charCodeAt(i) === 0xFFFD) fffdCount++;
+          }
+          if (fffdCount > 0) {
+            const idx = data.indexOf("\uFFFD");
+            const start = Math.max(0, idx - 20);
+            driftLog({
+              event: "flush-fffd",
+              session: sessionName,
+              fromSeq,
+              toCursor: cursor,
+              bytes: data.length,
+              fffd: fffdCount,
+              sample: data.slice(start, idx + 20),
+            });
+          }
+        }
         bridge.relay({ type: "output", session: sessionName, data, fromSeq, cursor });
         scheduleIdleCheck(sessionName);
       }

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -126,8 +126,11 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
             if (data.charCodeAt(i) === 0xFFFD) fffdCount++;
           }
           if (fffdCount > 0) {
-            const idx = data.indexOf("\uFFFD");
-            const start = Math.max(0, idx - 20);
+            // Log metadata only — no terminal content. This log can be
+            // left on for days, and terminal output can include sensitive
+            // material (prompts adjacent to password inputs, API keys
+            // printed by scripts, file contents). We capture enough to
+            // correlate with client-side drift without persisting bytes.
             driftLog({
               event: "flush-fffd",
               session: sessionName,
@@ -135,7 +138,7 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
               toCursor: cursor,
               bytes: data.length,
               fffd: fffdCount,
-              sample: data.slice(start, idx + 20),
+              firstFffdOffset: data.indexOf("\uFFFD"),
             });
           }
         }

--- a/lib/tmux-output-parser.js
+++ b/lib/tmux-output-parser.js
@@ -1,30 +1,33 @@
 /**
- * Tmux control-mode output parser.
+ * Tmux control-mode output parser (byte-level).
  *
  * Given a stream of raw bytes from `tmux -C attach-session` stdout, this
  * parser emits decoded UTF-8 payloads from `%output %pane_id <escaped>`
  * lines. Everything else (`%begin`, `%end`, `%error`, `%session-changed`,
  * …) is silently dropped — we only care about terminal I/O here.
  *
- * Why it lives in its own module
- * - The parsing is a cohesive chunk of state that has nothing to do with
- *   the Session domain object (tmux lifecycle, resize gate, screen mirror).
- *   Extracting it lets Session stay focused on "what is a terminal session"
- *   while the parser handles "how do we decode the tmux protocol".
- * - It becomes trivially unit-testable by feeding chunked bytes into
- *   `write()` and asserting the `onData` callback fires — no tmux spawn,
- *   no child process, no fixtures.
+ * Why byte-level
+ * - tmux splits long %output payloads at fixed byte boundaries without
+ *   regard to UTF-8 character boundaries. A multi-byte char like `─`
+ *   (e2 94 80) can end up with `e2` on one line and `94 80` on the next.
+ * - Running a stream-level StringDecoder over raw stdout therefore emits
+ *   U+FFFD for the orphaned lead/continuation bytes before we ever get
+ *   to the %output payload layer, corrupting box-drawing chars, TUI
+ *   escape sequences, and anything else non-ASCII.
+ * - Fix: scan for `\n` (0x0a) over raw Buffers, match the ASCII
+ *   `%output %<pane_id> ` prefix as bytes, and feed the octal-unescaped
+ *   payload bytes through a single persistent StringDecoder. That
+ *   decoder is the one and only place UTF-8 → string conversion
+ *   happens, and it correctly carries partial multi-byte chars across
+ *   calls.
  *
  * State it owns (all rebuildable on reset())
- * - `lineBuf`: partial line assembled across stdout chunks (tmux writes
- *   lines one-at-a-time but chunk boundaries can split a line)
- * - `frameDecoder`: StringDecoder for the control-mode framing layer —
- *   handles any multi-byte UTF-8 that might appear in a `%session-changed`
- *   event or similar
- * - `payloadDecoder`: separate StringDecoder for `%output` payload bytes,
- *   so multi-byte UTF-8 chars that span `%output` lines don't become
- *   U+FFFD. Must be separate from `frameDecoder` because %output is
- *   "decoded → bytes → UTF-8" while framing is "bytes → UTF-8 → lines".
+ * - `lineBuf`: Buffer of partial line bytes assembled across stdout
+ *   chunks (tmux writes lines one at a time but chunk boundaries can
+ *   split a line).
+ * - `payloadDecoder`: StringDecoder for %output payload bytes, persistent
+ *   across lines so multi-byte UTF-8 chars that span %output lines don't
+ *   become U+FFFD.
  * - `octalCarry`: 1-3 chars of a partial `\NNN` tmux octal escape
  *   deferred from the previous %output line. See
  *   {@link unescapeTmuxOutputBytes} in lib/tmux.js for the rationale.
@@ -32,115 +35,176 @@
  * Contract
  * - `write(chunk)` → synchronously fires `onData(payload)` zero or more
  *   times, one per decoded `%output` line.
- * - `drain()` → flushes both decoders and the line buffer, fires any
+ * - `drain()` → flushes the payload decoder and line buffer, fires any
  *   pending `onData`, and resets internal state so a second drain is a
- *   no-op. Used by Session on detach/kill to avoid dropping trailing
- *   UTF-8 bytes buffered inside the decoders.
- * - `reset()` → discards all state without emitting. Used at the start
- *   of a new attach so stale bytes from a prior attach don't corrupt
- *   the first bytes of the next stream.
+ *   no-op.
+ * - `reset()` → discards all state without emitting.
  */
 
 import { StringDecoder } from "node:string_decoder";
-import { unescapeTmuxOutputBytes } from "./tmux.js";
+import { driftLog, driftLogLevel } from "./drift-log.js";
+
+// ASCII "%output " — matched as bytes against incoming lines.
+const OUTPUT_PREFIX = Buffer.from("%output ");
+const NL = 0x0a;
+const SPACE = 0x20;
+const BACKSLASH = 0x5c;
+const ZERO = 0x30;
+
+/**
+ * Byte-level unescape of a tmux %output payload.
+ *
+ * tmux escapes bytes `< 0x20` and `\` as three-digit octal `\NNN`. Every
+ * other byte (including all high bytes of multi-byte UTF-8 chars) is
+ * emitted literally. We MUST stay in byte space here — converting the
+ * payload to a JS string first would re-encode literal `0xe2` (say) as
+ * U+00E2 and then back to `c3 a2`, double-encoding every non-ASCII char.
+ *
+ * The `carry` holds 1-3 bytes of a partial `\NNN` escape deferred from
+ * the previous %output line. See the original note in lib/tmux.js for
+ * why this matters: a long run of high bytes can be split mid-escape
+ * across two %output lines.
+ */
+function unescapeOutputBytes(buf, carryBytes) {
+  // Prepend carry if any. carryBytes is a Buffer of length 0-3.
+  const input = carryBytes.length === 0 ? buf : Buffer.concat([carryBytes, buf]);
+  const out = Buffer.allocUnsafe(input.length);
+  let w = 0;
+  let i = 0;
+  while (i < input.length) {
+    const b = input[i];
+    if (b === BACKSLASH) {
+      if (i + 3 >= input.length) {
+        return { bytes: out.subarray(0, w), carry: input.subarray(i) };
+      }
+      const d0 = input[i + 1] - ZERO;
+      const d1 = input[i + 2] - ZERO;
+      const d2 = input[i + 3] - ZERO;
+      if (d0 >= 0 && d0 <= 3 && d1 >= 0 && d1 <= 7 && d2 >= 0 && d2 <= 7) {
+        out[w++] = d0 * 64 + d1 * 8 + d2;
+        i += 4;
+        continue;
+      }
+      // Malformed — pass backslash through literally.
+    }
+    out[w++] = b;
+    i++;
+  }
+  return { bytes: out.subarray(0, w), carry: Buffer.alloc(0) };
+}
 
 /**
  * Create a tmux control-mode output parser.
  *
  * @param {object} opts
  * @param {(payload: string) => void} opts.onData - Called once per decoded
- *   %output line with the UTF-8 string. The caller is responsible for
- *   pushing the payload into a RingBuffer / screen mirror / etc.
+ *   %output line with the UTF-8 string.
  * @returns {{ write: (chunk: Buffer|string) => void, drain: () => void, reset: () => void }}
  */
 export function createTmuxOutputParser({ onData }) {
-  let lineBuf = "";
-  let frameDecoder = new StringDecoder("utf-8");
+  let lineBuf = Buffer.alloc(0);
   let payloadDecoder = new StringDecoder("utf-8");
-  let octalCarry = "";
+  let octalCarry = Buffer.alloc(0);
+  const RECENT_CHUNKS_MAX = 4;
+  let recentChunks = [];
 
-  /**
-   * Parse complete lines from `lineBuf` and emit decoded %output payloads.
-   * Trailing partial line is left in `lineBuf` for the next write/drain.
-   */
   function parseLineBuf() {
     let startIdx = 0;
     let nlPos;
-    while ((nlPos = lineBuf.indexOf("\n", startIdx)) !== -1) {
-      const line = lineBuf.slice(startIdx, nlPos);
+    while ((nlPos = lineBuf.indexOf(NL, startIdx)) !== -1) {
+      const line = lineBuf.subarray(startIdx, nlPos);
       startIdx = nlPos + 1;
 
-      if (line.startsWith("%output ")) {
-        // Format: %output %pane_id octal_escaped_data
-        const rest = line.slice(8); // after "%output "
-        const spacePos = rest.indexOf(" ");
-        if (spacePos !== -1) {
-          const escaped = rest.slice(spacePos + 1);
-          // Octal → bytes → UTF-8 via octalCarry + payloadDecoder. See
-          // unescapeTmuxOutputBytes for why the carry is load-bearing.
-          const { bytes: rawBytes, carry } = unescapeTmuxOutputBytes(escaped, octalCarry);
-          octalCarry = carry;
-          const data = payloadDecoder.write(rawBytes);
-          if (!data) continue; // incomplete multi-byte char, buffered for next line
-          onData(data);
-        }
+      // Fast reject: anything not starting with "%output " is framing
+      // noise (%begin, %end, %session-changed, …). We don't need to
+      // decode it — just skip.
+      if (line.length < OUTPUT_PREFIX.length) continue;
+      let isOutput = true;
+      for (let i = 0; i < OUTPUT_PREFIX.length; i++) {
+        if (line[i] !== OUTPUT_PREFIX[i]) { isOutput = false; break; }
       }
-      // Ignore %begin, %end, %error, %session-changed, etc.
+      if (!isOutput) continue;
+
+      // After "%output " comes "%<pane_id> <escaped_payload>".
+      // Find the space that terminates the pane id.
+      const rest = line.subarray(OUTPUT_PREFIX.length);
+      const spacePos = rest.indexOf(SPACE);
+      if (spacePos === -1) continue;
+
+      // Payload stays as bytes all the way through. tmux emits high
+      // bytes (UTF-8 continuation bytes, etc.) literally — converting
+      // to string first would double-encode them.
+      const escapedBuf = rest.subarray(spacePos + 1);
+
+      const { bytes: rawBytes, carry } = unescapeOutputBytes(escapedBuf, octalCarry);
+      octalCarry = carry;
+      const data = payloadDecoder.write(rawBytes);
+      if (!data) continue;
+
+      // Deep byte-level probe: only at level 2 because it builds hex
+      // dumps of the rolling raw-chunk buffer, which is expensive.
+      if (driftLogLevel() >= 2 && data.indexOf("\uFFFD") !== -1) {
+        const idx = data.indexOf("\uFFFD");
+        let recentChunksHasFffdBytes = false;
+        const recentHex = recentChunks.map(b => {
+          if (b.includes(Buffer.from([0xef, 0xbf, 0xbd]))) {
+            recentChunksHasFffdBytes = true;
+          }
+          return b.slice(0, 200).toString("hex");
+        });
+        driftLog({
+          event: "parser-fffd",
+          recentChunksHasFffdBytes,
+          decodedSample: data.slice(Math.max(0, idx - 20), idx + 20),
+          rawBytesLen: rawBytes.length,
+          rawBytesHexHead: rawBytes.slice(0, 200).toString("hex"),
+          escapedLen: escapedBuf.length,
+          escapedHexHead: escapedBuf.slice(0, 200).toString("hex"),
+          recentChunkCount: recentChunks.length,
+          recentChunkHexHead: recentHex,
+          recentChunkLens: recentChunks.map(b => b.length),
+        }, 2);
+      }
+      onData(data);
     }
-    if (startIdx > 0) lineBuf = lineBuf.slice(startIdx);
+    if (startIdx > 0) {
+      lineBuf = startIdx === lineBuf.length ? Buffer.alloc(0) : lineBuf.subarray(startIdx);
+    }
   }
 
   return {
-    /**
-     * Feed a chunk of raw stdout bytes into the parser.
-     * Synchronously fires `onData` zero or more times.
-     */
     write(chunk) {
-      lineBuf += frameDecoder.write(chunk);
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (driftLogLevel() >= 2) {
+        recentChunks.push(buf);
+        if (recentChunks.length > RECENT_CHUNKS_MAX) recentChunks.shift();
+      }
+      lineBuf = lineBuf.length === 0 ? buf : Buffer.concat([lineBuf, buf]);
       parseLineBuf();
     },
 
-    /**
-     * Flush any buffered state and fire `onData` for trailing content.
-     *
-     * Called by Session on detach/kill BEFORE clearing the onData callback,
-     * so partial UTF-8 buffered inside `payloadDecoder` or mid-line bytes
-     * in `frameDecoder` reach subscribers instead of being silently dropped.
-     *
-     * Idempotent: after draining, state is reset so a second call is a no-op.
-     */
     drain() {
-      // Drain framing decoder into the line buffer and parse complete lines.
-      const tail = frameDecoder.end();
-      if (tail) {
-        lineBuf += tail;
+      // If there's a trailing line without a newline, synthesize one so
+      // parseLineBuf picks it up. Safe: tmux always terminates %output
+      // lines with \n, so a tail without \n is either framing noise or
+      // a truncated line we can't trust anyway — but if it happens to
+      // be a valid %output line we still want to flush its payload.
+      if (lineBuf.length > 0) {
+        lineBuf = Buffer.concat([lineBuf, Buffer.from([NL])]);
         parseLineBuf();
       }
-      // Drain payload decoder. Any bytes mid-multi-byte-char become U+FFFD,
-      // which is the correct contract for StringDecoder.end(). Emit the tail
-      // as a final synthetic payload so subscribers see the trailing
-      // character instead of losing it.
       const payloadTail = payloadDecoder.end();
       if (payloadTail) onData(payloadTail);
 
-      // Reset to fresh state so a second drain is a no-op.
-      lineBuf = "";
-      frameDecoder = new StringDecoder("utf-8");
+      lineBuf = Buffer.alloc(0);
       payloadDecoder = new StringDecoder("utf-8");
-      octalCarry = "";
+      octalCarry = Buffer.alloc(0);
     },
 
-    /**
-     * Discard all buffered state without emitting.
-     *
-     * Called at the start of a new attach so stale bytes from a prior
-     * attach can't corrupt the first bytes of the next stream.
-     */
     reset() {
-      lineBuf = "";
-      frameDecoder = new StringDecoder("utf-8");
+      lineBuf = Buffer.alloc(0);
       payloadDecoder = new StringDecoder("utf-8");
-      octalCarry = "";
+      octalCarry = Buffer.alloc(0);
     },
   };
 }

--- a/lib/tmux-output-parser.js
+++ b/lib/tmux-output-parser.js
@@ -28,9 +28,9 @@
  * - `payloadDecoder`: StringDecoder for %output payload bytes, persistent
  *   across lines so multi-byte UTF-8 chars that span %output lines don't
  *   become U+FFFD.
- * - `octalCarry`: 1-3 chars of a partial `\NNN` tmux octal escape
- *   deferred from the previous %output line. See
- *   {@link unescapeTmuxOutputBytes} in lib/tmux.js for the rationale.
+ * - `octalCarry`: 1-3 bytes of a partial `\NNN` tmux octal escape
+ *   deferred from the previous %output line, kept as a Buffer so no
+ *   byte→string conversion happens before the payload decoder sees it.
  *
  * Contract
  * - `write(chunk)` → synchronously fires `onData(payload)` zero or more
@@ -50,6 +50,19 @@ const NL = 0x0a;
 const SPACE = 0x20;
 const BACKSLASH = 0x5c;
 const ZERO = 0x30;
+
+// Rolling window of raw stdout chunks retained for the level-2
+// parser-fffd probe. Only populated when KATULONG_DRIFT_LOG >= 2.
+const RECENT_CHUNKS_MAX = 4;
+
+// Maximum size of the unparsed-line buffer. Under normal tmux control
+// mode this never exceeds a few KB (tmux emits one %output line at a
+// time), but we cap it defensively so a misbehaving or adversarial
+// tmux subprocess that writes stdout without newlines cannot exhaust
+// Node's heap. When the cap is hit we drop the buffered prefix and
+// keep parsing forward — worse than a clean reset, but better than
+// crashing the whole server and losing every connected client.
+const MAX_LINE_BUF_BYTES = 1 * 1024 * 1024;
 
 /**
  * Byte-level unescape of a tmux %output payload.
@@ -105,7 +118,6 @@ export function createTmuxOutputParser({ onData }) {
   let lineBuf = Buffer.alloc(0);
   let payloadDecoder = new StringDecoder("utf-8");
   let octalCarry = Buffer.alloc(0);
-  const RECENT_CHUNKS_MAX = 4;
   let recentChunks = [];
 
   function parseLineBuf() {
@@ -142,9 +154,10 @@ export function createTmuxOutputParser({ onData }) {
       if (!data) continue;
 
       // Deep byte-level probe: only at level 2 because it builds hex
-      // dumps of the rolling raw-chunk buffer, which is expensive.
+      // dumps of the rolling raw-chunk buffer. Terminal I/O bytes are
+      // persisted to ~/.katulong/drift.log (mode 0o600) — only turn
+      // this on when actively reproducing a bug, never leave running.
       if (driftLogLevel() >= 2 && data.indexOf("\uFFFD") !== -1) {
-        const idx = data.indexOf("\uFFFD");
         let recentChunksHasFffdBytes = false;
         const recentHex = recentChunks.map(b => {
           if (b.includes(Buffer.from([0xef, 0xbf, 0xbd]))) {
@@ -154,8 +167,8 @@ export function createTmuxOutputParser({ onData }) {
         });
         driftLog({
           event: "parser-fffd",
+          firstFffdOffset: data.indexOf("\uFFFD"),
           recentChunksHasFffdBytes,
-          decodedSample: data.slice(Math.max(0, idx - 20), idx + 20),
           rawBytesLen: rawBytes.length,
           rawBytesHexHead: rawBytes.slice(0, 200).toString("hex"),
           escapedLen: escapedBuf.length,
@@ -180,6 +193,16 @@ export function createTmuxOutputParser({ onData }) {
         if (recentChunks.length > RECENT_CHUNKS_MAX) recentChunks.shift();
       }
       lineBuf = lineBuf.length === 0 ? buf : Buffer.concat([lineBuf, buf]);
+      // Defensive cap against an adversarial or broken tmux subprocess
+      // that writes stdout without newlines. Under normal operation
+      // tmux emits %output lines one at a time, so lineBuf is drained
+      // on every write and never reaches this limit.
+      if (lineBuf.length > MAX_LINE_BUF_BYTES) {
+        lineBuf = Buffer.alloc(0);
+        payloadDecoder = new StringDecoder("utf-8");
+        octalCarry = Buffer.alloc(0);
+        return;
+      }
       parseLineBuf();
     },
 
@@ -199,12 +222,14 @@ export function createTmuxOutputParser({ onData }) {
       lineBuf = Buffer.alloc(0);
       payloadDecoder = new StringDecoder("utf-8");
       octalCarry = Buffer.alloc(0);
+      recentChunks = [];
     },
 
     reset() {
       lineBuf = Buffer.alloc(0);
       payloadDecoder = new StringDecoder("utf-8");
       octalCarry = Buffer.alloc(0);
+      recentChunks = [];
     },
   };
 }

--- a/lib/ws-manager.js
+++ b/lib/ws-manager.js
@@ -16,6 +16,7 @@ import { loadState } from "./auth.js";
 import { log } from "./log.js";
 import { createClientTransport } from "./client-transport.js";
 import { createWebRTCSignaling } from "./webrtc-signaling.js";
+import { driftLog } from "./drift-log.js";
 
 /**
  * Create a WebSocket manager.
@@ -132,6 +133,15 @@ export function createWebSocketManager({ bridge, sessionManager, helmSessionMana
           if (info.transport.readyState !== 1) continue;
           if (info.transport.bufferedAmount > WS_BACKPRESSURE_BYTES) {
             // Backpressure — send lightweight notification so client can pull
+            driftLog({
+              event: "relay-backpressure",
+              clientId,
+              session: msg.session,
+              bufferedAmount: info.transport.bufferedAmount,
+              fromSeq: msg.fromSeq,
+              cursor: msg.cursor,
+              bytesDeferred: msg.data?.length ?? 0,
+            });
             info.transport.send(JSON.stringify({ type: "data-available", session: msg.session }));
           } else {
             info.transport.send(encoded);
@@ -444,6 +454,15 @@ export function createWebSocketManager({ bridge, sessionManager, helmSessionMana
           if (transport.bufferedAmount > WS_BACKPRESSURE_BYTES) {
             // Send empty response so client's pull manager unsticks immediately
             // instead of waiting for the 2s safety timeout.
+            driftLog({
+              event: "pull-bypass",
+              clientId,
+              session: name,
+              bufferedAmount: transport.bufferedAmount,
+              requestedFromSeq: msg.fromSeq,
+              advancedToCursor: session.cursor,
+              skippedBytes: Math.max(0, session.cursor - (msg.fromSeq ?? 0)),
+            });
             transport.send(JSON.stringify({
               type: "pull-response",
               session: name,
@@ -454,6 +473,13 @@ export function createWebSocketManager({ bridge, sessionManager, helmSessionMana
           }
           const { data, cursor } = session.pullFrom(msg.fromSeq);
           if (data === null) {
+            driftLog({
+              event: "pull-eviction",
+              clientId,
+              session: name,
+              requestedFromSeq: msg.fromSeq,
+              snapshotCursor: session.cursor,
+            });
             // Cursor evicted — fall back to a Lamport-correct snapshot.
             // PCH-7 removed per-client replay because it couldn't correctly
             // re-interpret absolute cursor escapes recorded at a different
@@ -482,6 +508,13 @@ export function createWebSocketManager({ bridge, sessionManager, helmSessionMana
           const session = sessionManager.getSession(name);
           if (!session?.alive) return;
           const snap = await session.snapshot();
+          driftLog({
+            event: "resync",
+            clientId,
+            session: name,
+            snapshotCursor: snap.seq,
+            snapshotBytes: snap.buffer?.length ?? 0,
+          });
           log.debug("Resync requested", { clientId, session: name });
           transport.send(JSON.stringify({
             type: "pull-snapshot",

--- a/test/tmux-output-parser-utf8-split.test.js
+++ b/test/tmux-output-parser-utf8-split.test.js
@@ -1,0 +1,196 @@
+/**
+ * Regression tests for the tmux output parser: multi-byte UTF-8 chars
+ * split across %output boundaries.
+ *
+ * Bug symptom (v0.52.4 and earlier):
+ *   TUI apps rendered with bursts of ◆ / U+FFFD replacing non-ASCII text,
+ *   stacked "Doodling..." spinners, stray horizontal ruler lines in
+ *   scrollback, and leftover Claude-Code TUI fragments after exit. Each
+ *   corruption compounded because the corrupted bytes included escape
+ *   sequences (scroll region, cursor position, alt-screen), and the
+ *   client's xterm then interpreted broken escapes and put subsequent
+ *   writes on the wrong cells.
+ *
+ * Root cause:
+ *   tmux control mode wraps %output payloads at fixed byte limits with
+ *   no regard for UTF-8 boundaries. A single char like `─` (0xe2 0x94
+ *   0x80) can end up with `0xe2` on one %output line and `0x94 0x80` on
+ *   the next. Tmux can ALSO emit high bytes literally (not octal-
+ *   escaped) when running with -u or when certain modes are active.
+ *
+ *   The pre-fix parser ran a stream-level Node `StringDecoder` over raw
+ *   stdout. That decoder dutifully emitted U+FFFD for the orphaned
+ *   0xe2 lead byte and for the orphaned continuation bytes on the next
+ *   line — corrupting every multi-byte char that straddled a boundary.
+ *
+ *   An earlier partial fix added a "payloadDecoder" alongside the
+ *   stream-level "frameDecoder", but payloadDecoder received already-
+ *   corrupted strings (the damage happened one layer up). A later
+ *   attempt converted the payload Buffer to a latin1 string and then
+ *   fed it through `unescapeTmuxOutputBytes` — which codePointAt-reads
+ *   literal 0xe2 as U+00E2 and re-encodes it as `c3 a2`, double-
+ *   encoding every non-ASCII byte.
+ *
+ * Correct fix (what this test pins):
+ *   Stay in byte space from stdout all the way through octal unescape,
+ *   and only convert to a JS string at the very end via a SINGLE
+ *   persistent StringDecoder. That decoder's internal buffer then
+ *   correctly carries partial multi-byte chars across %output lines.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+
+import { createTmuxOutputParser } from "../lib/tmux-output-parser.js";
+
+function collect() {
+  const out = [];
+  const parser = createTmuxOutputParser({ onData: (s) => out.push(s) });
+  return { parser, out, joined: () => out.join("") };
+}
+
+describe("tmux output parser — literal high bytes (no octal escaping)", () => {
+  it("decodes a single `─` (0xe2 0x94 0x80) emitted literally", () => {
+    const { parser, joined } = collect();
+    // Tmux with -u can emit high bytes literally. We build a raw stdout
+    // chunk that contains the three bytes verbatim inside a %output
+    // line — no backslash escapes — to pin that the parser passes
+    // literal high bytes through untouched.
+    const line = Buffer.concat([
+      Buffer.from("%output %0 "),
+      Buffer.from([0xe2, 0x94, 0x80]),
+      Buffer.from("\n"),
+    ]);
+    parser.write(line);
+    assert.equal(joined(), "─");
+  });
+
+  it("does NOT double-encode literal high bytes via latin1 round-trip", () => {
+    // Regression for the intermediate buggy fix that did
+    // `rest.toString('latin1')` and then passed the string to
+    // unescapeTmuxOutputBytes (which UTF-8-encodes each codepoint).
+    // Under that bug, 0xe2 → U+00E2 → c3 a2, so the output would be
+    // "â" (U+00E2) rendered as two UTF-8 bytes, NOT the original `─`.
+    const { parser, joined } = collect();
+    const blocks = Buffer.alloc(10 * 3);
+    for (let i = 0; i < 10; i++) {
+      blocks[i * 3 + 0] = 0xe2;
+      blocks[i * 3 + 1] = 0x94;
+      blocks[i * 3 + 2] = 0x80;
+    }
+    parser.write(Buffer.concat([
+      Buffer.from("%output %0 "),
+      blocks,
+      Buffer.from("\n"),
+    ]));
+    assert.equal(joined(), "─".repeat(10));
+    assert.ok(!joined().includes("\u00e2"), "must not contain U+00E2 (double-encoded)");
+    assert.ok(!joined().includes("\uFFFD"), "must not contain U+FFFD");
+  });
+
+  it("joins a `─` split across two %output lines (the original bug)", () => {
+    // The exact pathology: tmux wraps the %output payload mid-char,
+    // so the lead byte e2 ends one line and the continuation bytes
+    // 94 80 start the next. The persistent payload decoder must
+    // carry the partial char between lines.
+    const { parser, joined } = collect();
+    parser.write(Buffer.concat([
+      Buffer.from("%output %0 "),
+      Buffer.from([0xe2]),
+      Buffer.from("\n%output %0 "),
+      Buffer.from([0x94, 0x80]),
+      Buffer.from("\n"),
+    ]));
+    assert.equal(joined(), "─");
+    assert.ok(!joined().includes("\uFFFD"));
+  });
+
+  it("joins a `─` split across two raw stdout chunks mid-%output-line", () => {
+    // Second flavour: the UTF-8 char is all on one %output line but
+    // the raw stdout chunk boundary splits it. The parser must buffer
+    // the partial line at the byte level (not via a stream-level
+    // StringDecoder that would immediately emit FFFD).
+    const { parser, joined } = collect();
+    parser.write(Buffer.concat([
+      Buffer.from("%output %0 "),
+      Buffer.from([0xe2]),
+    ]));
+    parser.write(Buffer.concat([
+      Buffer.from([0x94, 0x80]),
+      Buffer.from("\n"),
+    ]));
+    assert.equal(joined(), "─");
+  });
+
+  it("exhaustively survives single-char splits at every byte position", () => {
+    // A row of 20 box-drawing chars, split at every possible raw-chunk
+    // boundary. Every split must produce the exact original string
+    // with zero FFFDs.
+    const row = "─".repeat(20);
+    const payload = Buffer.from(row, "utf-8");
+    const full = Buffer.concat([
+      Buffer.from("%output %0 "),
+      payload,
+      Buffer.from("\n"),
+    ]);
+    for (let split = 1; split < full.length; split++) {
+      const { parser, joined } = collect();
+      parser.write(full.subarray(0, split));
+      parser.write(full.subarray(split));
+      assert.equal(
+        joined(),
+        row,
+        `split=${split}: expected ${row.length} chars, got ${JSON.stringify(joined())}`,
+      );
+      assert.ok(
+        !joined().includes("\uFFFD"),
+        `split=${split}: contains U+FFFD`,
+      );
+    }
+  });
+
+  it("preserves octal-escaped low bytes alongside literal high bytes", () => {
+    // Realistic payload mixing both: a CR (octal \015), a literal `─`,
+    // and plain ASCII. Tmux escapes control chars and backslash but
+    // emits high bytes literally.
+    const { parser, joined } = collect();
+    const payload = Buffer.concat([
+      Buffer.from("hello\\015"), // ASCII + octal CR
+      Buffer.from([0xe2, 0x94, 0x80]), // literal `─`
+      Buffer.from("world"),
+    ]);
+    parser.write(Buffer.concat([
+      Buffer.from("%output %0 "),
+      payload,
+      Buffer.from("\n"),
+    ]));
+    assert.equal(joined(), "hello\r─world");
+  });
+
+  it("ignores framing lines (%begin/%end/%session-changed)", () => {
+    const { parser, joined } = collect();
+    parser.write(Buffer.from(
+      "%begin 123 456 0\n" +
+      "%output %0 alpha\n" +
+      "%end 123 456 0\n" +
+      "%session-changed $0 whatever\n" +
+      "%output %0 beta\n",
+    ));
+    assert.equal(joined(), "alphabeta");
+  });
+
+  it("reset() clears partial-line and partial-char state", () => {
+    const { parser, joined } = collect();
+    // Feed a partial %output line (no newline) and a leading UTF-8 byte.
+    parser.write(Buffer.concat([
+      Buffer.from("%output %0 "),
+      Buffer.from([0xe2]),
+    ]));
+    // Reset — the stray 0xe2 must not corrupt the next attach.
+    parser.reset();
+    parser.write(Buffer.from("%output %0 clean\n"));
+    assert.equal(joined(), "clean");
+    assert.ok(!joined().includes("\uFFFD"));
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes the intermittent TUI garble that's been plaguing v0.52.4: ◆/U+FFFD bursts, stacked spinners, stray ruler lines, leftover Claude Code fragments after exit.
- Root cause: tmux splits `%output` payloads at fixed byte boundaries without regard for UTF-8 char boundaries. The old stream-level `StringDecoder` emitted U+FFFD for the orphaned lead/continuation bytes before payload processing could recover them. The damage then cascaded because corrupted bytes included escape sequences (scroll region, cursor position, alt-screen), so the client's xterm put subsequent writes on the wrong cells.
- Fix: rewrite `lib/tmux-output-parser.js` to stay in byte space all the way through octal unescape, then funnel through a SINGLE persistent `StringDecoder` whose internal buffer correctly carries partial multi-byte chars across `%output` lines.
- Ships a new env-gated `lib/drift-log.js` with two verbosity levels so future garble bugs can be debugged the same way this one was. `bin/debug-drift.sh [level]` and `bin/restart-drift.sh [level]` are first-class tooling.
- 8 new regression tests in `test/tmux-output-parser-utf8-split.test.js` including an exhaustive single-char split at every byte position of a 20-char row. All 1900 unit tests pass.

See the commit message for the full what-was-tried-and-failed walkthrough (two previous partial fixes — second decoder layer, and latin1 intermediate — both failed in instructive ways).

## Test plan

- [x] `npm run test:unit` — 1900/1900 pass
- [x] New unit tests: 8/8 pass
- [x] Manual verification: ran local checkout with `KATULONG_DRIFT_LOG=2`, reproduced a Claude Code session with box-drawing chars, confirmed zero garble and zero FFFDs in the drift log
- [ ] E2E suite (runs on pre-push hook)