### PR TITLE
fix: image paste shows green check but never reaches Claude

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1664,9 +1664,7 @@
 
     const pasteHandler = createPasteHandler({
       getSession: () => state.session.name,
-      onImage: (file, sessionName) => uploadImageToTerminal(file, {
-        onSend: rawSend, sessionName, getWebSocket: () => state.connection.ws,
-      }),
+      onImage: uploadImageToTerminal,
       // Use xterm.js paste() so text is wrapped in bracketed paste
       // markers (\x1b[200~…\x1b[201~) when the app has enabled it.
       // Without this, multiline pastes arrive without brackets and

--- a/test/image-drop.test.js
+++ b/test/image-drop.test.js
@@ -462,6 +462,61 @@ describe("uploadImageToTerminal", () => {
     assert.equal(sent[0], "/uploads/photo.png ");
   });
 
+  it("routes Ctrl+V to the correct session via sendFn when sessionName is provided", async () => {
+    globalThis.fetch = mock.fn(async () => ({
+      ok: true,
+      json: async () => ({ clipboard: true, fsPath: "/uploads/photo.png" }),
+    }));
+
+    const { uploadImageToTerminal } = await import("../public/lib/image-upload.js");
+
+    const wsMsgs = [];
+    const file = fakeFile("photo.png", "image/png");
+
+    uploadImageToTerminal(file, {
+      onSend: () => { throw new Error("onSend should not be called when sendFn is provided"); },
+      toast: () => {},
+      sessionName: "my-session",
+      sendFn: (msg) => wsMsgs.push(msg),
+    });
+    await new Promise(r => setTimeout(r, 50));
+
+    // sendFn should receive a JSON string with the session name as a string
+    assert.equal(wsMsgs.length, 1);
+    const parsed = JSON.parse(wsMsgs[0]);
+    assert.equal(parsed.type, "input");
+    assert.equal(parsed.data, "\x16");
+    assert.equal(parsed.session, "my-session");
+    assert.equal(typeof parsed.session, "string", "session must be a string, not an object");
+  });
+
+  it("routes fsPath to the correct session via sendFn when clipboard is false", async () => {
+    globalThis.fetch = mock.fn(async () => ({
+      ok: true,
+      json: async () => ({ clipboard: false, fsPath: "/uploads/photo.png" }),
+    }));
+
+    const { uploadImageToTerminal } = await import("../public/lib/image-upload.js");
+
+    const wsMsgs = [];
+    const file = fakeFile("photo.png", "image/png");
+
+    uploadImageToTerminal(file, {
+      onSend: () => { throw new Error("onSend should not be called when sendFn is provided"); },
+      toast: () => {},
+      sessionName: "my-session",
+      sendFn: (msg) => wsMsgs.push(msg),
+    });
+    await new Promise(r => setTimeout(r, 50));
+
+    assert.equal(wsMsgs.length, 1);
+    const parsed = JSON.parse(wsMsgs[0]);
+    assert.equal(parsed.type, "input");
+    assert.equal(parsed.data, "/uploads/photo.png ");
+    assert.equal(parsed.session, "my-session");
+    assert.equal(typeof parsed.session, "string");
+  });
+
   it("sends correct headers and body in the upload request", async () => {
     globalThis.fetch = mock.fn(async () => ({
       ok: true,


### PR DESCRIPTION
## Summary

- Fixed `onImage` callback in `createPasteHandler` wiring that was passing an options object instead of a string session name to `uploadImageToTerminal`, causing the Ctrl+V keystroke to be silently misrouted via WebSocket
- Added two regression tests verifying that `sendFn` receives a properly-typed string `session` field for both clipboard (Ctrl+V) and filesystem path delivery paths

## Root cause

The `onImage` callback was double-wrapping options — it created `{ onSend, sessionName, getWebSocket }` and passed it as the second argument where the local `uploadImageToTerminal` wrapper expected a plain session name string. The server couldn't route the keystroke to any real tmux session, so the clipboard bridge completed (green check) but Claude never read the clipboard.

## Test plan

- [x] `npm test` passes (1970 tests, 0 failures)
- [x] Pre-push hooks pass (unit + integration + smoke E2E + review agents)
- [x] Manual verification: staged instance on iPad, pasted image, confirmed Claude received it