### PR TITLE
fix: sync carousel and notepad on WebSocket session rename

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1988,7 +1988,11 @@
           clearFocusedSessionUI();
         }
       },
+      carouselRename: (e) => {
+        if (carousel.isActive()) carousel.renameCard(e.oldName, e.newName);
+      },
       poolRename: (e) => terminalPool.rename(e.oldName, e.newName),
+      notepadRename: (e) => notepad.rename(e.oldName, e.newName),
       tabRename: (e) => windowTabSet.renameTab(e.oldName, e.newName),
       resizeSync: () => {
         // Another client resized the shared PTY. Recalculate our own

--- a/public/app.js
+++ b/public/app.js
@@ -1993,6 +1993,9 @@
       },
       poolRename: (e) => terminalPool.rename(e.oldName, e.newName),
       notepadRename: (e) => notepad.rename(e.oldName, e.newName),
+      shortcutBarRename: (e) => {
+        if (shortcutBarInstance) shortcutBarInstance.renameTabEl(e.oldName, e.newName);
+      },
       tabRename: (e) => windowTabSet.renameTab(e.oldName, e.newName),
       resizeSync: () => {
         // Another client resized the shared PTY. Recalculate our own

--- a/public/lib/ws-message-handlers.js
+++ b/public/lib/ws-message-handlers.js
@@ -120,7 +120,9 @@ export const wsMessageHandlers = {
     return {
       stateUpdates: { 'session.name': msg.name },
       effects: [
+        { type: 'carouselRename', oldName: ctx.currentSessionName, newName: msg.name },
         { type: 'poolRename', oldName: ctx.currentSessionName, newName: msg.name },
+        { type: 'notepadRename', oldName: ctx.currentSessionName, newName: msg.name },
         { type: 'tabRename', oldName: ctx.currentSessionName, newName: msg.name },
         { type: 'updateSessionUI', name: msg.name },
       ],

--- a/public/lib/ws-message-handlers.js
+++ b/public/lib/ws-message-handlers.js
@@ -123,7 +123,9 @@ export const wsMessageHandlers = {
         { type: 'carouselRename', oldName: ctx.currentSessionName, newName: msg.name },
         { type: 'poolRename', oldName: ctx.currentSessionName, newName: msg.name },
         { type: 'notepadRename', oldName: ctx.currentSessionName, newName: msg.name },
+        { type: 'shortcutBarRename', oldName: ctx.currentSessionName, newName: msg.name },
         { type: 'tabRename', oldName: ctx.currentSessionName, newName: msg.name },
+        { type: 'invalidateSessions', name: msg.name },
         { type: 'updateSessionUI', name: msg.name },
       ],
     };


### PR DESCRIPTION
## Summary

- The WebSocket `session-renamed` handler was missing `carouselRename` and `notepadRename` effects, causing the carousel to lose track of the renamed session (zombie card) and jump to the end
- Added both effects to `ws-message-handlers.js` and their handlers to `app.js`, matching the ordering used by the local rename path (carousel before tab rename, since `reorderCards` needs the card ID already updated)

## Test plan

- [x] `npm run test:unit` — 1955 pass, 0 fail
- [x] Smoke E2E passes
- [ ] Manual: rename a session while carousel is active — verify card stays focused and functional
- [ ] Manual: rename a session from a second device — verify the first device's carousel updates correctly