### PR TITLE
fix: image paste silently dropped when DataChannel active

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1607,7 +1607,7 @@
       onSend: rawSend,
       toast: showToast,
       sessionName: sessionName || state.session.name,
-      getWebSocket: () => cm.transport?.ws
+      sendFn: (msg) => cm.send(msg)
     });
 
     // --- Upload button (file picker) ---
@@ -1625,7 +1625,7 @@
           onSend: rawSend,
           toast: showToast,
           sessionName: state.session.name,
-          getWebSocket: () => cm.transport?.ws,
+          sendFn: (msg) => cm.send(msg),
         });
       }
       _uploadInput.value = ""; // reset so same file can be re-selected
@@ -1653,7 +1653,7 @@
           return;
         }
         // Upload in parallel, paste via single server request
-        uploadImagesToTerminalFn(imageFiles, { onSend: rawSend, toast: showToast, sessionName: state.session.name, getWebSocket: () => cm.transport?.ws });
+        uploadImagesToTerminalFn(imageFiles, { onSend: rawSend, toast: showToast, sessionName: state.session.name, sendFn: (msg) => cm.send(msg) });
       }
     });
 

--- a/public/lib/image-upload.js
+++ b/public/lib/image-upload.js
@@ -176,18 +176,15 @@ function getCsrfToken() {
 }
 
 /**
- * Send data to a specific session via WebSocket input message.
+ * Send data to a specific session via the connection manager.
  * Uses explicit session field so the server routes to the correct
  * session even if the user switched tabs since the paste started.
  * Falls back to onSend (which uses the input sender's current session).
  */
-function _sendToSession(data, sessionName, getWebSocket, onSend) {
-  if (sessionName && getWebSocket) {
-    const ws = getWebSocket();
-    if (ws && ws.readyState === 1) {
-      ws.send(JSON.stringify({ type: "input", data, session: sessionName }));
-      return;
-    }
+function _sendToSession(data, sessionName, sendFn, onSend) {
+  if (sessionName && sendFn) {
+    sendFn(JSON.stringify({ type: "input", data, session: sessionName }));
+    return;
   }
   if (onSend) onSend(data);
 }
@@ -199,7 +196,7 @@ function _sendToSession(data, sessionName, getWebSocket, onSend) {
  * to the PTY for each image sequentially — no per-file round-trips.
  */
 export async function uploadImagesToTerminal(files, options = {}) {
-  const { onSend, toast = showToast, sessionName, getWebSocket } = options;
+  const { onSend, toast = showToast, sessionName, sendFn } = options;
   const tracker = getTracker();
   const entries = [];
 
@@ -230,9 +227,9 @@ export async function uploadImagesToTerminal(files, options = {}) {
     // bridge). Send Ctrl+V with explicit session to avoid tab-switch race.
     const { id, data } = successEntries[0];
     if (data.clipboard === true) {
-      _sendToSession("\x16", sessionName, getWebSocket, onSend);
+      _sendToSession("\x16", sessionName, sendFn, onSend);
     } else if (data.fsPath) {
-      _sendToSession(data.fsPath + " ", sessionName, getWebSocket, onSend);
+      _sendToSession(data.fsPath + " ", sessionName, sendFn, onSend);
     }
     tracker.complete(id, true);
     return;


### PR DESCRIPTION
## Summary

- Image paste (Ctrl+V after upload) was silently dropped when WebRTC DataChannel was active — the `\x16` was sent on the raw WebSocket which the server ignores when DC is the active transport
- Root cause: PR #553 (connection rewrite) changed `getWebSocket: () => state.connection.ws` to `cm.transport?.ws`, switching from the transport layer to the raw socket
- Fix: pass `cm.send` as a plain `sendFn`, matching the pattern used by `inputSender` — no transport/WS references leak into image-upload.js (design doc principle #6)

## Test plan

- [ ] `npm test` passes (unit + integration)
- [ ] Paste image from remote device (iPad/Mac) → image appears in terminal (Claude Code reads clipboard)
- [ ] Verify with DataChannel active (green connection dot)
- [ ] Verify drag-drop image upload still works
- [ ] Verify multi-file paste still works