### PR TITLE
fix: restrict feed topics to Claude events only

### DIFF
--- a/docs/agent-progress-tile.md
+++ b/docs/agent-progress-tile.md
@@ -104,7 +104,7 @@ The topic broker wraps this in an envelope:
 
 Convention: `_build/{branch-name}` for implementation work,
 `_agent/{session-name}` for ad-hoc agent tasks. The `_` prefix
-signals system topics (same convention as `_notify`).
+signals system topics (underscore prefix convention).
 
 ## Progress tile renderer
 

--- a/docs/dorkyrobot-stack.md
+++ b/docs/dorkyrobot-stack.md
@@ -201,7 +201,7 @@ hooks:
 | SubagentStop | `crew/{project}/{role}/agent-done` | Mark task review |
 | TaskCompleted | (direct CLI call) | Move task on board |
 | Stop | `crew/{project}/{role}/session-idle` | Show idle in TUI |
-| Session exit | `sessions/{name}/output` (event: exit) | Mark role-session offline |
+| Session exit | poll `GET /sessions/{name}/status` | Mark role-session offline |
 
 ## sipag — Design
 

--- a/lib/cli/commands/crew.js
+++ b/lib/cli/commands/crew.js
@@ -198,62 +198,53 @@ async function output(args) {
 
   const sessionName = crewSessionName(project, worker);
 
-  // Initial fetch
-  const result = await api.get(`/sessions/${encodeURIComponent(sessionName)}/output?lines=${lines}`);
+  const encodedName = encodeURIComponent(sessionName);
+
+  // Initial fetch — get visible lines plus a sequence cursor for follow mode
+  const result = await api.get(`/sessions/${encodedName}/output?lines=${lines}`);
   process.stdout.write((result.data || result.screen || "") + "\n");
 
   if (!follow) return;
 
-  // Follow mode: subscribe to SSE stream via topic broker
+  // Follow mode: poll the session output endpoint using fromSeq for
+  // incremental reads from the ring buffer. Avoids the topic broker
+  // entirely — works whether or not session output is published to topics.
   process.on("SIGINT", () => process.exit(0));
 
-  const topic = `sessions/${sessionName}/output`;
+  // Get initial cursor from a screen snapshot
+  let seq;
   try {
-    const response = await fetch(`${getBase()}/sub/${topic}`);
-    if (!response.ok) {
-      console.error(`Error subscribing to output stream: ${response.status}`);
-      process.exit(1);
-    }
+    const snap = await api.get(`/sessions/${encodedName}/output?screen=true`);
+    seq = snap.seq ?? 0;
+  } catch {
+    seq = 0;
+  }
 
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
+  while (true) {
+    await new Promise(r => setTimeout(r, 500));
 
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop();
-
-      for (const line of lines) {
-        if (!line.startsWith("data: ")) continue;
-        try {
-          const envelope = JSON.parse(line.slice(6));
-          if (envelope.event === "exit") {
-            console.error("\nSession ended.");
-            reader.cancel();
-            return;
-          }
-          if (envelope.message) {
-            process.stdout.write(envelope.message);
-          }
-        } catch {
-          // Skip malformed SSE data
-        }
+    let chunk;
+    try {
+      chunk = await api.get(`/sessions/${encodedName}/output?fromSeq=${seq}`);
+    } catch (err) {
+      if (err.message.includes("404") || err.message.includes("Not found")) {
+        console.error("\nSession ended.");
+        return;
       }
+      throw err;
     }
-  } catch (err) {
-    // Match api-client.request()'s guard: fetch wraps some errors in `cause`
-    // (common on Linux/macOS), while others surface `code` directly (varies
-    // by Node version). Checking both covers the full matrix.
-    if (err.cause?.code === "ECONNREFUSED" || err.code === "ECONNREFUSED") {
-      console.error("Server is not running. Start with: katulong start");
-    } else {
-      console.error(`Error: ${err.message}`);
+
+    if (chunk.evicted) {
+      // Ring buffer wrapped — reset with a full screen snapshot
+      process.stdout.write(chunk.screen || "");
+      seq = chunk.seq ?? 0;
+      continue;
     }
-    process.exit(1);
+
+    if (chunk.data) {
+      process.stdout.write(chunk.data);
+    }
+    seq = chunk.seq ?? seq;
   }
 }
 

--- a/lib/cli/commands/crew.js
+++ b/lib/cli/commands/crew.js
@@ -245,6 +245,11 @@ async function output(args) {
       process.stdout.write(chunk.data);
     }
     seq = chunk.seq ?? seq;
+
+    if (chunk.alive === false && !chunk.data) {
+      console.error("\nSession ended.");
+      return;
+    }
   }
 }
 

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -37,9 +37,6 @@ export function createAppRoutes(ctx) {
     auth, csrf, topicBroker, getExternalUrl,
   } = ctx;
 
-  // Session output bridge → topic broker removed (too noisy in the feed).
-  // Only Claude events are published to topics for now.
-
   function configPutRoute(path, fieldName, setter, getter) {
     return { method: "PUT", path, handler: auth(csrf(async (req, res) => {
       const body = await parseJSON(req);

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -37,17 +37,8 @@ export function createAppRoutes(ctx) {
     auth, csrf, topicBroker, getExternalUrl,
   } = ctx;
 
-  // Publish session output and exit events to topic broker for SSE subscribers
-  // (used by `crew output --follow` to replace polling with push).
-  if (topicBroker && bridge) {
-    bridge.register((msg) => {
-      if (msg.type === "output" && msg.session && msg.data) {
-        topicBroker.publish(`sessions/${msg.session}/output`, msg.data);
-      } else if (msg.type === "exit" && msg.session) {
-        topicBroker.publish(`sessions/${msg.session}/output`, "", { event: "exit", code: msg.code });
-      }
-    });
-  }
+  // Session output bridge → topic broker removed (too noisy in the feed).
+  // Only Claude events are published to topics for now.
 
   function configPutRoute(path, fieldName, setter, getter) {
     return { method: "PUT", path, handler: auth(csrf(async (req, res) => {
@@ -268,7 +259,6 @@ export function createAppRoutes(ctx) {
       if (!message) return json(res, 400, { error: "Missing message" });
       const title = typeof data.title === "string" ? data.title.slice(0, 200) : "Katulong";
       bridge.relay({ type: "notification", title, message });
-      if (topicBroker) topicBroker.publish("_notify", message, { title });
       json(res, 200, { ok: true });
     }))},
 

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -464,7 +464,7 @@ export function createAppRoutes(ctx) {
           const snap = await session.snapshot();
           return json(res, 200, { screen: snap.buffer, seq: snap.seq, evicted: true });
         }
-        return json(res, 200, { data, seq: cursor });
+        return json(res, 200, { data, seq: cursor, alive: session.alive });
       }
       if (lines !== null) {
         const n = parseInt(lines, 10);


### PR DESCRIPTION
## Summary

- Remove session output bridge → topic broker publishing (every terminal keystroke was creating topic events)
- Remove `_notify` topic publishing from /notify route (browser notifications still work via WebSocket bridge)
- Only Claude Code activity events (`/api/claude-events`) now appear in feed topics

## Test plan

- [x] `npm test` passes (unit + integration + smoke E2E)
- [x] Pre-push review agents passed
- [ ] Feed tile only shows Claude event topics, no session output noise
- [ ] `/notify` endpoint still delivers browser notifications via WebSocket