### PR TITLE
fix: XSS, dead state keys, topic-new purity

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -49,6 +49,7 @@
     import { navigateTab as computeNavigateTab, moveTab as computeMoveTab, jumpToTab as computeJumpToTab } from "/lib/navigation.js";
     import { createIconStore } from "/lib/icon-store.js";
     import { createReconcilerStore } from "/lib/reconciler-store.js";
+    import { escapeHtml } from "/lib/utils.js";
 
     // --- Modal Manager ---
     const modals = new ModalRegistry();
@@ -1296,12 +1297,12 @@
           const keys = await api.get("/api/api-keys");
           if (!keys.length) { listEl.innerHTML = '<p class="tokens-loading">No API keys yet.</p>'; return; }
           listEl.innerHTML = keys.map(k => `
-            <div class="token-item" data-id="${k.id}">
+            <div class="token-item" data-id="${escapeHtml(k.id)}">
               <div class="token-item-info">
-                <span class="token-item-name">${k.name}</span>
-                <span class="token-item-meta">${k.prefix}... · ${k.lastUsedAt ? "used " + new Date(k.lastUsedAt).toLocaleDateString() : "never used"}</span>
+                <span class="token-item-name">${escapeHtml(k.name)}</span>
+                <span class="token-item-meta">${escapeHtml(k.prefix)}... · ${k.lastUsedAt ? "used " + new Date(k.lastUsedAt).toLocaleDateString() : "never used"}</span>
               </div>
-              <button class="token-item-revoke" data-id="${k.id}">Revoke</button>
+              <button class="token-item-revoke" data-id="${escapeHtml(k.id)}">Revoke</button>
             </div>
           `).join("");
           listEl.querySelectorAll(".token-item-revoke").forEach(btn => {
@@ -1328,8 +1329,8 @@
             form.style.display = "none"; createBtn.style.display = ""; nameInput.value = "";
             const el = document.createElement("div");
             el.className = "token-item token-item-new";
-            el.innerHTML = '<div class="token-item-info"><span class="token-item-name">' + data.name + '</span>'
-              + '<code style="display:block;margin-top:0.25rem;font-size:0.75rem;word-break:break-all;color:var(--success);cursor:pointer;">' + data.key + '</code>'
+            el.innerHTML = '<div class="token-item-info"><span class="token-item-name">' + escapeHtml(data.name) + '</span>'
+              + '<code style="display:block;margin-top:0.25rem;font-size:0.75rem;word-break:break-all;color:var(--success);cursor:pointer;">' + escapeHtml(data.key) + '</code>'
               + '<span class="token-item-meta">Click key to copy. It won\'t be shown again.</span></div>';
             el.querySelector("code").addEventListener("click", () => navigator.clipboard.writeText(data.key).then(() => showToast("Copied!")));
             listEl.prepend(el);
@@ -1956,6 +1957,11 @@
       openTab: (e) => {
         windowTabSet.addTab(e.session);
         switchSession(e.session);
+      },
+      dispatchTopicNew: (e) => {
+        window.dispatchEvent(new CustomEvent('katulong:topic-new', {
+          detail: { topic: e.topic, meta: e.meta },
+        }));
       },
       showNotification: (e) => {
         const t = e.title || "Katulong";

--- a/public/app.js
+++ b/public/app.js
@@ -49,7 +49,7 @@
     import { navigateTab as computeNavigateTab, moveTab as computeMoveTab, jumpToTab as computeJumpToTab } from "/lib/navigation.js";
     import { createIconStore } from "/lib/icon-store.js";
     import { createReconcilerStore } from "/lib/reconciler-store.js";
-    import { escapeHtml } from "/lib/utils.js";
+    import { escapeHtml, escapeAttr } from "/lib/utils.js";
 
     // --- Modal Manager ---
     const modals = new ModalRegistry();
@@ -1297,12 +1297,12 @@
           const keys = await api.get("/api/api-keys");
           if (!keys.length) { listEl.innerHTML = '<p class="tokens-loading">No API keys yet.</p>'; return; }
           listEl.innerHTML = keys.map(k => `
-            <div class="token-item" data-id="${escapeHtml(k.id)}">
+            <div class="token-item" data-id="${escapeAttr(k.id)}">
               <div class="token-item-info">
                 <span class="token-item-name">${escapeHtml(k.name)}</span>
                 <span class="token-item-meta">${escapeHtml(k.prefix)}... · ${k.lastUsedAt ? "used " + new Date(k.lastUsedAt).toLocaleDateString() : "never used"}</span>
               </div>
-              <button class="token-item-revoke" data-id="${escapeHtml(k.id)}">Revoke</button>
+              <button class="token-item-revoke" data-id="${escapeAttr(k.id)}">Revoke</button>
             </div>
           `).join("");
           listEl.querySelectorAll(".token-item-revoke").forEach(btn => {
@@ -1313,9 +1313,6 @@
             });
           });
         } catch { if (listEl) listEl.innerHTML = '<p class="tokens-loading">Failed to load.</p>'; }
-      }
-
-      async function loadBaseUrl() {
       }
 
       if (createBtn && form) {
@@ -1340,7 +1337,7 @@
       }
 
       document.querySelectorAll(".settings-tab").forEach(tab => {
-        tab.addEventListener("click", () => { if (tab.dataset.tab === "api") { loadApiKeys(); loadBaseUrl(); } });
+        tab.addEventListener("click", () => { if (tab.dataset.tab === "api") { loadApiKeys(); } });
       });
     }
 

--- a/public/lib/ws-message-handlers.js
+++ b/public/lib/ws-message-handlers.js
@@ -10,7 +10,6 @@ export const wsMessageHandlers = {
   attached(msg, ctx) {
     return {
       stateUpdates: {
-        'session.name': msg.session,
         'scroll.userScrolledUpBeforeDisconnect': false,
       },
       effects: [
@@ -26,9 +25,7 @@ export const wsMessageHandlers = {
 
   switched(msg, ctx) {
     return {
-      stateUpdates: {
-        'session.name': msg.session,
-      },
+      stateUpdates: {},
       effects: [
         // No terminalReset — the terminal pool keeps each session's xterm
         // intact with its content. No snapshot replay either — the pull
@@ -118,7 +115,7 @@ export const wsMessageHandlers = {
 
   'session-renamed'(msg, ctx) {
     return {
-      stateUpdates: { 'session.name': msg.name },
+      stateUpdates: {},
       effects: [
         { type: 'carouselRename', oldName: ctx.currentSessionName, newName: msg.name },
         { type: 'poolRename', oldName: ctx.currentSessionName, newName: msg.name },
@@ -155,11 +152,10 @@ export const wsMessageHandlers = {
   },
 
   'topic-new'(msg, ctx) {
-    // Dispatch DOM event so feed tile pickers can update live
-    window.dispatchEvent(new CustomEvent('katulong:topic-new', {
-      detail: { topic: msg.topic, meta: msg.meta },
-    }));
-    return { stateUpdates: {}, effects: [] };
+    return {
+      stateUpdates: {},
+      effects: [{ type: 'dispatchTopicNew', topic: msg.topic, meta: msg.meta }],
+    };
   },
 
   'device-auth-request'(msg, ctx) {


### PR DESCRIPTION
## Summary

- **Fix API key XSS** — escape all server-supplied values (`k.name`, `k.id`, `k.prefix`, `data.name`, `data.key`) in innerHTML assignments in the API key settings panel using `escapeHtml()` from utils.js
- **Remove dead `session.name` state keys** — `attached`, `switched`, and `session-renamed` handlers in ws-message-handlers.js returned `'session.name'` in stateUpdates that app.js silently discards (session name is now derived from uiStore.focusedId)
- **Fix `topic-new` handler purity** — moved `window.dispatchEvent` call from the handler into a new `dispatchTopicNew` effect handler in app.js, keeping ws-message-handlers pure

## Test plan

- [x] `npm test` passes (2061 pass, 0 fail)
- [ ] Create an API key with `<img onerror=alert(1)>` in the name — verify it renders as text, not HTML
- [ ] Verify topic-new events still update feed tile pickers live
- [ ] Verify attach/switch/rename still work correctly without session.name state keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)