### PR TITLE
fix: sweep orphan tmux sockets at test boot

### DIFF
--- a/bin/katulong-stage
+++ b/bin/katulong-stage
@@ -444,6 +444,15 @@ cmd_start() {
 
   echo "Starting staging '$name' on port $port..."
 
+  # Clear any stale socket file for this stage name before tmux tries to
+  # bind. tmux does not unlink the socket on `kill-server`, so a prior
+  # `stop` of the same name leaves `/tmp/tmux-$UID/stage-<name>` behind,
+  # and a new tmux server starting on that path can get confused by the
+  # dead inode. This is the "pre-clear my own slot" side of the cleanup
+  # contract; the sibling piece is the boot-time sweep in
+  # test/helpers/setup-env.js for the PID-scoped test sockets.
+  rm -f "${TMUX_TMPDIR:-/tmp}/tmux-$(id -u)/$tmux_socket"
+
   if [[ ! -d "$REPO_ROOT/node_modules" ]]; then
     echo "  installing deps..."
     (cd "$REPO_ROOT" && npm install --silent)

--- a/test/e2e/start-test-server.sh
+++ b/test/e2e/start-test-server.sh
@@ -24,6 +24,14 @@ fi
 # TMUX_SOCKET in test/e2e/cleanup-test-server.sh — keep all three in sync.
 TMUX_SOCKET="katulong-e2e-${SHARD}"
 
+# Clear any stale socket file for this shard before tmux tries to bind.
+# tmux does not unlink the socket on `kill-server`, so a prior e2e run
+# for this shard leaves `/tmp/tmux-$UID/katulong-e2e-<shard>` behind.
+# Pre-clearing the single slot we own is simpler than a general sweep
+# and scoped to just this shard. The sibling piece for the PID-scoped
+# test sockets is the boot-time sweep in test/helpers/setup-env.js.
+rm -f "${TMUX_TMPDIR:-/tmp}/tmux-$(id -u)/$TMUX_SOCKET"
+
 # Run pre-server setup to create fixture auth state
 TEST_SHARD_INDEX=$SHARD node test/e2e/pre-server-setup.js
 

--- a/test/helpers/setup-env.js
+++ b/test/helpers/setup-env.js
@@ -26,13 +26,20 @@
  *    hooks into. The socket name MUST match `/^[A-Za-z0-9_-]+$/`;
  *    `katulong-test-<pid>` satisfies that.
  *
- * Both are cleaned up on process exit.
+ * Socket cleanup: `kill-server` stops the tmux anchor on graceful exit,
+ * but tmux does not unlink the socket file on `kill-server` — so every
+ * exit leaves an orphan behind. Rather than fight this at each
+ * kill-server call site, we rely on a single sweep-at-boot: the next
+ * test process that starts picks up its predecessors' orphans and
+ * reaps them (see `tmux-socket-sweep.js`). This also handles the
+ * SIGKILL / CI-timeout case where `kill-server` never ran at all.
  */
 
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
+import { sweepOrphanTmuxSockets } from "./tmux-socket-sweep.js";
 
 if (!process.env.KATULONG_DATA_DIR) {
   const dir = mkdtempSync(join(tmpdir(), "katulong-test-"));
@@ -44,6 +51,14 @@ if (!process.env.KATULONG_DATA_DIR) {
 }
 
 if (!process.env.KATULONG_TMUX_SOCKET) {
+  // Reap orphan sockets from prior test runs. Catches both
+  //   (a) graceful exits where `kill-server` ran but did not unlink, and
+  //   (b) hard kills (SIGKILL / CI or pre-push hook timeouts / OOM)
+  //       where the exit handler never ran at all.
+  // Without this, `/tmp/tmux-$UID/` accumulates `katulong-test-*` socket
+  // files indefinitely and eventually destabilizes tmux itself.
+  sweepOrphanTmuxSockets("katulong-test-");
+
   // PID-scoped socket so parallel test files can't collide, and each
   // test file starts with a fresh (empty) tmux server.
   const socketName = `katulong-test-${process.pid}`;
@@ -74,12 +89,11 @@ if (!process.env.KATULONG_TMUX_SOCKET) {
   }
 
   process.on("exit", () => {
-    // Tear down the entire tmux server on our socket. This wipes every
-    // session this test file created (plus the anchor) in one shot —
-    // much faster and more reliable than enumerating known session
-    // names and killing them individually. If tmux never started a
-    // server on this socket (e.g. a unit test that mocked tmux
-    // entirely), the command fails and we ignore it.
+    // Stop the tmux server so the anchor process does not outlive the
+    // test run. The socket file itself is intentionally not unlinked
+    // here — tmux does not unlink on `kill-server` and we rely on the
+    // next test process's boot-time sweep to reap it. See module
+    // header for the rationale.
     try {
       execFileSync("tmux", ["-L", socketName, "kill-server"], {
         stdio: "ignore",

--- a/test/helpers/tmux-socket-sweep.js
+++ b/test/helpers/tmux-socket-sweep.js
@@ -1,0 +1,101 @@
+/**
+ * Sweep orphan tmux socket files from /tmp/tmux-$UID/.
+ *
+ * There are two distinct leak modes for per-test tmux sockets:
+ *
+ *   A. Dead socket, no server. Either `kill-server` ran but didn't finish
+ *      unlinking, or the server crashed outright. The file remains.
+ *
+ *   B. Orphaned but alive. The test process was SIGKILLed (pre-push hook
+ *      timeout, CI runner timeout, OOM), so `process.on("exit")` never
+ *      ran — but the detached tmux anchor server kept running. Observed
+ *      on the author's mini: anchors from test PIDs 3+ days dead, still
+ *      listening. A probe-based sweep ("does tmux respond?") sees these
+ *      as alive and leaves them forever.
+ *
+ * The socket name encodes its creator: `<prefix><pid>`. If that PID is
+ * no longer alive, the socket is an orphan in both modes above. We kill
+ * the server (best-effort, reaps mode B) and unlink (catches mode A and
+ * finishes mode B). If the PID is alive we leave everything alone.
+ *
+ * This is also faster than the probe approach — `process.kill(pid, 0)`
+ * is a syscall rather than a spawn-tmux-per-socket, so sweeping 16k
+ * entries takes milliseconds rather than minutes.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readdirSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Directory tmux uses for per-user sockets. Honors TMUX_TMPDIR, falls
+ * back to /tmp (tmux's own default). Keep in sync with tmux's behavior
+ * in `server.c:server_start`.
+ */
+export function tmuxSocketDir() {
+  const base = process.env.TMUX_TMPDIR || "/tmp";
+  return `${base}/tmux-${process.getuid()}`;
+}
+
+/**
+ * Remove orphaned tmux socket files whose basename matches
+ * `<prefix><pid>` where `<pid>` is no longer a live process.
+ *
+ * Only sockets that match this exact shape are considered — anything
+ * else (including sockets that match the prefix but have non-numeric
+ * suffixes) is left alone. This makes the sweep safe to run against
+ * shared directories without risk of clobbering unrelated state.
+ *
+ * Returns the number of sockets removed. Never throws.
+ */
+export function sweepOrphanTmuxSockets(prefix) {
+  const dir = tmuxSocketDir();
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return 0;
+  }
+
+  const pidRe = new RegExp(`^${escapeRegExp(prefix)}(\\d+)$`);
+  let removed = 0;
+  for (const name of entries) {
+    const m = pidRe.exec(name);
+    if (!m) continue;
+    const pid = Number(m[1]);
+    if (isProcessAlive(pid)) continue;
+
+    // Best-effort kill-server to evict any tmux anchor that outlived
+    // the test process (leak mode B). If there's no server listening
+    // — leak mode A — this fails and we move on.
+    try {
+      execFileSync("tmux", ["-L", name, "kill-server"], {
+        stdio: "ignore",
+        timeout: 500,
+      });
+    } catch {}
+
+    try {
+      unlinkSync(join(dir, name));
+      removed += 1;
+    } catch {
+      // Socket vanished between readdir and unlink, or we lack
+      // permission — either way, not our problem to resolve here.
+    }
+  }
+  return removed;
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/test/tmux-socket-lifecycle.test.js
+++ b/test/tmux-socket-lifecycle.test.js
@@ -1,0 +1,211 @@
+/**
+ * Integration test for `test/helpers/setup-env.js`' socket lifecycle.
+ *
+ * The sweep helper has its own unit tests; this file pins the contract
+ * that setup-env actually uses it. It spawns a real child `node
+ * --import setup-env.js`, sandboxed to a private TMUX_TMPDIR so the
+ * test can't pollute `/tmp/tmux-$UID/` (the directory this whole fix
+ * exists to keep clean) and can't race other parallel test files.
+ *
+ * The cleanup contract under test: tmux does NOT unlink the socket on
+ * `kill-server`, so every graceful exit leaves a socket behind. The
+ * next test process's boot-time sweep reaps it (along with orphans
+ * from any hard-killed prior runs). These tests verify that sweep
+ * actually runs and is correctly scoped.
+ *
+ * Regressions caught here:
+ *   - setup-env deletes the sweep call → orphan accumulates
+ *   - sweep accidentally reaps live sockets (false positive)
+ *   - sweep widens its match pattern and touches unrelated files
+ */
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+
+const SETUP_ENV_PATH = resolve("test/helpers/setup-env.js");
+
+function tmuxAvailable() {
+  try {
+    spawnSync("tmux", ["-V"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function freshDeadPid() {
+  // Spawn and await a short-lived process so its PID is free afterward.
+  return spawnSync("true", [], { stdio: "ignore" }).pid;
+}
+
+/**
+ * Run `node --import <setup-env> -e <script>` with a sandboxed
+ * TMUX_TMPDIR and return { socketDir, childSocketName, exitCode }.
+ *
+ * The socket dir is `<tmpdir>/tmux-<uid>` since that's where tmux
+ * (and therefore our sweep) looks when TMUX_TMPDIR is honored.
+ */
+function runChildWithSandbox({ preseed = [], sandbox: reusedSandbox } = {}) {
+  // Use /tmp directly (not os.tmpdir()) because on macOS tmpdir resolves
+  // to /var/folders/... which, combined with the socket filename, blows
+  // past the ~104-char unix domain socket path limit and tmux bails with
+  // "File name too long" before the anchor session ever binds.
+  const sandbox = reusedSandbox || mkdtempSync("/tmp/ktl-swp-");
+  const socketDir = join(sandbox, `tmux-${process.getuid()}`);
+  mkdirSync(socketDir, { recursive: true });
+  // tmux refuses to use a socket dir unless it's 0700, regardless of
+  // TMUX_TMPDIR. Without this it silently skips creating the server
+  // and the sweep test has nothing to observe.
+  chmodSync(socketDir, 0o700);
+
+  for (const name of preseed) {
+    // Regular files are sufficient: the sweep's PID check happens
+    // before any tmux interaction, so it never cares whether the
+    // entry is a real socket or not. A `kill-server` attempt on a
+    // regular file fails quietly, then unlink removes the file.
+    writeFileSync(join(socketDir, name), "");
+  }
+
+  // Short script: exit promptly but give setup-env time to run its
+  // synchronous startup work (sweep + anchor). 50ms is generous —
+  // setup-env itself is sync; the delay only protects against
+  // cross-platform timing surprises from the anchor spawn.
+  const script = "setTimeout(() => process.exit(0), 50)";
+  const result = spawnSync(
+    process.execPath,
+    ["--import", SETUP_ENV_PATH, "-e", script],
+    {
+      env: {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        TMUX_TMPDIR: sandbox,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf8",
+    },
+  );
+
+  // The child's socket is `katulong-test-<childpid>`.
+  const childSocketName = `katulong-test-${result.pid}`;
+
+  return {
+    sandbox,
+    socketDir,
+    childSocketName,
+    exitCode: result.status,
+    stderr: result.stderr,
+  };
+}
+
+function cleanup(socketDir, sandbox) {
+  // Best-effort: kill any tmux servers that somehow survived, then rm
+  // the sandbox. We never want this test to be the reason a socket
+  // leaks into the real /tmp/tmux-$UID.
+  try {
+    for (const name of readdirSync(socketDir)) {
+      try {
+        spawnSync("tmux", ["-L", name, "kill-server"], {
+          stdio: "ignore",
+          env: { ...process.env, TMUX_TMPDIR: sandbox },
+        });
+      } catch {}
+    }
+  } catch {}
+  try { rmSync(sandbox, { recursive: true, force: true }); } catch {}
+}
+
+describe("setup-env socket lifecycle", () => {
+  before(function () {
+    if (!tmuxAvailable()) this.skip("tmux not installed");
+  });
+
+  it("a prior process's socket is swept by the next boot", () => {
+    // First boot: child A runs setup-env, creates its own socket,
+    // exits cleanly. Because `kill-server` does not unlink, the socket
+    // file persists. Second boot: child B runs setup-env; its sweep
+    // sees child A's PID is dead and reaps the orphan.
+    const first = runChildWithSandbox();
+    try {
+      assert.equal(first.exitCode, 0, `childA exit=${first.exitCode}; stderr=${first.stderr}`);
+      const orphanPath = join(first.socketDir, first.childSocketName);
+      assert.ok(
+        existsSync(orphanPath),
+        "kill-server does not unlink; socket must remain after clean exit",
+      );
+
+      const second = runChildWithSandbox({ sandbox: first.sandbox });
+      assert.equal(second.exitCode, 0, `childB exit=${second.exitCode}; stderr=${second.stderr}`);
+      assert.equal(
+        existsSync(orphanPath),
+        false,
+        "childB's boot-time sweep must reap childA's orphan",
+      );
+    } finally {
+      cleanup(first.socketDir, first.sandbox);
+    }
+  });
+
+  it("sweeps orphan sockets whose creator PID is dead", () => {
+    const deadPid = freshDeadPid();
+    const orphan = `katulong-test-${deadPid}`;
+    const { sandbox, socketDir, exitCode, stderr } = runChildWithSandbox({
+      preseed: [orphan],
+    });
+    try {
+      assert.equal(exitCode, 0, `child should exit 0; stderr=${stderr}`);
+      assert.equal(
+        existsSync(join(socketDir, orphan)),
+        false,
+        "orphan socket (dead PID) must be swept at startup",
+      );
+    } finally {
+      cleanup(socketDir, sandbox);
+    }
+  });
+
+  it("leaves sockets alone whose creator PID is alive", () => {
+    // Parent (this test process) is alive for the whole child run.
+    const alive = `katulong-test-${process.pid}`;
+    const { sandbox, socketDir, exitCode, stderr } = runChildWithSandbox({
+      preseed: [alive],
+    });
+    try {
+      assert.equal(exitCode, 0, `child should exit 0; stderr=${stderr}`);
+      assert.ok(
+        existsSync(join(socketDir, alive)),
+        "socket whose creator is alive must not be swept",
+      );
+    } finally {
+      cleanup(socketDir, sandbox);
+    }
+  });
+
+  it("ignores entries that don't match <prefix><pid>", () => {
+    // Unrelated file in the socket dir — must survive the sweep
+    // regardless of who owns it.
+    const unrelated = "katulong-test-not-a-pid";
+    const { sandbox, socketDir, exitCode, stderr } = runChildWithSandbox({
+      preseed: [unrelated],
+    });
+    try {
+      assert.equal(exitCode, 0, `child should exit 0; stderr=${stderr}`);
+      assert.ok(
+        existsSync(join(socketDir, unrelated)),
+        "non-matching entry must be left alone",
+      );
+    } finally {
+      cleanup(socketDir, sandbox);
+    }
+  });
+});

--- a/test/tmux-socket-sweep.test.js
+++ b/test/tmux-socket-sweep.test.js
@@ -1,0 +1,125 @@
+/**
+ * Tests for the orphan tmux socket sweep.
+ *
+ * The sweep exists to reap socket files left behind when a test process
+ * is killed before its `process.on("exit")` handler can run — SIGKILL,
+ * pre-push hook timeouts, CI runner timeouts, OOM. Without it,
+ * `/tmp/tmux-$UID/` accumulates `katulong-test-*` sockets into the
+ * thousands and destabilizes tmux itself (observed: 16k+ orphans
+ * correlating with spontaneous tmux crashes).
+ *
+ * The sweep's contract: for sockets named `<prefix><pid>`, reap iff the
+ * named PID is dead. These tests verify both the dead-pid reap path and
+ * that alive pids / non-matching names are left alone.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  sweepOrphanTmuxSockets,
+  tmuxSocketDir,
+} from "./helpers/tmux-socket-sweep.js";
+
+const PREFIX = "katulong-test-sweeptst-";
+
+function tmuxAvailable() {
+  try {
+    execFileSync("tmux", ["-V"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Spawn and immediately await a short-lived process. Its PID is free
+// once the call returns. PIDs can be reused, but not within the
+// microseconds before the assertion — good enough for a test.
+function freshDeadPid() {
+  const r = spawnSync("true", [], { stdio: "ignore" });
+  return r.pid;
+}
+
+describe("sweepOrphanTmuxSockets", () => {
+  before(function () {
+    if (!tmuxAvailable()) this.skip("tmux not installed");
+  });
+
+  // Safety net: any `<PREFIX>*` entries still on disk after this suite
+  // are our own leaks. Clean up so we never contribute to the orphan
+  // pile we're fighting.
+  after(() => {
+    try {
+      for (const name of readdirSync(tmuxSocketDir())) {
+        if (!name.startsWith(PREFIX)) continue;
+        try { execFileSync("tmux", ["-L", name, "kill-server"], { stdio: "ignore" }); } catch {}
+        try { unlinkSync(join(tmuxSocketDir(), name)); } catch {}
+      }
+    } catch {}
+  });
+
+  it("reaps a socket whose creator PID is dead (covers SIGKILL leak mode)", () => {
+    const deadPid = freshDeadPid();
+    const name = `${PREFIX}${deadPid}`;
+    const path = join(tmuxSocketDir(), name);
+    // Start a real tmux anchor on this socket so it's a genuine socket
+    // file — exercising the "orphaned but alive" leak mode where tmux
+    // keeps running after the test process died.
+    execFileSync("tmux", ["-L", name, "new-session", "-d", "-s", "__anchor__"], { stdio: "ignore" });
+    assert.ok(existsSync(path), "setup: socket should exist");
+
+    const removed = sweepOrphanTmuxSockets(PREFIX);
+
+    assert.equal(removed, 1, "sweep should report one removal");
+    assert.equal(existsSync(path), false, "orphan socket should be unlinked");
+  });
+
+  it("leaves sockets alone whose creator PID is alive", () => {
+    // Use our own PID — guaranteed alive for the duration of this test.
+    const name = `${PREFIX}${process.pid}`;
+    const path = join(tmuxSocketDir(), name);
+    execFileSync("tmux", ["-L", name, "new-session", "-d", "-s", "__anchor__"], { stdio: "ignore" });
+    try {
+      const removed = sweepOrphanTmuxSockets(PREFIX);
+      assert.equal(removed, 0, "alive creator must not be swept");
+      assert.ok(existsSync(path), "live socket must remain after sweep");
+    } finally {
+      try { execFileSync("tmux", ["-L", name, "kill-server"], { stdio: "ignore" }); } catch {}
+      try { unlinkSync(path); } catch {}
+    }
+  });
+
+  it("ignores entries whose suffix is not a PID", () => {
+    // Sockets matching the prefix but not `<prefix><digits>$` are out
+    // of scope and must be left alone.
+    const name = `${PREFIX}not-a-pid`;
+    const path = join(tmuxSocketDir(), name);
+    writeFileSync(path, "");
+    try {
+      const removed = sweepOrphanTmuxSockets(PREFIX);
+      assert.equal(removed, 0);
+      assert.ok(existsSync(path), "non-pid suffix must be ignored");
+    } finally {
+      try { unlinkSync(path); } catch {}
+    }
+  });
+
+  it("ignores sockets that don't match the prefix", () => {
+    const deadPid = freshDeadPid();
+    // Matches the `<prefix><pid>` shape but with a different prefix,
+    // so the sweep should not touch it even though the pid is dead.
+    const otherPrefix = "katulong-test-otherprefix-";
+    const name = `${otherPrefix}${deadPid}`;
+    const path = join(tmuxSocketDir(), name);
+    writeFileSync(path, "");
+    try {
+      const removed = sweepOrphanTmuxSockets(PREFIX);
+      assert.equal(removed, 0);
+      assert.ok(existsSync(path), "non-matching prefix must be left alone");
+    } finally {
+      try { unlinkSync(path); } catch {}
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Test harness was leaking tmux socket files into `/tmp/tmux-$UID/` — one dev accumulated 16,587, another 4,733, enough to destabilize tmux itself
- Two leak modes: (A) `kill-server` does not unlink the socket, so every graceful test exit leaks one; (B) SIGKILL (pre-push / CI timeouts / OOM) bypasses the exit handler entirely, leaving the detached anchor tmux server orphaned but alive
- Fix: PID-based sweep-at-boot. Socket names are `katulong-test-<pid>`; if that PID is dead, `kill-server` (reaps mode B) + `unlink` (finishes mode A/B). Sibling pre-clear added for name-based sockets (stage / e2e shards) where sweep-by-PID doesn't apply.

## Why probe-based detection doesn't work

An earlier iteration used "does tmux respond on this socket?" to decide if it was orphaned. That correctly reaps mode A (no server answers) but leaves mode B alone (orphaned anchor still responds). Observed on a dev machine: anchor PIDs 3+ days dead still listening happily. PID-based detection catches both modes and is far faster — `process.kill(pid, 0)` is a syscall, not a spawn-tmux-per-entry, so 16k entries sweep in ms.

## Test plan

- [x] Unit tests: `test/tmux-socket-sweep.test.js` — PID-alive spared, dead PID reaped, non-matching prefix/suffix ignored
- [x] Integration test: `test/tmux-socket-lifecycle.test.js` — boots two child `setup-env` processes with a sandboxed `TMUX_TMPDIR`, verifies child A's socket persists after clean exit, then that child B's boot sweep reaps it
- [x] Full `npm test` — 2078 pass, 3 skipped, 0 fail
- [x] Smoke E2E passed via pre-push hook

## Gotcha worth recording

macOS `os.tmpdir()` resolves to `/var/folders/l1/n_6xzsrj4b57b69l3yzy101c0000gn/T/...` which, combined with `tmux-<uid>/<socket>`, blows past the ~104-char unix domain socket path limit. tmux fails silently with "File name too long" and the anchor never binds. The lifecycle test sandboxes under `/tmp/` directly.