### PR TITLE
fix: feed button opens matching Claude topic directly

### DIFF
--- a/lib/cli/commands/relay-hook.js
+++ b/lib/cli/commands/relay-hook.js
@@ -16,10 +16,28 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { execFileSync } from "node:child_process";
 import { readServerInfo } from "../process-manager.js";
 import envConfig from "../../env-config.js";
 
 const DATA_DIR = envConfig.dataDir;
+
+/**
+ * Detect the tmux session name we're running inside.
+ * Returns null if we're not in a tmux session.
+ */
+function detectTmuxSession() {
+  if (!process.env.TMUX) return null;
+  try {
+    return execFileSync("tmux", ["display-message", "-p", "#{session_name}"], {
+      encoding: "utf8",
+      timeout: 1000,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim() || null;
+  } catch {
+    return null;
+  }
+}
 
 function readConfig(key) {
   try {
@@ -42,8 +60,23 @@ export default async function relayHook(_args) {
   // Read payload from stdin
   const chunks = [];
   for await (const chunk of process.stdin) chunks.push(chunk);
-  const payload = Buffer.concat(chunks).toString();
+  let payload = Buffer.concat(chunks).toString();
   if (!payload.trim()) process.exit(0);
+
+  // Inject tmux session name so the server can associate Claude topics
+  // with the terminal session they're running in.
+  const tmuxSession = detectTmuxSession();
+  if (tmuxSession) {
+    try {
+      const obj = JSON.parse(payload);
+      if (!obj.tmux_session) {
+        obj.tmux_session = tmuxSession;
+        payload = JSON.stringify(obj);
+      }
+    } catch {
+      // Not valid JSON — forward as-is
+    }
+  }
 
   // Try local server first (localhost — auth bypassed automatically)
   const serverInfo = readServerInfo();

--- a/lib/cli/commands/setup.js
+++ b/lib/cli/commands/setup.js
@@ -103,7 +103,7 @@ async function selfAccess(args) {
   }
 }
 
-const HOOK_EVENTS = ["PostToolUse", "Stop", "SubagentStart", "SubagentStop"];
+const HOOK_EVENTS = ["UserPromptSubmit", "PostToolUse", "Stop", "SubagentStart", "SubagentStop"];
 const RELAY_HOOK = { type: "command", command: "katulong relay-hook" };
 
 async function claudeHooks(args) {

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -350,18 +350,25 @@ export function createAppRoutes(ctx) {
       const result = transformClaudeEvent(payload);
       if (!result) return json(res, 400, { error: "Missing session_id or hook_event_name" });
 
-      // Set topic meta on first publish so the feed tile uses progress rendering
+      // Set topic meta on first publish so the feed tile uses progress rendering.
+      // Also backfill sessionName if it was missing on the initial publish
+      // (e.g., older topics created before relay-hook injected tmux_session).
       const meta = topicBroker.getMeta(result.topic);
       const isNewTopic = !meta || !meta.type;
+      const tmuxSession = typeof payload.tmux_session === "string" ? payload.tmux_session.slice(0, 128) : null;
       if (isNewTopic) {
         const newMeta = {
           type: "progress",
-          sessionName: typeof payload.name === "string" ? payload.name.slice(0, 128) : null,
+          sessionName: tmuxSession,
           cwd: typeof payload.cwd === "string" ? payload.cwd.slice(0, 512) : null,
         };
         topicBroker.setMeta(result.topic, newMeta);
         // Notify connected clients so feed tile pickers update live
         bridge.relay({ type: "topic-new", topic: result.topic, meta: newMeta });
+      } else if (!meta.sessionName && tmuxSession) {
+        // Backfill sessionName for existing topics that were created
+        // before the relay hook started injecting tmux_session.
+        topicBroker.setMeta(result.topic, { sessionName: tmuxSession });
       }
 
       // Extract and publish any new assistant text from the transcript


### PR DESCRIPTION
## Summary

- **relay-hook.js**: Injects `tmux_session` into the Claude Code hook payload by detecting the tmux session name at relay time, so the server can associate Claude topics with terminal sessions
- **app-routes.js**: Uses `payload.tmux_session` (instead of the nonexistent `payload.name`) for `meta.sessionName`; backfills existing topics missing `sessionName` on next event
- **setup.js**: Adds `UserPromptSubmit` to hook events so topic-session association happens on first user interaction

**Root cause**: `openClaudeFeedTile()` matches Claude topics by `meta.sessionName`, but `sessionName` was read from `payload.name` — a field Claude Code hook payloads never include. Every topic had `sessionName: null`, match always failed, users got the topic picker instead of the feed.

## Test plan

- [ ] `npm test` passes (unit + integration)
- [ ] Click feed button on a tile running Claude → opens matching feed directly (not topic list)
- [ ] Existing Claude topics without `sessionName` get backfilled on next event
- [ ] Re-run `katulong setup claude-hooks` to pick up `UserPromptSubmit` hook