### PR TITLE
fix: detect zombie terminals caused by dead control mode stdin

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -157,6 +157,26 @@ export class Session {
 
     proc.stdout.on("data", (chunk) => this._parser.write(chunk));
 
+    // Catch stdin pipe errors — if the control mode process's stdin
+    // breaks (EPIPE, pipe reset, etc.), the session's input path is
+    // dead. Without this listener the error goes unhandled and the
+    // session sits in STATE_ATTACHED forever silently dropping input
+    // (the "zombie terminal" bug). Treat stdin errors the same as a
+    // process crash: transition to DETACHED and fire onExit so the
+    // session manager can clean up and clients reconnect.
+    proc.stdin.on("error", (err) => {
+      if (this.controlProc !== proc) return;
+      log.warn("Control mode stdin error — session input is dead, triggering exit", {
+        session: this.name, error: err.message,
+      });
+      if (this.state === Session.STATE_ATTACHED) {
+        this.state = Session.STATE_DETACHED;
+        if (this._onExit) {
+          this._onExit(this.name, 1);
+        }
+      }
+    });
+
     // Close/error handlers capture `proc` in the closure. If the session
     // is reattached before this process's close event fires, the parser
     // state will have been reset by `_parser.reset()` for the new attach
@@ -191,12 +211,34 @@ export class Session {
 
   /**
    * Send a command to the tmux control mode stdin.
+   *
+   * If stdin is no longer writable but the session still thinks it's
+   * attached, we have a zombie: input silently vanishes. Rather than
+   * swallow the write, log a warning and trigger the exit path so the
+   * session transitions to DETACHED and the client sees a disconnect.
+   *
    * @private
+   * @returns {boolean} true if the command was written, false otherwise
    */
   _sendControlCmd(cmd) {
-    if (this.controlProc && this.controlProc.stdin.writable) {
-      this.controlProc.stdin.write(cmd + "\n");
+    if (!this.controlProc) return false;
+    if (!this.controlProc.stdin.writable) {
+      // Zombie detection: stdin is dead but session is still ATTACHED.
+      // This is the root cause of the "can't type, even after refresh"
+      // bug — every keystroke silently hits this branch and vanishes.
+      if (this.state === Session.STATE_ATTACHED) {
+        log.warn("Control mode stdin not writable — zombie detected, triggering exit", {
+          session: this.name,
+        });
+        this.state = Session.STATE_DETACHED;
+        if (this._onExit) {
+          this._onExit(this.name, 1);
+        }
+      }
+      return false;
     }
+    this.controlProc.stdin.write(cmd + "\n");
+    return true;
   }
 
   /**

--- a/test/garble-octal-split.test.js
+++ b/test/garble-octal-split.test.js
@@ -88,7 +88,7 @@ class MockReadable {
 
 class MockProc {
   constructor() {
-    this.stdin = { write() {}, end() {}, writable: true };
+    this.stdin = { write() {}, end() {}, writable: true, on() {} };
     this.stdout = new MockReadable();
     this._closeHandlers = [];
     this._errorHandlers = [];

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -981,22 +981,19 @@ describe("Session", () => {
 
     it("handles stdin error event by transitioning to DETACHED", () => {
       let exitCalled = false;
-      const { session, mockProc } = createSimpleTestSession("stdin-error", {
+      const session = new Session("stdin-error", tmuxSessionName("stdin-error"), {
         onExit: () => { exitCalled = true; },
       });
 
+      // Stub _spawn so attachControlMode uses our mock proc
+      const mockProc = new MockControlProc();
+      session._spawn = () => mockProc;
+      session.attachControlMode(80, 24);
+
       assert.strictEqual(session.state, Session.STATE_ATTACHED);
 
-      // Wire up the stdin error handler the same way attachControlMode does
-      mockProc.stdin.on("error", (err) => {
-        if (session.controlProc !== mockProc) return;
-        if (session.state === Session.STATE_ATTACHED) {
-          session.state = Session.STATE_DETACHED;
-          if (session._onExit) session._onExit(session.name, 1);
-        }
-      });
-
-      // Simulate an EPIPE error on stdin
+      // Simulate an EPIPE error on stdin — exercises the real handler
+      // registered by attachControlMode, not a hand-wired copy
       mockProc.stdin.simulateError(new Error("write EPIPE"));
 
       assert.strictEqual(session.state, Session.STATE_DETACHED);
@@ -1006,22 +1003,19 @@ describe("Session", () => {
 
     it("ignores stdin error from superseded control process", () => {
       let exitCalled = false;
-      const { session, mockProc: oldProc } = createSimpleTestSession("stdin-stale", {
+      const session = new Session("stdin-stale", tmuxSessionName("stdin-stale"), {
         onExit: () => { exitCalled = true; },
       });
 
-      // Wire up stdin error handler for old proc
-      oldProc.stdin.on("error", (err) => {
-        if (session.controlProc !== oldProc) return; // stale guard
-        if (session.state === Session.STATE_ATTACHED) {
-          session.state = Session.STATE_DETACHED;
-          if (session._onExit) session._onExit(session.name, 1);
-        }
-      });
+      // First attach — registers stdin error handler on oldProc
+      const oldProc = new MockControlProc();
+      session._spawn = () => oldProc;
+      session.attachControlMode(80, 24);
 
-      // Simulate reattach: new proc replaces old
+      // Second attach — supersedes oldProc with newProc
       const newProc = new MockControlProc();
-      session.controlProc = newProc;
+      session._spawn = () => newProc;
+      session.attachControlMode(80, 24);
 
       // Old proc's stdin errors — should be ignored (stale guard)
       oldProc.stdin.simulateError(new Error("write EPIPE"));

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -284,9 +284,17 @@ class MockWritable {
     this.written = [];
     this.writable = true;
     this.ended = false;
+    this._errorHandlers = [];
   }
   write(data) { this.written.push(data); }
   end() { this.ended = true; this.writable = false; }
+  on(event, handler) {
+    if (event === "error") this._errorHandlers.push(handler);
+  }
+  // Test helper: simulate a stdin pipe error (EPIPE, broken pipe, etc.)
+  simulateError(err) {
+    for (const handler of [...this._errorHandlers]) handler(err);
+  }
 }
 
 class MockReadable {
@@ -926,6 +934,125 @@ describe("Session", () => {
       assert.ok(buffer.includes("line2"));
       assert.ok(buffer.includes("line3"));
       assert.ok(buffer.includes("line4"));
+    });
+  });
+
+  describe("zombie terminal detection", () => {
+    it("detects zombie when stdin becomes unwritable and triggers exit", () => {
+      let exitCalled = false;
+      let exitCode = null;
+      const { session, mockProc } = createSimpleTestSession("zombie-test", {
+        onExit: (name, code) => { exitCalled = true; exitCode = code; },
+      });
+
+      // Simulate stdin becoming unwritable (pipe break, tmux crash, etc.)
+      mockProc.stdin.writable = false;
+
+      // Session still thinks it's attached
+      assert.strictEqual(session.state, Session.STATE_ATTACHED);
+      assert.strictEqual(session.alive, true);
+
+      // Attempt to write — should detect zombie and trigger exit
+      session.write("hello");
+
+      assert.strictEqual(session.state, Session.STATE_DETACHED);
+      assert.strictEqual(session.alive, false);
+      assert.strictEqual(exitCalled, true);
+      assert.strictEqual(exitCode, 1);
+    });
+
+    it("only triggers exit once even with multiple writes to dead stdin", () => {
+      let exitCount = 0;
+      const { session, mockProc } = createSimpleTestSession("zombie-multi", {
+        onExit: () => { exitCount++; },
+      });
+
+      mockProc.stdin.writable = false;
+
+      // First write detects zombie and triggers exit
+      session.write("a");
+      assert.strictEqual(exitCount, 1);
+      assert.strictEqual(session.state, Session.STATE_DETACHED);
+
+      // Second write throws SessionNotAliveError (session is now DETACHED)
+      assert.throws(() => session.write("b"), SessionNotAliveError);
+      assert.strictEqual(exitCount, 1); // exit not called again
+    });
+
+    it("handles stdin error event by transitioning to DETACHED", () => {
+      let exitCalled = false;
+      const { session, mockProc } = createSimpleTestSession("stdin-error", {
+        onExit: () => { exitCalled = true; },
+      });
+
+      assert.strictEqual(session.state, Session.STATE_ATTACHED);
+
+      // Wire up the stdin error handler the same way attachControlMode does
+      mockProc.stdin.on("error", (err) => {
+        if (session.controlProc !== mockProc) return;
+        if (session.state === Session.STATE_ATTACHED) {
+          session.state = Session.STATE_DETACHED;
+          if (session._onExit) session._onExit(session.name, 1);
+        }
+      });
+
+      // Simulate an EPIPE error on stdin
+      mockProc.stdin.simulateError(new Error("write EPIPE"));
+
+      assert.strictEqual(session.state, Session.STATE_DETACHED);
+      assert.strictEqual(session.alive, false);
+      assert.strictEqual(exitCalled, true);
+    });
+
+    it("ignores stdin error from superseded control process", () => {
+      let exitCalled = false;
+      const { session, mockProc: oldProc } = createSimpleTestSession("stdin-stale", {
+        onExit: () => { exitCalled = true; },
+      });
+
+      // Wire up stdin error handler for old proc
+      oldProc.stdin.on("error", (err) => {
+        if (session.controlProc !== oldProc) return; // stale guard
+        if (session.state === Session.STATE_ATTACHED) {
+          session.state = Session.STATE_DETACHED;
+          if (session._onExit) session._onExit(session.name, 1);
+        }
+      });
+
+      // Simulate reattach: new proc replaces old
+      const newProc = new MockControlProc();
+      session.controlProc = newProc;
+
+      // Old proc's stdin errors — should be ignored (stale guard)
+      oldProc.stdin.simulateError(new Error("write EPIPE"));
+
+      assert.strictEqual(session.state, Session.STATE_ATTACHED);
+      assert.strictEqual(session.alive, true);
+      assert.strictEqual(exitCalled, false);
+    });
+
+    it("_sendControlCmd returns false when stdin is not writable", () => {
+      const { session, mockProc } = createSimpleTestSession("cmd-return", {
+        onExit: () => {},
+      });
+
+      // Normal write succeeds
+      const ok = session._sendControlCmd("send-keys -H 68 69");
+      assert.strictEqual(ok, true);
+      assert.strictEqual(mockProc.stdin.written.length, 1);
+
+      // Break stdin — next write fails and returns false
+      mockProc.stdin.writable = false;
+      const fail = session._sendControlCmd("send-keys -H 6c 6f");
+      assert.strictEqual(fail, false);
+      assert.strictEqual(mockProc.stdin.written.length, 1); // no new write
+    });
+
+    it("_sendControlCmd returns false when controlProc is null", () => {
+      const { session } = createSimpleTestSession("cmd-null");
+      session.controlProc = null;
+      const result = session._sendControlCmd("anything");
+      assert.strictEqual(result, false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Detect and recover from zombie terminals where `controlProc.stdin` becomes unwritable but the session stays in `STATE_ATTACHED`, silently dropping all input
- `_sendControlCmd()` now detects the zombie condition on the first failed write, transitions to DETACHED, and fires `onExit` — the client sees a disconnect and can reconnect
- `attachControlMode()` registers a `proc.stdin.on("error")` handler so stdin pipe breaks (EPIPE) immediately trigger session cleanup
- 6 new tests covering zombie detection, single-fire exit, stdin error handling, stale-process guard, and return value semantics

## Root cause

`_sendControlCmd()` checked `stdin.writable` and silently returned when false. No logging, no error, no state transition. The session reported `alive: true` forever while input vanished. Hard refresh reconnected to the same broken session. Only killing the session and recreating it worked.

## Test plan

- [x] `npm test` passes (1946/1946, pre-existing file-browser-tile failure excluded)
- [x] Smoke E2E passes
- [x] Pre-push review agents approve
- [ ] Manual: kill tmux control mode process while session is active → session transitions to DETACHED, client sees disconnect
- [ ] Manual: verify reconnect after zombie detection restores input

## Files changed

- `lib/session.js` — stdin error listener in `attachControlMode()`, zombie detection + recovery in `_sendControlCmd()`
- `test/session.test.js` — 6 new zombie detection tests, `MockWritable` gains `on("error")` + `simulateError()`
- `test/garble-octal-split.test.js` — add `on()` to `MockProc.stdin` stub