### PR TITLE
fix: chunk large paste to avoid tmux yacc overflow

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -8,6 +8,10 @@ import {
   stripDaResponses, tmuxKillSession, tmuxSocketArgs,
 } from "./tmux.js";
 
+// tmux's yacc parser overflows at ~9997 arguments to send-keys -H.
+// Chunk large input to stay safely under that limit.
+const SEND_KEYS_MAX_BYTES = 4096;
+
 // Resize gate: defer SIGWINCH when output is actively flowing.
 // The client-side terminal-pool.js applies an 80ms upstream debounce;
 // this server-side gate adds a second layer at the tmux control mode
@@ -201,6 +205,11 @@ export class Session {
 
   /**
    * Write data to the session via tmux send-keys.
+   *
+   * Large input is chunked because tmux's yacc command parser overflows
+   * at ~9997 arguments.  Each byte becomes one hex-pair argument, so we
+   * split at SEND_KEYS_MAX_BYTES (4096) to stay well under the limit.
+   *
    * @param {string} data
    * @throws {SessionNotAliveError}
    */
@@ -212,9 +221,13 @@ export class Session {
     const filtered = stripDaResponses(data);
     if (!filtered) return;
 
-    const hex = encodeHexKeys(filtered);
-    if (hex) {
-      this._sendControlCmd(`send-keys -H ${hex}`);
+    const buf = Buffer.from(filtered);
+    for (let off = 0; off < buf.length; off += SEND_KEYS_MAX_BYTES) {
+      const chunk = buf.subarray(off, off + SEND_KEYS_MAX_BYTES);
+      const hex = encodeHexKeys(chunk);
+      if (hex) {
+        this._sendControlCmd(`send-keys -H ${hex}`);
+      }
     }
   }
 

--- a/lib/tmux.js
+++ b/lib/tmux.js
@@ -18,9 +18,10 @@ export function tmuxSessionName(name) {
 
 /**
  * Encode bytes as hex pairs for `tmux send-keys -H`.
+ * @param {string|Buffer} data
  */
 export function encodeHexKeys(data) {
-  const buf = Buffer.from(data);
+  const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
   const parts = [];
   for (let i = 0; i < buf.length; i++) {
     parts.push(buf[i].toString(16).padStart(2, "0"));

--- a/public/app.js
+++ b/public/app.js
@@ -1582,7 +1582,9 @@
 
     const pasteHandler = createPasteHandler({
       getSession: () => state.session.name,
-      onImage: (file, sessionName) => uploadImageToTerminal(file, sessionName),
+      onImage: (file, sessionName) => uploadImageToTerminal(file, {
+        onSend: rawSend, sessionName, getWebSocket: () => state.connection.ws,
+      }),
       // Use xterm.js paste() so text is wrapped in bracketed paste
       // markers (\x1b[200~…\x1b[201~) when the app has enabled it.
       // Without this, multiline pastes arrive without brackets and

--- a/test/paste-handler.test.js
+++ b/test/paste-handler.test.js
@@ -41,8 +41,8 @@ function createPasteHandlerForTest(options = {}) {
       _blocked = true;
       _capturedSession = getSession ? getSession() : null;
       e.stopImmediatePropagation();
-      e.preventDefault();
-      _fallbackTimer = setTimeout(() => handleClipboardFallback(), 200);
+      // No preventDefault — it suppresses the native paste event on WebKit
+      _fallbackTimer = setTimeout(() => handleClipboardFallback(), 300);
     }
   }
 
@@ -257,12 +257,12 @@ describe("paste-handler", () => {
 
       const keyEvent = createKeydownEvent("v", { meta: true });
       handler.handleKeydown(keyEvent);
-      assert.equal(keyEvent.preventDefault.mock.callCount(), 1);
+      assert.equal(keyEvent.stopImmediatePropagation.mock.callCount(), 1);
 
       navigator.clipboard.read = mock.fn(async () => { throw new Error("not supported"); });
       navigator.clipboard.readText = mock.fn(async () => "clipboard text");
 
-      await new Promise(r => setTimeout(r, 250));
+      await new Promise(r => setTimeout(r, 350));
 
       assert.equal(onTextPaste.mock.callCount(), 1);
       assert.equal(onTextPaste.mock.calls[0].arguments[0], "clipboard text");
@@ -277,7 +277,7 @@ describe("paste-handler", () => {
       navigator.clipboard.read = mock.fn(async () => { throw new Error("denied"); });
       navigator.clipboard.readText = mock.fn(async () => "text from readText");
 
-      await new Promise(r => setTimeout(r, 250));
+      await new Promise(r => setTimeout(r, 350));
 
       assert.equal(onTextPaste.mock.callCount(), 1);
       assert.equal(onTextPaste.mock.calls[0].arguments[0], "text from readText");
@@ -294,7 +294,7 @@ describe("paste-handler", () => {
       navigator.clipboard.read = mock.fn(async () => { throw new Error("denied"); });
       navigator.clipboard.readText = mock.fn(async () => { throw new Error("denied"); });
 
-      await new Promise(r => setTimeout(r, 250));
+      await new Promise(r => setTimeout(r, 350));
 
       assert.equal(syntheticPaste.mock.callCount(), 1, "should trigger synthetic paste as last resort");
     });
@@ -308,7 +308,7 @@ describe("paste-handler", () => {
         target: { tagName: "TEXTAREA", classList: { contains: () => false } },
       });
       handler.handleKeydown(keyEvent);
-      assert.equal(keyEvent.preventDefault.mock.callCount(), 0);
+      assert.equal(keyEvent.stopImmediatePropagation.mock.callCount(), 0);
     });
 
     it("DOES intercept Cmd+V in xterm helper textarea", () => {
@@ -318,14 +318,16 @@ describe("paste-handler", () => {
         target: { tagName: "TEXTAREA", classList: { contains: (c) => c === "xterm-helper-textarea" } },
       });
       handler.handleKeydown(keyEvent);
-      assert.equal(keyEvent.preventDefault.mock.callCount(), 1);
+      assert.equal(keyEvent.stopImmediatePropagation.mock.callCount(), 1);
+      // No preventDefault — it suppresses the native paste event on WebKit
+      assert.equal(keyEvent.preventDefault.mock.callCount(), 0);
     });
 
     it("does not intercept Alt+V", () => {
       const handler = createPasteHandlerForTest({ getSession: () => "sess" });
       const keyEvent = createKeydownEvent("v", { meta: true, alt: true });
       handler.handleKeydown(keyEvent);
-      assert.equal(keyEvent.preventDefault.mock.callCount(), 0);
+      assert.equal(keyEvent.stopImmediatePropagation.mock.callCount(), 0);
     });
   });
 
@@ -341,7 +343,7 @@ describe("paste-handler", () => {
 
       navigator.clipboard.readText = mock.fn(async () => "from fallback");
 
-      await new Promise(r => setTimeout(r, 250));
+      await new Promise(r => setTimeout(r, 350));
 
       // Should only have the paste event's text, not the fallback
       assert.equal(onTextPaste.mock.callCount(), 1);

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -401,6 +401,33 @@ describe("Session", () => {
 
       assert.strictEqual(mockProc.stdin.written.length, 3);
     });
+
+    it("chunks large input to avoid tmux yacc overflow", () => {
+      const { session, mockProc } = createSimpleTestSession("test");
+
+      // 12KB paste — exceeds tmux's ~9997 hex-argument yacc limit
+      const largeInput = "A".repeat(12000);
+      session.write(largeInput);
+
+      // 12000 bytes / 4096 chunk = 3 send-keys commands
+      assert.strictEqual(mockProc.stdin.written.length, 3);
+      for (const cmd of mockProc.stdin.written) {
+        assert.ok(cmd.startsWith("send-keys -H "));
+        // Each hex pair is "XX " (3 chars), count pairs by splitting on space
+        const hexPart = cmd.replace("send-keys -H ", "").trim();
+        const pairCount = hexPart.split(" ").length;
+        assert.ok(pairCount <= 4096, `chunk has ${pairCount} pairs, expected <= 4096`);
+      }
+    });
+
+    it("sends small input as a single command", () => {
+      const { session, mockProc } = createSimpleTestSession("test");
+
+      session.write("hello");
+
+      assert.strictEqual(mockProc.stdin.written.length, 1);
+      assert.ok(mockProc.stdin.written[0].startsWith("send-keys -H "));
+    });
   });
 
   describe("resize", () => {


### PR DESCRIPTION
## Summary
- Large text paste (>~10KB) caused silent `send-keys -H` failure due to tmux's yacc parser stack overflow at ~9,997 arguments — each byte is one hex-pair argument, so a 12KB paste sends ~12,000 args
- `Session.write()` now chunks at 4,096 bytes per `send-keys -H` command, well under the limit
- Fixed `onImage` callback passing a string where `uploadImageToTerminal` expected an options object
- Synced paste-handler test with production code (removed stale `preventDefault` on keydown, fixed fallback timer to 300ms)

## Test plan
- [ ] Paste short text (<1KB) into terminal via tunnel — should work as before
- [ ] Paste large text (~12KB markdown file) into terminal via tunnel — should now work instead of disconnecting
- [ ] Paste image into terminal — should upload correctly (was broken by `onImage` signature mismatch)
- [ ] `npm test` passes (1899 tests, 0 failures)

Staging: https://large-paste-fix.felixflor.es