### PR TITLE
fix: persist feed tile checkbox state across refresh

### DIFF
--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -114,9 +114,11 @@ export const feedRenderer = {
     function showTopicPicker() {
       if (es) { es.close(); es = null; }
       root.innerHTML = "";
-      const selected = new Set();
 
-      // Clear persisted topic so we're back to picker state
+      // Restore checked state from persisted props
+      const selected = new Set(props.checked || []);
+
+      // Clear persisted topic so we're back to picker state (keep checked)
       if (dispatch) {
         dispatch({ type: "ui/UPDATE_PROPS", id, patch: { topic: null, title: "Feed", meta: {} } });
       }
@@ -184,6 +186,11 @@ export const feedRenderer = {
             });
           } catch { /* continue with others */ }
         }
+        // Clear deleted topics from persisted checked state
+        if (dispatch) {
+          props.checked = [];
+          dispatch({ type: "ui/UPDATE_PROPS", id, patch: { checked: [] } });
+        }
         showTopicPicker();
       }
 
@@ -210,10 +217,20 @@ export const feedRenderer = {
         cb.type = "checkbox";
         cb.className = "feed-tile-picker-cb";
         cb.addEventListener("click", (e) => e.stopPropagation());
+        // Restore checked state from persisted selection
+        if (selected.has(t.name)) {
+          cb.checked = true;
+          item.classList.add("selected");
+        }
         cb.addEventListener("change", () => {
           if (cb.checked) selected.add(t.name); else selected.delete(t.name);
           item.classList.toggle("selected", cb.checked);
           updateToolbar();
+          // Persist checked state to tile props
+          if (dispatch) {
+            props.checked = [...selected];
+            dispatch({ type: "ui/UPDATE_PROPS", id, patch: { checked: [...selected] } });
+          }
         });
         item.appendChild(cb);
 
@@ -259,6 +276,7 @@ export const feedRenderer = {
 
           if (topics.length > 0) {
             for (const t of topics) createTopicItem(t);
+            updateToolbar();
           } else {
             emptyEl = document.createElement("div");
             emptyEl.className = "feed-tile-picker-empty";

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -188,7 +188,6 @@ export const feedRenderer = {
         }
         // Clear deleted topics from persisted checked state
         if (dispatch) {
-          props.checked = [];
           dispatch({ type: "ui/UPDATE_PROPS", id, patch: { checked: [] } });
         }
         showTopicPicker();
@@ -228,7 +227,6 @@ export const feedRenderer = {
           updateToolbar();
           // Persist checked state to tile props
           if (dispatch) {
-            props.checked = [...selected];
             dispatch({ type: "ui/UPDATE_PROPS", id, patch: { checked: [...selected] } });
           }
         });
@@ -276,13 +274,21 @@ export const feedRenderer = {
 
           if (topics.length > 0) {
             for (const t of topics) createTopicItem(t);
-            updateToolbar();
           } else {
             emptyEl = document.createElement("div");
             emptyEl.className = "feed-tile-picker-empty";
             emptyEl.textContent = "No topics yet. Publish events to create one.";
             listArea.appendChild(emptyEl);
           }
+
+          // Prune stale topic names that no longer exist on the server
+          for (const name of selected) {
+            if (!knownTopics.has(name)) selected.delete(name);
+          }
+          if (dispatch) {
+            dispatch({ type: "ui/UPDATE_PROPS", id, patch: { checked: [...selected] } });
+          }
+          updateToolbar();
         });
     }
 

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -282,10 +282,11 @@ export const feedRenderer = {
           }
 
           // Prune stale topic names that no longer exist on the server
+          let pruned = false;
           for (const name of selected) {
-            if (!knownTopics.has(name)) selected.delete(name);
+            if (!knownTopics.has(name)) { selected.delete(name); pruned = true; }
           }
-          if (dispatch) {
+          if (pruned && dispatch) {
             dispatch({ type: "ui/UPDATE_PROPS", id, patch: { checked: [...selected] } });
           }
           updateToolbar();


### PR DESCRIPTION
## Summary
- Feed tile topic picker checkmarks were lost on refresh or navigation (back/forward into feed view)
- Checkbox state is now persisted in tile props (`checked` array) via the ui-store → localStorage pipeline
- Restored on render, cleared on batch-delete

## Test plan
- [ ] Open feed tile, check several topics — refresh page — checkmarks should still be checked
- [ ] Check topics, click into a feed, click back — checkmarks preserved
- [ ] Check topics, delete them — checkmarks cleared, picker refreshes clean
- [ ] Action bar (delete button) shows correctly on load when items are pre-checked