### PR TITLE
fix: hide empty key-island tool row on desktop

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -879,6 +879,10 @@
       border-top: 1px solid var(--border);
       user-select: none; -webkit-user-select: none;
     }
+    /* Desktop has no touch keys — hide the empty tool row */
+    body[data-platform="desktop"] #key-island:not(:has(.key-island-btn)) {
+      display: none;
+    }
     .key-island-btn {
       height: 2.25rem; padding: 0 0.875rem;
       border: 1px solid var(--border); border-radius: var(--radius-sm);
@@ -936,10 +940,8 @@
       }
       /* Tab row floats over the terminal tile on phone so the terminal
          gets the full viewport height instead of sharing it with tabs. */
-      #shortcut-bar.bar-ipad,
-      #shortcut-bar.bar-phone { overflow: visible; }
-      #shortcut-bar.bar-ipad .bar-tab-row,
-      #shortcut-bar.bar-phone .bar-tab-row {
+      #shortcut-bar.bar-ipad { overflow: visible; }
+      #shortcut-bar.bar-ipad .bar-tab-row {
         position: absolute;
         bottom: 100%;
         left: 0; right: 0;
@@ -954,8 +956,7 @@
     /* Carousel mode: hide sidebar, tab bar at bottom */
     #sidebar { display: none !important; }
     #sidebar-backdrop { display: none !important; }
-    #shortcut-bar.bar-ipad,
-    #shortcut-bar.bar-phone {
+    #shortcut-bar.bar-ipad {
       order: 1; /* after terminal = bottom */
       border-bottom: none;
       border-top: 1px solid var(--border);
@@ -967,14 +968,12 @@
       gap: 0;
     }
     /* Tabs: taller for touch, shrink to fit */
-    #shortcut-bar.bar-ipad .tab-bar-tab,
-    #shortcut-bar.bar-phone .tab-bar-tab {
+    #shortcut-bar.bar-ipad .tab-bar-tab {
       flex: 1 1 0; min-width: 3rem; max-width: 12rem;
       height: 2.5rem; padding: 0 var(--space-md);
     }
     /* + button: inline in the tab row */
-    #shortcut-bar.bar-ipad,
-    #shortcut-bar.bar-phone { position: relative; }
+    #shortcut-bar.bar-ipad { position: relative; }
     .ipad-add-btn {
       flex-shrink: 0;
       width: 2.5rem; height: 2.5rem;

--- a/public/lib/shortcut-bar.js
+++ b/public/lib/shortcut-bar.js
@@ -1020,7 +1020,7 @@ export function createShortcutBar(options = {}) {
 
     // Platform class — set once, never changes (platform is const)
     container.classList.remove("bar-desktop", "bar-ipad", "bar-phone");
-    container.classList.add(`bar-${platform}`);
+    container.classList.add("bar-ipad");
     document.body.dataset.platform = platform;
 
     // ── Tab strip ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Hide the `#key-island` tool row on desktop when it has no touch-key buttons, removing the thin horizontal line that appeared below the tab bar
- Revert the `bar-${platform}` class approach (b0e8ae3) — desktop needs `bar-ipad` layout styling; the platform-specific class broke the tab bar layout
- Use `body[data-platform="desktop"]` + `:has()` CSS selector instead for a targeted fix

## Test plan

- [ ] Desktop: no horizontal line below the tab bar
- [ ] iPad: touch keys and tab bar still render correctly
- [ ] Phone: touch keys and tab bar still render correctly
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)