### PR TITLE
feat: add close button to document tile viewer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2168,7 +2168,8 @@
 
     /* --- Document Tile --- */
     .doc-tile-root { display: flex; flex-direction: column; height: 100%; width: 100%; background: var(--bg); color: var(--text); font-family: var(--font-mono); font-size: var(--text-sm); }
-    .doc-tile-header { padding: var(--space-xs) var(--space-sm); border-bottom: 1px solid var(--border); flex-shrink: 0; background: var(--bg-surface); color: var(--text-secondary); font-size: var(--text-xs); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .doc-tile-header { display: flex; align-items: center; gap: var(--space-xs); padding: var(--space-xs) var(--space-sm); border-bottom: 1px solid var(--border); flex-shrink: 0; background: var(--bg-surface); color: var(--text-secondary); font-size: var(--text-xs); }
+    .doc-tile-header-title { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .doc-tile-content { flex: 1; overflow: auto; margin: 0; padding: var(--space-sm); white-space: pre-wrap; word-wrap: break-word; tab-size: 2; line-height: 1.5; outline: none; }
     .doc-tile-content:focus { outline: none; }
     .doc-tile-error { color: var(--text-error, #f66); }

--- a/public/lib/tiles/document-tile.js
+++ b/public/lib/tiles/document-tile.js
@@ -72,7 +72,7 @@ export function createDocumentTileFactory(_deps = {}) {
 
       get filePath() { return filePath || null; },
 
-      mount(el, _ctx) {
+      mount(el, ctx) {
         container = el;
         mounted = true;
 
@@ -81,7 +81,19 @@ export function createDocumentTileFactory(_deps = {}) {
 
         const header = document.createElement("div");
         header.className = "doc-tile-header";
-        header.textContent = filePath || title || "";
+
+        const headerTitle = document.createElement("span");
+        headerTitle.className = "doc-tile-header-title";
+        headerTitle.textContent = filePath || title || "";
+        header.appendChild(headerTitle);
+
+        const closeBtn = document.createElement("button");
+        closeBtn.className = "fb-btn fb-close-btn";
+        closeBtn.setAttribute("aria-label", "Close document");
+        closeBtn.innerHTML = '<i class="ph ph-x"></i>';
+        closeBtn.addEventListener("click", () => ctx.requestClose());
+        header.appendChild(closeBtn);
+
         root.appendChild(header);
 
         let contentEl;

--- a/public/lib/tiles/document-tile.js
+++ b/public/lib/tiles/document-tile.js
@@ -91,7 +91,7 @@ export function createDocumentTileFactory(_deps = {}) {
         closeBtn.className = "fb-btn fb-close-btn";
         closeBtn.setAttribute("aria-label", "Close document");
         closeBtn.innerHTML = '<i class="ph ph-x"></i>';
-        closeBtn.addEventListener("click", () => ctx.requestClose());
+        closeBtn.addEventListener("click", () => ctx?.requestClose?.());
         header.appendChild(closeBtn);
 
         root.appendChild(header);


### PR DESCRIPTION
## Summary

- Add an × close button to the document tile header, matching the file browser's existing close button
- Header is now a flex row: file path (truncated with ellipsis) on the left, close button on the right
- Reuses existing `.fb-btn` / `.fb-close-btn` styles and `ph-x` Phosphor icon for consistency

## Test plan

- [ ] `npm test` passes (unit + integration)
- [ ] Open a document tile (e.g., click a markdown file) and verify the × button appears in the header
- [ ] Click the × button and verify the tile closes
- [ ] Verify long file paths still truncate with ellipsis
- [ ] Verify file browser close button still works as before