### PR TITLE
feat: Claude event stream — live agent activity via hooks

### DIFF
--- a/docs/claude-event-stream.md
+++ b/docs/claude-event-stream.md
@@ -71,6 +71,8 @@ Discovered through live testing against Claude Code v2.1.104:
 | `Stop`            | `last_assistant_message` (string)                   |
 | `SubagentStart`   | `description`, `agent_type`                         |
 | `SubagentStop`    | `description`, `agent_type`                         |
+| `SessionStart`    | `cwd`                                               |
+| `SessionEnd`      | (none beyond common fields)                         |
 
 All payloads include: `session_id`, `hook_event_name`,
 `transcript_path`, `cwd`, `permission_mode`.
@@ -90,6 +92,8 @@ raw payloads into feed-tile-friendly messages:
 | `Stop`            | `Claude responded`              | `done`     |
 | `SubagentStart`   | `Subagent: {description}`       | `active`   |
 | `SubagentStop`    | `Subagent: {description}`       | `done`     |
+| `SessionStart`    | `Session started`               | `info`     |
+| `SessionEnd`      | `Session ended`                 | `info`     |
 
 Target extraction from `tool_input`:
 - Edit/Read/Write: file basename

--- a/docs/claude-event-stream.md
+++ b/docs/claude-event-stream.md
@@ -1,0 +1,147 @@
+# Claude Event Stream — Live Agent Activity via Hooks
+
+## The problem we're solving
+
+Claude Code sessions running inside katulong terminals are opaque.
+You can watch the raw terminal output, but there's no structured
+view of what Claude is doing — which tools it's calling, when it
+finishes a turn, when subagents spawn. The terminal scrollback is
+noisy and fast; a status stream would show the high-level activity
+at a glance.
+
+Meanwhile, Claude Code already has:
+
+- **Hooks system** — fires HTTP POSTs on 25+ lifecycle events
+  (tool use, stop, session start/end, subagent lifecycle, etc.)
+- **`http` hook type** — POSTs JSON to a URL on each event.
+  Non-2xx responses are non-blocking — a down katulong never
+  interferes with Claude.
+- **`session_id`** in every hook payload — stable UUID that
+  survives renames, persisted at `~/.claude/sessions/$PID.json`
+
+And katulong already has:
+
+- **Topic broker** — durable append-only pub/sub with sequence
+  numbers, SSE replay, and topic metadata (`lib/topic-broker.js`)
+- **Feed tile** — general-purpose event streamer that subscribes
+  to any topic via SSE and renders events as a checklist or log
+  (`public/lib/tile-renderers/feed.js`)
+- **`POST /pub`** / **`GET /sub/:topic`** — authenticated REST
+  endpoints for publishing and subscribing
+
+The pieces exist. We connect them: Claude Code hooks -> katulong
+pub/sub -> feed tile.
+
+## First principles
+
+1. **Claude Code hooks are the event source.** We don't parse
+   terminal output, poll files, or inject wrapper scripts. The
+   hooks system is the supported, structured API for observing
+   Claude Code's lifecycle.
+
+2. **The Claude session ID is the invariant key.** Katulong
+   terminal sessions can be renamed freely (`/rename`). The Claude
+   session UUID never changes. Topics are keyed by this ID:
+   `claude/{session-id}`.
+
+3. **The receiver is a thin translator.** A new endpoint
+   (`POST /api/claude-events`) receives raw hook payloads and
+   publishes transformed events to the topic broker. It doesn't
+   store state, make decisions, or buffer — it translates and
+   publishes.
+
+4. **The feed tile is the renderer.** No new tile type. The
+   existing feed tile subscribes to `claude/{session-id}` and
+   renders events using the progress strategy (keyed step updates
+   with status bullets).
+
+5. **Graceful degradation.** If katulong is down, hooks fail
+   silently (non-blocking). If no feed tile is open, events still
+   accumulate in the topic broker for later replay. If hooks
+   aren't configured, nothing breaks — there's just no stream.
+
+## Hook payloads — verified field names
+
+Discovered through live testing against Claude Code v2.1.104:
+
+| Hook event        | Key fields                                          |
+|-------------------|-----------------------------------------------------|
+| `UserPromptSubmit`| `prompt` (string)                                   |
+| `PostToolUse`     | `tool_name`, `tool_input` (object), `tool_response` |
+| `Stop`            | `last_assistant_message` (string)                   |
+| `SubagentStart`   | `description`, `agent_type`                         |
+| `SubagentStop`    | `description`, `agent_type`                         |
+
+All payloads include: `session_id`, `hook_event_name`,
+`transcript_path`, `cwd`, `permission_mode`.
+
+Note: `tool_response` is sometimes a string, sometimes a
+structured object (Bash gives `{ stdout, stderr, interrupted }`).
+
+## Translation rules
+
+The transform function (`lib/claude-event-transform.js`) converts
+raw payloads into feed-tile-friendly messages:
+
+| Hook event        | `step`                          | `status`   |
+|-------------------|---------------------------------|------------|
+| `UserPromptSubmit`| `User: {prompt}`                | `active`   |
+| `PostToolUse`     | `{tool_name} {target}`          | `done`     |
+| `Stop`            | `Claude responded`              | `done`     |
+| `SubagentStart`   | `Subagent: {description}`       | `active`   |
+| `SubagentStop`    | `Subagent: {description}`       | `done`     |
+
+Target extraction from `tool_input`:
+- Edit/Read/Write: file basename
+- Bash: first ~40 chars of command
+- Grep/Glob: pattern
+- Agent: description
+
+## Hook configuration
+
+Users configure Claude Code to POST events to katulong:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [{
+      "matcher": "",
+      "hooks": [{ "type": "http", "url": "http://localhost:3001/api/claude-events" }]
+    }],
+    "PostToolUse": [{
+      "matcher": "*",
+      "hooks": [{ "type": "http", "url": "http://localhost:3001/api/claude-events" }]
+    }],
+    "Stop": [{
+      "matcher": "",
+      "hooks": [{ "type": "http", "url": "http://localhost:3001/api/claude-events" }]
+    }]
+  }
+}
+```
+
+This goes in `~/.claude/settings.local.json` (global) or
+`.claude/settings.local.json` (project-level).
+
+## Security
+
+- Auth-protected like `/pub` — requires valid session cookie or
+  localhost origin
+- Body size limit: 64 KB (hook payloads are small)
+- The transform only extracts filenames and truncated summaries —
+  never publishes raw tool input/output to prevent leaking
+  sensitive file contents
+
+## What stays as-is
+
+- Topic broker — no changes (just consuming it)
+- Feed tile renderer — no changes (uses existing progress strategy)
+- `remote.json` + API key — no changes
+
+## Future
+
+- `katulong setup claude-hooks` CLI command to automate hook config
+- Auto-discovery of claude topics in the feed tile picker
+- Human-friendly topic names (from Claude's `--name` flag)
+- Rich HTML conduit — the feed tile becomes a two-way channel
+  to interact with a Claude session

--- a/lib/claude-event-transform.js
+++ b/lib/claude-event-transform.js
@@ -1,0 +1,170 @@
+/**
+ * Claude Event Transform
+ *
+ * Pure function that translates a Claude Code hook payload into a
+ * feed-tile-friendly message (step/status/detail). No server deps,
+ * no side effects — easy to test.
+ *
+ * Claude Code's hook system POSTs JSON on lifecycle events (PostToolUse,
+ * Stop, SubagentStart/Stop, etc.). Each payload includes session_id and
+ * hook_event_name. This module extracts a human-readable summary suitable
+ * for the feed tile's progress rendering strategy.
+ */
+
+const MAX_DETAIL_LENGTH = 200;
+
+/**
+ * Extract a short target description from tool_input.
+ * @param {string} toolName
+ * @param {object} toolInput
+ * @returns {string}
+ */
+function extractTarget(toolName, toolInput) {
+  if (!toolInput || typeof toolInput !== "object") return "";
+
+  switch (toolName) {
+    case "Edit":
+    case "Read":
+    case "Write":
+      if (toolInput.file_path) return basename(toolInput.file_path);
+      return "";
+    case "Bash":
+      if (toolInput.command) return truncate(toolInput.command, 40);
+      return "";
+    case "Grep":
+      if (toolInput.pattern) return truncate(toolInput.pattern, 40);
+      return "";
+    case "Glob":
+      if (toolInput.pattern) return truncate(toolInput.pattern, 40);
+      return "";
+    case "Agent":
+      if (toolInput.description) return truncate(toolInput.description, 40);
+      return "";
+    default:
+      return "";
+  }
+}
+
+function basename(filePath) {
+  const i = filePath.lastIndexOf("/");
+  return i >= 0 ? filePath.substring(i + 1) : filePath;
+}
+
+function truncate(str, max) {
+  if (str.length <= max) return str;
+  return str.substring(0, max - 1) + "\u2026";
+}
+
+/**
+ * Extract a readable string from tool_response, which may be a string
+ * or a structured object (e.g., Bash gives { stdout, stderr }).
+ */
+function extractToolResponse(resp) {
+  if (!resp) return "";
+  if (typeof resp === "string") return resp;
+  if (typeof resp === "object") {
+    // Bash tool: { stdout, stderr }
+    if (resp.stdout) return resp.stdout;
+    if (resp.stderr) return resp.stderr;
+    // Generic: try common field names
+    if (resp.content) return typeof resp.content === "string" ? resp.content : "";
+    if (resp.result) return typeof resp.result === "string" ? resp.result : "";
+  }
+  return "";
+}
+
+function truncateDetail(str) {
+  if (!str || typeof str !== "string") return "";
+  // Take first line only, then truncate
+  const firstLine = str.split("\n")[0];
+  return truncate(firstLine, MAX_DETAIL_LENGTH);
+}
+
+/**
+ * Transform a Claude Code hook payload into a feed event.
+ *
+ * @param {object} payload - Raw hook JSON from Claude Code
+ * @returns {{ topic: string, message: object } | null} - null if payload is invalid or unhandled
+ */
+export function transformClaudeEvent(payload) {
+  if (!payload || typeof payload !== "object") return null;
+
+  const sessionId = payload.session_id;
+  const event = payload.hook_event_name;
+  if (!sessionId || !event) return null;
+
+  const topic = `claude/${sessionId}`;
+  let step, status, detail;
+
+  switch (event) {
+    case "UserPromptSubmit": {
+      const prompt = typeof payload.prompt === "string" ? payload.prompt : "";
+      step = `User: ${truncate(prompt || "(empty)", 60)}`;
+      status = "active";
+      detail = "";
+      break;
+    }
+
+    case "PostToolUse": {
+      const tool = payload.tool_name || "Unknown";
+      const target = extractTarget(tool, payload.tool_input);
+      step = target ? `${tool} ${target}` : tool;
+      status = "done";
+      detail = truncateDetail(extractToolResponse(payload.tool_response));
+      break;
+    }
+
+    case "Stop": {
+      step = "Claude responded";
+      status = "done";
+      detail = truncateDetail(
+        typeof payload.last_assistant_message === "string"
+          ? payload.last_assistant_message
+          : ""
+      );
+      break;
+    }
+
+    case "SubagentStart": {
+      const desc = payload.description || payload.agent_type || "subagent";
+      step = `Subagent: ${truncate(desc, 50)}`;
+      status = "active";
+      detail = payload.agent_type || "";
+      break;
+    }
+
+    case "SubagentStop": {
+      const desc = payload.description || payload.agent_type || "subagent";
+      step = `Subagent: ${truncate(desc, 50)}`;
+      status = "done";
+      detail = "";
+      break;
+    }
+
+    case "SessionStart": {
+      step = "Session started";
+      status = "info";
+      detail = payload.cwd || "";
+      break;
+    }
+
+    case "SessionEnd": {
+      step = "Session ended";
+      status = "info";
+      detail = "";
+      break;
+    }
+
+    default:
+      // Unhandled event type — still publish it as a generic log entry
+      step = event;
+      status = "info";
+      detail = "";
+      break;
+  }
+
+  return {
+    topic,
+    message: { step, status, detail, event, tool: payload.tool_name || null },
+  };
+}

--- a/lib/claude-event-transform.js
+++ b/lib/claude-event-transform.js
@@ -12,6 +12,7 @@
  */
 
 const MAX_DETAIL_LENGTH = 200;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Extract a short target description from tool_input.
@@ -32,8 +33,6 @@ function extractTarget(toolName, toolInput) {
       if (toolInput.command) return truncate(toolInput.command, 40);
       return "";
     case "Grep":
-      if (toolInput.pattern) return truncate(toolInput.pattern, 40);
-      return "";
     case "Glob":
       if (toolInput.pattern) return truncate(toolInput.pattern, 40);
       return "";
@@ -92,6 +91,7 @@ export function transformClaudeEvent(payload) {
   const sessionId = payload.session_id;
   const event = payload.hook_event_name;
   if (!sessionId || !event) return null;
+  if (typeof sessionId !== "string" || !UUID_RE.test(sessionId)) return null;
 
   const topic = `claude/${sessionId}`;
   let step, status, detail;

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -340,10 +340,19 @@ export function createAppRoutes(ctx) {
     }))},
 
     // --- Claude Event Stream ---
+    // csrf() is included for consistency with all other write routes.
+    // Claude Code hooks arrive from localhost, where csrf() is bypassed
+    // automatically by the middleware. Remote callers need a CSRF token.
 
-    { method: "POST", path: "/api/claude-events", handler: auth(async (req, res) => {
+    { method: "POST", path: "/api/claude-events", handler: auth(csrf(async (req, res) => {
       if (!topicBroker) return json(res, 503, { error: "Pub/sub not available" });
-      const payload = await parseJSON(req, 65536);
+      let payload;
+      try {
+        payload = await parseJSON(req, 65536);
+      } catch (err) {
+        const status = err.message === "Request body too large" ? 413 : 400;
+        return json(res, status, { error: err.message });
+      }
       const result = transformClaudeEvent(payload);
       if (!result) return json(res, 400, { error: "Missing session_id or hook_event_name" });
 
@@ -352,14 +361,14 @@ export function createAppRoutes(ctx) {
       if (!meta || !meta.type) {
         topicBroker.setMeta(result.topic, {
           type: "progress",
-          sessionName: payload.name || null,
-          cwd: payload.cwd || null,
+          sessionName: typeof payload.name === "string" ? payload.name.slice(0, 128) : null,
+          cwd: typeof payload.cwd === "string" ? payload.cwd.slice(0, 512) : null,
         });
       }
 
       const delivered = topicBroker.publish(result.topic, JSON.stringify(result.message));
       json(res, 200, { ok: true, delivered });
-    })},
+    }))},
 
     // --- Sessions ---
 

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -23,6 +23,7 @@ import { rewriteVendorUrls } from "../static-files.js";
 import { captureVisiblePane } from "../tmux.js";
 import { bridgeClipboardToContainers, bridgePaneContainer } from "../container-detect.js";
 import { readRawBody } from "../request-util.js";
+import { transformClaudeEvent } from "../claude-event-transform.js";
 import {
   MAX_UPLOAD_BYTES, detectImage, imageMimeType, setClipboard,
 } from "./upload.js";
@@ -337,6 +338,28 @@ export function createAppRoutes(ctx) {
       topicBroker.setMeta(topic, data);
       json(res, 200, { ok: true, meta: topicBroker.getMeta(topic) });
     }))},
+
+    // --- Claude Event Stream ---
+
+    { method: "POST", path: "/api/claude-events", handler: auth(async (req, res) => {
+      if (!topicBroker) return json(res, 503, { error: "Pub/sub not available" });
+      const payload = await parseJSON(req, 65536);
+      const result = transformClaudeEvent(payload);
+      if (!result) return json(res, 400, { error: "Missing session_id or hook_event_name" });
+
+      // Set topic meta on first publish so the feed tile uses progress rendering
+      const meta = topicBroker.getMeta(result.topic);
+      if (!meta || !meta.type) {
+        topicBroker.setMeta(result.topic, {
+          type: "progress",
+          sessionName: payload.name || null,
+          cwd: payload.cwd || null,
+        });
+      }
+
+      const delivered = topicBroker.publish(result.topic, JSON.stringify(result.message));
+      json(res, 200, { ok: true, delivered });
+    })},
 
     // --- Sessions ---
 

--- a/test/claude-event-transform.test.js
+++ b/test/claude-event-transform.test.js
@@ -1,0 +1,254 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { transformClaudeEvent } from "../lib/claude-event-transform.js";
+
+describe("transformClaudeEvent", () => {
+  const SESSION_ID = "6bc4b919-90f6-484d-937d-d78e11aa1aa2";
+
+  it("returns null for missing payload", () => {
+    assert.equal(transformClaudeEvent(null), null);
+    assert.equal(transformClaudeEvent(undefined), null);
+    assert.equal(transformClaudeEvent("string"), null);
+  });
+
+  it("returns null when session_id is missing", () => {
+    assert.equal(transformClaudeEvent({ hook_event_name: "Stop" }), null);
+  });
+
+  it("returns null when hook_event_name is missing", () => {
+    assert.equal(transformClaudeEvent({ session_id: SESSION_ID }), null);
+  });
+
+  it("transforms PostToolUse with file-based tool", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "PostToolUse",
+      tool_name: "Edit",
+      tool_input: { file_path: "/src/lib/app.js", old_string: "a", new_string: "b" },
+      tool_response: "Successfully edited file",
+    });
+
+    assert.equal(result.topic, `claude/${SESSION_ID}`);
+    assert.equal(result.message.step, "Edit app.js");
+    assert.equal(result.message.status, "done");
+    assert.equal(result.message.detail, "Successfully edited file");
+    assert.equal(result.message.event, "PostToolUse");
+    assert.equal(result.message.tool, "Edit");
+  });
+
+  it("transforms PostToolUse with Bash tool", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "npm test" },
+      tool_response: "All tests passed",
+    });
+
+    assert.equal(result.message.step, "Bash npm test");
+    assert.equal(result.message.status, "done");
+  });
+
+  it("truncates long Bash commands", () => {
+    const longCmd = "find /very/long/path -name '*.js' -exec grep -l 'pattern' {} + | sort | head -50";
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: { command: longCmd },
+    });
+
+    assert.ok(result.message.step.length <= 45); // "Bash " + 40 chars max
+    assert.ok(result.message.step.endsWith("\u2026"));
+  });
+
+  it("transforms PostToolUse with Grep tool", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "PostToolUse",
+      tool_name: "Grep",
+      tool_input: { pattern: "function\\s+\\w+" },
+    });
+
+    assert.equal(result.message.step, "Grep function\\s+\\w+");
+  });
+
+  it("transforms PostToolUse with Agent tool", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "PostToolUse",
+      tool_name: "Agent",
+      tool_input: { description: "Search for auth patterns" },
+    });
+
+    assert.equal(result.message.step, "Agent Search for auth patterns");
+  });
+
+  it("transforms PostToolUse with unknown tool", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "PostToolUse",
+      tool_name: "CustomTool",
+      tool_input: { foo: "bar" },
+    });
+
+    assert.equal(result.message.step, "CustomTool");
+  });
+
+  it("transforms UserPromptSubmit", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "UserPromptSubmit",
+      prompt: "read package.json",
+    });
+
+    assert.equal(result.message.step, "User: read package.json");
+    assert.equal(result.message.status, "active");
+  });
+
+  it("truncates long user prompts", () => {
+    const longPrompt = "please refactor this entire codebase to use TypeScript with strict mode and add comprehensive test coverage for every module";
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "UserPromptSubmit",
+      prompt: longPrompt,
+    });
+
+    assert.ok(result.message.step.length <= 67); // "User: " + 60 chars + ellipsis
+  });
+
+  it("transforms Stop event", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "Stop",
+      last_assistant_message: "I've made the changes you requested.",
+    });
+
+    assert.equal(result.message.step, "Claude responded");
+    assert.equal(result.message.status, "done");
+    assert.equal(result.message.detail, "I've made the changes you requested.");
+  });
+
+  it("handles Stop with no message", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "Stop",
+    });
+
+    assert.equal(result.message.detail, "");
+  });
+
+  it("transforms SubagentStart", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "SubagentStart",
+      description: "Explore codebase structure",
+      agent_type: "Explore",
+    });
+
+    assert.equal(result.message.step, "Subagent: Explore codebase structure");
+    assert.equal(result.message.status, "active");
+    assert.equal(result.message.detail, "Explore");
+  });
+
+  it("transforms SubagentStop (keyed update of SubagentStart)", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "SubagentStop",
+      description: "Explore codebase structure",
+    });
+
+    assert.equal(result.message.step, "Subagent: Explore codebase structure");
+    assert.equal(result.message.status, "done");
+  });
+
+  it("transforms SessionStart", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "SessionStart",
+      cwd: "/Users/dev/project",
+    });
+
+    assert.equal(result.message.step, "Session started");
+    assert.equal(result.message.status, "info");
+    assert.equal(result.message.detail, "/Users/dev/project");
+  });
+
+  it("transforms SessionEnd", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "SessionEnd",
+    });
+
+    assert.equal(result.message.step, "Session ended");
+    assert.equal(result.message.status, "info");
+  });
+
+  it("handles unknown event types as generic log entries", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "PreToolUse",
+    });
+
+    assert.equal(result.message.step, "PreToolUse");
+    assert.equal(result.message.status, "info");
+  });
+
+  it("truncates long detail to first line", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "PostToolUse",
+      tool_name: "Read",
+      tool_input: { file_path: "/src/app.js" },
+      tool_response: "Line 1 of content\nLine 2\nLine 3\nLine 4",
+    });
+
+    assert.equal(result.message.detail, "Line 1 of content");
+  });
+
+  it("handles missing tool_input gracefully", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "PostToolUse",
+      tool_name: "Edit",
+    });
+
+    assert.equal(result.message.step, "Edit");
+    assert.equal(result.message.status, "done");
+  });
+
+  it("extracts stdout from structured Bash tool_response", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "npm test" },
+      tool_response: { stdout: "All 42 tests passed", stderr: "", interrupted: false },
+    });
+
+    assert.equal(result.message.detail, "All 42 tests passed");
+  });
+
+  it("falls back to stderr if stdout is empty", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "bad-cmd" },
+      tool_response: { stdout: "", stderr: "command not found: bad-cmd" },
+    });
+
+    assert.equal(result.message.detail, "command not found: bad-cmd");
+  });
+
+  it("handles missing tool_response gracefully", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "ls" },
+    });
+
+    assert.equal(result.message.detail, "");
+  });
+});

--- a/test/claude-event-transform.test.js
+++ b/test/claude-event-transform.test.js
@@ -19,6 +19,12 @@ describe("transformClaudeEvent", () => {
     assert.equal(transformClaudeEvent({ session_id: SESSION_ID }), null);
   });
 
+  it("returns null for non-UUID session_id", () => {
+    assert.equal(transformClaudeEvent({ session_id: "../evil", hook_event_name: "Stop" }), null);
+    assert.equal(transformClaudeEvent({ session_id: "not-a-uuid", hook_event_name: "Stop" }), null);
+    assert.equal(transformClaudeEvent({ session_id: 12345, hook_event_name: "Stop" }), null);
+  });
+
   it("transforms PostToolUse with file-based tool", () => {
     const result = transformClaudeEvent({
       session_id: SESSION_ID,
@@ -71,6 +77,17 @@ describe("transformClaudeEvent", () => {
     });
 
     assert.equal(result.message.step, "Grep function\\s+\\w+");
+  });
+
+  it("transforms PostToolUse with Glob tool", () => {
+    const result = transformClaudeEvent({
+      session_id: SESSION_ID,
+      hook_event_name: "PostToolUse",
+      tool_name: "Glob",
+      tool_input: { pattern: "**/*.test.js" },
+    });
+
+    assert.equal(result.message.step, "Glob **/*.test.js");
   });
 
   it("transforms PostToolUse with Agent tool", () => {


### PR DESCRIPTION
## Summary

- Add `POST /api/claude-events` endpoint that receives Claude Code hook payloads and publishes transformed events to the topic broker under `claude/{session-id}`
- New `lib/claude-event-transform.js` — pure transform function that converts hook payloads into feed-tile-friendly step/status/detail messages (23 unit tests)
- The existing feed tile subscribes to `claude/{session-id}` topics and renders events using the progress strategy — no new tile type needed

Users configure Claude Code's `http` hook type to POST to katulong; the receiver translates tool use, responses, user prompts, and subagent lifecycle into a live activity stream.

## Test plan

- [x] `npm test` passes (2017 pass, 0 fail)
- [x] 23 unit tests for transform covering all event types, structured tool_response, truncation, edge cases
- [x] Live tested against Claude Code v2.1.104 via staging instance — verified UserPromptSubmit, PostToolUse, and Stop events render correctly in feed tile