### PR TITLE
fix: feed tile text overflow on mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2196,13 +2196,13 @@
     /* --- Feed Tile --- */
     .feed-tile-root { display: flex; flex-direction: column; height: 100%; width: 100%; overflow: hidden; background: var(--bg); color: var(--text); font-family: var(--font-sans, -apple-system, sans-serif); font-size: var(--text-sm); }
     .feed-tile-header { display: flex; align-items: center; gap: var(--space-sm); padding: var(--space-xs) var(--space-sm); border-bottom: 1px solid var(--border); flex-shrink: 0; background: var(--bg-surface); color: var(--text-secondary); font-size: var(--text-xs); font-weight: 600; min-width: 0; overflow: hidden; }
-    .feed-tile-header > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-    .feed-tile-badge { padding: 1px 6px; border-radius: 3px; background: var(--accent, #58a6ff); color: var(--bg); font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+    .feed-tile-header-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+    .feed-tile-badge { flex-shrink: 0; padding: 1px 6px; border-radius: 3px; background: var(--accent, #58a6ff); color: var(--bg); font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
     .feed-tile-list { flex: 1; overflow-y: auto; overflow-x: hidden; padding: var(--space-sm); outline: none; }
     .feed-tile-item { display: flex; flex-wrap: wrap; align-items: baseline; gap: var(--space-xs); padding: var(--space-xs) 0; min-width: 0; }
     .feed-tile-bullet { flex-shrink: 0; width: 1.2em; text-align: center; }
-    .feed-tile-step { font-weight: 500; min-width: 0; overflow-wrap: break-word; word-break: break-word; }
-    .feed-tile-detail { width: 100%; padding-left: 1.6em; color: var(--text-secondary); font-size: var(--text-xs); overflow-wrap: break-word; word-break: break-word; }
+    .feed-tile-step { font-weight: 500; min-width: 0; overflow-wrap: break-word; }
+    .feed-tile-detail { width: 100%; padding-left: 1.6em; color: var(--text-secondary); font-size: var(--text-xs); overflow-wrap: break-word; }
     .feed-status-pending .feed-tile-bullet { color: var(--text-secondary); }
     .feed-status-active .feed-tile-bullet { color: var(--accent, #58a6ff); animation: feed-pulse 1.5s ease-in-out infinite; }
     .feed-status-done .feed-tile-bullet { color: var(--text-success, #3fb950); }

--- a/public/index.html
+++ b/public/index.html
@@ -2194,14 +2194,15 @@
     .doc-tile-markdown img { max-width: 100%; }
 
     /* --- Feed Tile --- */
-    .feed-tile-root { display: flex; flex-direction: column; height: 100%; width: 100%; background: var(--bg); color: var(--text); font-family: var(--font-sans, -apple-system, sans-serif); font-size: var(--text-sm); }
-    .feed-tile-header { display: flex; align-items: center; gap: var(--space-sm); padding: var(--space-xs) var(--space-sm); border-bottom: 1px solid var(--border); flex-shrink: 0; background: var(--bg-surface); color: var(--text-secondary); font-size: var(--text-xs); font-weight: 600; }
+    .feed-tile-root { display: flex; flex-direction: column; height: 100%; width: 100%; overflow: hidden; background: var(--bg); color: var(--text); font-family: var(--font-sans, -apple-system, sans-serif); font-size: var(--text-sm); }
+    .feed-tile-header { display: flex; align-items: center; gap: var(--space-sm); padding: var(--space-xs) var(--space-sm); border-bottom: 1px solid var(--border); flex-shrink: 0; background: var(--bg-surface); color: var(--text-secondary); font-size: var(--text-xs); font-weight: 600; min-width: 0; overflow: hidden; }
+    .feed-tile-header > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
     .feed-tile-badge { padding: 1px 6px; border-radius: 3px; background: var(--accent, #58a6ff); color: var(--bg); font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
-    .feed-tile-list { flex: 1; overflow-y: auto; padding: var(--space-sm); outline: none; }
-    .feed-tile-item { display: flex; flex-wrap: wrap; align-items: baseline; gap: var(--space-xs); padding: var(--space-xs) 0; }
+    .feed-tile-list { flex: 1; overflow-y: auto; overflow-x: hidden; padding: var(--space-sm); outline: none; }
+    .feed-tile-item { display: flex; flex-wrap: wrap; align-items: baseline; gap: var(--space-xs); padding: var(--space-xs) 0; min-width: 0; }
     .feed-tile-bullet { flex-shrink: 0; width: 1.2em; text-align: center; }
-    .feed-tile-step { font-weight: 500; }
-    .feed-tile-detail { width: 100%; padding-left: 1.6em; color: var(--text-secondary); font-size: var(--text-xs); }
+    .feed-tile-step { font-weight: 500; min-width: 0; overflow-wrap: break-word; word-break: break-word; }
+    .feed-tile-detail { width: 100%; padding-left: 1.6em; color: var(--text-secondary); font-size: var(--text-xs); overflow-wrap: break-word; word-break: break-word; }
     .feed-status-pending .feed-tile-bullet { color: var(--text-secondary); }
     .feed-status-active .feed-tile-bullet { color: var(--accent, #58a6ff); animation: feed-pulse 1.5s ease-in-out infinite; }
     .feed-status-done .feed-tile-bullet { color: var(--text-success, #3fb950); }
@@ -2210,7 +2211,7 @@
     @keyframes feed-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
     .feed-log-item { gap: var(--space-sm); border-bottom: 1px solid var(--border-subtle, rgba(255,255,255,0.04)); }
     .feed-tile-time { flex-shrink: 0; color: var(--text-muted); font-family: var(--font-mono); font-size: var(--text-xs); }
-    .feed-tile-text { font-family: var(--font-mono); word-break: break-all; }
+    .feed-tile-text { font-family: var(--font-mono); word-break: break-all; min-width: 0; }
 
     /* --- Feed Tile: inline topic picker --- */
     .feed-tile-picker { display: flex; flex-direction: column; height: 100%; padding: var(--space-md); gap: var(--space-sm); color: var(--text); }

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -181,6 +181,7 @@ export const feedRenderer = {
       header.className = "feed-tile-header";
 
       const headerTitle = document.createElement("span");
+      headerTitle.className = "feed-tile-header-title";
       headerTitle.textContent = topic;
       header.appendChild(headerTitle);
 


### PR DESCRIPTION
## Summary

- Fix feed tile text overflowing horizontally on narrow mobile viewports
- Add `overflow: hidden` to root/list containers, `min-width: 0` to flex children, and `overflow-wrap`/`word-break` to text elements
- Add ellipsis truncation to header spans

## Test plan

- [x] `npm test` passes (1994 tests, 0 failures)
- [ ] Manual verification on mobile — long text wraps instead of overflowing