### PR TITLE
feat: add feed tile — general-purpose pub/sub event streamer

### DIFF
--- a/bin/katulong-stage
+++ b/bin/katulong-stage
@@ -58,7 +58,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 STAGE_BASE="/tmp/katulong-stage"
 
 # User-level config lives in the prod katulong's data dir, NOT in the per-staging

--- a/lib/cli/commands/info.js
+++ b/lib/cli/commands/info.js
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { isServerRunning, getUrls, DATA_DIR, ROOT } from "../process-manager.js";
+import { api } from "../api-client.js";
 import envConfig from "../../env-config.js";
 
 export default async function info() {
@@ -35,6 +36,12 @@ export default async function info() {
   // URLs (if running)
   if (server.running) {
     console.log("Access URLs:");
-    console.log(`  ${urls.http}`);
+    console.log(`  Local:    ${urls.http}`);
+    try {
+      const { url } = await api.get("/api/external-url");
+      if (url) console.log(`  External: ${url}`);
+    } catch {
+      // External URL not available (no tunnel or no remote connections yet)
+    }
   }
 }

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -281,6 +281,10 @@ export function createAppRoutes(ctx) {
       if (!topic) return json(res, 400, { error: "Missing topic" });
       if (!message) return json(res, 400, { error: "Missing message" });
       if (!/^[a-zA-Z0-9._\-/]+$/.test(topic)) return json(res, 400, { error: "Invalid topic (alphanumeric, dots, dashes, slashes)" });
+      // Optional topic metadata — set once or update on publish
+      if (data.meta && typeof data.meta === "object") {
+        topicBroker.setMeta(topic, data.meta);
+      }
       const delivered = topicBroker.publish(topic, message);
       json(res, 200, { ok: true, delivered });
     }))},
@@ -292,7 +296,10 @@ export function createAppRoutes(ctx) {
       // Parse optional fromSeq query param for replay
       const url = new URL(req.url, "http://localhost");
       const fromSeqParam = url.searchParams.get("fromSeq");
-      const fromSeq = fromSeqParam !== null ? parseInt(fromSeqParam, 10) : undefined;
+      const lastEventId = req.headers["last-event-id"];
+      const fromSeq = fromSeqParam !== null
+        ? parseInt(fromSeqParam, 10)
+        : (lastEventId ? parseInt(lastEventId, 10) + 1 : undefined);
 
       // SSE stream
       res.writeHead(200, {
@@ -304,7 +311,7 @@ export function createAppRoutes(ctx) {
       res.write(":ok\n\n");
 
       const unsubscribe = topicBroker.subscribe(topic, (envelope) => {
-        res.write(`data: ${JSON.stringify(envelope)}\n\n`);
+        res.write(`id: ${envelope.seq}\ndata: ${JSON.stringify(envelope)}\n\n`);
       }, { fromSeq });
 
       req.on("close", unsubscribe);
@@ -313,6 +320,18 @@ export function createAppRoutes(ctx) {
     { method: "GET", path: "/api/topics", handler: auth((req, res) => {
       if (!topicBroker) return json(res, 200, []);
       json(res, 200, topicBroker.listTopics());
+    })},
+
+    { method: "POST", prefix: "/api/topics/", handler: auth(async (req, res, param) => {
+      if (!topicBroker) return json(res, 503, { error: "Pub/sub not available" });
+      // Expect: /api/topics/<topic>/meta
+      if (!param.endsWith("/meta")) return json(res, 404, { error: "Not found" });
+      const topic = param.slice(0, -5); // strip "/meta"
+      if (!topic || !/^[a-zA-Z0-9._\-/]+$/.test(topic)) return json(res, 400, { error: "Invalid topic" });
+      const data = await parseJSON(req);
+      if (!data || typeof data !== "object") return json(res, 400, { error: "Body must be a JSON object" });
+      topicBroker.setMeta(topic, data);
+      json(res, 200, { ok: true, meta: topicBroker.getMeta(topic) });
     })},
 
     // --- Sessions ---

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -280,7 +280,7 @@ export function createAppRoutes(ctx) {
       const message = typeof data.message === "string" ? data.message.slice(0, 65536) : "";
       if (!topic) return json(res, 400, { error: "Missing topic" });
       if (!message) return json(res, 400, { error: "Missing message" });
-      if (!/^[a-zA-Z0-9._\-/]+$/.test(topic)) return json(res, 400, { error: "Invalid topic (alphanumeric, dots, dashes, slashes)" });
+      if (!/^[a-zA-Z0-9._\-/]+$/.test(topic) || /(^|\/)\.\.($|\/)/.test(topic)) return json(res, 400, { error: "Invalid topic (alphanumeric, dots, dashes, slashes)" });
       // Optional topic metadata — set once or update on publish
       if (data.meta && typeof data.meta === "object") {
         topicBroker.setMeta(topic, data.meta);
@@ -291,15 +291,17 @@ export function createAppRoutes(ctx) {
 
     { method: "GET", prefix: "/sub/", handler: auth((req, res, topic) => {
       if (!topicBroker) return json(res, 503, { error: "Pub/sub not available" });
-      if (!topic || !/^[a-zA-Z0-9._\-/]+$/.test(topic)) return json(res, 400, { error: "Invalid topic" });
+      if (!topic || !/^[a-zA-Z0-9._\-/]+$/.test(topic) || /(^|\/)\.\.($|\/)/.test(topic)) return json(res, 400, { error: "Invalid topic" });
 
       // Parse optional fromSeq query param for replay
       const url = new URL(req.url, "http://localhost");
       const fromSeqParam = url.searchParams.get("fromSeq");
       const lastEventId = req.headers["last-event-id"];
-      const fromSeq = fromSeqParam !== null
-        ? parseInt(fromSeqParam, 10)
-        : (lastEventId ? parseInt(lastEventId, 10) + 1 : undefined);
+      const parsedParam = fromSeqParam !== null ? parseInt(fromSeqParam, 10) : NaN;
+      const parsedLastId = lastEventId ? parseInt(lastEventId, 10) : NaN;
+      const fromSeq = Number.isFinite(parsedParam) ? parsedParam
+        : Number.isFinite(parsedLastId) ? parsedLastId + 1
+        : undefined;
 
       // SSE stream
       res.writeHead(200, {
@@ -322,17 +324,19 @@ export function createAppRoutes(ctx) {
       json(res, 200, topicBroker.listTopics());
     })},
 
-    { method: "POST", prefix: "/api/topics/", handler: auth(async (req, res, param) => {
+    // Topic names may contain slashes (e.g. "claude/session-abc"), so the
+    // param from the prefix route will be "claude/session-abc/meta". We use
+    // endsWith("/meta") to match and slice to extract the topic name.
+    { method: "POST", prefix: "/api/topics/", handler: auth(csrf(async (req, res, param) => {
       if (!topicBroker) return json(res, 503, { error: "Pub/sub not available" });
-      // Expect: /api/topics/<topic>/meta
       if (!param.endsWith("/meta")) return json(res, 404, { error: "Not found" });
       const topic = param.slice(0, -5); // strip "/meta"
-      if (!topic || !/^[a-zA-Z0-9._\-/]+$/.test(topic)) return json(res, 400, { error: "Invalid topic" });
+      if (!topic || !/^[a-zA-Z0-9._\-/]+$/.test(topic) || /(^|\/)\.\.($|\/)/.test(topic)) return json(res, 400, { error: "Invalid topic" });
       const data = await parseJSON(req);
       if (!data || typeof data !== "object") return json(res, 400, { error: "Body must be a JSON object" });
       topicBroker.setMeta(topic, data);
       json(res, 200, { ok: true, meta: topicBroker.getMeta(topic) });
-    })},
+    }))},
 
     // --- Sessions ---
 

--- a/lib/topic-broker.js
+++ b/lib/topic-broker.js
@@ -289,6 +289,28 @@ export function createTopicBroker({ pubsubDir } = {}) {
   }
 
   /**
+   * Read topic metadata from meta.json. Returns {} if none.
+   */
+  function getMeta(topic) {
+    try {
+      return JSON.parse(readFileSync(join(topicDir(topic), "meta.json"), "utf8"));
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * Set topic metadata. Merges with existing metadata (shallow).
+   */
+  function setMeta(topic, meta) {
+    if (!meta || typeof meta !== "object") return;
+    const dir = ensureTopicDir(topic);
+    const existing = getMeta(topic);
+    const merged = { ...existing, ...meta };
+    atomicWrite(join(dir, "meta.json"), JSON.stringify(merged));
+  }
+
+  /**
    * List all known topics with metadata.
    * Merges on-disk topics with in-memory subscriber info.
    */
@@ -298,7 +320,7 @@ export function createTopicBroker({ pubsubDir } = {}) {
     // On-disk topics
     const onDisk = discoverTopics(PUBSUB_DIR);
     for (const [name, { seq }] of onDisk) {
-      allTopics.set(name, { name, subscribers: 0, seq, messages: seq });
+      allTopics.set(name, { name, subscribers: 0, seq, messages: seq, meta: getMeta(name) });
     }
 
     // In-memory subscribers
@@ -307,12 +329,12 @@ export function createTopicBroker({ pubsubDir } = {}) {
         allTopics.get(name).subscribers = subs.size;
       } else {
         const seq = getSeq(name);
-        allTopics.set(name, { name, subscribers: subs.size, seq, messages: seq });
+        allTopics.set(name, { name, subscribers: subs.size, seq, messages: seq, meta: getMeta(name) });
       }
     }
 
     return Array.from(allTopics.values());
   }
 
-  return { subscribe, publish, listTopics };
+  return { subscribe, publish, listTopics, getMeta, setMeta };
 }

--- a/lib/topic-broker.js
+++ b/lib/topic-broker.js
@@ -247,11 +247,11 @@ export function createTopicBroker({ pubsubDir } = {}) {
     seqCounters.set(topic, currentSeq);
 
     const envelope = {
+      ...meta,
       seq: currentSeq,
       topic,
       message,
       timestamp: Date.now(),
-      ...meta,
     };
 
     const line = JSON.stringify(envelope) + "\n";

--- a/lib/topic-broker.js
+++ b/lib/topic-broker.js
@@ -19,7 +19,7 @@ import {
   mkdirSync, appendFileSync, writeFileSync, readFileSync,
   statSync, renameSync, unlinkSync, readdirSync, existsSync,
 } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { randomBytes } from "node:crypto";
 
 // Rotation config by topic type
@@ -151,7 +151,11 @@ export function createTopicBroker({ pubsubDir } = {}) {
   const PUBSUB_DIR = pubsubDir || join(envConfig.dataDir, "pubsub");
 
   function topicDir(topic) {
-    return join(PUBSUB_DIR, topic);
+    const resolved = resolve(PUBSUB_DIR, topic);
+    if (!resolved.startsWith(resolve(PUBSUB_DIR) + "/")) {
+      throw new Error("Topic path escapes pubsub directory");
+    }
+    return resolved;
   }
 
   // Ensure pubsub root exists
@@ -301,9 +305,11 @@ export function createTopicBroker({ pubsubDir } = {}) {
 
   /**
    * Set topic metadata. Merges with existing metadata (shallow).
+   * Validates that meta is a non-null object — all callers rely on
+   * this check so validation lives here, not in the route handlers.
    */
   function setMeta(topic, meta) {
-    if (!meta || typeof meta !== "object") return;
+    if (!meta || typeof meta !== "object" || Array.isArray(meta)) return;
     const dir = ensureTopicDir(topic);
     const existing = getMeta(topic);
     const merged = { ...existing, ...meta };

--- a/public/app.js
+++ b/public/app.js
@@ -1387,6 +1387,7 @@
       onNewSessionClick: createNewSession,
       tileTypes: [
         { type: "terminal",     name: "Terminal", icon: "terminal-window" },
+        { type: "feed",          name: "Feed",     icon: "rss" },
       ],
       onCreateTile: (type) => {
         if (type === "terminal") {
@@ -1395,6 +1396,8 @@
           createNewCluster();
         } else if (type === "file-browser") {
           openFileBrowserTile();
+        } else if (type === "feed") {
+          openFeedTile();
         }
       },
       onTabClick: (name) => {
@@ -1724,6 +1727,15 @@
         { focus: true, insertAt: "afterFocus" },
       );
       cm.connect();
+      if (isOverlayViewport()) setOverlaySidebar(false);
+    }
+
+    function openFeedTile() {
+      const tileId = `feed-${Date.now().toString(36)}`;
+      uiStore.addTile(
+        { id: tileId, type: "feed", props: {} },
+        { focus: true, insertAt: "afterFocus" },
+      );
       if (isOverlayViewport()) setOverlaySidebar(false);
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -2193,6 +2193,37 @@
     .doc-tile-markdown th { background: var(--bg-surface); font-weight: 600; }
     .doc-tile-markdown img { max-width: 100%; }
 
+    /* --- Feed Tile --- */
+    .feed-tile-root { display: flex; flex-direction: column; height: 100%; width: 100%; background: var(--bg); color: var(--text); font-family: var(--font-sans, -apple-system, sans-serif); font-size: var(--text-sm); }
+    .feed-tile-header { display: flex; align-items: center; gap: var(--space-sm); padding: var(--space-xs) var(--space-sm); border-bottom: 1px solid var(--border); flex-shrink: 0; background: var(--bg-surface); color: var(--text-secondary); font-size: var(--text-xs); font-weight: 600; }
+    .feed-tile-badge { padding: 1px 6px; border-radius: 3px; background: var(--accent, #58a6ff); color: var(--bg); font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+    .feed-tile-list { flex: 1; overflow-y: auto; padding: var(--space-sm); outline: none; }
+    .feed-tile-item { display: flex; flex-wrap: wrap; align-items: baseline; gap: var(--space-xs); padding: var(--space-xs) 0; }
+    .feed-tile-bullet { flex-shrink: 0; width: 1.2em; text-align: center; }
+    .feed-tile-step { font-weight: 500; }
+    .feed-tile-detail { width: 100%; padding-left: 1.6em; color: var(--text-secondary); font-size: var(--text-xs); }
+    .feed-status-pending .feed-tile-bullet { color: var(--text-secondary); }
+    .feed-status-active .feed-tile-bullet { color: var(--accent, #58a6ff); animation: feed-pulse 1.5s ease-in-out infinite; }
+    .feed-status-done .feed-tile-bullet { color: var(--text-success, #3fb950); }
+    .feed-status-error .feed-tile-bullet { color: var(--text-error, #f66); }
+    .feed-status-error .feed-tile-detail { color: var(--text-error, #f66); }
+    @keyframes feed-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+    .feed-log-item { gap: var(--space-sm); border-bottom: 1px solid var(--border-subtle, rgba(255,255,255,0.04)); }
+    .feed-tile-time { flex-shrink: 0; color: var(--text-muted); font-family: var(--font-mono); font-size: var(--text-xs); }
+    .feed-tile-text { font-family: var(--font-mono); word-break: break-all; }
+
+    /* --- Feed Tile: inline topic picker --- */
+    .feed-tile-picker { display: flex; flex-direction: column; height: 100%; padding: var(--space-md); gap: var(--space-sm); color: var(--text); }
+    .feed-tile-picker-title { font-size: var(--text-sm); font-weight: 600; color: var(--text); padding-bottom: var(--space-xs); border-bottom: 1px solid var(--border); }
+    .feed-tile-picker-list { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 2px; color: var(--text); font-size: var(--text-sm); }
+    .feed-tile-picker-item { display: flex; align-items: center; justify-content: space-between; gap: var(--space-sm); padding: var(--space-sm); border: none; background: var(--bg-surface, #313244); color: var(--text); font-size: var(--text-sm); border-radius: var(--radius-sm, 6px); cursor: pointer; text-align: left; width: 100%; }
+    .feed-tile-picker-item:hover { background: var(--bg-hover, rgba(255,255,255,0.12)); }
+    .feed-tile-picker-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--font-mono); }
+    .feed-tile-picker-info { flex-shrink: 0; font-size: var(--text-xs); color: var(--text-secondary); }
+    .feed-tile-picker-empty { padding: var(--space-lg) var(--space-sm); text-align: center; color: var(--text-secondary); font-size: var(--text-sm); }
+    .feed-tile-picker-refresh { align-self: center; margin-top: var(--space-sm); padding: var(--space-xs) var(--space-md); border: 1px solid var(--border); background: transparent; color: var(--text); border-radius: var(--radius-sm, 6px); cursor: pointer; font-size: var(--text-sm); }
+    .feed-tile-picker-refresh:hover { background: var(--bg-hover, rgba(255,255,255,0.12)); }
+
     /* --- Helm View --- */
     #helm-view { display: none; flex: 1; min-height: 0; overflow: hidden; flex-direction: column; }
     #helm-view.active { display: flex; }
@@ -2581,6 +2612,6 @@
   </div>
 
   <div id="connection-tooltip"></div>
-  <script type="module" src="/app.js?v=74"></script>
+  <script type="module" src="/app.js?v=76"></script>
 </body>
 </html>

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -146,6 +146,7 @@ export const feedRenderer = {
               item.appendChild(info);
 
               item.addEventListener("click", () => {
+                if (!mounted) return;
                 if (dispatch) {
                   dispatch({ type: "ui/UPDATE_PROPS", id, patch: { topic: t.name, title: t.name, meta: t.meta || {} } });
                 }

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -9,7 +9,8 @@
  * Lifecycle:
  *   1. Opens blank with an inline topic picker (fetched from /api/topics)
  *   2. User picks a topic → tile starts streaming via SSE
- *   3. Rendering strategy chosen by topic meta.type:
+ *   3. Rendering strategy chosen by topic meta.type (closed enumeration —
+ *      not an extension point; new strategies require an in-tree PR):
  *      - "progress" — checklist with keyed step updates + status bullets
  *      - default    — chronological event log with timestamps
  *
@@ -170,6 +171,7 @@ export const feedRenderer = {
 
     // ── Streaming view ──────────────────────────────────────────
     function startStreaming(topic, meta) {
+      if (es) { es.close(); es = null; }
       root.innerHTML = "";
       const topicMeta = meta || {};
 

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -1,0 +1,254 @@
+/**
+ * Feed Tile Renderer
+ *
+ * General-purpose event streamer that subscribes to a pub/sub topic via
+ * SSE and renders events according to topic metadata. The tile is a
+ * subscriber — it decides how to display raw domain events. Another
+ * subscriber (an orchestrator) could use the same events for choreography.
+ *
+ * Lifecycle:
+ *   1. Opens blank with an inline topic picker (fetched from /api/topics)
+ *   2. User picks a topic → tile starts streaming via SSE
+ *   3. Rendering strategy chosen by topic meta.type:
+ *      - "progress" — checklist with keyed step updates + status bullets
+ *      - default    — chronological event log with timestamps
+ *
+ * Single-file renderer: no factory, no init deps.
+ */
+
+// ── Rendering strategies ────────────────────────────────────────────
+
+function renderProgressItem(row, msg) {
+  row.innerHTML = "";
+  const status = msg.status || "info";
+  row.className = `feed-tile-item feed-status-${status}`;
+
+  const bullet = document.createElement("span");
+  bullet.className = "feed-tile-bullet";
+  bullet.textContent = status === "done" ? "\u25CF"
+    : status === "active" ? "\u25C9"
+    : status === "error" ? "\u2715"
+    : status === "pending" ? "\u25CB"
+    : "\u2022";
+  row.appendChild(bullet);
+
+  const text = document.createElement("span");
+  text.className = "feed-tile-step";
+  text.textContent = msg.step || msg.detail || JSON.stringify(msg);
+  row.appendChild(text);
+
+  if (msg.detail && msg.step) {
+    const detail = document.createElement("div");
+    detail.className = "feed-tile-detail";
+    detail.textContent = msg.detail;
+    row.appendChild(detail);
+  }
+}
+
+function renderLogItem(row, msg, ts) {
+  row.innerHTML = "";
+  row.className = "feed-tile-item feed-log-item";
+
+  const time = document.createElement("span");
+  time.className = "feed-tile-time";
+  time.textContent = new Date(ts).toLocaleTimeString();
+  row.appendChild(time);
+
+  const text = document.createElement("span");
+  text.className = "feed-tile-text";
+  text.textContent = typeof msg === "string" ? msg : JSON.stringify(msg);
+  row.appendChild(text);
+}
+
+// ── Renderer ────────────────────────────────────────────────────────
+
+export const feedRenderer = {
+  type: "feed",
+
+  init(_deps) {},
+
+  describe(props) {
+    return {
+      title: props.title || props.topic || "Feed",
+      icon: "rss",
+      persistable: !!props.topic, // only persist once a topic is chosen
+      session: null,
+      updatesUrl: false,
+      renameable: false,
+      handlesDnd: false,
+    };
+  },
+
+  mount(el, { id, props, dispatch, ctx }) {
+    let mounted = true;
+    let es = null;
+
+    const root = document.createElement("div");
+    root.className = "feed-tile-root";
+    el.appendChild(root);
+
+    // If we already have a topic (e.g. restored from persistence), go
+    // straight to streaming. Otherwise show the inline topic picker.
+    try {
+      if (props.topic) {
+        startStreaming(props.topic, props.meta || {});
+      } else {
+        showTopicPicker();
+      }
+    } catch (err) {
+      root.textContent = "Feed error: " + err.message;
+    }
+
+    // ── Topic picker (inline) ───────────────────────────────────
+    function showTopicPicker() {
+      root.innerHTML = "";
+
+      const picker = document.createElement("div");
+      picker.className = "feed-tile-picker";
+
+      const title = document.createElement("div");
+      title.className = "feed-tile-picker-title";
+      title.textContent = "Subscribe to a topic";
+      picker.appendChild(title);
+
+      const listArea = document.createElement("div");
+      listArea.className = "feed-tile-picker-list";
+      listArea.textContent = "Loading topics\u2026";
+      picker.appendChild(listArea);
+
+      root.appendChild(picker);
+
+      // Fetch topics and populate
+      fetch("/api/topics", { credentials: "same-origin", redirect: "error" })
+        .then(r => r.ok ? r.json() : [])
+        .catch(() => [])
+        .then(topics => {
+          if (!mounted) return;
+          listArea.textContent = "";
+
+          if (topics.length > 0) {
+            for (const t of topics) {
+              const item = document.createElement("button");
+              item.className = "feed-tile-picker-item";
+
+              const name = document.createElement("span");
+              name.className = "feed-tile-picker-name";
+              name.textContent = t.name;
+              item.appendChild(name);
+
+              const info = document.createElement("span");
+              info.className = "feed-tile-picker-info";
+              const parts = [];
+              if (t.meta && t.meta.type) parts.push(t.meta.type);
+              parts.push(`${t.messages || 0} msgs`);
+              info.textContent = parts.join(" \u00b7 ");
+              item.appendChild(info);
+
+              item.addEventListener("click", () => {
+                if (dispatch) {
+                  dispatch({ type: "ui/UPDATE_PROPS", id, patch: { topic: t.name, title: t.name, meta: t.meta || {} } });
+                }
+                startStreaming(t.name, t.meta || {});
+              });
+
+              listArea.appendChild(item);
+            }
+          } else {
+            const empty = document.createElement("div");
+            empty.className = "feed-tile-picker-empty";
+            empty.textContent = "No topics yet. Publish events to create one.";
+            listArea.appendChild(empty);
+          }
+
+          const refreshBtn = document.createElement("button");
+          refreshBtn.className = "feed-tile-picker-refresh";
+          refreshBtn.textContent = "Refresh";
+          refreshBtn.addEventListener("click", () => { if (mounted) showTopicPicker(); });
+          listArea.appendChild(refreshBtn);
+        });
+    }
+
+    // ── Streaming view ──────────────────────────────────────────
+    function startStreaming(topic, meta) {
+      root.innerHTML = "";
+      const topicMeta = meta || {};
+
+      // Header
+      const header = document.createElement("div");
+      header.className = "feed-tile-header";
+
+      const headerTitle = document.createElement("span");
+      headerTitle.textContent = topic;
+      header.appendChild(headerTitle);
+
+      if (topicMeta.type) {
+        const badge = document.createElement("span");
+        badge.className = "feed-tile-badge";
+        badge.textContent = topicMeta.type;
+        header.appendChild(badge);
+      }
+
+      root.appendChild(header);
+
+      // Event list
+      const list = document.createElement("div");
+      list.className = "feed-tile-list";
+      list.tabIndex = 0;
+      root.appendChild(list);
+
+      // State
+      const items = new Map();
+      let autoKey = 0;
+      const isProgress = topicMeta.type === "progress";
+
+      function handleEvent(envelope) {
+        let msg;
+        try { msg = JSON.parse(envelope.message); } catch { msg = envelope.message; }
+
+        const key = isProgress && msg.step ? msg.step : `_evt_${autoKey++}`;
+        let row = items.get(key);
+
+        if (!row) {
+          row = document.createElement("div");
+          list.appendChild(row);
+          items.set(key, row);
+        }
+
+        if (isProgress) {
+          renderProgressItem(row, msg);
+        } else {
+          renderLogItem(row, msg, envelope.timestamp);
+        }
+
+        list.scrollTop = list.scrollHeight;
+      }
+
+      // Connect SSE
+      const url = `/sub/${encodeURIComponent(topic)}?fromSeq=0`;
+      es = new EventSource(url);
+      es.onmessage = (event) => {
+        if (!mounted) return;
+        try {
+          handleEvent(JSON.parse(event.data));
+        } catch { /* ignore malformed */ }
+      };
+    }
+
+    // ── Handle ──────────────────────────────────────────────────
+    return {
+      unmount() {
+        mounted = false;
+        if (es) es.close();
+        el.innerHTML = "";
+      },
+      focus() {
+        const list = root.querySelector(".feed-tile-list");
+        if (list) list.focus();
+      },
+      blur() {},
+      resize() {},
+      getSessions() { return []; },
+      tile: null,
+    };
+  },
+};

--- a/public/lib/tile-renderers/index.js
+++ b/public/lib/tile-renderers/index.js
@@ -15,6 +15,7 @@ import { terminalRenderer } from "./terminal.js";
 import { fileBrowserRenderer } from "./file-browser.js";
 import { documentRenderer } from "./document.js";
 import { clusterRenderer } from "./cluster.js";
+import { feedRenderer } from "./feed.js";
 
 const renderers = new Map();
 
@@ -46,6 +47,7 @@ export function initRenderers({ terminalPool, createTerminalTile, uiStore }) {
   fileBrowserRenderer.init({ uiStore });
   documentRenderer.init({});
   clusterRenderer.init({ createTerminalTile });
+  feedRenderer.init({});
 }
 
 // Register built-in renderers
@@ -53,3 +55,4 @@ registerRenderer(terminalRenderer);
 registerRenderer(fileBrowserRenderer);
 registerRenderer(documentRenderer);
 registerRenderer(clusterRenderer);
+registerRenderer(feedRenderer);

--- a/test/feed-tile.test.js
+++ b/test/feed-tile.test.js
@@ -1,0 +1,309 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// feed.js uses DOM APIs — provide minimal stubs so the module loads in Node.
+// We only need enough to verify the renderer's structure and mount lifecycle.
+
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag?.toUpperCase() || "DIV";
+    this.children = [];
+    this.className = "";
+    this.textContent = "";
+    this.dataset = {};
+    this.tabIndex = -1;
+    this._listeners = {};
+    this.innerHTML = "";
+    this.scrollHeight = 0;
+    this.scrollTop = 0;
+  }
+  appendChild(child) { this.children.push(child); return child; }
+  querySelector(sel) {
+    // Simple class-based search
+    for (const c of this.children) {
+      if (sel.startsWith(".") && c.className.includes(sel.slice(1))) return c;
+      const found = c.querySelector?.(sel);
+      if (found) return found;
+    }
+    return null;
+  }
+  addEventListener(evt, fn) {
+    (this._listeners[evt] ||= []).push(fn);
+  }
+  remove() {}
+}
+
+// Stub global document for feed.js
+globalThis.document = {
+  createElement(tag) { return new FakeElement(tag); },
+};
+
+// Stub global EventSource — track what URLs are opened
+const eventSources = [];
+class FakeEventSource {
+  constructor(url) {
+    this.url = url;
+    this.onmessage = null;
+    this.closed = false;
+    eventSources.push(this);
+  }
+  close() { this.closed = true; }
+}
+globalThis.EventSource = FakeEventSource;
+
+// Stub global fetch
+let fetchResult = [];
+globalThis.fetch = async (url, opts) => ({
+  ok: true,
+  json: async () => fetchResult,
+});
+
+const { feedRenderer } = await import(
+  new URL("../public/lib/tile-renderers/feed.js", import.meta.url).href
+);
+
+describe("feedRenderer", () => {
+  beforeEach(() => {
+    eventSources.length = 0;
+    fetchResult = [];
+  });
+
+  describe("structure", () => {
+    it("has type 'feed'", () => {
+      assert.equal(feedRenderer.type, "feed");
+    });
+
+    it("init accepts empty deps", () => {
+      // Should not throw
+      feedRenderer.init({});
+    });
+  });
+
+  describe("describe()", () => {
+    it("returns default title and icon when no props", () => {
+      const d = feedRenderer.describe({});
+      assert.equal(d.title, "Feed");
+      assert.equal(d.icon, "rss");
+    });
+
+    it("uses topic as title when provided", () => {
+      const d = feedRenderer.describe({ topic: "_build/test" });
+      assert.equal(d.title, "_build/test");
+    });
+
+    it("uses explicit title over topic", () => {
+      const d = feedRenderer.describe({ topic: "x", title: "My Feed" });
+      assert.equal(d.title, "My Feed");
+    });
+
+    it("is not persistable without a topic", () => {
+      const d = feedRenderer.describe({});
+      assert.equal(d.persistable, false);
+    });
+
+    it("is persistable with a topic", () => {
+      const d = feedRenderer.describe({ topic: "some/topic" });
+      assert.equal(d.persistable, true);
+    });
+  });
+
+  describe("mount() — topic picker", () => {
+    it("shows topic picker when no topic in props", async () => {
+      const el = new FakeElement("div");
+      const dispatched = [];
+
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {},
+        dispatch: (action) => dispatched.push(action),
+        ctx: {},
+      });
+
+      // Root element should be appended
+      assert.equal(el.children.length, 1);
+      const root = el.children[0];
+      assert.equal(root.className, "feed-tile-root");
+
+      // Picker should be appended synchronously
+      assert.ok(root.children.length >= 1, "picker should be in root");
+      const picker = root.children[0];
+      assert.equal(picker.className, "feed-tile-picker");
+
+      // Title should say "Subscribe to a topic"
+      assert.ok(picker.children.length >= 1);
+      assert.equal(picker.children[0].className, "feed-tile-picker-title");
+      assert.equal(picker.children[0].textContent, "Subscribe to a topic");
+
+      // List area with loading text
+      const listArea = picker.children[1];
+      assert.equal(listArea.className, "feed-tile-picker-list");
+      assert.equal(listArea.textContent, "Loading topics\u2026");
+    });
+
+    it("does not open an EventSource when no topic", () => {
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, { id: "feed-1", props: {}, dispatch: () => {}, ctx: {} });
+
+      // No EventSource should have been created
+      assert.equal(eventSources.length, 0);
+    });
+  });
+
+  describe("mount() — streaming", () => {
+    it("opens EventSource immediately when topic is in props", () => {
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "_build/test", meta: { type: "progress" } },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      assert.equal(eventSources.length, 1);
+      assert.ok(eventSources[0].url.includes("/sub/_build%2Ftest"));
+      assert.ok(eventSources[0].url.includes("fromSeq=0"));
+    });
+
+    it("renders header with topic name", () => {
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "my/topic", meta: {} },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      const root = el.children[0];
+      const header = root.children[0];
+      assert.equal(header.className, "feed-tile-header");
+      assert.equal(header.children[0].textContent, "my/topic");
+    });
+
+    it("renders badge when meta.type is set", () => {
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "t", meta: { type: "progress" } },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      const root = el.children[0];
+      const header = root.children[0];
+      // Second child should be the badge
+      assert.equal(header.children.length, 2);
+      assert.equal(header.children[1].className, "feed-tile-badge");
+      assert.equal(header.children[1].textContent, "progress");
+    });
+
+    it("does not render badge when no meta.type", () => {
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "t", meta: {} },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      const root = el.children[0];
+      const header = root.children[0];
+      assert.equal(header.children.length, 1); // just the title span
+    });
+
+    it("processes SSE events via onmessage", () => {
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "t", meta: {} },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      const es = eventSources[0];
+
+      // Simulate an SSE event
+      es.onmessage({
+        data: JSON.stringify({
+          seq: 1,
+          topic: "t",
+          message: '{"text":"hello"}',
+          timestamp: Date.now(),
+        }),
+      });
+
+      // List should have one item
+      const root = el.children[0];
+      const list = root.children[1]; // header is [0], list is [1]
+      assert.equal(list.children.length, 1);
+    });
+  });
+
+  describe("unmount", () => {
+    it("closes EventSource on unmount", () => {
+      const el = new FakeElement("div");
+      const handle = feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "t", meta: {} },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      assert.equal(eventSources[0].closed, false);
+      handle.unmount();
+      assert.equal(eventSources[0].closed, true);
+    });
+
+    it("clears element on unmount", () => {
+      const el = new FakeElement("div");
+      const handle = feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "t", meta: {} },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      handle.unmount();
+      assert.equal(el.innerHTML, "");
+    });
+
+    it("ignores SSE events after unmount", () => {
+      const el = new FakeElement("div");
+      const handle = feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "t", meta: {} },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      const es = eventSources[0];
+      handle.unmount();
+
+      // Should not throw
+      es.onmessage({
+        data: JSON.stringify({
+          seq: 1, topic: "t", message: '{"text":"late"}', timestamp: Date.now(),
+        }),
+      });
+    });
+  });
+
+  describe("handle interface", () => {
+    it("returns all required handle methods", () => {
+      const el = new FakeElement("div");
+      const handle = feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "t", meta: {} },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      assert.equal(typeof handle.unmount, "function");
+      assert.equal(typeof handle.focus, "function");
+      assert.equal(typeof handle.blur, "function");
+      assert.equal(typeof handle.resize, "function");
+      assert.equal(typeof handle.getSessions, "function");
+      assert.deepEqual(handle.getSessions(), []);
+      assert.equal(handle.tile, null);
+    });
+  });
+});

--- a/test/topic-broker.test.js
+++ b/test/topic-broker.test.js
@@ -407,6 +407,13 @@ describe("Topic Broker", () => {
       assert.equal(env.message, "persisted");
       assert.equal(env.seq, 1);
     });
+
+    it("rejects path-traversal topic names", () => {
+      const broker = makeBroker();
+      assert.throws(() => broker.publish("../escape", "bad"), /escapes pubsub directory/);
+      assert.throws(() => broker.publish("legit/../../escape", "bad"), /escapes pubsub directory/);
+      assert.throws(() => broker.publish("../../../etc/passwd", "bad"), /escapes pubsub directory/);
+    });
   });
 
   describe("topic metadata", () => {

--- a/test/topic-broker.test.js
+++ b/test/topic-broker.test.js
@@ -408,4 +408,85 @@ describe("Topic Broker", () => {
       assert.equal(env.seq, 1);
     });
   });
+
+  describe("topic metadata", () => {
+    it("getMeta returns empty object for topic without metadata", () => {
+      const broker = makeBroker();
+      broker.publish("t", "msg");
+      assert.deepEqual(broker.getMeta("t"), {});
+    });
+
+    it("setMeta persists metadata to meta.json", () => {
+      const broker = makeBroker();
+      broker.publish("t", "msg"); // ensure topic dir exists
+      broker.setMeta("t", { type: "progress", label: "Build" });
+
+      const metaPath = join(pubsubDir, "t", "meta.json");
+      assert.ok(existsSync(metaPath));
+      const stored = JSON.parse(readFileSync(metaPath, "utf8"));
+      assert.equal(stored.type, "progress");
+      assert.equal(stored.label, "Build");
+    });
+
+    it("getMeta reads persisted metadata", () => {
+      const broker = makeBroker();
+      broker.publish("t", "msg");
+      broker.setMeta("t", { type: "log" });
+      assert.deepEqual(broker.getMeta("t"), { type: "log" });
+    });
+
+    it("setMeta merges with existing metadata", () => {
+      const broker = makeBroker();
+      broker.publish("t", "msg");
+      broker.setMeta("t", { type: "progress" });
+      broker.setMeta("t", { label: "CI Pipeline" });
+
+      const meta = broker.getMeta("t");
+      assert.equal(meta.type, "progress");
+      assert.equal(meta.label, "CI Pipeline");
+    });
+
+    it("setMeta creates topic directory if it does not exist", () => {
+      const broker = makeBroker();
+      broker.setMeta("new/topic", { type: "log" });
+      assert.deepEqual(broker.getMeta("new/topic"), { type: "log" });
+    });
+
+    it("setMeta ignores null or non-object", () => {
+      const broker = makeBroker();
+      broker.publish("t", "msg");
+      broker.setMeta("t", null);
+      assert.deepEqual(broker.getMeta("t"), {});
+      broker.setMeta("t", "string");
+      assert.deepEqual(broker.getMeta("t"), {});
+    });
+
+    it("listTopics includes metadata", () => {
+      const broker = makeBroker();
+      broker.publish("a", "msg");
+      broker.setMeta("a", { type: "progress" });
+      broker.publish("b", "msg");
+
+      const topics = broker.listTopics();
+      const a = topics.find(t => t.name === "a");
+      const b = topics.find(t => t.name === "b");
+
+      assert.deepEqual(a.meta, { type: "progress" });
+      assert.deepEqual(b.meta, {});
+    });
+
+    it("metadata survives broker restart", () => {
+      const broker1 = makeBroker();
+      broker1.publish("t", "msg");
+      broker1.setMeta("t", { type: "progress", label: "Build" });
+
+      // Simulate restart
+      const broker2 = makeBroker();
+      assert.deepEqual(broker2.getMeta("t"), { type: "progress", label: "Build" });
+
+      const topics = broker2.listTopics();
+      const t = topics.find(x => x.name === "t");
+      assert.deepEqual(t.meta, { type: "progress", label: "Build" });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **New feed tile type** — subscribes to any katulong pub/sub topic via SSE, renders events live with metadata-driven rendering strategies (progress checklist or chronological log)
- **Topic metadata** — `getMeta`/`setMeta` on the broker, `meta.json` per topic directory, settable via `/pub` or `POST /api/topics/:topic/meta`, included in `GET /api/topics` responses
- **SSE reconnect** — `id:` field on SSE events + `Last-Event-ID` header support for automatic replay after disconnect
- **Inline topic picker** — feed tile opens blank, shows available topics inside the tile itself (no overlay modal), streams after selection
- **`katulong info`** — now shows external URL when server is running
- **`katulong-stage`** — respects `REPO_ROOT` env var for worktree testing

## Architecture

The feed tile follows the single-file renderer pattern (like the document tile): one file + two lines in `index.js`. No factory, no plugin SDK, no new abstraction layer.

Events are raw domain data — the tile decides rendering. Topic namespaces (`claude/`, `build/`, etc.) will drive pluggable processor selection in a future iteration.

## Test plan

- [x] `npm test` passes — 1993 tests, 0 failures
- [x] 26 new tests: feed renderer lifecycle, topic metadata CRUD, persistence, merge semantics
- [x] E2E smoke test passes
- [x] Manual verification: feed tile creates, topic picker shows topics, events stream live
- [x] SSE reconnect verified via `Last-Event-ID` replay