### PR TITLE
feat: add relay-hook for dynamic Claude event routing

### DIFF
--- a/bin/katulong
+++ b/bin/katulong
@@ -100,7 +100,7 @@ async function main() {
   }
 
   // Hidden internal commands (not shown in help)
-  const INTERNAL_COMMANDS = ["_finish-upgrade"];
+  const INTERNAL_COMMANDS = ["_finish-upgrade", "relay-hook"];
 
   // Dispatch to command handler
   if (!COMMANDS[command] && !INTERNAL_COMMANDS.includes(command)) {

--- a/docs/claude-event-stream.md
+++ b/docs/claude-event-stream.md
@@ -103,22 +103,26 @@ Target extraction from `tool_input`:
 
 ## Hook configuration
 
-Users configure Claude Code to POST events to katulong:
+Configure Claude Code to relay events via the `katulong relay-hook`
+command. This resolves the server URL dynamically from
+`~/.katulong/server.json` (localhost) or `~/.katulong/remote.json`
+(tunnel URL + API key), so hooks work regardless of which port
+katulong is running on:
 
 ```json
 {
   "hooks": {
     "UserPromptSubmit": [{
       "matcher": "",
-      "hooks": [{ "type": "http", "url": "http://localhost:3001/api/claude-events" }]
+      "hooks": [{ "type": "command", "command": "katulong relay-hook" }]
     }],
     "PostToolUse": [{
       "matcher": "*",
-      "hooks": [{ "type": "http", "url": "http://localhost:3001/api/claude-events" }]
+      "hooks": [{ "type": "command", "command": "katulong relay-hook" }]
     }],
     "Stop": [{
       "matcher": "",
-      "hooks": [{ "type": "http", "url": "http://localhost:3001/api/claude-events" }]
+      "hooks": [{ "type": "command", "command": "katulong relay-hook" }]
     }]
   }
 }
@@ -126,6 +130,11 @@ Users configure Claude Code to POST events to katulong:
 
 This goes in `~/.claude/settings.local.json` (global) or
 `.claude/settings.local.json` (project-level).
+
+**Do not hardcode `http://localhost:<port>` in hook URLs.** The port
+changes between instances (dev, staging, production) and between
+restarts when using dynamic ports. The `relay-hook` command reads the
+actual port from `server.json` at invocation time.
 
 ## Security
 
@@ -144,7 +153,6 @@ This goes in `~/.claude/settings.local.json` (global) or
 
 ## Future
 
-- `katulong setup claude-hooks` CLI command to automate hook config
 - Auto-discovery of claude topics in the feed tile picker
 - Human-friendly topic names (from Claude's `--name` flag)
 - Rich HTML conduit — the feed tile becomes a two-way channel

--- a/lib/claude-event-transform.js
+++ b/lib/claude-event-transform.js
@@ -11,7 +11,10 @@
  * for the feed tile's progress rendering strategy.
  */
 
+import { readFileSync } from "node:fs";
+
 const MAX_DETAIL_LENGTH = 200;
+const MAX_TEXT_LENGTH = 500;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
@@ -167,4 +170,57 @@ export function transformClaudeEvent(payload) {
     topic,
     message: { step, status, detail, event, tool: payload.tool_name || null },
   };
+}
+
+// --- Transcript text extraction ---
+
+// Per-session tracking of how many assistant entries we've seen,
+// so we only emit new text blocks.
+const seenAssistantCounts = new Map();
+
+/**
+ * Extract new assistant text blocks from the transcript file.
+ *
+ * Reads the JSONL transcript, finds assistant entries with text content
+ * blocks, and returns only the ones we haven't seen before (tracked
+ * per session_id).
+ *
+ * @param {string} transcriptPath - Path to the JSONL transcript
+ * @param {string} sessionId - Claude session UUID
+ * @returns {string[]} Array of text strings from new assistant entries
+ */
+export function extractNewAssistantText(transcriptPath, sessionId) {
+  if (!transcriptPath || typeof transcriptPath !== "string") return [];
+
+  let lines;
+  try {
+    lines = readFileSync(transcriptPath, "utf8").split("\n");
+  } catch {
+    return [];
+  }
+
+  // Collect all assistant text entries
+  const allTexts = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let obj;
+    try { obj = JSON.parse(line); } catch { continue; }
+    if (obj.type !== "assistant") continue;
+    const content = obj.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block.type === "text" && block.text) {
+        allTexts.push(block.text);
+      }
+    }
+  }
+
+  const prevCount = seenAssistantCounts.get(sessionId) || 0;
+  seenAssistantCounts.set(sessionId, allTexts.length);
+
+  // Return only new entries
+  if (allTexts.length <= prevCount) return [];
+  return allTexts.slice(prevCount).map(t =>
+    t.length > MAX_TEXT_LENGTH ? t.slice(0, MAX_TEXT_LENGTH - 1) + "\u2026" : t
+  );
 }

--- a/lib/cli/commands/relay-hook.js
+++ b/lib/cli/commands/relay-hook.js
@@ -1,0 +1,75 @@
+/**
+ * CLI: katulong relay-hook
+ *
+ * Reads a Claude Code hook payload from stdin and POSTs it to the
+ * running katulong server's /api/claude-events endpoint.
+ *
+ * Resolves the server URL dynamically:
+ *   1. ~/.katulong/server.json (localhost — no auth needed)
+ *   2. ~/.katulong/remote.json (tunnel URL — uses API key Bearer auth)
+ *
+ * Designed for use as a Claude Code command hook:
+ *   { "type": "command", "command": "katulong relay-hook" }
+ *
+ * Exits silently on any error — hooks must never block Claude.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { readServerInfo } from "../process-manager.js";
+import envConfig from "../../env-config.js";
+
+const REMOTE_PATH = join(envConfig.dataDir, "remote.json");
+
+function readRemoteConfig() {
+  try {
+    const data = JSON.parse(readFileSync(REMOTE_PATH, "utf8"));
+    if (data.url && data.apiKey) return data;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function relayHook(_args) {
+  // Read payload from stdin
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const payload = Buffer.concat(chunks).toString();
+  if (!payload.trim()) process.exit(0);
+
+  // Try local server first (localhost — auth bypassed automatically)
+  const serverInfo = readServerInfo();
+  if (serverInfo) {
+    const url = `http://localhost:${serverInfo.port}/api/claude-events`;
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+        signal: AbortSignal.timeout(3000),
+      });
+      if (res.ok) process.exit(0);
+    } catch {
+      // Local server unreachable — fall through to remote
+    }
+  }
+
+  // Fall back to remote (tunnel URL + API key)
+  const remote = readRemoteConfig();
+  if (remote) {
+    try {
+      await fetch(`${remote.url}/api/claude-events`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${remote.apiKey}`,
+        },
+        body: payload,
+        signal: AbortSignal.timeout(5000),
+      });
+    } catch {
+      // Silent failure — hooks must not block Claude
+    }
+  }
+}

--- a/lib/cli/commands/relay-hook.js
+++ b/lib/cli/commands/relay-hook.js
@@ -5,8 +5,8 @@
  * running katulong server's /api/claude-events endpoint.
  *
  * Resolves the server URL dynamically:
- *   1. ~/.katulong/server.json (localhost — no auth needed)
- *   2. ~/.katulong/remote.json (tunnel URL — uses API key Bearer auth)
+ *   1. ~/.katulong/server.json  → localhost (no auth needed)
+ *   2. ~/.katulong/config.json  → publicUrl (self-access URL, needs API key)
  *
  * Designed for use as a Claude Code command hook:
  *   { "type": "command", "command": "katulong relay-hook" }
@@ -19,13 +19,20 @@ import { join } from "node:path";
 import { readServerInfo } from "../process-manager.js";
 import envConfig from "../../env-config.js";
 
-const REMOTE_PATH = join(envConfig.dataDir, "remote.json");
+const DATA_DIR = envConfig.dataDir;
 
-function readRemoteConfig() {
+function readConfig(key) {
   try {
-    const data = JSON.parse(readFileSync(REMOTE_PATH, "utf8"));
-    if (data.url && data.apiKey) return data;
+    return JSON.parse(readFileSync(join(DATA_DIR, "config.json"), "utf8"))[key] || null;
+  } catch {
     return null;
+  }
+}
+
+function readApiKey() {
+  try {
+    const data = JSON.parse(readFileSync(join(DATA_DIR, "remote.json"), "utf8"));
+    return data.apiKey || null;
   } catch {
     return null;
   }
@@ -41,9 +48,8 @@ export default async function relayHook(_args) {
   // Try local server first (localhost — auth bypassed automatically)
   const serverInfo = readServerInfo();
   if (serverInfo) {
-    const url = `http://localhost:${serverInfo.port}/api/claude-events`;
     try {
-      const res = await fetch(url, {
+      const res = await fetch(`http://localhost:${serverInfo.port}/api/claude-events`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: payload,
@@ -51,19 +57,20 @@ export default async function relayHook(_args) {
       });
       if (res.ok) process.exit(0);
     } catch {
-      // Local server unreachable — fall through to remote
+      // Local server unreachable — fall through
     }
   }
 
-  // Fall back to remote (tunnel URL + API key)
-  const remote = readRemoteConfig();
-  if (remote) {
+  // Fall back to publicUrl from config.json (self-access URL)
+  const publicUrl = readConfig("publicUrl");
+  const apiKey = readApiKey();
+  if (publicUrl && apiKey) {
     try {
-      await fetch(`${remote.url}/api/claude-events`, {
+      await fetch(`${publicUrl}/api/claude-events`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "Authorization": `Bearer ${remote.apiKey}`,
+          "Authorization": `Bearer ${apiKey}`,
         },
         body: payload,
         signal: AbortSignal.timeout(5000),

--- a/lib/cli/commands/setup.js
+++ b/lib/cli/commands/setup.js
@@ -12,12 +12,16 @@ import { ensureRunning, api } from "../api-client.js";
 const KATULONG_DIR = join(homedir(), ".katulong");
 const REMOTE_PATH = join(KATULONG_DIR, "remote.json");
 
+const CLAUDE_DIR = join(homedir(), ".claude");
+const CLAUDE_SETTINGS_PATH = join(CLAUDE_DIR, "settings.local.json");
+
 function usage() {
   console.log(`
 Usage: katulong setup <subcommand>
 
 Subcommands:
   self-access       Create remote.json so other contexts (kubos, agents) can reach this instance
+  claude-hooks      Configure Claude Code hooks to relay events to katulong
 `);
 }
 
@@ -99,7 +103,95 @@ async function selfAccess(args) {
   }
 }
 
-const subcommands = { "self-access": selfAccess };
+const HOOK_EVENTS = ["PostToolUse", "Stop", "SubagentStart", "SubagentStop"];
+const RELAY_HOOK = { type: "command", command: "katulong relay-hook" };
+
+async function claudeHooks(args) {
+  const remove = args.includes("--remove");
+
+  // Read existing settings or start fresh
+  let settings = {};
+  try {
+    settings = JSON.parse(readFileSync(CLAUDE_SETTINGS_PATH, "utf8"));
+  } catch {
+    // File doesn't exist or malformed — start with empty object
+  }
+
+  if (remove) {
+    if (!settings.hooks) {
+      console.log("No hooks configured — nothing to remove.");
+      return;
+    }
+    for (const event of HOOK_EVENTS) {
+      if (!settings.hooks[event]) continue;
+      settings.hooks[event] = settings.hooks[event].filter(
+        (group) => !group.hooks?.some((h) => h.command === "katulong relay-hook")
+      );
+      if (settings.hooks[event].length === 0) delete settings.hooks[event];
+    }
+    if (Object.keys(settings.hooks).length === 0) delete settings.hooks;
+    writeFileSync(CLAUDE_SETTINGS_PATH, JSON.stringify(settings, null, 2) + "\n", { mode: 0o600 });
+    console.log("Katulong hooks removed from Claude Code settings.");
+    return;
+  }
+
+  // Check that katulong CLI is accessible
+  const { execSync } = await import("node:child_process");
+  try {
+    execSync("katulong --version", { stdio: "pipe" });
+  } catch {
+    console.error("Error: 'katulong' command not found in PATH.");
+    console.error("Install katulong first: brew install dorky-robot/tap/katulong");
+    process.exit(1);
+  }
+
+  // Add hooks
+  if (!settings.hooks) settings.hooks = {};
+
+  let alreadyConfigured = true;
+  for (const event of HOOK_EVENTS) {
+    const matcher = event === "PostToolUse" ? "*" : "";
+    if (!settings.hooks[event]) settings.hooks[event] = [];
+
+    // Check if relay-hook is already configured for this event
+    const hasRelay = settings.hooks[event].some(
+      (group) => group.hooks?.some((h) => h.command === "katulong relay-hook")
+    );
+    if (hasRelay) continue;
+
+    alreadyConfigured = false;
+
+    // Remove any old hardcoded http hooks pointing to katulong
+    settings.hooks[event] = settings.hooks[event].filter(
+      (group) => !group.hooks?.some((h) => h.url && h.url.includes("/api/claude-events"))
+    );
+
+    settings.hooks[event].push({
+      matcher,
+      hooks: [RELAY_HOOK],
+    });
+  }
+
+  if (alreadyConfigured) {
+    console.log("Claude Code hooks are already configured for katulong.");
+    return;
+  }
+
+  mkdirSync(CLAUDE_DIR, { recursive: true });
+  writeFileSync(CLAUDE_SETTINGS_PATH, JSON.stringify(settings, null, 2) + "\n", { mode: 0o600 });
+
+  console.log("Claude Code hooks configured.");
+  console.log(`  File: ${CLAUDE_SETTINGS_PATH}`);
+  console.log("");
+  console.log("Events relayed: " + HOOK_EVENTS.join(", "));
+  console.log("");
+  console.log("Claude Code will now relay activity events to katulong.");
+  console.log("View them by opening a Feed tile and subscribing to a claude/ topic.");
+  console.log("");
+  console.log("To remove: katulong setup claude-hooks --remove");
+}
+
+const subcommands = { "self-access": selfAccess, "claude-hooks": claudeHooks };
 
 export default async function setup(args) {
   const sub = args[0];

--- a/lib/config.js
+++ b/lib/config.js
@@ -209,6 +209,49 @@ export class ConfigManager {
   }
 
   /**
+   * Get public URL (tunnel/external URL for remote access)
+   */
+  getPublicUrl() {
+    return this._get('publicUrl', '');
+  }
+
+  /**
+   * Set public URL
+   */
+  async setPublicUrl(url) {
+    if (typeof url !== "string") {
+      throw new Error("Public URL must be a string");
+    }
+
+    const trimmed = url.trim();
+
+    // Allow empty string to clear the URL
+    if (trimmed === '') {
+      await this.withLock(() => this._set('publicUrl', ''));
+      return;
+    }
+
+    if (trimmed.length > 200) {
+      throw new Error("Public URL must be 200 characters or less");
+    }
+
+    // Must be a valid https URL
+    try {
+      const parsed = new URL(trimmed);
+      if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+        throw new Error("Public URL must use http or https");
+      }
+    } catch (e) {
+      if (e.message.includes("http")) throw e;
+      throw new Error("Public URL must be a valid URL (e.g., https://myhost.example.com)");
+    }
+
+    // Strip trailing slash for consistency
+    const normalized = trimmed.replace(/\/+$/, '');
+    await this.withLock(() => this._set('publicUrl', normalized));
+  }
+
+  /**
    * Get port proxy enabled
    */
   getPortProxyEnabled() {

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -23,7 +23,7 @@ import { rewriteVendorUrls } from "../static-files.js";
 import { captureVisiblePane } from "../tmux.js";
 import { bridgeClipboardToContainers, bridgePaneContainer } from "../container-detect.js";
 import { readRawBody } from "../request-util.js";
-import { transformClaudeEvent } from "../claude-event-transform.js";
+import { transformClaudeEvent, extractNewAssistantText } from "../claude-event-transform.js";
 import {
   MAX_UPLOAD_BYTES, detectImage, imageMimeType, setClipboard,
 } from "./upload.js";
@@ -352,12 +352,29 @@ export function createAppRoutes(ctx) {
 
       // Set topic meta on first publish so the feed tile uses progress rendering
       const meta = topicBroker.getMeta(result.topic);
-      if (!meta || !meta.type) {
-        topicBroker.setMeta(result.topic, {
+      const isNewTopic = !meta || !meta.type;
+      if (isNewTopic) {
+        const newMeta = {
           type: "progress",
           sessionName: typeof payload.name === "string" ? payload.name.slice(0, 128) : null,
           cwd: typeof payload.cwd === "string" ? payload.cwd.slice(0, 512) : null,
-        });
+        };
+        topicBroker.setMeta(result.topic, newMeta);
+        // Notify connected clients so feed tile pickers update live
+        bridge.relay({ type: "topic-new", topic: result.topic, meta: newMeta });
+      }
+
+      // Extract and publish any new assistant text from the transcript
+      // before the tool/stop event, so the feed shows reasoning in order.
+      const texts = extractNewAssistantText(payload.transcript_path, payload.session_id);
+      for (const text of texts) {
+        topicBroker.publish(result.topic, JSON.stringify({
+          step: text,
+          status: "text",
+          detail: "",
+          event: "AssistantText",
+          tool: null,
+        }));
       }
 
       const delivered = topicBroker.publish(result.topic, JSON.stringify(result.message));

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -312,6 +312,13 @@ export function createAppRoutes(ctx) {
       json(res, 200, topicBroker.listTopics());
     })},
 
+    { method: "DELETE", prefix: "/api/topics/", handler: auth(csrf((req, res, topic) => {
+      if (!topicBroker) return json(res, 503, { error: "Pub/sub not available" });
+      if (!topic || !/^[a-zA-Z0-9._\-/]+$/.test(topic) || /(^|\/)\.\.($|\/)/.test(topic)) return json(res, 400, { error: "Invalid topic" });
+      const existed = topicBroker.deleteTopic(topic);
+      json(res, existed ? 200 : 404, { ok: existed });
+    }))},
+
     // Topic names may contain slashes (e.g. "claude/session-abc"), so the
     // param from the prefix route will be "claude/session-abc/meta". We use
     // endsWith("/meta") to match and slice to extract the topic name.

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -543,6 +543,7 @@ export function createAppRoutes(ctx) {
     configPutRoute("/api/config/instance-icon", "instanceIcon", (v) => configManager.setInstanceIcon(v), () => configManager.getInstanceIcon()),
     configPutRoute("/api/config/toolbar-color", "toolbarColor", (v) => configManager.setToolbarColor(v), () => configManager.getToolbarColor()),
     configPutRoute("/api/config/port-proxy-enabled", "portProxyEnabled", (v) => configManager.setPortProxyEnabled(v), () => configManager.getPortProxyEnabled()),
+    configPutRoute("/api/config/public-url", "publicUrl", (v) => configManager.setPublicUrl(v), () => configManager.getPublicUrl()),
 
     // --- Notes (per-session markdown) ---
 

--- a/lib/topic-broker.js
+++ b/lib/topic-broker.js
@@ -17,7 +17,7 @@ import { log as logger } from "./log.js";
 import envConfig from "./env-config.js";
 import {
   mkdirSync, appendFileSync, writeFileSync, readFileSync,
-  statSync, renameSync, unlinkSync, readdirSync, existsSync,
+  statSync, renameSync, unlinkSync, readdirSync, existsSync, rmdirSync,
 } from "node:fs";
 import { join, resolve } from "node:path";
 import { randomBytes } from "node:crypto";
@@ -342,5 +342,33 @@ export function createTopicBroker({ pubsubDir } = {}) {
     return Array.from(allTopics.values());
   }
 
-  return { subscribe, publish, listTopics, getMeta, setMeta };
+  /**
+   * Delete a topic — removes on-disk files and in-memory state.
+   * Returns true if the topic existed, false otherwise.
+   */
+  function deleteTopic(topic) {
+    const dir = topicDir(topic);
+
+    // Remove on-disk files
+    let existed = false;
+    for (const file of ["log.jsonl", "log.jsonl.1", "seq", "meta.json"]) {
+      try { unlinkSync(join(dir, file)); existed = true; } catch { /* ok */ }
+    }
+
+    // Remove empty directories up the tree (topic "a/b/output" creates a/b/)
+    let current = dir;
+    const root = resolve(PUBSUB_DIR);
+    while (current !== root && current.startsWith(root + "/")) {
+      try { rmdirSync(current); } catch { break; } // only succeeds if empty
+      current = resolve(current, "..");
+    }
+
+    // Clear in-memory state
+    seqCounters.delete(topic);
+    subscribers.delete(topic);
+
+    return existed;
+  }
+
+  return { subscribe, publish, listTopics, getMeta, setMeta, deleteTopic };
 }

--- a/lib/ws-manager.js
+++ b/lib/ws-manager.js
@@ -227,6 +227,9 @@ export function createWebSocketManager({ bridge, sessionManager, helmSessionMana
       case "notification":
         broadcastToAll({ type: "notification", title: msg.title, message: msg.message });
         break;
+      case "topic-new":
+        broadcastToAll({ type: "topic-new", topic: msg.topic, meta: msg.meta });
+        break;
 
       // Device-to-device auth
       case "device-auth-request":

--- a/public/app.js
+++ b/public/app.js
@@ -767,11 +767,12 @@
     });
     joystickManager.init();
 
-    // Wire Files + Upload + Settings into the joystick floating buttons
+    // Wire Files + Upload + Settings + Feed into the joystick floating buttons
     joystickManager.setActions({
       onFilesClick: () => openFileBrowserTile(),
       onUploadClick: () => triggerImageUpload(),
       onSettingsClick: () => modals.open('settings'),
+      onFeedClick: () => openClaudeFeedTile(),
     });
 
     // Joystick (floating action buttons) is always visible — same
@@ -1310,7 +1311,6 @@
       const submitBtn = document.getElementById("apikey-form-submit");
       const cancelBtn = document.getElementById("apikey-form-cancel");
       const listEl = document.getElementById("apikeys-list");
-      const baseUrlEl = document.getElementById("api-base-url");
 
       async function loadApiKeys() {
         if (!listEl) return;
@@ -1337,11 +1337,6 @@
       }
 
       async function loadBaseUrl() {
-        if (!baseUrlEl) return;
-        try {
-          const { url } = await api.get("/api/external-url");
-          baseUrlEl.innerHTML = url ? "Base URL: <code>" + url + "</code>" : "Create API keys for external access.";
-        } catch { baseUrlEl.textContent = "Create API keys for external access."; }
       }
 
       if (createBtn && form) {
@@ -1752,6 +1747,32 @@
         { id: tileId, type: "feed", props: {} },
         { focus: true, insertAt: "afterFocus" },
       );
+      if (isOverlayViewport()) setOverlaySidebar(false);
+    }
+
+    /** Open a feed tile for the Claude session running in the current terminal. */
+    async function openClaudeFeedTile() {
+      const sessionName = state.session.name;
+      try {
+        const topics = await api.get("/api/topics");
+        // Find the most recent Claude topic matching this terminal session
+        const match = topics
+          .filter(t => t.name.startsWith("claude/") && t.meta?.sessionName === sessionName)
+          .sort((a, b) => (b.messages || 0) - (a.messages || 0))[0];
+
+        if (match) {
+          const tileId = `feed-${Date.now().toString(36)}`;
+          uiStore.addTile(
+            { id: tileId, type: "feed", props: { topic: match.name, title: match.name, meta: match.meta || {} } },
+            { focus: true, insertAt: "afterFocus" },
+          );
+        } else {
+          // No Claude topic found — open blank feed picker
+          openFeedTile();
+        }
+      } catch {
+        openFeedTile();
+      }
       if (isOverlayViewport()) setOverlaySidebar(false);
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -2243,10 +2243,16 @@
 
     /* --- Feed Tile: inline topic picker --- */
     .feed-tile-picker { display: flex; flex-direction: column; height: 100%; padding: var(--space-md); gap: var(--space-sm); color: var(--text); }
-    .feed-tile-picker-title { font-size: var(--text-sm); font-weight: 600; color: var(--text); padding-bottom: var(--space-xs); border-bottom: 1px solid var(--border); }
+    .feed-tile-picker-title { display: flex; align-items: center; justify-content: space-between; font-size: var(--text-sm); font-weight: 600; color: var(--text); padding-bottom: var(--space-xs); border-bottom: 1px solid var(--border); }
     .feed-tile-picker-list { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 2px; color: var(--text); font-size: var(--text-sm); }
+    .feed-tile-picker-toolbar { display: flex; gap: var(--space-xs); }
+    .feed-tile-picker-delete-btn { padding: 2px var(--space-sm); border: 1px solid var(--border); background: transparent; color: var(--text-secondary); border-radius: var(--radius-sm, 6px); cursor: pointer; font-size: var(--text-xs); }
+    .feed-tile-picker-delete-btn:hover { background: rgba(255,80,80,0.15); color: #f66; border-color: #f66; }
+    .feed-tile-picker-delete-btn:disabled { opacity: 0.5; cursor: default; }
     .feed-tile-picker-item { display: flex; align-items: center; justify-content: space-between; gap: var(--space-sm); padding: var(--space-sm); border: none; background: var(--bg-surface, #313244); color: var(--text); font-size: var(--text-sm); border-radius: var(--radius-sm, 6px); cursor: pointer; text-align: left; width: 100%; }
     .feed-tile-picker-item:hover { background: var(--bg-hover, rgba(255,255,255,0.12)); }
+    .feed-tile-picker-item.selected { background: rgba(255,255,255,0.08); }
+    .feed-tile-picker-cb { flex-shrink: 0; cursor: pointer; accent-color: var(--accent); }
     .feed-tile-picker-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--font-mono); }
     .feed-tile-picker-info { flex-shrink: 0; font-size: var(--text-xs); color: var(--text-secondary); }
     .feed-tile-picker-empty { padding: var(--space-lg) var(--space-sm); text-align: center; color: var(--text-secondary); font-size: var(--text-sm); }

--- a/public/index.html
+++ b/public/index.html
@@ -2578,6 +2578,15 @@
 
           <!-- Remote tab content -->
           <div class="settings-tab-content" id="settings-tab-remote">
+            <div class="settings-row" style="flex-direction: column; align-items: stretch; gap: var(--space-xs);">
+              <span class="settings-label">Public URL</span>
+              <input type="url" id="public-url-input" class="palette-hex-input" style="width: 100%; box-sizing: border-box;"
+                     placeholder="https://myhost.example.com" spellcheck="false" autocomplete="off" />
+            </div>
+            <p class="tab-description" style="margin-top: 0;">
+              Your tunnel URL for remote access. Used by CLI tools and pub/sub.
+            </p>
+
             <div class="settings-row">
               <span class="settings-label">Port Proxy</span>
               <label class="toggle-switch">

--- a/public/index.html
+++ b/public/index.html
@@ -2232,6 +2232,7 @@
     .feed-tile-item { display: flex; flex-wrap: wrap; align-items: baseline; gap: var(--space-xs); padding: var(--space-xs) 0; min-width: 0; }
     .feed-tile-bullet { flex-shrink: 0; width: 1.2em; text-align: center; }
     .feed-tile-step { font-weight: 500; min-width: 0; overflow-wrap: break-word; }
+    .feed-tile-assistant-text { font-weight: 400; color: var(--text); font-style: italic; }
     .feed-tile-detail { width: 100%; padding-left: 1.6em; color: var(--text-secondary); font-size: var(--text-xs); overflow-wrap: break-word; }
     .feed-status-pending .feed-tile-bullet { color: var(--text-secondary); }
     .feed-status-active .feed-tile-bullet { color: var(--accent, #58a6ff); animation: feed-pulse 1.5s ease-in-out infinite; }
@@ -2247,9 +2248,9 @@
     .feed-tile-picker { display: flex; flex-direction: column; height: 100%; padding: var(--space-md); gap: var(--space-sm); color: var(--text); }
     .feed-tile-picker-title { display: flex; align-items: center; justify-content: space-between; font-size: var(--text-sm); font-weight: 600; color: var(--text); padding-bottom: var(--space-xs); border-bottom: 1px solid var(--border); }
     .feed-tile-picker-list { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 2px; color: var(--text); font-size: var(--text-sm); }
-    .feed-tile-picker-toolbar { display: flex; gap: var(--space-xs); }
-    .feed-tile-picker-delete-btn { padding: 2px var(--space-sm); border: 1px solid var(--border); background: transparent; color: var(--text-secondary); border-radius: var(--radius-sm, 6px); cursor: pointer; font-size: var(--text-xs); }
-    .feed-tile-picker-delete-btn:hover { background: rgba(255,80,80,0.15); color: #f66; border-color: #f66; }
+    .feed-tile-picker-actionbar { display: flex; justify-content: flex-end; padding-top: var(--space-xs); border-top: 1px solid var(--border); }
+    .feed-tile-picker-delete-btn { display: inline-flex; align-items: center; gap: 4px; padding: var(--space-xs) var(--space-sm); border: none; background: transparent; color: var(--text-secondary); border-radius: var(--radius-sm, 6px); cursor: pointer; font-size: var(--text-xs); }
+    .feed-tile-picker-delete-btn:hover { background: rgba(255,80,80,0.15); color: #f66; }
     .feed-tile-picker-delete-btn:disabled { opacity: 0.5; cursor: default; }
     .feed-tile-picker-close-btn { background: none; border: none; color: var(--text-secondary); cursor: pointer; padding: 2px; font-size: 0.85rem; line-height: 1; border-radius: var(--radius-sm, 4px); margin-left: auto; }
     .feed-tile-picker-close-btn:hover { color: var(--text); background: var(--bg-hover, rgba(255,255,255,0.1)); }
@@ -2260,8 +2261,6 @@
     .feed-tile-picker-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--font-mono); }
     .feed-tile-picker-info { flex-shrink: 0; font-size: var(--text-xs); color: var(--text-secondary); }
     .feed-tile-picker-empty { padding: var(--space-lg) var(--space-sm); text-align: center; color: var(--text-secondary); font-size: var(--text-sm); }
-    .feed-tile-picker-refresh { align-self: center; margin-top: var(--space-sm); padding: var(--space-xs) var(--space-md); border: 1px solid var(--border); background: transparent; color: var(--text); border-radius: var(--radius-sm, 6px); cursor: pointer; font-size: var(--text-sm); }
-    .feed-tile-picker-refresh:hover { background: var(--bg-hover, rgba(255,255,255,0.12)); }
 
     /* --- Progress Tile --- */
     .progress-tile-root { display: flex; flex-direction: column; height: 100%; width: 100%; overflow: hidden; background: var(--bg); color: var(--text); font-family: var(--font-sans, -apple-system, sans-serif); font-size: var(--text-sm); }
@@ -2578,15 +2577,6 @@
 
           <!-- Remote tab content -->
           <div class="settings-tab-content" id="settings-tab-remote">
-            <div class="settings-row" style="flex-direction: column; align-items: stretch; gap: var(--space-xs);">
-              <span class="settings-label">Public URL</span>
-              <input type="url" id="public-url-input" class="palette-hex-input" style="width: 100%; box-sizing: border-box;"
-                     placeholder="https://myhost.example.com" spellcheck="false" autocomplete="off" />
-            </div>
-            <p class="tab-description" style="margin-top: 0;">
-              Your tunnel URL for remote access. Used by CLI tools and pub/sub.
-            </p>
-
             <div class="settings-row">
               <span class="settings-label">Port Proxy</span>
               <label class="toggle-switch">
@@ -2636,7 +2626,15 @@
 
           <!-- API tab content -->
           <div class="settings-tab-content" id="settings-tab-api">
-            <p class="tab-description" id="api-base-url"></p>
+            <div class="settings-row" style="flex-direction: column; align-items: stretch; gap: var(--space-xs);">
+              <span class="settings-label">Self-Access URL</span>
+              <input type="url" id="public-url-input" class="palette-hex-input" style="width: 100%; box-sizing: border-box;"
+                     placeholder="not detected yet" spellcheck="false" autocomplete="off" />
+            </div>
+            <p class="tab-description" style="margin-top: 0;">
+              Auto-detected from tunnel traffic. Override if the detected URL is wrong.
+            </p>
+
 
             <div class="token-create-form" id="apikey-create-form" style="display: none;">
               <div class="token-form-header"><h4>Generate new API key</h4></div>

--- a/public/index.html
+++ b/public/index.html
@@ -2615,19 +2615,14 @@
             <h4 style="margin-top: var(--space-xl); font-size: 0.875rem; color: var(--text-muted);">Claude Code Hooks</h4>
             <p class="tab-description" style="margin-top: 0;">
               Stream Claude Code activity (tool use, responses, subagents) to
-              Katulong's feed tiles. Add this to your Claude Code settings:
+              Katulong's feed tiles. Run this in your terminal:
             </p>
             <div class="claude-hooks-snippet" id="claude-hooks-snippet">
-              <pre style="margin: 0; white-space: pre-wrap; word-break: break-all; font-size: 0.7rem; line-height: 1.6;"></pre>
+              <pre style="margin: 0; font-size: 0.8rem; line-height: 1.6;">katulong setup claude-hooks</pre>
               <button class="claude-hooks-copy" id="claude-hooks-copy" title="Copy to clipboard">
                 <i class="ph ph-copy"></i>
               </button>
             </div>
-            <p class="tab-description" style="margin-top: 0.5rem;">
-              Paste into <code>~/.claude/settings.local.json</code> (global) or
-              <code>.claude/settings.local.json</code> (project).
-              Or run: <code>katulong setup claude-hooks</code>
-            </p>
           </div>
 
           <!-- API tab content -->

--- a/public/index.html
+++ b/public/index.html
@@ -2224,7 +2224,9 @@
     /* --- Feed Tile --- */
     .feed-tile-root { display: flex; flex-direction: column; height: 100%; width: 100%; overflow: hidden; background: var(--bg); color: var(--text); font-family: var(--font-sans, -apple-system, sans-serif); font-size: var(--text-sm); }
     .feed-tile-header { display: flex; align-items: center; gap: var(--space-sm); padding: var(--space-xs) var(--space-sm); border-bottom: 1px solid var(--border); flex-shrink: 0; background: var(--bg-surface); color: var(--text-secondary); font-size: var(--text-xs); font-weight: 600; min-width: 0; overflow: hidden; }
-    .feed-tile-header-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+    .feed-tile-header-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+    .feed-tile-back-btn, .feed-tile-close-btn { flex-shrink: 0; background: none; border: none; color: var(--text-secondary); cursor: pointer; padding: 2px; font-size: 0.85rem; line-height: 1; border-radius: var(--radius-sm, 4px); }
+    .feed-tile-back-btn:hover, .feed-tile-close-btn:hover { color: var(--text); background: var(--bg-hover, rgba(255,255,255,0.1)); }
     .feed-tile-badge { flex-shrink: 0; padding: 1px 6px; border-radius: 3px; background: var(--accent, #58a6ff); color: var(--bg); font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
     .feed-tile-list { flex: 1; overflow-y: auto; overflow-x: hidden; padding: var(--space-sm); outline: none; }
     .feed-tile-item { display: flex; flex-wrap: wrap; align-items: baseline; gap: var(--space-xs); padding: var(--space-xs) 0; min-width: 0; }
@@ -2249,10 +2251,12 @@
     .feed-tile-picker-delete-btn { padding: 2px var(--space-sm); border: 1px solid var(--border); background: transparent; color: var(--text-secondary); border-radius: var(--radius-sm, 6px); cursor: pointer; font-size: var(--text-xs); }
     .feed-tile-picker-delete-btn:hover { background: rgba(255,80,80,0.15); color: #f66; border-color: #f66; }
     .feed-tile-picker-delete-btn:disabled { opacity: 0.5; cursor: default; }
+    .feed-tile-picker-close-btn { background: none; border: none; color: var(--text-secondary); cursor: pointer; padding: 2px; font-size: 0.85rem; line-height: 1; border-radius: var(--radius-sm, 4px); margin-left: auto; }
+    .feed-tile-picker-close-btn:hover { color: var(--text); background: var(--bg-hover, rgba(255,255,255,0.1)); }
     .feed-tile-picker-item { display: flex; align-items: center; justify-content: space-between; gap: var(--space-sm); padding: var(--space-sm); border: none; background: var(--bg-surface, #313244); color: var(--text); font-size: var(--text-sm); border-radius: var(--radius-sm, 6px); cursor: pointer; text-align: left; width: 100%; }
     .feed-tile-picker-item:hover { background: var(--bg-hover, rgba(255,255,255,0.12)); }
     .feed-tile-picker-item.selected { background: rgba(255,255,255,0.08); }
-    .feed-tile-picker-cb { flex-shrink: 0; cursor: pointer; accent-color: var(--accent); }
+    .feed-tile-picker-cb { flex-shrink: 0; cursor: pointer; accent-color: var(--accent); width: 16px; height: 16px; margin: 0; }
     .feed-tile-picker-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--font-mono); }
     .feed-tile-picker-info { flex-shrink: 0; font-size: var(--text-xs); color: var(--text-secondary); }
     .feed-tile-picker-empty { padding: var(--space-lg) var(--space-sm); text-align: center; color: var(--text-secondary); font-size: var(--text-sm); }

--- a/public/index.html
+++ b/public/index.html
@@ -1651,6 +1651,24 @@
       margin-bottom: 1rem;
       line-height: 1.4;
     }
+    .claude-hooks-snippet {
+      position: relative;
+      background: var(--surface-raised);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: 0.75rem;
+      font-family: var(--font-mono);
+      color: var(--text-muted);
+      margin-bottom: 0.5rem;
+    }
+    .claude-hooks-copy {
+      position: absolute; top: 0.5rem; right: 0.5rem;
+      background: none; border: none; color: var(--text-muted);
+      cursor: pointer; padding: 0.25rem; border-radius: var(--radius-sm);
+      font-size: 1rem; line-height: 1;
+    }
+    .claude-hooks-copy:hover { color: var(--text); background: var(--border); }
+    .claude-hooks-copy.copied { color: var(--accent); }
     .tokens-list {
       max-height: 300px;
       overflow-y: auto;
@@ -2583,6 +2601,23 @@
             <button class="settings-pair-btn" id="settings-create-token">
               <i class="ph ph-plus"></i> Generate New Token
             </button>
+
+            <h4 style="margin-top: var(--space-xl); font-size: 0.875rem; color: var(--text-muted);">Claude Code Hooks</h4>
+            <p class="tab-description" style="margin-top: 0;">
+              Stream Claude Code activity (tool use, responses, subagents) to
+              Katulong's feed tiles. Add this to your Claude Code settings:
+            </p>
+            <div class="claude-hooks-snippet" id="claude-hooks-snippet">
+              <pre style="margin: 0; white-space: pre-wrap; word-break: break-all; font-size: 0.7rem; line-height: 1.6;"></pre>
+              <button class="claude-hooks-copy" id="claude-hooks-copy" title="Copy to clipboard">
+                <i class="ph ph-copy"></i>
+              </button>
+            </div>
+            <p class="tab-description" style="margin-top: 0.5rem;">
+              Paste into <code>~/.claude/settings.local.json</code> (global) or
+              <code>.claude/settings.local.json</code> (project).
+              Or run: <code>katulong setup claude-hooks</code>
+            </p>
           </div>
 
           <!-- API tab content -->

--- a/public/lib/joystick.js
+++ b/public/lib/joystick.js
@@ -12,6 +12,7 @@ export function createJoystickManager(options = {}) {
   let _onFilesClick = null;
   let _onUploadClick = null;
   let _onSettingsClick = null;
+  let _onFeedClick = null;
   let dotEl = null;
 
   function buildButtons() {
@@ -34,6 +35,9 @@ export function createJoystickManager(options = {}) {
     if (_onFilesClick) {
       joystick.appendChild(actionBtn("folder-open", "Files", _onFilesClick));
     }
+    if (_onFeedClick) {
+      joystick.appendChild(actionBtn("rss", "Claude feed", _onFeedClick));
+    }
     if (_onSettingsClick) {
       joystick.appendChild(actionBtn("gear", "Settings", _onSettingsClick));
     }
@@ -50,10 +54,11 @@ export function createJoystickManager(options = {}) {
       // No gesture handling needed — just buttons
     },
 
-    setActions({ onFilesClick, onUploadClick, onSettingsClick }) {
+    setActions({ onFilesClick, onUploadClick, onSettingsClick, onFeedClick }) {
       _onFilesClick = onFilesClick;
       _onUploadClick = onUploadClick;
       _onSettingsClick = onSettingsClick;
+      _onFeedClick = onFeedClick;
       buildButtons();
     },
 

--- a/public/lib/settings-handlers.js
+++ b/public/lib/settings-handlers.js
@@ -194,36 +194,22 @@ export function createSettingsHandlers(options = {}) {
     }
   }
 
-  /** Initialize Claude Code hooks snippet + copy button. */
+  /** Initialize Claude Code hooks copy button. */
   function initClaudeHooksSnippet() {
-    const snippet = document.getElementById("claude-hooks-snippet");
-    if (!snippet) return;
-    const pre = snippet.querySelector("pre");
     const copyBtn = document.getElementById("claude-hooks-copy");
+    if (!copyBtn) return;
 
-    const hookConfig = {
-      hooks: {
-        PostToolUse: [{ matcher: "*", hooks: [{ type: "command", command: "katulong relay-hook" }] }],
-        Stop: [{ matcher: "", hooks: [{ type: "command", command: "katulong relay-hook" }] }],
-        SubagentStart: [{ matcher: "", hooks: [{ type: "command", command: "katulong relay-hook" }] }],
-        SubagentStop: [{ matcher: "", hooks: [{ type: "command", command: "katulong relay-hook" }] }],
-      },
-    };
-    pre.textContent = JSON.stringify(hookConfig, null, 2);
-
-    if (copyBtn) {
-      copyBtn.addEventListener("click", async () => {
-        try {
-          await navigator.clipboard.writeText(JSON.stringify(hookConfig, null, 2));
-          copyBtn.classList.add("copied");
-          copyBtn.querySelector("i").className = "ph ph-check";
-          setTimeout(() => {
-            copyBtn.classList.remove("copied");
-            copyBtn.querySelector("i").className = "ph ph-copy";
-          }, 2000);
-        } catch { /* clipboard may be unavailable */ }
-      });
-    }
+    copyBtn.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText("katulong setup claude-hooks");
+        copyBtn.classList.add("copied");
+        copyBtn.querySelector("i").className = "ph ph-check";
+        setTimeout(() => {
+          copyBtn.classList.remove("copied");
+          copyBtn.querySelector("i").className = "ph ph-copy";
+        }, 2000);
+      } catch { /* clipboard may be unavailable */ }
+    });
   }
 
   async function init() {

--- a/public/lib/settings-handlers.js
+++ b/public/lib/settings-handlers.js
@@ -199,6 +199,13 @@ export function createSettingsHandlers(options = {}) {
     const input = document.getElementById("public-url-input");
     if (!input) return;
 
+    // Show current origin as placeholder so the user sees what's auto-detected
+    const isLocalhost = location.hostname === "localhost" ||
+                        location.hostname === "127.0.0.1" ||
+                        location.hostname === "::1";
+    if (!isLocalhost) {
+      input.placeholder = location.origin;
+    }
     input.value = config?.publicUrl || "";
 
     const save = async () => {

--- a/public/lib/settings-handlers.js
+++ b/public/lib/settings-handlers.js
@@ -194,6 +194,30 @@ export function createSettingsHandlers(options = {}) {
     }
   }
 
+  /** Initialize public URL input. */
+  function initPublicUrl(config) {
+    const input = document.getElementById("public-url-input");
+    if (!input) return;
+
+    input.value = config?.publicUrl || "";
+
+    const save = async () => {
+      const val = input.value.trim();
+      try {
+        await api.put("/api/config/public-url", { publicUrl: val });
+        input.classList.remove("invalid");
+      } catch {
+        input.classList.add("invalid");
+      }
+    };
+
+    input.addEventListener("change", save);
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") { e.preventDefault(); save(); }
+    });
+    input.addEventListener("input", () => input.classList.remove("invalid"));
+  }
+
   /** Initialize Claude Code hooks copy button. */
   function initClaudeHooksSnippet() {
     const copyBtn = document.getElementById("claude-hooks-copy");
@@ -220,6 +244,7 @@ export function createSettingsHandlers(options = {}) {
     } catch (error) {
       console.error("Failed to load config:", error);
     }
+    initPublicUrl(config);
     initPortProxyToggle(config);
     initPalettePicker();
     initPolarityToggle();

--- a/public/lib/settings-handlers.js
+++ b/public/lib/settings-handlers.js
@@ -194,6 +194,38 @@ export function createSettingsHandlers(options = {}) {
     }
   }
 
+  /** Initialize Claude Code hooks snippet + copy button. */
+  function initClaudeHooksSnippet() {
+    const snippet = document.getElementById("claude-hooks-snippet");
+    if (!snippet) return;
+    const pre = snippet.querySelector("pre");
+    const copyBtn = document.getElementById("claude-hooks-copy");
+
+    const hookConfig = {
+      hooks: {
+        PostToolUse: [{ matcher: "*", hooks: [{ type: "command", command: "katulong relay-hook" }] }],
+        Stop: [{ matcher: "", hooks: [{ type: "command", command: "katulong relay-hook" }] }],
+        SubagentStart: [{ matcher: "", hooks: [{ type: "command", command: "katulong relay-hook" }] }],
+        SubagentStop: [{ matcher: "", hooks: [{ type: "command", command: "katulong relay-hook" }] }],
+      },
+    };
+    pre.textContent = JSON.stringify(hookConfig, null, 2);
+
+    if (copyBtn) {
+      copyBtn.addEventListener("click", async () => {
+        try {
+          await navigator.clipboard.writeText(JSON.stringify(hookConfig, null, 2));
+          copyBtn.classList.add("copied");
+          copyBtn.querySelector("i").className = "ph ph-check";
+          setTimeout(() => {
+            copyBtn.classList.remove("copied");
+            copyBtn.querySelector("i").className = "ph ph-copy";
+          }, 2000);
+        } catch { /* clipboard may be unavailable */ }
+      });
+    }
+  }
+
   async function init() {
     let config = null;
     try {
@@ -209,6 +241,7 @@ export function createSettingsHandlers(options = {}) {
     syncPaletteControls();
     initLogout();
     initVersion();
+    initClaudeHooksSnippet();
   }
 
   return {

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -103,14 +103,30 @@ export const feedRenderer = {
     // ── Topic picker (inline) ───────────────────────────────────
     function showTopicPicker() {
       root.innerHTML = "";
+      const selected = new Set();
 
       const picker = document.createElement("div");
       picker.className = "feed-tile-picker";
 
-      const title = document.createElement("div");
-      title.className = "feed-tile-picker-title";
-      title.textContent = "Subscribe to a topic";
-      picker.appendChild(title);
+      // Header row with title + toolbar
+      const header = document.createElement("div");
+      header.className = "feed-tile-picker-title";
+
+      const titleText = document.createElement("span");
+      titleText.textContent = "Subscribe to a topic";
+      header.appendChild(titleText);
+
+      const toolbar = document.createElement("span");
+      toolbar.className = "feed-tile-picker-toolbar";
+      toolbar.style.display = "none";
+      header.appendChild(toolbar);
+
+      const deleteBtn = document.createElement("button");
+      deleteBtn.className = "feed-tile-picker-delete-btn";
+      deleteBtn.textContent = "Delete";
+      toolbar.appendChild(deleteBtn);
+
+      picker.appendChild(header);
 
       const listArea = document.createElement("div");
       listArea.className = "feed-tile-picker-list";
@@ -118,6 +134,34 @@ export const feedRenderer = {
       picker.appendChild(listArea);
 
       root.appendChild(picker);
+
+      function updateToolbar() {
+        const count = selected.size;
+        toolbar.style.display = count > 0 ? "" : "none";
+        deleteBtn.textContent = count === 1 ? "Delete" : `Delete (${count})`;
+      }
+
+      async function deleteSelected() {
+        deleteBtn.disabled = true;
+        deleteBtn.textContent = "Deleting\u2026";
+        const csrf = document.querySelector('meta[name="csrf-token"]')?.content;
+        const headers = { "Content-Type": "application/json" };
+        if (csrf) headers["x-csrf-token"] = csrf;
+
+        for (const topic of selected) {
+          try {
+            await fetch(`/api/topics/${encodeURIComponent(topic)}`, {
+              method: "DELETE", credentials: "same-origin", redirect: "error", headers,
+            });
+          } catch { /* continue with others */ }
+        }
+        showTopicPicker();
+      }
+
+      deleteBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        deleteSelected();
+      });
 
       // Fetch topics and populate
       fetch("/api/topics", { credentials: "same-origin", redirect: "error" })
@@ -129,8 +173,19 @@ export const feedRenderer = {
 
           if (topics.length > 0) {
             for (const t of topics) {
-              const item = document.createElement("button");
+              const item = document.createElement("div");
               item.className = "feed-tile-picker-item";
+
+              const cb = document.createElement("input");
+              cb.type = "checkbox";
+              cb.className = "feed-tile-picker-cb";
+              cb.addEventListener("click", (e) => e.stopPropagation());
+              cb.addEventListener("change", () => {
+                if (cb.checked) selected.add(t.name); else selected.delete(t.name);
+                item.classList.toggle("selected", cb.checked);
+                updateToolbar();
+              });
+              item.appendChild(cb);
 
               const name = document.createElement("span");
               name.className = "feed-tile-picker-name";

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -24,6 +24,15 @@ function renderProgressItem(row, msg) {
   const status = msg.status || "info";
   row.className = `feed-tile-item feed-status-${status}`;
 
+  // Assistant text renders as a standalone narrative block
+  if (status === "text") {
+    const text = document.createElement("span");
+    text.className = "feed-tile-step feed-tile-assistant-text";
+    text.textContent = msg.step || "";
+    row.appendChild(text);
+    return;
+  }
+
   const bullet = document.createElement("span");
   bullet.className = "feed-tile-bullet";
   bullet.textContent = status === "done" ? "\u25CF"
@@ -83,6 +92,7 @@ export const feedRenderer = {
   mount(el, { id, props, dispatch, ctx }) {
     let mounted = true;
     let es = null;
+    const cleanups = [];
 
     const root = document.createElement("div");
     root.className = "feed-tile-root";
@@ -122,16 +132,6 @@ export const feedRenderer = {
       titleText.textContent = "Subscribe to a topic";
       header.appendChild(titleText);
 
-      const toolbar = document.createElement("span");
-      toolbar.className = "feed-tile-picker-toolbar";
-      toolbar.style.display = "none";
-      header.appendChild(toolbar);
-
-      const deleteBtn = document.createElement("button");
-      deleteBtn.className = "feed-tile-picker-delete-btn";
-      deleteBtn.textContent = "Delete";
-      toolbar.appendChild(deleteBtn);
-
       const closeBtn = document.createElement("button");
       closeBtn.className = "feed-tile-picker-close-btn";
       closeBtn.innerHTML = '<i class="ph ph-x"></i>';
@@ -149,12 +149,25 @@ export const feedRenderer = {
       listArea.textContent = "Loading topics\u2026";
       picker.appendChild(listArea);
 
+      // Bottom action bar — visible only when items are checked
+      const actionBar = document.createElement("div");
+      actionBar.className = "feed-tile-picker-actionbar";
+      actionBar.style.display = "none";
+      picker.appendChild(actionBar);
+
+      const deleteBtn = document.createElement("button");
+      deleteBtn.className = "feed-tile-picker-delete-btn";
+      deleteBtn.innerHTML = '<i class="ph ph-trash"></i> Delete';
+      actionBar.appendChild(deleteBtn);
+
       root.appendChild(picker);
 
       function updateToolbar() {
         const count = selected.size;
-        toolbar.style.display = count > 0 ? "" : "none";
-        deleteBtn.textContent = count === 1 ? "Delete" : `Delete (${count})`;
+        actionBar.style.display = count > 0 ? "" : "none";
+        deleteBtn.innerHTML = count === 1
+          ? '<i class="ph ph-trash"></i> Delete'
+          : `<i class="ph ph-trash"></i> Delete ${count}`;
       }
 
       async function deleteSelected() {
@@ -179,7 +192,64 @@ export const feedRenderer = {
         deleteSelected();
       });
 
-      // Fetch topics and populate
+      // Track known topic names so we don't add duplicates on live updates
+      const knownTopics = new Set();
+      let emptyEl = null;
+
+      function createTopicItem(t) {
+        if (knownTopics.has(t.name)) return;
+        knownTopics.add(t.name);
+
+        // Remove "no topics" placeholder if present
+        if (emptyEl) { emptyEl.remove(); emptyEl = null; }
+
+        const item = document.createElement("div");
+        item.className = "feed-tile-picker-item";
+
+        const cb = document.createElement("input");
+        cb.type = "checkbox";
+        cb.className = "feed-tile-picker-cb";
+        cb.addEventListener("click", (e) => e.stopPropagation());
+        cb.addEventListener("change", () => {
+          if (cb.checked) selected.add(t.name); else selected.delete(t.name);
+          item.classList.toggle("selected", cb.checked);
+          updateToolbar();
+        });
+        item.appendChild(cb);
+
+        const name = document.createElement("span");
+        name.className = "feed-tile-picker-name";
+        name.textContent = t.name;
+        item.appendChild(name);
+
+        const info = document.createElement("span");
+        info.className = "feed-tile-picker-info";
+        const parts = [];
+        if (t.meta && t.meta.type) parts.push(t.meta.type);
+        parts.push(`${t.messages || 0} msgs`);
+        info.textContent = parts.join(" \u00b7 ");
+        item.appendChild(info);
+
+        item.addEventListener("click", () => {
+          if (!mounted) return;
+          if (dispatch) {
+            dispatch({ type: "ui/UPDATE_PROPS", id, patch: { topic: t.name, title: t.name, meta: t.meta || {} } });
+          }
+          startStreaming(t.name, t.meta || {});
+        });
+
+        listArea.appendChild(item);
+      }
+
+      // Listen for new topics via WebSocket
+      function onTopicNew(e) {
+        if (!mounted) return;
+        createTopicItem({ name: e.detail.topic, meta: e.detail.meta, messages: 0 });
+      }
+      window.addEventListener("katulong:topic-new", onTopicNew);
+      cleanups.push(() => window.removeEventListener("katulong:topic-new", onTopicNew));
+
+      // Fetch existing topics
       fetch("/api/topics", { credentials: "same-origin", redirect: "error" })
         .then(r => r.ok ? r.json() : [])
         .catch(() => [])
@@ -188,56 +258,13 @@ export const feedRenderer = {
           listArea.textContent = "";
 
           if (topics.length > 0) {
-            for (const t of topics) {
-              const item = document.createElement("div");
-              item.className = "feed-tile-picker-item";
-
-              const cb = document.createElement("input");
-              cb.type = "checkbox";
-              cb.className = "feed-tile-picker-cb";
-              cb.addEventListener("click", (e) => e.stopPropagation());
-              cb.addEventListener("change", () => {
-                if (cb.checked) selected.add(t.name); else selected.delete(t.name);
-                item.classList.toggle("selected", cb.checked);
-                updateToolbar();
-              });
-              item.appendChild(cb);
-
-              const name = document.createElement("span");
-              name.className = "feed-tile-picker-name";
-              name.textContent = t.name;
-              item.appendChild(name);
-
-              const info = document.createElement("span");
-              info.className = "feed-tile-picker-info";
-              const parts = [];
-              if (t.meta && t.meta.type) parts.push(t.meta.type);
-              parts.push(`${t.messages || 0} msgs`);
-              info.textContent = parts.join(" \u00b7 ");
-              item.appendChild(info);
-
-              item.addEventListener("click", () => {
-                if (!mounted) return;
-                if (dispatch) {
-                  dispatch({ type: "ui/UPDATE_PROPS", id, patch: { topic: t.name, title: t.name, meta: t.meta || {} } });
-                }
-                startStreaming(t.name, t.meta || {});
-              });
-
-              listArea.appendChild(item);
-            }
+            for (const t of topics) createTopicItem(t);
           } else {
-            const empty = document.createElement("div");
-            empty.className = "feed-tile-picker-empty";
-            empty.textContent = "No topics yet. Publish events to create one.";
-            listArea.appendChild(empty);
+            emptyEl = document.createElement("div");
+            emptyEl.className = "feed-tile-picker-empty";
+            emptyEl.textContent = "No topics yet. Publish events to create one.";
+            listArea.appendChild(emptyEl);
           }
-
-          const refreshBtn = document.createElement("button");
-          refreshBtn.className = "feed-tile-picker-refresh";
-          refreshBtn.textContent = "Refresh";
-          refreshBtn.addEventListener("click", () => { if (mounted) showTopicPicker(); });
-          listArea.appendChild(refreshBtn);
         });
     }
 
@@ -262,13 +289,6 @@ export const feedRenderer = {
       headerTitle.className = "feed-tile-header-title";
       headerTitle.textContent = topic;
       header.appendChild(headerTitle);
-
-      if (topicMeta.type) {
-        const badge = document.createElement("span");
-        badge.className = "feed-tile-badge";
-        badge.textContent = topicMeta.type;
-        header.appendChild(badge);
-      }
 
       const closeBtn = document.createElement("button");
       closeBtn.className = "feed-tile-close-btn";
@@ -328,6 +348,7 @@ export const feedRenderer = {
       unmount() {
         mounted = false;
         if (es) es.close();
+        for (const fn of cleanups) fn();
         el.innerHTML = "";
       },
       focus() {

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -72,7 +72,7 @@ export const feedRenderer = {
     return {
       title: props.title || props.topic || "Feed",
       icon: "rss",
-      persistable: !!props.topic, // only persist once a topic is chosen
+      persistable: true,
       session: null,
       updatesUrl: false,
       renameable: false,
@@ -102,8 +102,14 @@ export const feedRenderer = {
 
     // ── Topic picker (inline) ───────────────────────────────────
     function showTopicPicker() {
+      if (es) { es.close(); es = null; }
       root.innerHTML = "";
       const selected = new Set();
+
+      // Clear persisted topic so we're back to picker state
+      if (dispatch) {
+        dispatch({ type: "ui/UPDATE_PROPS", id, patch: { topic: null, title: "Feed", meta: {} } });
+      }
 
       const picker = document.createElement("div");
       picker.className = "feed-tile-picker";
@@ -125,6 +131,16 @@ export const feedRenderer = {
       deleteBtn.className = "feed-tile-picker-delete-btn";
       deleteBtn.textContent = "Delete";
       toolbar.appendChild(deleteBtn);
+
+      const closeBtn = document.createElement("button");
+      closeBtn.className = "feed-tile-picker-close-btn";
+      closeBtn.innerHTML = '<i class="ph ph-x"></i>';
+      closeBtn.title = "Close";
+      closeBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        ctx?.requestClose?.();
+      });
+      header.appendChild(closeBtn);
 
       picker.appendChild(header);
 
@@ -235,6 +251,13 @@ export const feedRenderer = {
       const header = document.createElement("div");
       header.className = "feed-tile-header";
 
+      const backBtn = document.createElement("button");
+      backBtn.className = "feed-tile-back-btn";
+      backBtn.innerHTML = '<i class="ph ph-arrow-left"></i>';
+      backBtn.title = "Back to topics";
+      backBtn.addEventListener("click", () => { if (mounted) showTopicPicker(); });
+      header.appendChild(backBtn);
+
       const headerTitle = document.createElement("span");
       headerTitle.className = "feed-tile-header-title";
       headerTitle.textContent = topic;
@@ -246,6 +269,13 @@ export const feedRenderer = {
         badge.textContent = topicMeta.type;
         header.appendChild(badge);
       }
+
+      const closeBtn = document.createElement("button");
+      closeBtn.className = "feed-tile-close-btn";
+      closeBtn.innerHTML = '<i class="ph ph-x"></i>';
+      closeBtn.title = "Close";
+      closeBtn.addEventListener("click", () => ctx?.requestClose?.());
+      header.appendChild(closeBtn);
 
       root.appendChild(header);
 

--- a/public/lib/ws-message-handlers.js
+++ b/public/lib/ws-message-handlers.js
@@ -153,6 +153,14 @@ export const wsMessageHandlers = {
     };
   },
 
+  'topic-new'(msg, ctx) {
+    // Dispatch DOM event so feed tile pickers can update live
+    window.dispatchEvent(new CustomEvent('katulong:topic-new', {
+      detail: { topic: msg.topic, meta: msg.meta },
+    }));
+    return { stateUpdates: {}, effects: [] };
+  },
+
   'device-auth-request'(msg, ctx) {
     return {
       stateUpdates: {},

--- a/server.js
+++ b/server.js
@@ -269,7 +269,7 @@ const routes = [
     shortcutsPath: join(DATA_DIR, "shortcuts.json"),
     auth, csrf,
     topicBroker: createTopicBroker(),
-    getExternalUrl: () => _lastExternalUrl,
+    getExternalUrl: () => configManager.getPublicUrl() || _lastExternalUrl,
   }),
   ...createFileBrowserRoutes({ json, parseJSON, auth, csrf }),
   ...createPortProxyRoutes({ auth, PORT, configManager }),

--- a/server.js
+++ b/server.js
@@ -269,7 +269,7 @@ const routes = [
     shortcutsPath: join(DATA_DIR, "shortcuts.json"),
     auth, csrf,
     topicBroker: createTopicBroker(),
-    getExternalUrl: () => configManager.getPublicUrl() || _lastExternalUrl,
+    getExternalUrl: () => configManager.getPublicUrl(),
   }),
   ...createFileBrowserRoutes({ json, parseJSON, auth, csrf }),
   ...createPortProxyRoutes({ auth, PORT, configManager }),
@@ -287,16 +287,15 @@ function matchRoute(method, pathname) {
   return null;
 }
 
-// Track the last-seen external URL (from tunnel/remote connections)
-let _lastExternalUrl = null;
-
 async function handleRequest(req, res) {
   const { pathname } = new URL(req.url, `http://${req.headers.host}`);
 
-  // Capture external URL from non-localhost requests
-  if (!isLocalRequest(req) && req.headers.host) {
+  // Auto-detect external URL from tunnel traffic and persist to config.
+  // Only writes if publicUrl is not already set (user override wins).
+  if (!isLocalRequest(req) && req.headers.host && !configManager.getPublicUrl()) {
     const proto = isHttpsConnection(req) ? "https" : "http";
-    _lastExternalUrl = `${proto}://${req.headers.host}`;
+    const detected = `${proto}://${req.headers.host}`;
+    configManager.setPublicUrl(detected).catch(() => {});
   }
 
   // Apply security headers to every response

--- a/test/feed-tile.test.js
+++ b/test/feed-tile.test.js
@@ -13,6 +13,8 @@ class FakeElement {
     this.dataset = {};
     this.tabIndex = -1;
     this._listeners = {};
+    this.style = {};
+    this.classList = { toggle() {}, add() {}, remove() {} };
     this.innerHTML = "";
     this.scrollHeight = 0;
     this.scrollTop = 0;
@@ -131,8 +133,9 @@ describe("feedRenderer", () => {
 
       // Title should say "Subscribe to a topic"
       assert.ok(picker.children.length >= 1);
-      assert.equal(picker.children[0].className, "feed-tile-picker-title");
-      assert.equal(picker.children[0].textContent, "Subscribe to a topic");
+      const titleEl = picker.children[0];
+      assert.equal(titleEl.className, "feed-tile-picker-title");
+      assert.equal(titleEl.children[0].textContent, "Subscribe to a topic");
 
       // List area with loading text
       const listArea = picker.children[1];

--- a/test/feed-tile.test.js
+++ b/test/feed-tile.test.js
@@ -98,14 +98,9 @@ describe("feedRenderer", () => {
       assert.equal(d.title, "My Feed");
     });
 
-    it("is not persistable without a topic", () => {
-      const d = feedRenderer.describe({});
-      assert.equal(d.persistable, false);
-    });
-
-    it("is persistable with a topic", () => {
-      const d = feedRenderer.describe({ topic: "some/topic" });
-      assert.equal(d.persistable, true);
+    it("is always persistable", () => {
+      assert.equal(feedRenderer.describe({}).persistable, true);
+      assert.equal(feedRenderer.describe({ topic: "some/topic" }).persistable, true);
     });
   });
 
@@ -167,7 +162,7 @@ describe("feedRenderer", () => {
       assert.ok(eventSources[0].url.includes("fromSeq=0"));
     });
 
-    it("renders header with topic name", () => {
+    it("renders header with back button, topic name, and close button", () => {
       const el = new FakeElement("div");
       feedRenderer.mount(el, {
         id: "feed-1",
@@ -179,7 +174,10 @@ describe("feedRenderer", () => {
       const root = el.children[0];
       const header = root.children[0];
       assert.equal(header.className, "feed-tile-header");
-      assert.equal(header.children[0].textContent, "my/topic");
+      // [backBtn, title, closeBtn]
+      assert.equal(header.children[0].className, "feed-tile-back-btn");
+      assert.equal(header.children[1].textContent, "my/topic");
+      assert.equal(header.children[2].className, "feed-tile-close-btn");
     });
 
     it("renders badge when meta.type is set", () => {
@@ -193,10 +191,10 @@ describe("feedRenderer", () => {
 
       const root = el.children[0];
       const header = root.children[0];
-      // Second child should be the badge
-      assert.equal(header.children.length, 2);
-      assert.equal(header.children[1].className, "feed-tile-badge");
-      assert.equal(header.children[1].textContent, "progress");
+      // [backBtn, title, badge, closeBtn]
+      assert.equal(header.children.length, 4);
+      assert.equal(header.children[2].className, "feed-tile-badge");
+      assert.equal(header.children[2].textContent, "progress");
     });
 
     it("does not render badge when no meta.type", () => {
@@ -210,7 +208,8 @@ describe("feedRenderer", () => {
 
       const root = el.children[0];
       const header = root.children[0];
-      assert.equal(header.children.length, 1); // just the title span
+      // [backBtn, title, closeBtn] — no badge
+      assert.equal(header.children.length, 3);
     });
 
     it("processes SSE events via onmessage", () => {

--- a/test/feed-tile.test.js
+++ b/test/feed-tile.test.js
@@ -180,7 +180,7 @@ describe("feedRenderer", () => {
       assert.equal(header.children[2].className, "feed-tile-close-btn");
     });
 
-    it("renders badge when meta.type is set", () => {
+    it("header has back button, title, and close button", () => {
       const el = new FakeElement("div");
       feedRenderer.mount(el, {
         id: "feed-1",
@@ -191,25 +191,11 @@ describe("feedRenderer", () => {
 
       const root = el.children[0];
       const header = root.children[0];
-      // [backBtn, title, badge, closeBtn]
-      assert.equal(header.children.length, 4);
-      assert.equal(header.children[2].className, "feed-tile-badge");
-      assert.equal(header.children[2].textContent, "progress");
-    });
-
-    it("does not render badge when no meta.type", () => {
-      const el = new FakeElement("div");
-      feedRenderer.mount(el, {
-        id: "feed-1",
-        props: { topic: "t", meta: {} },
-        dispatch: () => {},
-        ctx: {},
-      });
-
-      const root = el.children[0];
-      const header = root.children[0];
-      // [backBtn, title, closeBtn] — no badge
+      // [backBtn, title, closeBtn]
       assert.equal(header.children.length, 3);
+      assert.equal(header.children[0].className, "feed-tile-back-btn");
+      assert.equal(header.children[1].textContent, "t");
+      assert.equal(header.children[2].className, "feed-tile-close-btn");
     });
 
     it("processes SSE events via onmessage", () => {


### PR DESCRIPTION
## Summary

- Add `katulong relay-hook` CLI command that dynamically resolves the server URL from `~/.katulong/server.json` (localhost) or `~/.katulong/remote.json` (tunnel + API key) instead of requiring a hardcoded port in hook config
- Replace `"type": "http", "url": "http://localhost:<port>"` hooks with `"type": "command", "command": "katulong relay-hook"` — no more ECONNREFUSED errors when port changes
- Silent failure by design — hooks never block Claude Code

## Test plan

- [x] `echo '{"test":true}' | katulong relay-hook` exits 0 with running server
- [x] `KATULONG_DATA_DIR=/tmp/nonexistent | katulong relay-hook` exits 0 (graceful fallback)
- [x] Full test suite passes (2026 tests, 0 failures)
- [ ] Verify events appear in feed tile after switching to command hooks