### PR TITLE
feat: katulong tmux-sweep CLI + brew post_install hook

### DIFF
--- a/Formula/katulong.rb
+++ b/Formula/katulong.rb
@@ -16,6 +16,17 @@ class Katulong < Formula
   end
 
   def post_install
+    katulong = bin/"katulong"
+
+    # Best-effort orphan tmux socket cleanup. Dev machines that have
+    # run the test suite accumulate `katulong-test-<pid>` sockets in
+    # /tmp/tmux-$UID/ (one machine hit 16k+), which eventually
+    # destabilizes tmux itself. The sweep is prefix-scoped and only
+    # touches entries whose creator PID is dead, so it's always safe
+    # to run. Failure here must never block the install — we run in
+    # a subshell that always exits 0.
+    system "/bin/sh", "-c", "#{katulong} tmux-sweep --quiet 2>/dev/null || true"
+
     # When `katulong update` is driving the upgrade, it creates a sentinel
     # file and handles the smoke-test-and-swap restart itself.  Skip here
     # so we don't race with that process or hit EPERM on the plist.
@@ -26,7 +37,6 @@ class Katulong < Formula
     end
 
     # Standalone `brew upgrade` (not via `katulong update`): restart normally.
-    katulong = bin/"katulong"
     if (Pathname.new(Dir.home) / "Library/LaunchAgents/com.dorkyrobot.katulong.plist").exist?
       system katulong, "service", "restart"
     else

--- a/bin/katulong
+++ b/bin/katulong
@@ -31,6 +31,7 @@ const COMMANDS = {
   notes: "Read per-session notepad content (read, list)",
   setup: "One-time setup (self-access for kubos and agents)",
   service: "Manage macOS LaunchAgent (install, uninstall, restart, status)",
+  "tmux-sweep": "Reap orphaned katulong-test-<pid> tmux sockets",
 };
 
 function showHelp() {

--- a/lib/cli/commands/tmux-sweep.js
+++ b/lib/cli/commands/tmux-sweep.js
@@ -1,0 +1,30 @@
+import { sweepOrphanTmuxSockets, tmuxSocketDir } from "../../tmux-socket-sweep.js";
+
+/**
+ * `katulong tmux-sweep` — reap orphaned `katulong-test-<pid>` sockets.
+ *
+ * On dev machines these accumulate into the thousands when SIGKILL
+ * (pre-push timeouts, CI timeouts, OOM) bypasses the test harness's
+ * exit handler. Also wired into the Homebrew post_install so upgrading
+ * the package implicitly cleans up.
+ *
+ * Safe to run any time: only reaps sockets whose creator PID is no
+ * longer alive, and only those matching the `katulong-test-` prefix.
+ * Prints a short summary.
+ *
+ * Flags:
+ *   --quiet    suppress the summary line (used from post_install)
+ */
+export default async function tmuxSweep(args) {
+  const quiet = args.includes("--quiet") || args.includes("-q");
+
+  const removed = sweepOrphanTmuxSockets("katulong-test-");
+
+  if (!quiet) {
+    if (removed === 0) {
+      console.log(`No orphan tmux sockets to sweep in ${tmuxSocketDir()}.`);
+    } else {
+      console.log(`Swept ${removed} orphan tmux socket${removed === 1 ? "" : "s"} from ${tmuxSocketDir()}.`);
+    }
+  }
+}

--- a/lib/tmux-socket-sweep.js
+++ b/lib/tmux-socket-sweep.js
@@ -1,17 +1,24 @@
 /**
  * Sweep orphan tmux socket files from /tmp/tmux-$UID/.
  *
- * There are two distinct leak modes for per-test tmux sockets:
+ * Used in two places:
+ *   - test harness boot (`test/helpers/setup-env.js`) for
+ *     `katulong-test-<pid>` sockets accumulated by SIGKILLed or
+ *     timed-out test processes.
+ *   - `katulong tmux-sweep` CLI / brew post_install, so upgrading the
+ *     package reaps orphans from prior dev activity.
+ *
+ * There are two distinct leak modes for PID-scoped tmux sockets:
  *
  *   A. Dead socket, no server. Either `kill-server` ran but didn't finish
  *      unlinking, or the server crashed outright. The file remains.
  *
- *   B. Orphaned but alive. The test process was SIGKILLed (pre-push hook
- *      timeout, CI runner timeout, OOM), so `process.on("exit")` never
- *      ran — but the detached tmux anchor server kept running. Observed
- *      on the author's mini: anchors from test PIDs 3+ days dead, still
- *      listening. A probe-based sweep ("does tmux respond?") sees these
- *      as alive and leaves them forever.
+ *   B. Orphaned but alive. The creator process was SIGKILLed (pre-push
+ *      hook timeout, CI runner timeout, OOM), so its `process.on("exit")`
+ *      never ran — but the detached tmux anchor server kept running.
+ *      Observed on a dev machine: anchors from test PIDs 3+ days dead,
+ *      still listening. A probe-based sweep ("does tmux respond?") sees
+ *      these as alive and leaves them forever.
  *
  * The socket name encodes its creator: `<prefix><pid>`. If that PID is
  * no longer alive, the socket is an orphan in both modes above. We kill

--- a/test/helpers/setup-env.js
+++ b/test/helpers/setup-env.js
@@ -39,7 +39,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
-import { sweepOrphanTmuxSockets } from "./tmux-socket-sweep.js";
+import { sweepOrphanTmuxSockets } from "../../lib/tmux-socket-sweep.js";
 
 if (!process.env.KATULONG_DATA_DIR) {
   const dir = mkdtempSync(join(tmpdir(), "katulong-test-"));

--- a/test/tmux-socket-sweep.test.js
+++ b/test/tmux-socket-sweep.test.js
@@ -21,7 +21,7 @@ import { join } from "node:path";
 import {
   sweepOrphanTmuxSockets,
   tmuxSocketDir,
-} from "./helpers/tmux-socket-sweep.js";
+} from "../lib/tmux-socket-sweep.js";
 
 const PREFIX = "katulong-test-sweeptst-";
 


### PR DESCRIPTION
## Summary

Follow-up to #577 — make the orphan-tmux-socket cleanup easy for dev machines to actually pick up.

- Move the sweep helper from `test/helpers/` to `lib/` (it's shippable now)
- New `katulong tmux-sweep [--quiet]` CLI — reaps `katulong-test-<pid>` sockets whose creator PID is dead
- Homebrew `post_install` runs `katulong tmux-sweep --quiet` before the service restart

## Why

After upgrading to v0.55.6, a dev machine had 16k+ `katulong-test-*` orphans still in `/tmp/tmux-$UID/`. The #577 sweep only runs inside the test harness, so installing the release didn't reap anything — you'd only see the cleanup the next time you ran the suite. A `brew upgrade` is the natural moment to sweep: the post_install already restarts the service, and the sweep is cheap + prefix-scoped.

## Safety

- Prefix hardcoded to `katulong-test-`; can't clobber unrelated sockets
- Only reaps entries whose creator PID is dead (invariant unchanged from #577)
- `post_install` invocation is wrapped in `sh -c "… || true"` so a sweep failure can never block the install

## Test plan

- [x] `npm test` — 2078 pass, 3 skipped, 0 fail
- [x] End-to-end: seed a `katulong-test-<deadpid>` socket, run `katulong tmux-sweep`, confirm it's removed
- [x] Confirmed `katulong tmux-sweep` shows in `katulong --help` and the `--quiet` flag exits silently