### PR TITLE
feat: cute animated 404 error page for document tile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2201,6 +2201,17 @@
     .doc-tile-status-ok { color: var(--success); }
     .doc-tile-status-err { color: var(--danger); }
     .doc-tile-error { color: var(--text-error, #f66); }
+    .doc-tile-error-page { display: flex; flex-direction: column; align-items: center; justify-content: center; flex: 1; gap: var(--space-md); padding: var(--space-lg); text-align: center; }
+    .doc-tile-error-art { font-size: 3rem; line-height: 1; opacity: 0.7; user-select: none; }
+    .doc-tile-error-code { font-size: 2.5rem; font-weight: 700; color: var(--text-muted); font-family: var(--font-mono); letter-spacing: 0.1em; }
+    .doc-tile-error-msg { font-size: var(--text-sm); color: var(--text-dim); max-width: 28ch; line-height: 1.5; }
+    .doc-tile-error-path { font-size: var(--text-xs); color: var(--text-dim); opacity: 0.6; font-family: var(--font-mono); word-break: break-all; max-width: 36ch; }
+    .doc-tile-error-actions { display: flex; gap: var(--space-sm); margin-top: var(--space-xs); }
+    .doc-tile-error-btn { background: var(--bg-surface); color: var(--text-muted); border: 1px solid var(--border); border-radius: var(--radius); padding: var(--space-xs) var(--space-md); font-size: var(--text-xs); font-family: var(--font-mono); cursor: pointer; transition: background 0.15s, color 0.15s, border-color 0.15s; }
+    .doc-tile-error-btn:hover { background: var(--accent); color: var(--text); border-color: var(--accent-active); }
+    .doc-tile-error-btn:active { transform: scale(0.97); }
+    .doc-tile-error-shuffle { background: none; border: none; color: var(--text-dim); font-size: var(--text-xs); cursor: pointer; padding: var(--space-xs); opacity: 0.5; transition: opacity 0.15s; }
+    .doc-tile-error-shuffle:hover { opacity: 1; }
     /* Markdown rendering */
     .doc-tile-markdown { font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, sans-serif); white-space: normal; line-height: 1.6; }
     .doc-tile-markdown h1 { font-size: 1.6em; font-weight: 700; margin: 0.8em 0 0.4em; border-bottom: 1px solid var(--border); padding-bottom: 0.3em; }

--- a/public/lib/tiles/document-tile.js
+++ b/public/lib/tiles/document-tile.js
@@ -530,6 +530,7 @@ export function createDocumentTileFactory(_deps = {}) {
           } else {
             const loadInline = () => {
               if (stopErrorAnim) { stopErrorAnim(); stopErrorAnim = null; }
+              editorContainer.classList.remove("doc-tile-error");
               setupEditor(initialContent).catch((err) => {
                 if (!mounted) return;
                 stopErrorAnim = renderErrorPage(editorContainer, err, filePath || "inline content", loadInline);

--- a/public/lib/tiles/document-tile.js
+++ b/public/lib/tiles/document-tile.js
@@ -174,7 +174,9 @@ function renderErrorPage(parentEl, err, filePath, onRetry) {
   page.appendChild(actions);
   parentEl.appendChild(page);
 
-  return stopAnim;
+  // Return a stable wrapper so callers always stop the *current* interval,
+  // even after the shuffle button has reassigned the inner `stopAnim`.
+  return () => stopAnim();
 }
 
 /** Icon name based on file extension. */
@@ -526,12 +528,14 @@ export function createDocumentTileFactory(_deps = {}) {
             };
             loadFile();
           } else {
-            setupEditor(initialContent).catch((err) => {
-              if (!mounted) return;
-              stopErrorAnim = renderErrorPage(editorContainer, err, filePath || "inline content", () => {
-                setupEditor(initialContent);
+            const loadInline = () => {
+              if (stopErrorAnim) { stopErrorAnim(); stopErrorAnim = null; }
+              setupEditor(initialContent).catch((err) => {
+                if (!mounted) return;
+                stopErrorAnim = renderErrorPage(editorContainer, err, filePath || "inline content", loadInline);
               });
-            });
+            };
+            loadInline();
           }
         }
       },

--- a/public/lib/tiles/document-tile.js
+++ b/public/lib/tiles/document-tile.js
@@ -16,6 +16,167 @@ import { api } from "/lib/api-client.js";
 import { marked } from "/vendor/marked/marked.esm.js";
 import DOMPurify from "/vendor/dompurify/purify.es.mjs";
 
+/* ---------- cute animated error pages ---------- */
+
+// Each entry has `frames` (array of ASCII art strings cycled on a timer)
+// and `ms` (frame duration). Omit `ms` to use the default (400ms).
+
+const NOT_FOUND_PAGES = [
+  { frames: ["(o_O)", "(O_o)", "(o_O)", "(O_o)", "(o_o)", "(o_o)"], ms: 500,
+    msg: "This file is playing hide and seek. It's winning." },
+  { frames: ["(;-;)", "(;_;)", "(; ;)", "(;_;)"], ms: 600,
+    msg: "File not found. It was here a second ago, I swear." },
+  { frames: ["\\(o.o)/", "\\(o.o)>", "\\(o.o)/", "<(o.o)/"], ms: 350,
+    msg: "Gone. Poof. Like it was never here." },
+  { frames: ["(-_-)", "(-_-)", "(-_-)", "(- -)", "(-_-)", "(-_-)"], ms: 800,
+    msg: "The file has left the building." },
+  { frames: ["(x_x)", "(x_x)", "(X_X)", "(x_x)"], ms: 900,
+    msg: "This file exists only in the realm of imagination." },
+  { frames: ["(?.?)", "(?_?)", "(?.?)", "(?-?)"], ms: 700,
+    msg: "Are you sure that's the right path?" },
+  { frames: ["(@_@)", "(@.@)", "(@_@)", "(@-@)"], ms: 500,
+    msg: "Looked everywhere. Under the couch, behind the fridge. Nope." },
+  { frames: ["(~_~)", "(~.~)", "(~_~)", "(~-~)", "(~_~)", "(- -)"], ms: 800,
+    msg: "File's on vacation. Did not leave a forwarding address." },
+  { frames: ["(>.<)", "(>_<)", "(>.<)", "(>.<)", "(>.>)"], ms: 600,
+    msg: "So close, yet so 404." },
+  { frames: ["(._.)", "(._. )", "( ._.)", "(._.)", "(._.)", "(-_-)"], ms: 500,
+    msg: "This path leads nowhere. Philosophically and literally." },
+];
+
+const ERROR_PAGES = {
+  403: [
+    { frames: ["(#_#)", "(#.#)", "(#_#)", "(#-#)"], ms: 600,
+      msg: "Permission denied. This file has boundaries." },
+    { frames: ["(o_o)b", "(o_o)d", "(o_o)b", "(o_o)d"], ms: 500,
+      msg: "You shall not read! (Access denied.)" },
+  ],
+  413: [
+    { frames: ["(O_O)", "(O O)", "(O_O)", "(O_O)", "(O_O)", "(o_o)"], ms: 700,
+      msg: "This file is too chonky to display inline." },
+  ],
+  415: [
+    { frames: ["[bin]", "[BIN]", "[bin]", "[b1n]", "[bin]"], ms: 400,
+      msg: "Binary file. All zeroes and ones, no letters." },
+  ],
+};
+
+const GENERIC_FRAMES = ["(x_x)", "(x_x)", "(X_X)", "(x_x)", "(x_x)", "(+_+)"];
+
+function parseStatusCode(errMsg) {
+  const m = errMsg.match(/\((\d{3})\)\s*$/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+function pickRandom(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+/**
+ * Start an ASCII animation loop on an element.
+ * Returns a cleanup function that stops the interval.
+ */
+function animateArt(el, frames, ms) {
+  if (!frames || frames.length <= 1) return () => {};
+  let i = 0;
+  const id = setInterval(() => {
+    i = (i + 1) % frames.length;
+    el.textContent = frames[i];
+  }, ms || 400);
+  return () => clearInterval(id);
+}
+
+/**
+ * Render a styled error page inside `parentEl` with a retry button.
+ * @param {HTMLElement} parentEl - container to fill
+ * @param {Error} err - the fetch error
+ * @param {string} filePath - path that failed
+ * @param {() => void} onRetry - called when retry is clicked
+ * @returns {() => void} cleanup function to stop animations
+ */
+function renderErrorPage(parentEl, err, filePath, onRetry) {
+  const status = parseStatusCode(err.message);
+  const pool = status === 404 ? NOT_FOUND_PAGES
+    : ERROR_PAGES[status] ? ERROR_PAGES[status]
+    : null;
+
+  parentEl.textContent = "";
+  parentEl.classList.add("doc-tile-error");
+
+  const page = document.createElement("div");
+  page.className = "doc-tile-error-page";
+
+  let stopAnim = () => {};
+
+  let current = pool ? pickRandom(pool) : null;
+
+  if (pool) {
+    const codeEl = document.createElement("div");
+    codeEl.className = "doc-tile-error-code";
+    codeEl.textContent = String(status);
+    page.appendChild(codeEl);
+
+    const artEl = document.createElement("div");
+    artEl.className = "doc-tile-error-art";
+    artEl.textContent = current.frames[0];
+    stopAnim = animateArt(artEl, current.frames, current.ms);
+    page.appendChild(artEl);
+
+    const msgEl = document.createElement("div");
+    msgEl.className = "doc-tile-error-msg";
+    msgEl.textContent = current.msg;
+    page.appendChild(msgEl);
+
+    // cycle button (only if more than one option)
+    if (pool.length > 1) {
+      const shuffleBtn = document.createElement("button");
+      shuffleBtn.className = "doc-tile-error-shuffle";
+      shuffleBtn.textContent = "another one";
+      shuffleBtn.addEventListener("click", () => {
+        let next;
+        do { next = pickRandom(pool); } while (next === current && pool.length > 1);
+        current = next;
+        stopAnim();
+        artEl.textContent = next.frames[0];
+        stopAnim = animateArt(artEl, next.frames, next.ms);
+        msgEl.textContent = next.msg;
+      });
+      page.appendChild(shuffleBtn);
+    }
+  } else {
+    // generic error
+    const artEl = document.createElement("div");
+    artEl.className = "doc-tile-error-art";
+    artEl.textContent = GENERIC_FRAMES[0];
+    stopAnim = animateArt(artEl, GENERIC_FRAMES, 800);
+    page.appendChild(artEl);
+
+    const msgEl = document.createElement("div");
+    msgEl.className = "doc-tile-error-msg";
+    msgEl.textContent = err.message;
+    page.appendChild(msgEl);
+  }
+
+  const pathEl = document.createElement("div");
+  pathEl.className = "doc-tile-error-path";
+  pathEl.textContent = filePath;
+  page.appendChild(pathEl);
+
+  const actions = document.createElement("div");
+  actions.className = "doc-tile-error-actions";
+
+  const retryBtn = document.createElement("button");
+  retryBtn.className = "doc-tile-error-btn";
+  retryBtn.textContent = "Retry";
+  retryBtn.addEventListener("click", () => { stopAnim(); onRetry(); });
+  actions.appendChild(retryBtn);
+
+  page.appendChild(actions);
+  parentEl.appendChild(page);
+
+  return stopAnim;
+}
+
 /** Icon name based on file extension. */
 function extToIcon(ext) {
   if ([".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx"].includes(ext)) return "code";
@@ -176,6 +337,7 @@ export function createDocumentTileFactory(_deps = {}) {
     let saving = false;
     let statusEl = null;
     let originalContent = "";
+    let stopErrorAnim = null;
 
     const isFileBacked = !!filePath;
     const ext = filePath
@@ -253,17 +415,22 @@ export function createDocumentTileFactory(_deps = {}) {
           el.appendChild(root);
 
           if (isFileBacked) {
-            contentEl.textContent = "Loading…";
-            api.get(`/api/files/read?path=${encodeURIComponent(filePath)}`)
-              .then((data) => {
-                if (!mounted) return;
-                contentEl.innerHTML = DOMPurify.sanitize(marked.parse(data.content));
-              })
-              .catch((err) => {
-                if (!mounted) return;
-                contentEl.textContent = `Error: ${err.message}`;
-                contentEl.classList.add("doc-tile-error");
-              });
+            const loadMarkdown = () => {
+              if (stopErrorAnim) { stopErrorAnim(); stopErrorAnim = null; }
+              contentEl.textContent = "Loading…";
+              contentEl.classList.remove("doc-tile-error");
+              contentEl.innerHTML = "";
+              api.get(`/api/files/read?path=${encodeURIComponent(filePath)}`)
+                .then((data) => {
+                  if (!mounted) return;
+                  contentEl.innerHTML = DOMPurify.sanitize(marked.parse(data.content));
+                })
+                .catch((err) => {
+                  if (!mounted) return;
+                  stopErrorAnim = renderErrorPage(contentEl, err, filePath, loadMarkdown);
+                });
+            };
+            loadMarkdown();
           } else if (content != null) {
             contentEl.innerHTML = DOMPurify.sanitize(marked.parse(content));
           }
@@ -275,13 +442,6 @@ export function createDocumentTileFactory(_deps = {}) {
           el.appendChild(root);
 
           const initialContent = content ?? "";
-
-          // Show loading placeholder while CM loads
-          if (isFileBacked) {
-            editorContainer.textContent = "Loading…";
-            editorContainer.style.padding = "var(--space-sm)";
-            editorContainer.style.color = "var(--text-dim)";
-          }
 
           const setupEditor = async (text) => {
             if (!mounted) return;
@@ -346,21 +506,31 @@ export function createDocumentTileFactory(_deps = {}) {
           };
 
           if (isFileBacked) {
-            api.get(`/api/files/read?path=${encodeURIComponent(filePath)}`)
-              .then((data) => {
-                if (!mounted) return;
-                setupEditor(data.content);
-              })
-              .catch((err) => {
-                if (!mounted) return;
-                editorContainer.textContent = `Error: ${err.message}`;
-                editorContainer.classList.add("doc-tile-error");
-              });
+            const loadFile = () => {
+              if (stopErrorAnim) { stopErrorAnim(); stopErrorAnim = null; }
+              editorContainer.textContent = "Loading…";
+              editorContainer.style.padding = "var(--space-sm)";
+              editorContainer.style.color = "var(--text-dim)";
+              editorContainer.classList.remove("doc-tile-error");
+              api.get(`/api/files/read?path=${encodeURIComponent(filePath)}`)
+                .then((data) => {
+                  if (!mounted) return;
+                  setupEditor(data.content);
+                })
+                .catch((err) => {
+                  if (!mounted) return;
+                  editorContainer.style.padding = "";
+                  editorContainer.style.color = "";
+                  stopErrorAnim = renderErrorPage(editorContainer, err, filePath, loadFile);
+                });
+            };
+            loadFile();
           } else {
             setupEditor(initialContent).catch((err) => {
               if (!mounted) return;
-              editorContainer.textContent = `Error: ${err.message}`;
-              editorContainer.classList.add("doc-tile-error");
+              stopErrorAnim = renderErrorPage(editorContainer, err, filePath || "inline content", () => {
+                setupEditor(initialContent);
+              });
             });
           }
         }
@@ -368,6 +538,7 @@ export function createDocumentTileFactory(_deps = {}) {
 
       unmount() {
         if (!mounted) return;
+        if (stopErrorAnim) { stopErrorAnim(); stopErrorAnim = null; }
         if (editorView) {
           editorView.destroy();
           editorView = null;


### PR DESCRIPTION
## Summary

- Replaces raw error text in document tiles with a styled error page featuring animated ASCII art faces, witty messages, and a retry button
- 10 different 404 characters with unique animations (blinking, waving arms, shifting eyes, drifting) plus dedicated pages for 403/413/415 errors
- "another one" button cycles through different characters; animations clean up properly on unmount/retry

## Test plan

- [ ] `npm test` passes (unit + integration)
- [ ] Click a file reference in terminal output for a nonexistent file — animated 404 page appears
- [ ] Click "another one" — new character and message appear with different animation
- [ ] Click "Retry" — shows loading state then error page again (if file still missing)
- [ ] Close the document tile and reopen — no leaked intervals
- [ ] Try opening a file with no read permission — 403 error page appears
- [ ] Try opening a binary file — 415 error page appears