### PR TITLE
fix: restore port proxy HTTP handler

### DIFF
--- a/lib/port-proxy.js
+++ b/lib/port-proxy.js
@@ -184,6 +184,92 @@ function parseProxyUrl(pathname) {
 /**
  * Proxy an HTTP request to localhost:<port>.
  */
+export function proxyHttpRequest(req, res, port, path) {
+  const prefix = `/_proxy/${port}/`;
+
+  // Build headers to forward
+  const fwdHeaders = { ...req.headers };
+  delete fwdHeaders["accept-encoding"]; // avoid compressed responses we'd need to decompress
+  fwdHeaders.host = `127.0.0.1:${port}`;
+  const stripped = stripKatulongCookies(fwdHeaders.cookie);
+  if (stripped) {
+    fwdHeaders.cookie = stripped;
+  } else {
+    delete fwdHeaders.cookie;
+  }
+
+  const proxyReq = http.request(
+    {
+      hostname: "127.0.0.1",
+      port,
+      path,
+      method: req.method,
+      headers: fwdHeaders,
+    },
+    (proxyRes) => {
+      // Rewrite Location header for redirects
+      if (proxyRes.headers.location) {
+        proxyRes.headers.location = rewriteLocation(
+          proxyRes.headers.location, port, prefix
+        );
+      }
+
+      // Rewrite Set-Cookie Path attributes
+      if (proxyRes.headers["set-cookie"]) {
+        proxyRes.headers["set-cookie"] = (
+          Array.isArray(proxyRes.headers["set-cookie"])
+            ? proxyRes.headers["set-cookie"]
+            : [proxyRes.headers["set-cookie"]]
+        ).map(c =>
+          c.replace(/;\s*path\s*=\s*\//gi, `; Path=${prefix}`)
+        );
+      }
+
+      // Strip framing restrictions so the iframe works
+      delete proxyRes.headers["x-frame-options"];
+      const csp = proxyRes.headers["content-security-policy"];
+      if (csp) {
+        proxyRes.headers["content-security-policy"] = csp.replace(
+          /frame-ancestors\s+[^;]*(;|$)/gi,
+          ""
+        );
+      }
+
+      const contentType = proxyRes.headers["content-type"] || "";
+      const isHtml = contentType.includes("text/html");
+
+      if (isHtml) {
+        // Buffer HTML so we can rewrite it
+        const chunks = [];
+        proxyRes.on("data", (chunk) => chunks.push(chunk));
+        proxyRes.on("end", () => {
+          let body = Buffer.concat(chunks).toString("utf-8");
+          body = rewriteProxiedHtml(body, prefix);
+          // Update content-length after rewrite
+          delete proxyRes.headers["content-length"];
+          res.writeHead(proxyRes.statusCode, proxyRes.headers);
+          res.end(body);
+        });
+      } else {
+        // Stream non-HTML responses directly
+        res.writeHead(proxyRes.statusCode, proxyRes.headers);
+        proxyRes.pipe(res);
+      }
+    }
+  );
+
+  proxyReq.on("error", (err) => {
+    log.warn("Port proxy request failed", { port, path, error: err.message });
+    if (!res.headersSent) {
+      res.writeHead(502, { "Content-Type": "text/plain" });
+      res.end(`Could not connect to localhost:${port}`);
+    }
+  });
+
+  // Pipe the incoming request body to the proxy
+  req.pipe(proxyReq);
+}
+
 /**
  * Proxy a WebSocket upgrade to localhost:<port>.
  * Called after auth has already been verified in handleUpgrade.

--- a/lib/port-proxy.js
+++ b/lib/port-proxy.js
@@ -235,6 +235,15 @@ export function proxyHttpRequest(req, res, port, path) {
         );
       }
 
+      // Guard against upstream TCP reset mid-response
+      proxyRes.on("error", (err) => {
+        log.warn("Port proxy upstream error", { port, path, error: err.message });
+        if (!res.headersSent) {
+          res.writeHead(502, { "Content-Type": "text/plain" });
+        }
+        res.destroy();
+      });
+
       const contentType = proxyRes.headers["content-type"] || "";
       const isHtml = contentType.includes("text/html");
 


### PR DESCRIPTION
## Summary

- Restores `proxyHttpRequest()` in `lib/port-proxy.js`, which was incorrectly deleted in d1832fc as dead code
- Without this function, all `/_proxy/<port>/...` HTTP requests throw a ReferenceError caught by the global handler, returning `{"error":"Internal server error"}`
- The port forwarder feature was completely broken

## Test plan

- [x] `npm test` passes (unit + integration + smoke e2e)
- [x] Manual verification: started a test HTTP server on port 4000, confirmed port proxy returns the correct response instead of "Internal server error"