### PR TITLE
feat: pure selectors + navigation, kill state.session.name

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -46,8 +46,8 @@
     import { createUiStore, loadFromStorage, EMPTY_STATE } from "/lib/ui-store.js";
     import { initRenderers, isPersistable, getRenderer } from "/lib/tile-renderers/index.js";
     import { createTileHost } from "/lib/tile-host.js";
-    import { getFocusedSession, getTileSession } from "/lib/selectors.js";
-    import { navigateTab as _navigateTab, moveTab as _moveTab, jumpToTab as _jumpToTab } from "/lib/navigation.js";
+    import { getFocusedSession } from "/lib/selectors.js";
+    import { navigateTab as computeNavigateTab, moveTab as computeMoveTab, jumpToTab as computeJumpToTab } from "/lib/navigation.js";
 
     // --- Modal Manager ---
     const modals = new ModalRegistry();
@@ -147,9 +147,8 @@
     // --- Terminal pool ---
     // One xterm.js Terminal per managed session, visibility-toggled on switch.
 
-    // Late-bound ref — uiStore is created after the pool, but file link
-    // clicks only happen after full boot, so the ref is always populated.
-    let _uiStoreRef = null;
+    // _uiStore is also used by onFileLinkClick below — both closures
+    // share the same late-bound ref, assigned when createUiStore() runs.
 
     const terminalPool = createTerminalPool({
       parentEl: document.getElementById("terminal-container"),
@@ -157,7 +156,7 @@
         cm.send(JSON.stringify({ type: "resize", session: sessionName, cols, rows }));
       },
       onFileLinkClick: async (_event, filePath) => {
-        if (!_uiStoreRef) return;
+        if (!_uiStore) return;
         // Defense-in-depth: reject paths with traversal segments
         if (filePath.split("/").some(seg => seg === "..")) return;
         // Resolve relative paths against the active session's CWD
@@ -172,7 +171,7 @@
           }
         }
         const docId = `doc-${Date.now().toString(36)}`;
-        _uiStoreRef.addTile(
+        _uiStore.addTile(
           { id: docId, type: "document", props: { filePath: resolved } },
           { focus: true, insertAt: "afterFocus" },
         );
@@ -345,7 +344,6 @@
     // document tiles adjacent to the browser tile on single-click.
     const uiStore = createUiStore({ isPersistable });
     _uiStore = uiStore;
-    _uiStoreRef = uiStore;
 
     // Initialize the renderer registry with shared deps. This must happen
     // before any tile mount — renderers wrap the existing tile factories.
@@ -982,21 +980,20 @@
 
     // --- Keyboard shortcuts (Cmd+Shift+[/], Cmd+?) ---
 
-    // Navigation functions are pure (state → action). Dispatch the
-    // returned action; tile-host's onFocusChange handles WS bookkeeping.
+    // Navigation helpers: pure function → dispatch.
+    // tile-host's onFocusChange handles WS bookkeeping after dispatch.
     function navigateTab(direction) {
-      const action = _navigateTab(uiStore.getState(), direction);
+      const action = computeNavigateTab(uiStore.getState(), direction);
       if (action) uiStore.dispatch(action);
     }
 
     function moveTab(direction) {
-      const action = _moveTab(uiStore.getState(), direction);
+      const action = computeMoveTab(uiStore.getState(), direction);
       if (action) uiStore.dispatch(action);
     }
 
-    // Positional tab jump — Option+1..9 → tabs 1..9, Option+0 → tab 10.
     function jumpToTab(position) {
-      const action = _jumpToTab(uiStore.getState(), position);
+      const action = computeJumpToTab(uiStore.getState(), position);
       if (action) uiStore.dispatch(action);
     }
 
@@ -1982,6 +1979,19 @@
         if (shortcutBarInstance) shortcutBarInstance.renameTabEl(e.oldName, e.newName);
       },
       tabRename: (e) => windowTabSet.renameTab(e.oldName, e.newName),
+      // Update ui-store tile so getActiveSessionName() returns the new name.
+      // Mirrors the onTabRenamed path (shortcut-bar initiated rename).
+      uiStoreRename: (e) => {
+        const st = uiStore.getState();
+        const oldTile = st.tiles[e.oldName];
+        if (!oldTile) return;
+        const wasFocused = st.focusedId === e.oldName;
+        uiStore.removeTile(e.oldName);
+        uiStore.addTile(
+          { id: e.newName, type: oldTile.type, props: { ...oldTile.props, sessionName: e.newName } },
+          { focus: wasFocused },
+        );
+      },
       resizeSync: () => {
         // Another client resized the shared PTY. Recalculate our own
         // dimensions via fitActiveTerminal (font + rows from THIS viewport).

--- a/public/app.js
+++ b/public/app.js
@@ -46,6 +46,8 @@
     import { createUiStore, loadFromStorage, EMPTY_STATE } from "/lib/ui-store.js";
     import { initRenderers, isPersistable, getRenderer } from "/lib/tile-renderers/index.js";
     import { createTileHost } from "/lib/tile-host.js";
+    import { getFocusedSession, getTileSession } from "/lib/selectors.js";
+    import { navigateTab as _navigateTab, moveTab as _moveTab, jumpToTab as _jumpToTab } from "/lib/navigation.js";
 
     // --- Modal Manager ---
     const modals = new ModalRegistry();
@@ -78,40 +80,21 @@
 
     // --- State ---
 
-    // --- Centralized application state (at edge) ---
+    // URL ?s= hint — used only for boot, not as ongoing state.
     const explicitSession = new URLSearchParams(location.search).get("s");
-    const createAppState = () => {
-      const initialSessionName = explicitSession || null;
 
-      return {
-        session: {
-          name: initialSessionName,
-          shortcuts: []
-        },
-        scroll: {
-          userScrolledUpBeforeDisconnect: false
-        },
-        // Controlled state updates
-        update(path, value) {
-          const keys = path.split('.');
-          let obj = this;
-          for (let i = 0; i < keys.length - 1; i++) {
-            obj = obj[keys[i]];
-          }
-          obj[keys[keys.length - 1]] = value;
-          return this;
-        },
-        // Batch updates
-        updateMany(updates) {
-          Object.entries(updates).forEach(([path, value]) => {
-            this.update(path, value);
-          });
-          return this;
-        }
-      };
+    // Transient scroll state — will move to connection-store in a follow-up PR.
+    let scrolledUpBeforeDisconnect = false;
+
+    // Derive the active session name from ui-store + renderer registry.
+    // Replaces the old mutable `state.session.name` — the source of truth
+    // is now uiStore.focusedId, and the session name is a derived value.
+    // Late-bound: _uiStore is assigned when createUiStore() runs below.
+    let _uiStore = null;
+    const getActiveSessionName = () => {
+      if (!_uiStore) return null;
+      return getFocusedSession(_uiStore.getState(), getRenderer);
     };
-
-    const state = createAppState();
 
     let shortcutBarInstance = null;
     const getInstanceIcon = () => "terminal-window";
@@ -159,7 +142,7 @@
       document.title = INSTANCE_HOST ? `${base} · ${INSTANCE_HOST}` : base;
     };
 
-    setDocTitle(state.session.name);
+    setDocTitle(explicitSession);
 
     // --- Terminal pool ---
     // One xterm.js Terminal per managed session, visibility-toggled on switch.
@@ -180,7 +163,7 @@
         // Resolve relative paths against the active session's CWD
         let resolved = filePath;
         if (!filePath.startsWith("/")) {
-          const sessionName = state.session.name;
+          const sessionName = getActiveSessionName();
           if (sessionName) {
             try {
               const data = await api.get(`/sessions/cwd/${encodeURIComponent(sessionName)}`);
@@ -306,7 +289,7 @@
             sessionIcons.delete(currentName);
           }
           // Re-render tabs to show the new icon
-          if (shortcutBarInstance) shortcutBarInstance.render(state.session.name);
+          if (shortcutBarInstance) shortcutBarInstance.render(getActiveSessionName());
           // Notify server so other clients see the change
           cm.send(JSON.stringify({ type: "set-tab-icon", session: currentName, icon: iconName || null }));
           return true; // handled
@@ -361,6 +344,7 @@
     // Create ui-store first — the file-browser renderer needs it to open
     // document tiles adjacent to the browser tile on single-click.
     const uiStore = createUiStore({ isPersistable });
+    _uiStore = uiStore;
     _uiStoreRef = uiStore;
 
     // Initialize the renderer registry with shared deps. This must happen
@@ -448,7 +432,7 @@
           // Re-render the shortcut bar so tile-provided labels (file
           // browser tracks its cwd, future tiles may have dynamic titles)
           // flow into tab labels via getSessionList()/tile.getTitle().
-          if (shortcutBarInstance) shortcutBarInstance.render(state.session.name);
+          if (shortcutBarInstance) shortcutBarInstance.render(getActiveSessionName());
         },
         setIcon(_icon) {
           // Future: update tab icon dynamically
@@ -469,7 +453,6 @@
         // each tile, handling WS unsubscribe generically.
         uiStore.reset(EMPTY_STATE);
         cm.disconnect();
-        state.update('session.name', null);
         setDocTitle(null);
         const url = new URL(window.location);
         url.searchParams.delete("s");
@@ -502,7 +485,6 @@
         document.body.dataset.focusedNeedsWs = desc.session ? "1" : "0";
 
         if (desc.session) {
-          state.update("session.name", desc.session);
           setDocTitle(desc.session);
 
           const connReady = cm.getState().status === "ready";
@@ -531,7 +513,7 @@
           cm.send(JSON.stringify({ type: "unsubscribe", session: sessionName }));
         }
         // Legacy shortcut bar re-render
-        if (shortcutBarInstance) shortcutBarInstance.render(state.session.name);
+        if (shortcutBarInstance) shortcutBarInstance.render(getActiveSessionName());
       },
     });
 
@@ -738,7 +720,7 @@
     // Create buffered input sender
     const inputSender = createInputSender({
       sendFn: (payload) => cm.send(payload),
-      getSession: () => state.session.name,
+      getSession: () => getActiveSessionName(),
       onInput: () => {},
     });
 
@@ -753,7 +735,7 @@
     // When no explicit ?s= param, activation is deferred until we
     // resolve which session to attach to (or none).
     if (explicitSession) {
-      terminalPool.activate(state.session.name);
+      terminalPool.activate(explicitSession);
     }
 
     // --- Layout ---
@@ -837,9 +819,9 @@
 
     // --- Session manager (render takes data) ---
 
-    const sessionStore = createSessionStore(state.session.name);
+    const sessionStore = createSessionStore(explicitSession);
     const windowTabSet = createWindowTabSet({
-      getCurrentSession: () => state.session.name,
+      getCurrentSession: () => getActiveSessionName(),
       // When another browser window kills a session, tear it down fully in
       // this window: carousel card, pooled terminal, WS unsubscribe. Without
       // this, reorderCards only reorders — it re-appends missing ids — so
@@ -854,7 +836,7 @@
     // session in the gap between page load and the first /sessions response.
     // The TTL ensures a stale ?s= URL bookmark eventually becomes prunable.
     if (explicitSession) {
-      windowTabSet.addTab(state.session.name);
+      windowTabSet.addTab(explicitSession);
     }
 
     // Create session list component
@@ -880,7 +862,7 @@
       !window.matchMedia("(pointer: coarse) and (min-width: 768px)").matches;
 
     function loadSidebarData() {
-      invalidateSessions(sessionStore, state.session.name);
+      invalidateSessions(sessionStore, getActiveSessionName());
     }
 
     function setOverlaySidebar(open) {
@@ -934,7 +916,7 @@
     async function createNewSession() {
       try {
         const name = `session-${Date.now().toString(36)}`;
-        const data = await api.post("/sessions", { name, copyFrom: state.session.name });
+        const data = await api.post("/sessions", { name, copyFrom: getActiveSessionName() });
         if (sidebar?.classList.contains("collapsed")) {
           setSidebarCollapsed(false);
         }
@@ -982,7 +964,7 @@
     }
 
     function switchSession(name) {
-      if (name === state.session.name) return;
+      if (name === getActiveSessionName()) return;
       const url = new URL(window.location);
       url.searchParams.set("s", name);
       history.pushState(null, "", url);
@@ -993,57 +975,35 @@
     window.addEventListener("popstate", () => {
       const name = new URLSearchParams(location.search).get("s");
       if (!name) return; // bare URL without ?s= — stay on current session
-      if (name !== state.session.name) activateSession(name);
+      if (name !== getActiveSessionName()) activateSession(name);
     });
 
     const openSessionManager = () => toggleSidebar();
 
     // --- Keyboard shortcuts (Cmd+Shift+[/], Cmd+?) ---
 
+    // Navigation functions are pure (state → action). Dispatch the
+    // returned action; tile-host's onFocusChange handles WS bookkeeping.
     function navigateTab(direction) {
-      // Use carousel order (source of truth) when active, fall back to tab set
-      const tabs = carousel.isActive() ? carousel.getCards() : windowTabSet.getTabs();
-      if (tabs.length <= 1) return;
-      const idx = tabs.indexOf(state.session.name);
-      if (idx === -1) return;
-      switchSession(tabs[(idx + direction + tabs.length) % tabs.length]);
+      const action = _navigateTab(uiStore.getState(), direction);
+      if (action) uiStore.dispatch(action);
     }
 
     function moveTab(direction) {
-      const tabs = uiStore.getState().order;
-      if (tabs.length <= 1) return;
-      const idx = tabs.indexOf(state.session.name);
-      if (idx === -1) return;
-      const newIdx = idx + direction;
-      if (newIdx < 0 || newIdx >= tabs.length) return; // don't wrap
-      const reordered = [...tabs];
-      [reordered[idx], reordered[newIdx]] = [reordered[newIdx], reordered[idx]];
-      // Route through ui-store — tile-host drives carousel.reorderCards
-      uiStore.reorder(reordered);
+      const action = _moveTab(uiStore.getState(), direction);
+      if (action) uiStore.dispatch(action);
     }
 
     // Positional tab jump — Option+1..9 → tabs 1..9, Option+0 → tab 10.
-    // Silently no-ops if the target index doesn't exist (e.g., Option+7 with
-    // only 4 tabs open). Pure positional; deliberately does NOT implement the
-    // Chrome "Cmd+9 = last tab" trick, because we also expose Option+0 as
-    // "tab 10" — mixing "last" and "10th" would be inconsistent.
     function jumpToTab(position) {
-      const tabs = carousel.isActive() ? carousel.getCards() : windowTabSet.getTabs();
-      const idx = position - 1;
-      if (idx < 0 || idx >= tabs.length) return;
-      const name = tabs[idx];
-      if (name === state.session.name) return;
-      if (carousel.isActive()) {
-        routeToSession(name);
-      } else {
-        switchSession(name);
-      }
+      const action = _jumpToTab(uiStore.getState(), position);
+      if (action) uiStore.dispatch(action);
     }
 
     function renameCurrentSession() {
-      const name = state.session.name;
-      if (!name || !shortcutBarInstance) return;
-      shortcutBarInstance.beginRename(name);
+      const focusedId = uiStore.getState().focusedId;
+      if (!focusedId || !shortcutBarInstance) return;
+      shortcutBarInstance.beginRename(focusedId);
     }
 
     /**
@@ -1072,18 +1032,18 @@
     }
 
     function removeFocusedSessionFromUI() {
-      const name = state.session.name;
-      if (!name) return { name: null, hasNext: false };
-      const currentId = carousel.isActive() ? (carousel.getFocusedCard() || name) : name;
-      const hasNext = !!pickRightNeighbor(name);
+      const focusedId = uiStore.getState().focusedId;
+      if (!focusedId) return { id: null, sessionName: null, hasNext: false };
+      const sessionName = getActiveSessionName();
+      const hasNext = !!pickRightNeighbor(focusedId);
       // Route through ui-store — tile-host's reconcile handles carousel
       // removal, unmount, and onTileRemoved (WS cleanup, pool dispose).
-      uiStore.removeTile(currentId);
+      uiStore.removeTile(focusedId);
       if (!hasNext && shortcutBarInstance) {
         const addBtn = document.querySelector(".ipad-add-btn, .tab-add-btn");
         shortcutBarInstance.showAddMenu(addBtn);
       }
-      return { name, hasNext };
+      return { id: focusedId, sessionName, hasNext };
     }
 
     function closeCurrentSession() {
@@ -1091,11 +1051,11 @@
     }
 
     async function killCurrentSession() {
-      const { name } = removeFocusedSessionFromUI();
-      if (!name) return;
+      const { sessionName } = removeFocusedSessionFromUI();
+      if (!sessionName) return;
       // Kill on server (best-effort — may fail if disconnected)
       try {
-        await api.delete(`/sessions/${encodeURIComponent(name)}`);
+        await api.delete(`/sessions/${encodeURIComponent(sessionName)}`);
       } catch { /* disconnected or already dead — that's fine */ }
     }
 
@@ -1457,13 +1417,9 @@
             { focus: true },
           );
         }
-        if (state.session.name === oldName) {
-          state.update('session.name', newName);
-          setDocTitle(newName);
-          const url = new URL(window.location);
-          url.searchParams.set("s", newName);
-          history.replaceState(null, "", url);
-        }
+        // URL and doc title are updated reactively by the ui-store
+        // subscription (URL sync) and onFocusChange callback.
+        setDocTitle(newName);
       },
       onAdoptSession: async (name) => {
         windowTabSet.addTab(name);
@@ -1480,13 +1436,12 @@
       onFilesClick: () => openFileBrowserTile(),
       onPortForwardClick: () => openLocalhostBrowserTile(),
       onSettingsClick: () => modals.open('settings'),
-      onShortcutsClick: () => openShortcutsPopup(state.session.shortcuts),
+      onShortcutsClick: () => openShortcutsPopup(shortcutsStore.getState()),
       onDictationClick: () => openDictationModal(),
       onAllTabsClosed: () => {
         // Hide all terminal panes, disconnect WS, clear state
         terminalPool.forEach((name) => terminalPool.dispose(name));
         cm.disconnect();
-        state.update('session.name', null);
         setDocTitle(null);
         const url = new URL(window.location);
         url.searchParams.delete("s");
@@ -1538,8 +1493,8 @@
         { id: newName, type: tile.type, props: { ...tile.props, sessionName: newName } },
         { focus: uiState.focusedId === id },
       );
-      if (state.session.name === oldName) {
-        state.update("session.name", newName);
+      // Doc title updates reactively via onFocusChange
+      if (getActiveSessionName() === oldName || uiStore.getState().focusedId === id) {
         setDocTitle(newName);
       }
     });
@@ -1596,7 +1551,7 @@
 
     // Re-render bar if pointer capability changes (e.g., external mouse connected)
     window.matchMedia("(pointer: fine)").addEventListener("change", () => {
-      shortcutBarInstance.render(state.session.name);
+      shortcutBarInstance.render(getActiveSessionName());
     });
 
     const renderBar = (name) => shortcutBarInstance.render(name);
@@ -1615,12 +1570,9 @@
     });
 
     // Subscribe to shortcuts changes to re-render bar
-    shortcutsStore.subscribe((shortcuts) => {
-      // Update legacy state object (for backward compatibility)
-      state.update('session.shortcuts', shortcuts);
-
+    shortcutsStore.subscribe(() => {
       // Re-render bar when shortcuts change
-      renderBar(state.session.name);
+      renderBar(getActiveSessionName());
     });
 
 
@@ -1629,7 +1581,7 @@
     const uploadImageToTerminal = (file, sessionName) => uploadImageToTerminalFn(file, {
       onSend: rawSend,
       toast: showToast,
-      sessionName: sessionName || state.session.name,
+      sessionName: sessionName || getActiveSessionName(),
       sendFn: (msg) => cm.send(msg)
     });
 
@@ -1647,7 +1599,7 @@
         uploadImagesToTerminalFn(files, {
           onSend: rawSend,
           toast: showToast,
-          sessionName: state.session.name,
+          sessionName: getActiveSessionName(),
           sendFn: (msg) => cm.send(msg),
         });
       }
@@ -1676,7 +1628,7 @@
           return;
         }
         // Upload in parallel, paste via single server request
-        uploadImagesToTerminalFn(imageFiles, { onSend: rawSend, toast: showToast, sessionName: state.session.name, sendFn: (msg) => cm.send(msg) });
+        uploadImagesToTerminalFn(imageFiles, { onSend: rawSend, toast: showToast, sessionName: getActiveSessionName(), sendFn: (msg) => cm.send(msg) });
       }
     });
 
@@ -1685,7 +1637,7 @@
     // --- Global paste ---
 
     const pasteHandler = createPasteHandler({
-      getSession: () => state.session.name,
+      getSession: () => getActiveSessionName(),
       onImage: uploadImageToTerminal,
       // Use xterm.js paste() so text is wrapped in bracketed paste
       // markers (\x1b[200~…\x1b[201~) when the app has enabled it.
@@ -1721,7 +1673,7 @@
      *  previous "focus existing" shortcut was removed because it
      *  conflicts with the multi-instance file-browser UX. */
     async function openFileBrowserTile() {
-      const sessionName = state.session.name;
+      const sessionName = getActiveSessionName();
       let cwd = "";
       if (sessionName) {
         try {
@@ -1752,7 +1704,7 @@
 
     /** Open a feed tile for the Claude session running in the current terminal. */
     async function openClaudeFeedTile() {
-      const sessionName = state.session.name;
+      const sessionName = getActiveSessionName();
       try {
         const topics = await api.get("/api/topics");
         // Find the most recent Claude topic matching this terminal session
@@ -1812,7 +1764,7 @@
       if (notepad.isActive()) {
         notepad.hide();
       } else {
-        notepad.show(state.session.name);
+        notepad.show(getActiveSessionName());
       }
     }
 
@@ -1843,7 +1795,7 @@
       ensureHelmMounted();
       termContainer.classList.add("helm-hidden");
       helmViewEl.classList.add("active");
-      helmComponent.showSession(state.session.name);
+      helmComponent.showSession(getActiveSessionName());
       helmComponent.focus();
     }
 
@@ -1856,12 +1808,13 @@
     function toggleHelmView() {
       if (helmViewEl.classList.contains("active")) {
         hideHelmView();
-      } else if (helmActiveSessions.has(state.session.name)) {
+      } else if (helmActiveSessions.has(getActiveSessionName())) {
         showHelmView();
       }
     }
 
     function onHelmModeChanged(effect) {
+      const activeSession = getActiveSessionName();
       if (effect.active) {
         helmActiveSessions.add(effect.session);
         ensureHelmMounted();
@@ -1871,7 +1824,7 @@
           cwd: effect.cwd,
         });
         // Auto-switch to helm view if this is the active session
-        if (effect.session === state.session.name) {
+        if (effect.session === activeSession) {
           showHelmView();
         }
       } else {
@@ -1881,12 +1834,12 @@
           error: effect.error,
         });
         // If viewing helm for this session and it ended, switch back to terminal
-        if (effect.session === state.session.name && helmViewEl.classList.contains("active")) {
+        if (effect.session === activeSession && helmViewEl.classList.contains("active")) {
           hideHelmView();
         }
       }
       // Re-render the tab bar to show/hide helm indicator
-      renderBar(state.session.name);
+      renderBar(activeSession);
     }
 
     // --- Connection Manager ---
@@ -2010,7 +1963,7 @@
       },
       sessionRemoved: (e) => {
         const name = e.name;
-        const wasFocused = state.session.name === name;
+        const wasFocused = uiStore.getState().focusedId === name;
         const next = wasFocused ? pickRightNeighbor(name) : null;
         removeDeadSession(name);
         if (!wasFocused) return;
@@ -2045,7 +1998,7 @@
         } else {
           sessionIcons.delete(e.session);
         }
-        if (shortcutBarInstance) shortcutBarInstance.render(state.session.name);
+        if (shortcutBarInstance) shortcutBarInstance.render(getActiveSessionName());
       },
       openTab: (e) => {
         windowTabSet.addTab(e.session);
@@ -2198,19 +2151,15 @@
       if (!handler) return;
 
       const { stateUpdates, effects } = handler(msg, {
-        currentSessionName: state.session.name,
-        scroll: state.scroll,
+        currentSessionName: getActiveSessionName(),
+        scroll: { userScrolledUpBeforeDisconnect: scrolledUpBeforeDisconnect },
       });
 
-      // Apply state updates — filter out connection.* keys since connection
-      // state is now managed by the connection store, not the app state object.
-      if (stateUpdates && Object.keys(stateUpdates).length > 0) {
-        const filtered = {};
-        for (const [key, value] of Object.entries(stateUpdates)) {
-          if (!key.startsWith("connection.")) filtered[key] = value;
-        }
-        if (Object.keys(filtered).length > 0) {
-          state.updateMany(filtered);
+      // Apply state updates — session.name updates are now no-ops (derived
+      // from uiStore.focusedId). Only scroll state is still mutable here.
+      if (stateUpdates) {
+        if ('scroll.userScrolledUpBeforeDisconnect' in stateUpdates) {
+          scrolledUpBeforeDisconnect = stateUpdates['scroll.userScrolledUpBeforeDisconnect'];
         }
       }
 
@@ -2225,7 +2174,7 @@
 
     /** When transport is ready, send the attach message. */
     function handleTransportReady(transport) {
-      const sessionName = state.session.name;
+      const sessionName = getActiveSessionName();
       if (sessionName) {
         const term = getTerm();
         cm.send(JSON.stringify({
@@ -2239,7 +2188,7 @@
 
     // Create connection manager (replaces createWebSocketConnection + createNetworkMonitor)
     const cm = createConnectionManager({
-      getSessionName: () => state.session.name,
+      getSessionName: () => getActiveSessionName(),
       onMessage: handleWsMessage,
       onTransportReady: handleTransportReady,
     });
@@ -2340,7 +2289,7 @@
     cm.subscribe((connState) => {
       if (connState.status === "disconnected") {
         const term = getTerm();
-        state.scroll.userScrolledUpBeforeDisconnect = term ? !isAtBottom(term) : false;
+        scrolledUpBeforeDisconnect = term ? !isAtBottom(term) : false;
         pulls.clear();
         // Clean up WebRTC peer and retry timer on disconnect
         clearRtcRetry();
@@ -2403,7 +2352,6 @@
      *  removal path (onSessionRemoved) and the reconciler call this. */
     function clearFocusedSessionUI() {
       cm.disconnect();
-      state.update('session.name', null);
       setDocTitle(null);
       const url = new URL(window.location);
       url.searchParams.delete("s");
@@ -2480,7 +2428,7 @@
       reconcilePruneConfirmations = 0;
       lastDeadKey = "";
 
-      const wasFocusedDead = dead.has(state.session.name);
+      const wasFocusedDead = dead.has(uiStore.getState().focusedId);
       for (const name of dead) {
         removeDeadSession(name);
       }
@@ -2589,16 +2537,16 @@
     function bootFromState(bootState) {
       if (Object.keys(bootState.tiles).length === 0) return;
 
-      // Set active session for WS bookkeeping — capability-driven
+      // Set doc title from the focused tile's session (if any)
       const focused = bootState.tiles[bootState.focusedId];
       const desc = describeTile(focused);
       if (desc.session) {
-        state.update("session.name", desc.session);
         setDocTitle(desc.session);
       }
 
       // Single dispatch — tile-host is already subscribed (init'd
       // unconditionally above) and will pick up the state change.
+      // getActiveSessionName() will derive session from focusedId after this.
       uiStore.reset(bootState);
       cm.connect();
     }
@@ -2610,7 +2558,7 @@
     // With an empty store, reconcile is a no-op; once tiles arrive
     // (via RESET or ADD_TILE), the subscription picks them up.
     tileHost.init();
-    renderBar(state.session.name || "");
+    renderBar(getActiveSessionName() || "");
 
     if (!explicitSession && !wasEmptyState) {
       // No URL hint — check for persisted tiles first, then fall back to
@@ -2624,7 +2572,7 @@
           if (!r.ok) throw new Error(`HTTP ${r.status}`);
           return r.json();
         }).then(sessions => {
-          if (cm.getState().status !== "disconnected" || state.session.name !== null) return;
+          if (cm.getState().status !== "disconnected" || uiStore.getState().focusedId !== null) return;
           if (sessions.length > 0 && sessions[0].name) {
             const name = sessions[0].name;
             bootState.tiles[name] = { id: name, type: "terminal", props: { sessionName: name } };

--- a/public/lib/navigation.js
+++ b/public/lib/navigation.js
@@ -1,0 +1,67 @@
+/**
+ * Navigation — pure functions for tile tab navigation.
+ *
+ * Each function takes ui-store state and returns an action object
+ * (or null if the navigation is a no-op). The caller dispatches
+ * the action to the store; side effects (WS bookkeeping, URL sync)
+ * flow from store subscriptions.
+ *
+ * Pure: (uiState, ...args) => action | null.
+ */
+
+import { FOCUS_TILE, REORDER } from "./ui-store.js";
+
+/**
+ * Navigate to the next/previous tile in order.
+ * direction: +1 (right/next) or -1 (left/previous). Wraps around.
+ *
+ * @param {object} uiState — from uiStore.getState()
+ * @param {number} direction — +1 or -1
+ * @returns {{ type: string, id: string } | null}
+ */
+export function navigateTab(uiState, direction) {
+  const { order, focusedId } = uiState;
+  if (order.length <= 1) return null;
+  const idx = order.indexOf(focusedId);
+  if (idx === -1) return null;
+  const nextId = order[(idx + direction + order.length) % order.length];
+  if (nextId === focusedId) return null;
+  return { type: FOCUS_TILE, id: nextId };
+}
+
+/**
+ * Move the focused tile one position in the given direction.
+ * Does not wrap — stops at edges.
+ *
+ * @param {object} uiState
+ * @param {number} direction — +1 or -1
+ * @returns {{ type: string, order: string[] } | null}
+ */
+export function moveTab(uiState, direction) {
+  const { order, focusedId } = uiState;
+  if (order.length <= 1) return null;
+  const idx = order.indexOf(focusedId);
+  if (idx === -1) return null;
+  const newIdx = idx + direction;
+  if (newIdx < 0 || newIdx >= order.length) return null;
+  const reordered = [...order];
+  [reordered[idx], reordered[newIdx]] = [reordered[newIdx], reordered[idx]];
+  return { type: REORDER, order: reordered };
+}
+
+/**
+ * Jump to the tile at a 1-based position (Option+1 = first tile, etc.).
+ * No-ops if the position is out of range or already focused.
+ *
+ * @param {object} uiState
+ * @param {number} position — 1-based index
+ * @returns {{ type: string, id: string } | null}
+ */
+export function jumpToTab(uiState, position) {
+  const { order, focusedId } = uiState;
+  const idx = position - 1;
+  if (idx < 0 || idx >= order.length) return null;
+  const targetId = order[idx];
+  if (targetId === focusedId) return null;
+  return { type: FOCUS_TILE, id: targetId };
+}

--- a/public/lib/selectors.js
+++ b/public/lib/selectors.js
@@ -1,0 +1,68 @@
+/**
+ * Selectors — pure functions that derive values from store state.
+ *
+ * These replace the mutable `state.session.name` pattern. Instead of
+ * storing the "current session" as a side-effected variable, we derive
+ * it on-demand from the ui-store's focusedId and the renderer registry.
+ *
+ * Every function here is pure: (state, ...deps) => value.
+ * No side effects, no mutations, no subscriptions.
+ */
+
+/** The ID of the currently focused tile, or null. */
+export const getFocusedTileId = (uiState) => uiState.focusedId;
+
+/** The full tile object { id, type, props, x } for the focused tile, or null. */
+export const getFocusedTile = (uiState) =>
+  uiState.tiles[uiState.focusedId] || null;
+
+/** The type string of the focused tile (e.g. "terminal", "feed"), or null. */
+export const getFocusedTileType = (uiState) =>
+  uiState.tiles[uiState.focusedId]?.type || null;
+
+/**
+ * The tmux session name for the focused tile, or null.
+ *
+ * Only terminal and cluster tiles have a session — feed, file-browser,
+ * localhost-browser, and progress tiles return null. Callers that need
+ * to send WS messages (attach, switch, resize, subscribe) should use
+ * this selector and guard against null.
+ *
+ * @param {object} uiState — from uiStore.getState()
+ * @param {function} getRenderer — from tile-renderers/index.js
+ * @returns {string|null}
+ */
+export function getFocusedSession(uiState, getRenderer) {
+  const tile = uiState.tiles[uiState.focusedId];
+  if (!tile) return null;
+  const renderer = getRenderer(tile.type);
+  if (!renderer) return null;
+  return renderer.describe(tile.props).session || null;
+}
+
+/**
+ * The tmux session name for any tile by ID, or null.
+ *
+ * @param {object} uiState
+ * @param {string} tileId
+ * @param {function} getRenderer
+ * @returns {string|null}
+ */
+export function getTileSession(uiState, tileId, getRenderer) {
+  const tile = uiState.tiles[tileId];
+  if (!tile) return null;
+  const renderer = getRenderer(tile.type);
+  if (!renderer) return null;
+  return renderer.describe(tile.props).session || null;
+}
+
+/**
+ * Whether the focused tile needs a WebSocket connection (has a session).
+ *
+ * @param {object} uiState
+ * @param {function} getRenderer
+ * @returns {boolean}
+ */
+export function focusedTileNeedsWs(uiState, getRenderer) {
+  return getFocusedSession(uiState, getRenderer) !== null;
+}

--- a/public/lib/selectors.js
+++ b/public/lib/selectors.js
@@ -9,17 +9,6 @@
  * No side effects, no mutations, no subscriptions.
  */
 
-/** The ID of the currently focused tile, or null. */
-export const getFocusedTileId = (uiState) => uiState.focusedId;
-
-/** The full tile object { id, type, props, x } for the focused tile, or null. */
-export const getFocusedTile = (uiState) =>
-  uiState.tiles[uiState.focusedId] || null;
-
-/** The type string of the focused tile (e.g. "terminal", "feed"), or null. */
-export const getFocusedTileType = (uiState) =>
-  uiState.tiles[uiState.focusedId]?.type || null;
-
 /**
  * The tmux session name for the focused tile, or null.
  *
@@ -38,31 +27,4 @@ export function getFocusedSession(uiState, getRenderer) {
   const renderer = getRenderer(tile.type);
   if (!renderer) return null;
   return renderer.describe(tile.props).session || null;
-}
-
-/**
- * The tmux session name for any tile by ID, or null.
- *
- * @param {object} uiState
- * @param {string} tileId
- * @param {function} getRenderer
- * @returns {string|null}
- */
-export function getTileSession(uiState, tileId, getRenderer) {
-  const tile = uiState.tiles[tileId];
-  if (!tile) return null;
-  const renderer = getRenderer(tile.type);
-  if (!renderer) return null;
-  return renderer.describe(tile.props).session || null;
-}
-
-/**
- * Whether the focused tile needs a WebSocket connection (has a session).
- *
- * @param {object} uiState
- * @param {function} getRenderer
- * @returns {boolean}
- */
-export function focusedTileNeedsWs(uiState, getRenderer) {
-  return getFocusedSession(uiState, getRenderer) !== null;
 }

--- a/public/lib/ws-message-handlers.js
+++ b/public/lib/ws-message-handlers.js
@@ -125,6 +125,7 @@ export const wsMessageHandlers = {
         { type: 'notepadRename', oldName: ctx.currentSessionName, newName: msg.name },
         { type: 'shortcutBarRename', oldName: ctx.currentSessionName, newName: msg.name },
         { type: 'tabRename', oldName: ctx.currentSessionName, newName: msg.name },
+        { type: 'uiStoreRename', oldName: ctx.currentSessionName, newName: msg.name },
         { type: 'invalidateSessions', name: msg.name },
         { type: 'updateSessionUI', name: msg.name },
       ],

--- a/test/tab-order-sync.test.js
+++ b/test/tab-order-sync.test.js
@@ -1,8 +1,11 @@
 /**
- * Tests for tab order sync — carousel as source of truth
+ * Tests for tab order sync — ui-store as source of truth
  *
  * Verifies:
- * - navigateTab logic uses carousel order when carousel is active
+ * - navigateTab uses uiStore order and focusedId (pure function)
+ * - navigateTab works for non-terminal tiles (feed, file-browser)
+ * - moveTab reorders tiles in ui-store order
+ * - jumpToTab jumps to specific positions
  * - Tab bar session list uses carousel order when carousel is active
  * - windowTabSet syncs to carousel order after restore
  * - Drag reorder through windowTabSet syncs carousel via subscriber
@@ -33,6 +36,7 @@ globalThis.BroadcastChannel = class {
 };
 
 const { createWindowTabSet } = await import("../public/lib/window-tab-set.js");
+const { navigateTab, moveTab, jumpToTab } = await import("../public/lib/navigation.js");
 
 function makeTabSet(initialTabs = []) {
   stores.session = {};
@@ -51,16 +55,13 @@ function mockCarousel(cards, active = true) {
   };
 }
 
-/**
- * Extracted navigateTab logic — mirrors app.js implementation.
- * Uses carousel order when active, falls back to windowTabSet.
- */
-function navigateTab(direction, carousel, windowTabSet, currentSession) {
-  const tabs = carousel.isActive() ? carousel.getCards() : windowTabSet.getTabs();
-  if (tabs.length <= 1) return null;
-  const idx = tabs.indexOf(currentSession);
-  if (idx === -1) return null;
-  return tabs[(idx + direction + tabs.length) % tabs.length];
+/** Build a minimal uiState for navigation tests */
+function mockUiState(order, focusedId) {
+  const tiles = {};
+  for (const id of order) {
+    tiles[id] = { id, type: "terminal", props: {} };
+  }
+  return { order, focusedId, tiles };
 }
 
 /**
@@ -73,62 +74,120 @@ function getSessionList(carousel, windowTabSet, allSessions) {
   return tabNames.map(n => sessionMap.get(n) || { name: n }).filter(Boolean);
 }
 
-describe("navigateTab with carousel as source of truth", () => {
+describe("navigateTab — pure function using uiStore state", () => {
   beforeEach(() => {
     stores.session = {};
     stores.local = {};
   });
 
-  it("uses carousel order when carousel is active", () => {
-    const carousel = mockCarousel(["c", "a", "b"]);
-    const ts = makeTabSet(["a", "b", "c"]);
-
-    // From "a", next (+1) should go to "b" in carousel order [c, a, b]
-    const next = navigateTab(+1, carousel, ts, "a");
-    assert.equal(next, "b");
+  it("navigates to next tile by focusedId", () => {
+    const state = mockUiState(["c", "a", "b"], "a");
+    const action = navigateTab(state, +1);
+    assert.equal(action.id, "b");
   });
 
-  it("uses carousel order for previous tab", () => {
-    const carousel = mockCarousel(["c", "a", "b"]);
-    const ts = makeTabSet(["a", "b", "c"]);
-
-    // From "a", prev (-1) should go to "c" in carousel order [c, a, b]
-    const prev = navigateTab(-1, carousel, ts, "a");
-    assert.equal(prev, "c");
+  it("navigates to previous tile by focusedId", () => {
+    const state = mockUiState(["c", "a", "b"], "a");
+    const action = navigateTab(state, -1);
+    assert.equal(action.id, "c");
   });
 
-  it("wraps around at end of carousel", () => {
-    const carousel = mockCarousel(["c", "a", "b"]);
-    const ts = makeTabSet(["a", "b", "c"]);
-
-    // From "b" (last in carousel), next (+1) should wrap to "c"
-    const next = navigateTab(+1, carousel, ts, "b");
-    assert.equal(next, "c");
+  it("wraps around at end of order", () => {
+    const state = mockUiState(["c", "a", "b"], "b");
+    const action = navigateTab(state, +1);
+    assert.equal(action.id, "c");
   });
 
-  it("falls back to windowTabSet when carousel is inactive", () => {
-    const carousel = mockCarousel(["c", "a", "b"], false);
-    const ts = makeTabSet(["a", "b", "c"]);
-
-    // From "a", next (+1) should go to "b" in tab set order [a, b, c]
-    const next = navigateTab(+1, carousel, ts, "a");
-    assert.equal(next, "b");
+  it("wraps around at start of order", () => {
+    const state = mockUiState(["c", "a", "b"], "c");
+    const action = navigateTab(state, -1);
+    assert.equal(action.id, "b");
   });
 
-  it("returns null when current session is not in list", () => {
-    const carousel = mockCarousel(["a", "b"]);
-    const ts = makeTabSet(["a", "b"]);
-
-    const next = navigateTab(+1, carousel, ts, "unknown");
-    assert.equal(next, null);
+  it("returns null when focusedId is not in order", () => {
+    const state = mockUiState(["a", "b"], "unknown");
+    const action = navigateTab(state, +1);
+    assert.equal(action, null);
   });
 
-  it("returns null when only one tab", () => {
-    const carousel = mockCarousel(["a"]);
-    const ts = makeTabSet(["a"]);
+  it("returns null when only one tile", () => {
+    const state = mockUiState(["a"], "a");
+    const action = navigateTab(state, +1);
+    assert.equal(action, null);
+  });
 
-    const next = navigateTab(+1, carousel, ts, "a");
-    assert.equal(next, null);
+  it("works with non-terminal tile IDs (feed, file-browser)", () => {
+    // This is the key bug fix — tile IDs like "feed-abc123" are used
+    // as focusedId, not session names. Old code would fail here because
+    // state.session.name would hold a terminal session name, not the
+    // feed tile's ID.
+    const state = mockUiState(["session-1", "feed-abc123", "session-2"], "feed-abc123");
+    const action = navigateTab(state, +1);
+    assert.equal(action.id, "session-2");
+  });
+
+  it("navigates backward from non-terminal tile", () => {
+    const state = mockUiState(["session-1", "feed-abc123", "session-2"], "feed-abc123");
+    const action = navigateTab(state, -1);
+    assert.equal(action.id, "session-1");
+  });
+
+  it("wraps from non-terminal tile at end", () => {
+    const state = mockUiState(["session-1", "feed-abc123"], "feed-abc123");
+    const action = navigateTab(state, +1);
+    assert.equal(action.id, "session-1");
+  });
+});
+
+describe("moveTab — pure function using uiStore state", () => {
+  it("swaps focused tile with its right neighbor", () => {
+    const state = mockUiState(["a", "b", "c"], "b");
+    const action = moveTab(state, +1);
+    assert.deepEqual(action.order, ["a", "c", "b"]);
+  });
+
+  it("swaps focused tile with its left neighbor", () => {
+    const state = mockUiState(["a", "b", "c"], "b");
+    const action = moveTab(state, -1);
+    assert.deepEqual(action.order, ["b", "a", "c"]);
+  });
+
+  it("returns null at left edge (no wrap)", () => {
+    const state = mockUiState(["a", "b", "c"], "a");
+    const action = moveTab(state, -1);
+    assert.equal(action, null);
+  });
+
+  it("returns null at right edge (no wrap)", () => {
+    const state = mockUiState(["a", "b", "c"], "c");
+    const action = moveTab(state, +1);
+    assert.equal(action, null);
+  });
+});
+
+describe("jumpToTab — pure function using uiStore state", () => {
+  it("jumps to position 1 (first tile)", () => {
+    const state = mockUiState(["a", "b", "c"], "c");
+    const action = jumpToTab(state, 1);
+    assert.equal(action.id, "a");
+  });
+
+  it("jumps to position 3 (third tile)", () => {
+    const state = mockUiState(["a", "b", "c"], "a");
+    const action = jumpToTab(state, 3);
+    assert.equal(action.id, "c");
+  });
+
+  it("returns null when already at target position", () => {
+    const state = mockUiState(["a", "b", "c"], "a");
+    const action = jumpToTab(state, 1);
+    assert.equal(action, null);
+  });
+
+  it("returns null for out-of-range position", () => {
+    const state = mockUiState(["a", "b"], "a");
+    const action = jumpToTab(state, 5);
+    assert.equal(action, null);
   });
 });
 
@@ -182,7 +241,6 @@ describe("windowTabSet syncs to carousel order after restore", () => {
     const ts = makeTabSet(["a", "b", "c"]);
     assert.deepEqual(ts.getTabs(), ["a", "b", "c"]);
 
-    // Simulate carousel restoring with different order
     const carouselOrder = ["c", "a", "b"];
     ts.reorderTabs(carouselOrder);
 
@@ -192,10 +250,8 @@ describe("windowTabSet syncs to carousel order after restore", () => {
   it("reorderTabs drops tabs not in windowTabSet", () => {
     const ts = makeTabSet(["a", "b"]);
 
-    // Carousel has an extra card that windowTabSet doesn't know about
     ts.reorderTabs(["b", "unknown", "a"]);
 
-    // "unknown" is filtered out (not in ts.tabs)
     assert.deepEqual(ts.getTabs(), ["b", "a"]);
   });
 
@@ -219,7 +275,6 @@ describe("drag reorder syncs carousel via windowTabSet subscriber", () => {
     const ts = makeTabSet(["a", "b", "c"]);
     let carouselCards = ["a", "b", "c"];
 
-    // Simulate the app.js subscriber that syncs carousel from windowTabSet
     ts.subscribe(() => {
       const newOrder = ts.getTabs().filter(id => carouselCards.includes(id));
       for (const id of carouselCards) {
@@ -228,10 +283,8 @@ describe("drag reorder syncs carousel via windowTabSet subscriber", () => {
       carouselCards = newOrder;
     });
 
-    // Simulate drag reorder: move "c" to position 0
     ts.reorderTabs(["c", "a", "b"]);
 
-    // Both should now agree
     assert.deepEqual(ts.getTabs(), ["c", "a", "b"]);
     assert.deepEqual(carouselCards, ["c", "a", "b"]);
   });


### PR DESCRIPTION
## Summary

- **New `selectors.js`** — pure functions that derive focused session name on-demand from `uiStore` state + renderer registry, replacing 43+ reads of the mutable `state.session.name`
- **New `navigation.js`** — pure `navigateTab`, `moveTab`, `jumpToTab` functions: `(uiState, direction) => action | null`
- **Rewrote `app.js`** — deleted `createAppState()` and all `state.session.name` references; navigation dispatches actions from pure functions; WS operations derive session name via `getFocusedSession()` selector
- **Fixes Option+] navigation bug** — non-terminal tiles (feed, file-browser) now navigate correctly because we index by tile ID, not tmux session name

This is PR 1 of the tile harmony series — moving all frontend state into Redux-style store data objects with pure function derivations.

## Test plan

- [x] `npm test` passes (2035/2035, 0 failures)
- [ ] Manual: Option+] navigates between terminal + feed tiles
- [ ] Manual: Option+1-9 jump works for any tile type
- [ ] Manual: Option+Shift+] reorders non-terminal tiles
- [ ] Manual: Close non-terminal tile → correct neighbor gets focus
- [ ] Manual: WS reconnect still works after focus change