### PR TITLE
fix: add .mjs MIME type to prevent blank screen

### DIFF
--- a/lib/http-util.js
+++ b/lib/http-util.js
@@ -75,7 +75,7 @@ export function getOriginAndRpID(req) {
 
 // --- Public path check ---
 
-const STATIC_EXTS = new Set([".js", ".css", ".png", ".ico", ".webp", ".svg", ".woff2", ".json"]);
+const STATIC_EXTS = new Set([".js", ".mjs", ".css", ".png", ".ico", ".webp", ".svg", ".woff2", ".json"]);
 
 const PUBLIC_AUTH_ROUTES = new Set([
   "/auth/status",

--- a/lib/static-files.js
+++ b/lib/static-files.js
@@ -66,7 +66,7 @@ export function buildVendorHashes(publicDir) {
         walk(join(dir, entry.name), `${prefix}${entry.name}/`);
       } else {
         const ext = extname(entry.name);
-        if (ext === ".js" || ext === ".css") {
+        if (ext === ".js" || ext === ".mjs" || ext === ".css") {
           const filePath = join(dir, entry.name);
           const content = readFileSync(filePath);
           const hash = contentHash(content);
@@ -96,7 +96,7 @@ export function buildVendorHashes(publicDir) {
 export function rewriteVendorUrls(text) {
   // Match /vendor/....(js|css) optionally followed by ?anything, inside quotes
   return text.replace(
-    /(["'])(\/vendor\/[^"']+?\.(js|css))(?:\?[^"']*)?(\1)/g,
+    /(["'])(\/vendor\/[^"']+?\.(js|mjs|css))(?:\?[^"']*)?(\1)/g,
     (match, q1, path, _ext, q2) => {
       const hash = vendorHashes.get(path);
       if (hash) {

--- a/lib/static-files.js
+++ b/lib/static-files.js
@@ -27,6 +27,7 @@ const vendorHashes = new Map();
 export const MIME_TYPES = {
   ".html": "text/html; charset=utf-8",
   ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
   ".json": "application/json; charset=utf-8",
   ".css": "text/css; charset=utf-8",
   ".png": "image/png",


### PR DESCRIPTION
## Summary

- Add `.mjs` extension to `MIME_TYPES` map in `lib/static-files.js` with `application/javascript` content type
- Without this, DOMPurify (`purify.es.mjs`) was served as `application/octet-stream`, which browsers reject for ES module imports, causing a blank screen

## Test plan

- [x] `npm test` passes (1965 tests, 0 failures)
- [x] Staged and verified fix resolves blank screen