### PR TITLE
FP pre-req chain for multi-cluster: pure reducers + selectors (FP1-FP5)

### DIFF
--- a/docs/tile-clusters-design.md
+++ b/docs/tile-clusters-design.md
@@ -112,11 +112,11 @@ Before the multi-cluster substrate lands, the imperative chunks of `app.js` that
 **Scope is the critical path only.** WebRTC retry, iframe focus, connection-indicator tooltip, settings handlers, and other still-imperative chunks are orthogonal and stay deferred.
 
 Pre-req checklist (convert before multi-cluster strips):
-- [x] **FP1 — Carousel persistence reducer** (`app.js:2417–2483`). Extend `ui-store` shape to `{ version: 2, activeClusterId, clusters, tiles (with clusterId), focusedIdByCluster }`; extract `buildBootState()` as a pure function; legacy v1→v2 migration wraps existing tiles into a default cluster. Unblocks every downstream chunk. *Medium.*
-- [ ] **FP2 — Cluster activation action** (`app.js:442–449, 954–964`). Replace `carousel.isActive() ? carousel.getFocusedCard() : id` branching with a `uiStore` cluster-switch action + effect. *Small.*
-- [ ] **FP3 — `+` button routing factory** (`app.js:1490–1493, 911–934`). Pure `decideAddTileTarget()` + factory wrapping `tab-add` and sidebar add handlers so Level 2 can reuse them for cluster creation. *Small.*
-- [ ] **FP4 — Pinch level reducer** (`app.js:542–576`). Binary `carousel.setMode()` becomes a mode stack `{ level, mode }` with pinch thresholds as transition rules. *Medium.*
-- [ ] **FP5 — Carousel↔cluster isolation** (`app.js:463–517, 578–599`). Parameterize tile-host and `syncCarouselSubscriptions()` by cluster context so WS subscription routing is cluster-aware. *Medium.*
+- [x] **FP1 — Carousel persistence reducer** (`33aa3be`). v2 ui-store shape `{ version, activeClusterId, clusters, tiles (with clusterId), focusedIdByCluster }`; extracted `buildBootState()` to a pure module with legacy v1→v2 migration. *Medium.*
+- [x] **FP2 — Cluster activation cleanup** (`509da16`). Removed last imperative `carousel.isActive() ? carousel.getCards() : windowTabSet.getTabs()` branch in `pickRightNeighbor`; reads ui-store `state.order`/`focusedId` directly. (SWITCH_CLUSTER action landed in FP1; cluster-switch *effect* designed alongside MC3 when there's a caller.) *Small.*
+- [x] **FP3 — `+` button routing factory** (`668a450`). New `public/lib/add-target.js`: pure `decideAddTarget({level, activeClusterId, focusedId})` + `createAddHandler` factory + id generators. Sidebar-+ rewired through factory; level-2 path wired to `uiStore.addCluster` so MC3 only swaps `getLevel()`. 12 pure tests. *Small.*
+- [x] **FP4 — Pinch level reducer** (`3cb0138`). New `public/lib/pinch-levels.js`: pure `reducePinch(state, {scale})` for the full L1↔L2 state machine + `diffPinchState` for minimal side effects. App.js wiring threads `pinchState` through the reducer; L2 transitions clamped until MC3. 17 pure tests. *Medium.*
+- [x] **FP5 — Carousel↔cluster isolation** (`d39a96b`). New `selectClusterView(state, clusterId)` selector; tile-host accepts optional `getClusterId` (defaults to active cluster) and reconciles via the scoped view; `syncCarouselSubscriptions(clusterId?)` iterates ui-store order instead of carousel cards. 12 new selector tests. *Medium.*
 
 Then the multi-cluster work itself (each line below is a separate PR on top of the pre-req):
 - [ ] **MC1 — T2a columns data shape** (single-slot initially; a future v3 bump).

--- a/docs/tile-clusters-design.md
+++ b/docs/tile-clusters-design.md
@@ -105,6 +105,26 @@ Discussed but explicitly deferred until pinch + Level 1/2 are working:
 
 Everything after Step 1 follows the **Tier 1 / Tier 2 / Tier 3** plan in "Architectural decisions" below — a refactor lands *before* the new features so columns, file-browser-as-tile, and Level 2 build on a clean substrate instead of bolting onto the flat-array model.
 
+### FP pre-req for multi-cluster (2026-04-13)
+
+Before the multi-cluster substrate lands, the imperative chunks of `app.js` that multi-cluster will touch get converted into the established reducer/factory/effect-descriptor pattern (campaign history: `28f5538`, `29d6ec6`, `9868545`, `d9357ba`). Rationale: imperative state plus a new cluster layer produces hard-to-debug bugs; the conversion pays itself back in debuggability.
+
+**Scope is the critical path only.** WebRTC retry, iframe focus, connection-indicator tooltip, settings handlers, and other still-imperative chunks are orthogonal and stay deferred.
+
+Pre-req checklist (convert before multi-cluster strips):
+- [x] **FP1 — Carousel persistence reducer** (`app.js:2417–2483`). Extend `ui-store` shape to `{ version: 2, activeClusterId, clusters, tiles (with clusterId), focusedIdByCluster }`; extract `buildBootState()` as a pure function; legacy v1→v2 migration wraps existing tiles into a default cluster. Unblocks every downstream chunk. *Medium.*
+- [ ] **FP2 — Cluster activation action** (`app.js:442–449, 954–964`). Replace `carousel.isActive() ? carousel.getFocusedCard() : id` branching with a `uiStore` cluster-switch action + effect. *Small.*
+- [ ] **FP3 — `+` button routing factory** (`app.js:1490–1493, 911–934`). Pure `decideAddTileTarget()` + factory wrapping `tab-add` and sidebar add handlers so Level 2 can reuse them for cluster creation. *Small.*
+- [ ] **FP4 — Pinch level reducer** (`app.js:542–576`). Binary `carousel.setMode()` becomes a mode stack `{ level, mode }` with pinch thresholds as transition rules. *Medium.*
+- [ ] **FP5 — Carousel↔cluster isolation** (`app.js:463–517, 578–599`). Parameterize tile-host and `syncCarouselSubscriptions()` by cluster context so WS subscription routing is cluster-aware. *Medium.*
+
+Then the multi-cluster work itself (each line below is a separate PR on top of the pre-req):
+- [ ] **MC1 — T2a columns data shape** (single-slot initially; a future v3 bump).
+- [ ] **MC2 — T2b layout-change snapshot** (shortcut-bar consumes snapshot, stops importing carousel directly).
+- [ ] **MC3 — Level 2 cluster strips** (vertical stack of horizontal carousel strips, pinch-out from Level 1, uniform mode, `+` at Level 2, tap/pinch-in to return).
+
+Explicitly deferred from this round: T1a (flip extraction), T1b (file-browser polish), T2c (face-stack-of-N), drag-to-stack, deck-of-cards in exposé, columns with >1 tile, Level 3 spatial canvas.
+
 ## Architectural decisions (from /consult, 2026-04-09)
 
 The /consult agent revealed the file browser is *already* a tile (PR #533). The real structural problems are in the **container** (`card-carousel.js`), not the content. Recorded decisions:

--- a/public/app.js
+++ b/public/app.js
@@ -1003,21 +1003,16 @@
      * remove the card/tab, dispose the pooled terminal, and show the add
      * menu if nothing's left. Returns whether a neighbor was activated, so
      * callers can branch on "last tab closed".
-     *
-     * For clusters, the focused card id is NOT the session name (the
-     * cluster's sessionName getter aliases its first sub-tile). Use the
-     * carousel's actual focused id when active so indexOf finds the
-     * current card and we pick the correct right-neighbor — otherwise
-     * idx falls to -1 and `next` collapses to tabs[0] (the first tile).
      */
-    // Pick the right neighbor of `id` in the current tab/carousel order,
+    // Pick the right neighbor of `id` in the current cluster's tile order,
     // falling back to the previous tile if `id` is the last one. Returns
     // null if there is no neighbor (single tile, or id not found). Shared
     // by the explicit close path (Option+W) and the reactive session-
     // removed path so both land focus on the same tile.
     function pickRightNeighbor(id) {
-      const tabs = carousel.isActive() ? carousel.getCards() : windowTabSet.getTabs();
-      const currentId = carousel.isActive() ? (carousel.getFocusedCard() || id) : id;
+      const state = uiStore.getState();
+      const tabs = state.order;
+      const currentId = state.focusedId || id;
       const idx = tabs.indexOf(currentId);
       if (tabs.length <= 1 || idx === -1) return null;
       return tabs[idx === tabs.length - 1 ? idx - 1 : idx + 1];

--- a/public/app.js
+++ b/public/app.js
@@ -44,6 +44,7 @@
     import { dispatchNotification } from "/lib/notify.js";
     import { createUiStore, loadFromStorage, EMPTY_STATE } from "/lib/ui-store.js";
     import { buildBootState } from "/lib/boot-state.js";
+    import { createAddHandler, generateSessionName, generateClusterId } from "/lib/add-target.js";
     import { initRenderers, isPersistable, getRenderer } from "/lib/tile-renderers/index.js";
     import { createTileHost } from "/lib/tile-host.js";
     import { getFocusedSession } from "/lib/selectors.js";
@@ -915,7 +916,7 @@
     // --- New session creation (shared by sidebar + and shortcut bar +) ---
     async function createNewSession() {
       try {
-        const name = `session-${Date.now().toString(36)}`;
+        const name = generateSessionName();
         const data = await api.post("/sessions", { name, copyFrom: getActiveSessionName() });
         if (sidebar?.classList.contains("collapsed")) {
           setSidebarCollapsed(false);
@@ -930,8 +931,22 @@
       }
     }
 
+    // FP3 — + button routing. Pure decision in /lib/add-target.js; this
+    // factory wires it to the two side-effects (create terminal tile /
+    // create empty cluster). Level is hardcoded to 1 until MC3 introduces
+    // Level 2; at that point only getLevel() changes.
+    const handleAdd = createAddHandler({
+      getLevel: () => 1,
+      getState: () => {
+        const st = uiStore.getState();
+        return { activeClusterId: st.activeClusterId, focusedId: st.focusedId };
+      },
+      onAddTile: () => createNewSession(),
+      onAddCluster: () => uiStore.addCluster({ id: generateClusterId() }, { switchTo: true }),
+    });
+
     if (sidebarAddBtn) {
-      sidebarAddBtn.addEventListener("click", createNewSession);
+      sidebarAddBtn.addEventListener("click", handleAdd);
     }
 
     // Load session data: always on desktop (for tab bar), or when sidebar is expanded

--- a/public/app.js
+++ b/public/app.js
@@ -45,6 +45,7 @@
     import { createUiStore, loadFromStorage, EMPTY_STATE } from "/lib/ui-store.js";
     import { buildBootState } from "/lib/boot-state.js";
     import { createAddHandler, generateSessionName, generateClusterId } from "/lib/add-target.js";
+    import { reducePinch, diffPinchState, INITIAL_PINCH_STATE } from "/lib/pinch-levels.js";
     import { initRenderers, isPersistable, getRenderer } from "/lib/tile-renderers/index.js";
     import { createTileHost } from "/lib/tile-host.js";
     import { getFocusedSession } from "/lib/selectors.js";
@@ -539,26 +540,26 @@
       document.body.dataset.focusedNeedsWs = desc.session ? "1" : "0";
     });
 
-    // ── Pinch-to-expose gesture ──────────────────────────────────────
+    // ── Pinch-to-zoom gesture ────────────────────────────────────────
     //
-    // Step 1 of the tile-clusters design: pinch is the zoom verb.
-    // Pinch-out morphs the carousel into exposé (all tiles visible at
-    // once); pinch-in returns to carousel. Once Level 2 (cluster
-    // overview) exists this same gesture will carry through to it —
-    // the commit thresholds below are intentionally conservative so
-    // they can be re-framed as "level change" without rewriting.
+    // Pinch is the zoom verb across the tile-clusters design. The pure
+    // state machine lives in /lib/pinch-levels.js (FP4) — this wiring
+    // reads the current level/mode from module-local state, asks the
+    // reducer for the next state, and applies side effects via diffs.
     //
-    // Commit thresholds: we only switch mode on gesture end, and only
-    // if the final scale crossed ~15%. Mid-gesture we do NOT live-morph
-    // — that would require interpolating transforms per frame while
-    // dodging the running CSS transition, which in turn means reading
-    // offsetWidth mid-animation (the exact trap called out in
-    // positionCards's cachedCardW comment). A discrete commit-on-end
-    // is simpler, passes tests, and still feels gestural because the
-    // subsequent CSS transition is fast (350ms). Live interpolation
-    // can be layered on later without changing this contract.
-    const pinchCommitOut = 1.15; // >= this at end => carousel -> expose
-    const pinchCommitIn  = 0.87; // <= this at end => expose -> carousel
+    // Today only Level 1 exists (carousel ↔ expose). The reducer also
+    // models Level 1 expose → Level 2 expose, but we CLAMP transitions
+    // to level 1 here until MC3 adds the Level-2 renderer. The clamp
+    // is a single if-statement so MC3 removes it cleanly.
+    //
+    // Commit-on-end rationale: we only switch mode on gesture end (not
+    // mid-gesture). Live-morphing requires interpolating transforms per
+    // frame while dodging the running CSS transition — which means
+    // reading offsetWidth mid-animation (the exact trap in positionCards's
+    // cachedCardW comment). Discrete commit-on-end is simpler, passes
+    // tests, and feels gestural because the subsequent CSS transition
+    // is fast (350ms).
+    let pinchState = INITIAL_PINCH_STATE;
     const pinchTarget = document.getElementById("terminal-container");
     if (pinchTarget) {
       const pinch = createPinchGesture({
@@ -566,12 +567,14 @@
         onPinch: ({ scale, phase }) => {
           if (!carousel.isActive()) return;
           if (phase !== "end") return;
-          const cur = carousel.getMode();
-          if (cur === "carousel" && scale >= pinchCommitOut) {
-            carousel.setMode("expose");
-          } else if (cur === "expose" && scale <= pinchCommitIn) {
-            carousel.setMode("carousel");
-          }
+          let next = reducePinch(pinchState, { scale });
+          // Clamp to level 1 until MC3 lands. Remove this when Level 2
+          // renderer exists; the reducer already handles the transition.
+          if (next.level === 2) next = { level: 1, mode: next.mode };
+          const diff = diffPinchState(pinchState, next);
+          pinchState = next;
+          if (!diff) return;
+          if (diff.modeChanged) carousel.setMode(next.mode);
         },
       });
       pinch.attach();

--- a/public/app.js
+++ b/public/app.js
@@ -48,7 +48,7 @@
     import { reducePinch, diffPinchState, INITIAL_PINCH_STATE } from "/lib/pinch-levels.js";
     import { initRenderers, isPersistable, getRenderer } from "/lib/tile-renderers/index.js";
     import { createTileHost } from "/lib/tile-host.js";
-    import { getFocusedSession } from "/lib/selectors.js";
+    import { getFocusedSession, selectClusterView } from "/lib/selectors.js";
     import { navigateTab as computeNavigateTab, moveTab as computeMoveTab, jumpToTab as computeJumpToTab } from "/lib/navigation.js";
     import { createIconStore } from "/lib/icon-store.js";
     import { createReconcilerStore } from "/lib/reconciler-store.js";
@@ -580,14 +580,24 @@
       pinch.attach();
     }
 
-    /** Subscribe all carousel tiles to WS output via getSessions().
+    /** Subscribe all tiles in a cluster to WS output via getSessions().
      *  ALL tiles need subscriptions — including the focused one — because
      *  carousel swipe doesn't send `switch` (no server round-trip). Without
      *  a subscription, data-available notifications are dropped and the
-     *  terminal appears stuck. */
-    function syncCarouselSubscriptions() {
-      if (!carousel.isActive()) return;
-      for (const tileId of carousel.getCards()) {
+     *  terminal appears stuck.
+     *
+     *  Cluster-scoped (FP5): iterates a cluster's tile order from
+     *  ui-store rather than the visible carousel's card list. This keeps
+     *  subscription routing correct when MC3 introduces multiple carousels
+     *  (Level 2) — each cluster's tiles are subscribed independently of
+     *  whichever carousel is visually on screen.
+     *
+     *  @param {string} [clusterId] — defaults to the active cluster. */
+    function syncCarouselSubscriptions(clusterId) {
+      const state = uiStore.getState();
+      const view = selectClusterView(state, clusterId || state.activeClusterId);
+      if (view.order.length === 0) return;
+      for (const tileId of view.order) {
         const handle = tileHost.getHandle(tileId);
         if (!handle) continue;
         // getSessions() returns all WS session names this tile manages:
@@ -601,7 +611,7 @@
           cm.send(JSON.stringify(subMsg));
         }
       }
-      carousel.fitAll();
+      if (carousel.isActive()) carousel.fitAll();
     }
 
     /** Route a session through ui-store — adds the tile if absent, then

--- a/public/app.js
+++ b/public/app.js
@@ -43,6 +43,7 @@
     import { createFileBrowserTileFactory } from "/lib/tiles/file-browser-tile.js";
     import { dispatchNotification } from "/lib/notify.js";
     import { createUiStore, loadFromStorage, EMPTY_STATE } from "/lib/ui-store.js";
+    import { buildBootState } from "/lib/boot-state.js";
     import { initRenderers, isPersistable, getRenderer } from "/lib/tile-renderers/index.js";
     import { createTileHost } from "/lib/tile-host.js";
     import { getFocusedSession } from "/lib/selectors.js";
@@ -2414,72 +2415,21 @@
     const wasEmptyState = sessionStorage.getItem("katulong-empty-state");
     if (wasEmptyState) sessionStorage.removeItem("katulong-empty-state");
 
-    /** Build boot state from localStorage + URL hint + legacy migration. */
-    function buildBootState() {
-      // Start from persisted ui-store state
-      let initial = loadFromStorage();
-
-      // Legacy migration: if ui-store has nothing but the old carousel
-      // localStorage has tiles, migrate them. After migration, clear the
-      // old key so two persistence layers don't drift out of sync.
-      if (!initial || Object.keys(initial.tiles).length === 0) {
-        const carouselState = carousel.restore();
-        if (carouselState?.tiles?.length) {
-          const tiles = {};
-          const order = [];
-          for (const t of carouselState.tiles) {
-            const type = t.type === "dashboard" ? "cluster" : t.type;
-            if (!getRenderer(type)) continue;
-            tiles[t.id] = { id: t.id, type, props: { ...t } };
-            delete tiles[t.id].props.id;
-            delete tiles[t.id].props.type;
-            delete tiles[t.id].props.cardWidth;
-            order.push(t.id);
-          }
-          initial = {
-            version: 1,
-            tiles,
-            order,
-            focusedId: carouselState.focused || order[0] || null,
-          };
-          // Migration complete — clear old key
-          try { localStorage.removeItem("katulong-carousel"); } catch {}
-        }
+    /** Gather boot-state deps from the window, delegate to the pure
+     *  buildBootState() composer, and clear the legacy carousel key if
+     *  migration fired. */
+    function gatherBootState() {
+      const { state, migratedLegacy } = buildBootState({
+        persisted: loadFromStorage(),
+        legacyCarousel: carousel.restore(),
+        urlSession: explicitSession,
+        tabSetSessions: windowTabSet ? windowTabSet.getTabs() : [],
+        getRenderer,
+      });
+      if (migratedLegacy) {
+        try { localStorage.removeItem("katulong-carousel"); } catch {}
       }
-
-      if (!initial) initial = { version: 1, tiles: {}, order: [], focusedId: null };
-
-      // Merge ?s= URL hint. Only override focusedId when the URL
-      // introduced a NEW session — otherwise, the persisted focusedId
-      // wins. ?s= only tracks terminals, so it goes stale when the user
-      // focuses a non-terminal tile (file browser). Overriding
-      // unconditionally would lose that focus on every refresh.
-      if (explicitSession) {
-        if (!initial.tiles[explicitSession]) {
-          initial.tiles[explicitSession] = {
-            id: explicitSession,
-            type: "terminal",
-            props: { sessionName: explicitSession },
-          };
-          initial.order.push(explicitSession);
-          initial.focusedId = explicitSession;
-        }
-      }
-
-      // Merge windowTabSet sessions (legacy — ensures tabs from other windows
-      // appear even if they weren't in the persisted ui-store yet)
-      if (windowTabSet) {
-        for (const tab of windowTabSet.getTabs()) {
-          if (!initial.tiles[tab]) {
-            initial.tiles[tab] = {
-              id: tab, type: "terminal", props: { sessionName: tab },
-            };
-            initial.order.push(tab);
-          }
-        }
-      }
-
-      return initial;
+      return state;
     }
 
     function bootFromState(bootState) {
@@ -2511,11 +2461,13 @@
     if (!explicitSession && !wasEmptyState) {
       // No URL hint — check for persisted tiles first, then fall back to
       // fetching /sessions to find an existing session.
-      const bootState = buildBootState();
+      const bootState = gatherBootState();
       if (Object.keys(bootState.tiles).length > 0) {
         bootFromState(bootState);
       } else {
-        // No persisted tiles — ask the server for existing sessions
+        // No persisted tiles — ask the server for existing sessions.
+        // tileHost is already subscribed, so we dispatch via addTile +
+        // connect rather than rebuilding a boot state from scratch.
         fetch("/sessions").then(r => {
           if (!r.ok) throw new Error(`HTTP ${r.status}`);
           return r.json();
@@ -2523,10 +2475,12 @@
           if (cm.getState().status !== "disconnected" || uiStore.getState().focusedId !== null) return;
           if (sessions.length > 0 && sessions[0].name) {
             const name = sessions[0].name;
-            bootState.tiles[name] = { id: name, type: "terminal", props: { sessionName: name } };
-            bootState.order.push(name);
-            bootState.focusedId = name;
-            bootFromState(bootState);
+            uiStore.addTile(
+              { id: name, type: "terminal", props: { sessionName: name } },
+              { focus: true },
+            );
+            setDocTitle(name);
+            cm.connect();
           }
         }).catch(err => {
           console.warn("Failed to fetch sessions on load:", err);
@@ -2534,7 +2488,7 @@
       }
     } else if (!wasEmptyState) {
       // Explicit ?s= — build and boot immediately
-      bootFromState(buildBootState());
+      bootFromState(gatherBootState());
     }
     // If wasEmptyState, stay empty — user explicitly closed all tabs.
 

--- a/public/lib/add-target.js
+++ b/public/lib/add-target.js
@@ -1,0 +1,89 @@
+/**
+ * `+` button routing — pure decision + factory.
+ *
+ * The + button has two distinct behaviors depending on zoom level:
+ *   - Level 1 (focused cluster, default):  add a tile to the active cluster
+ *   - Level 2 (cluster overview):          add a new empty cluster
+ *
+ * FP3 in the multi-cluster FP pre-req chain. Goal is to shift add-routing
+ * load from integration tests onto pure unit tests — `decideAddTarget()`
+ * has zero I/O and can cover every branch in a handful of asserts.
+ *
+ * The factory (`createAddHandler`) wires the pure decision into a handler
+ * that sidebar-+, tab-add, and (future) Level-2-+ all share. Side effects
+ * (API calls, store dispatch) stay on the caller via injected `onAddTile`
+ * / `onAddCluster` — the factory never touches the outside world.
+ */
+
+/**
+ * @typedef {{ kind: "tile", clusterId: string, insertAfter: string | null }} TileTarget
+ * @typedef {{ kind: "cluster" }} ClusterTarget
+ * @typedef {TileTarget | ClusterTarget} AddTarget
+ */
+
+/**
+ * Decide what the + button should produce, given zoom level and state.
+ *
+ * @param {object} ctx
+ * @param {number} ctx.level           Current zoom level (1 = focused, 2 = overview).
+ * @param {string} ctx.activeClusterId Id of the currently-active cluster.
+ * @param {string|null} [ctx.focusedId] Focused tile id, if any.
+ * @returns {AddTarget}
+ */
+export function decideAddTarget({ level, activeClusterId, focusedId = null }) {
+  if (level >= 2) return { kind: "cluster" };
+  return {
+    kind: "tile",
+    clusterId: activeClusterId,
+    insertAfter: focusedId,
+  };
+}
+
+/**
+ * Unique session id. Pure given a clock; defaults to Date.now.
+ * Kept here so the callers (sidebar-+, menu) share one format.
+ *
+ * @param {() => number} [now]
+ */
+export function generateSessionName(now = Date.now) {
+  return `session-${now().toString(36)}`;
+}
+
+/**
+ * Unique cluster id. Same shape as generateSessionName so future
+ * migration code can recognize "generated" ids vs. hand-named ones.
+ *
+ * @param {() => number} [now]
+ */
+export function generateClusterId(now = Date.now) {
+  return `cluster-${now().toString(36)}`;
+}
+
+/**
+ * Factory for a unified + handler. Both Level 1 and Level 2 add-buttons
+ * call the returned function with no args; it reads fresh state, asks
+ * `decideAddTarget` what to do, and dispatches to the right effect.
+ *
+ * The separation matters for testability: every branch is covered by
+ * driving fake `getLevel`/`getState` into the factory and asserting on
+ * the injected `onAddTile`/`onAddCluster` spies.
+ *
+ * @param {object} deps
+ * @param {() => number} deps.getLevel
+ * @param {() => { activeClusterId: string, focusedId: string|null }} deps.getState
+ * @param {(target: TileTarget) => any} deps.onAddTile
+ * @param {(target: ClusterTarget) => any} deps.onAddCluster
+ * @returns {() => any} handleAdd
+ */
+export function createAddHandler({ getLevel, getState, onAddTile, onAddCluster }) {
+  return function handleAdd() {
+    const { activeClusterId, focusedId } = getState();
+    const target = decideAddTarget({
+      level: getLevel(),
+      activeClusterId,
+      focusedId,
+    });
+    if (target.kind === "cluster") return onAddCluster(target);
+    return onAddTile(target);
+  };
+}

--- a/public/lib/boot-state.js
+++ b/public/lib/boot-state.js
@@ -1,0 +1,130 @@
+/**
+ * Boot-state composition — pure function that builds the initial
+ * ui-store state from all the sources the app needs at launch.
+ *
+ * Moved out of app.js to make it testable without a DOM, and so the
+ * multi-cluster schema bump (FP1) has a single, reviewed place where
+ * persistence + URL hints + window tabsets meet.
+ *
+ * Sources, in priority order:
+ *   1. `persisted`       — result of ui-store `loadFromStorage()`.
+ *   2. `legacyCarousel`  — shape the pre-ui-store carousel persisted
+ *                          (`{ tiles: [...], focused }`). Only used
+ *                          when `persisted` is empty/missing, and
+ *                          signals `migratedLegacy: true` so the
+ *                          caller can clear the old storage key.
+ *   3. `urlSession`      — the `?s=<name>` hint. Adds a new terminal
+ *                          tile if the session isn't already present
+ *                          and focuses it.
+ *   4. `tabSetSessions`  — legacy windowTabSet sessions. Folds in any
+ *                          terminals that other windows know about
+ *                          but weren't persisted here yet.
+ */
+
+import { EMPTY_STATE, normalize, DEFAULT_CLUSTER_ID } from "./ui-store.js";
+
+/**
+ * @param {object} deps
+ * @param {object|null} [deps.persisted]         Normalized v2 state or null.
+ * @param {object|null} [deps.legacyCarousel]    Pre-ui-store carousel state or null.
+ * @param {string|null} [deps.urlSession]        Value of ?s= URL param.
+ * @param {string[]}    [deps.tabSetSessions]    Window tab-set session names.
+ * @param {function}    [deps.getRenderer]       Renderer lookup (type -> renderer|null).
+ *                                               Legacy tiles with unknown types are dropped.
+ * @returns {{ state: object, migratedLegacy: boolean }}
+ */
+export function buildBootState({
+  persisted = null,
+  legacyCarousel = null,
+  urlSession = null,
+  tabSetSessions = [],
+  getRenderer = () => ({}),
+} = {}) {
+  let state = persisted && Object.keys(persisted.tiles || {}).length > 0
+    ? persisted
+    : null;
+  let migratedLegacy = false;
+
+  if (!state && legacyCarousel?.tiles?.length) {
+    const tiles = {};
+    for (const t of legacyCarousel.tiles) {
+      const type = t.type === "dashboard" ? "cluster" : t.type;
+      if (!getRenderer(type)) continue;
+      const { id, type: _t, cardWidth: _cw, ...rest } = t;
+      tiles[t.id] = { id: t.id, type, props: rest, clusterId: DEFAULT_CLUSTER_ID };
+    }
+    if (Object.keys(tiles).length > 0) {
+      // Assign x from the order of the legacy array.
+      let x = 0;
+      for (const t of legacyCarousel.tiles) {
+        if (tiles[t.id]) tiles[t.id].x = x++;
+      }
+      state = normalize({
+        version: 2,
+        activeClusterId: DEFAULT_CLUSTER_ID,
+        clusters: { [DEFAULT_CLUSTER_ID]: { id: DEFAULT_CLUSTER_ID } },
+        tiles,
+        focusedIdByCluster: {
+          [DEFAULT_CLUSTER_ID]: legacyCarousel.focused || null,
+        },
+      });
+      migratedLegacy = true;
+    }
+  }
+
+  if (!state) state = EMPTY_STATE;
+
+  // ── Merge ?s= URL hint ──────────────────────────────────────────
+  // Only override focusedId when the URL actually introduces a NEW
+  // session. Otherwise the persisted focusedId wins — ?s= only tracks
+  // terminals and goes stale when the user focuses a non-terminal
+  // tile (e.g. file browser).
+  if (urlSession) {
+    if (!state.tiles[urlSession]) {
+      state = mergeTile(state, {
+        id: urlSession,
+        type: "terminal",
+        props: { sessionName: urlSession },
+        clusterId: state.activeClusterId,
+      }, { focus: true });
+    }
+  }
+
+  // ── Merge windowTabSet sessions ─────────────────────────────────
+  for (const name of tabSetSessions) {
+    if (!state.tiles[name]) {
+      state = mergeTile(state, {
+        id: name,
+        type: "terminal",
+        props: { sessionName: name },
+        clusterId: state.activeClusterId,
+      }, { focus: false });
+    }
+  }
+
+  return { state, migratedLegacy };
+}
+
+/**
+ * Add a tile to a v2 state (pure — returns a new state). Keeps the
+ * boot-state composition isolated from the reducer so it doesn't need
+ * a live store to compose initial state.
+ */
+function mergeTile(state, tile, { focus = false } = {}) {
+  const { clusterId } = tile;
+  // nextX within the tile's cluster.
+  let maxX = -1;
+  for (const t of Object.values(state.tiles)) {
+    if (t.clusterId === clusterId && typeof t.x === "number" && t.x > maxX) maxX = t.x;
+  }
+  const nextTile = { ...tile, x: maxX + 1 };
+  const tiles = { ...state.tiles, [tile.id]: nextTile };
+  const focusedIdByCluster = focus
+    ? { ...state.focusedIdByCluster, [clusterId]: tile.id }
+    : state.focusedIdByCluster;
+  return normalize({
+    ...state,
+    tiles,
+    focusedIdByCluster,
+  });
+}

--- a/public/lib/pinch-levels.js
+++ b/public/lib/pinch-levels.js
@@ -1,0 +1,78 @@
+/**
+ * Pinch-level reducer — pure state machine for the zoom verb.
+ *
+ * FP4 in the multi-cluster FP pre-req chain. Today the pinch gesture
+ * flips a binary `carousel.setMode("carousel"|"expose")`. The multi-
+ * cluster design extends this into a two-axis state:
+ *
+ *   { level: 1 | 2, mode: "carousel" | "expose" }
+ *
+ *   Level 1 = focused cluster. mode chooses carousel vs expose.
+ *   Level 2 = cluster overview (vertical stack of strips). mode is the
+ *             uniform sub-mode that every strip renders in — inherited
+ *             from whichever Level-1 mode the user pinched out from.
+ *
+ * The transitions below model the full state machine. Today MC3 (Level
+ * 2 UI) doesn't exist, so app.js clamps transitions to level 1 before
+ * applying side effects; the reducer still exposes the full contract so
+ * MC3 is a renderer addition, not a state-machine rewrite.
+ *
+ * Pinch thresholds are constants here — any caller that wants to tune
+ * them (tests, Level 3 someday) injects them explicitly.
+ */
+
+export const PINCH_OUT_THRESHOLD = 1.15;
+export const PINCH_IN_THRESHOLD = 0.87;
+
+export const INITIAL_PINCH_STATE = { level: 1, mode: "carousel" };
+
+/**
+ * Pure reducer. Given current pinch state and the final scale of a
+ * gesture, return the next pinch state.
+ *
+ * @param {{level:1|2, mode:"carousel"|"expose"}} state
+ * @param {{scale:number, out?:number, in?:number}} action
+ * @returns {{level:1|2, mode:"carousel"|"expose"}}
+ */
+export function reducePinch(
+  state,
+  { scale, out = PINCH_OUT_THRESHOLD, in: inThreshold = PINCH_IN_THRESHOLD } = {},
+) {
+  const pinchingOut = scale >= out;
+  const pinchingIn = scale <= inThreshold;
+  if (!pinchingOut && !pinchingIn) return state;
+
+  const { level, mode } = state;
+
+  if (pinchingOut) {
+    // Level 1 carousel → Level 1 expose (within-level mode change)
+    if (level === 1 && mode === "carousel") return { level: 1, mode: "expose" };
+    // Level 1 expose → Level 2 (overview, uniform mode inherited)
+    if (level === 1 && mode === "expose")   return { level: 2, mode: "expose" };
+    // Level 2 is the ceiling today (Level 3 parked in design doc)
+    return state;
+  }
+
+  // pinching in
+  // Level 2 → Level 1, keep uniform mode so the strip you land on is
+  // the one you were visually looking at.
+  if (level === 2) return { level: 1, mode };
+  // Level 1 expose → Level 1 carousel
+  if (level === 1 && mode === "expose") return { level: 1, mode: "carousel" };
+  // Level 1 carousel is the floor
+  return state;
+}
+
+/**
+ * Derive the minimal diff between two pinch states so the caller can
+ * apply exactly the side effects that changed (avoid redundant DOM
+ * writes). Returns null if states are equal.
+ *
+ * @returns {null | { levelChanged: boolean, modeChanged: boolean }}
+ */
+export function diffPinchState(prev, next) {
+  const levelChanged = prev.level !== next.level;
+  const modeChanged = prev.mode !== next.mode;
+  if (!levelChanged && !modeChanged) return null;
+  return { levelChanged, modeChanged };
+}

--- a/public/lib/selectors.js
+++ b/public/lib/selectors.js
@@ -28,3 +28,35 @@ export function getFocusedSession(uiState, getRenderer) {
   if (!renderer) return null;
   return renderer.describe(tile.props).session || null;
 }
+
+/**
+ * Cluster-scoped view of ui-store state.
+ *
+ * Returns a `{ tiles, order, focusedId }` triple filtered to a single
+ * cluster. Used by tile-host and WS-subscription code so each cluster
+ * can drive its own carousel and bookkeep its own session subscriptions
+ * independently.
+ *
+ * Pure: no dependency on renderer registry, no mutation of input. Given
+ * an unknown or missing cluster id, returns an empty view.
+ *
+ * @param {object} uiState
+ * @param {string} clusterId
+ * @returns {{ tiles: object, order: string[], focusedId: string|null }}
+ */
+export function selectClusterView(uiState, clusterId) {
+  if (!uiState?.clusters?.[clusterId]) {
+    return { tiles: {}, order: [], focusedId: null };
+  }
+  const tiles = {};
+  const arr = [];
+  for (const t of Object.values(uiState.tiles)) {
+    if (t.clusterId !== clusterId) continue;
+    tiles[t.id] = t;
+    arr.push(t);
+  }
+  arr.sort((a, b) => (a.x ?? 0) - (b.x ?? 0));
+  const order = arr.map(t => t.id);
+  const focusedId = uiState.focusedIdByCluster?.[clusterId] ?? null;
+  return { tiles, order, focusedId };
+}

--- a/public/lib/tile-host.js
+++ b/public/lib/tile-host.js
@@ -10,8 +10,16 @@
  * calls scattered across app.js, shortcut-bar.js, and the restore path.
  * All tile lifecycle now flows through one subscription.
  *
+ * Cluster isolation (FP5): each tile-host is scoped to a single cluster.
+ * Reads go through `selectClusterView(state, clusterId)` so tile-host
+ * only sees its cluster's tiles. A future MC3 Level-2 renderer can mount
+ * one tile-host per cluster strip; today there's one tile-host bound to
+ * the active cluster.
+ *
  * Design: docs/tile-state-rewrite.md, Step 3.
  */
+
+import { selectClusterView } from "./selectors.js";
 
 /**
  * Create a tile host.
@@ -20,10 +28,14 @@
  * @param {object} opts.store — ui-store instance (getState, subscribe, dispatch)
  * @param {object} opts.carousel — card-carousel instance
  * @param {function} opts.getRenderer — (type) → renderer object (from tile-renderers registry)
+ * @param {function} [opts.getClusterId] — () → clusterId this host is scoped to.
+ *   Defaults to reading `activeClusterId` from the store on every reconcile, so
+ *   today's single-cluster app behaves exactly like before.
  * @param {function} [opts.onFocusChange] — called after carousel focus settles,
  *   with (tileId, tileType). App.js uses this for WS subscription switching.
  */
-export function createTileHost({ store, carousel, getRenderer, onFocusChange, onTileRemoved }) {
+export function createTileHost({ store, carousel, getRenderer, getClusterId, onFocusChange, onTileRemoved }) {
+  const resolveClusterId = getClusterId || (() => store.getState().activeClusterId);
   // Map<tileId, { unmount, focus, blur, resize, tile }>
   const handles = new Map();
   let prevState = null;
@@ -46,12 +58,16 @@ export function createTileHost({ store, carousel, getRenderer, onFocusChange, on
   }
 
   function _reconcile(state) {
+    // Scope to this host's cluster — every tile-host sees only its own
+    // cluster's tiles. Today there's one tile-host bound to the active
+    // cluster; MC3 can mount one per strip.
+    const view = selectClusterView(state, resolveClusterId());
     const prev = prevState || { tiles: {}, order: [], focusedId: null };
-    prevState = state;
+    prevState = view;
 
     // ── Diff tiles ─────────────────────────────────────────────────
     const prevIds = new Set(Object.keys(prev.tiles));
-    const nextIds = new Set(Object.keys(state.tiles));
+    const nextIds = new Set(Object.keys(view.tiles));
 
     // Removed tiles
     for (const id of prevIds) {
@@ -71,7 +87,7 @@ export function createTileHost({ store, carousel, getRenderer, onFocusChange, on
 
     // Added tiles — must activate carousel first if it's not active
     const added = [];
-    for (const id of state.order) {
+    for (const id of view.order) {
       if (!prevIds.has(id) && nextIds.has(id)) {
         added.push(id);
       }
@@ -79,8 +95,8 @@ export function createTileHost({ store, carousel, getRenderer, onFocusChange, on
 
     if (added.length > 0 && !carousel.isActive()) {
       // First tiles ever — activate the carousel with all current tiles
-      const tilesToActivate = state.order.map(id => {
-        const tileDesc = state.tiles[id];
+      const tilesToActivate = view.order.map(id => {
+        const tileDesc = view.tiles[id];
         const renderer = getRenderer(tileDesc.type);
         if (!renderer) return null;
         // Create a thin tile adapter that carousel can mount
@@ -88,7 +104,7 @@ export function createTileHost({ store, carousel, getRenderer, onFocusChange, on
         return { id, tile: adapter };
       }).filter(Boolean);
 
-      carousel.activate(tilesToActivate, state.focusedId);
+      carousel.activate(tilesToActivate, view.focusedId);
 
       // Stash handles from the adapters that carousel just mounted
       for (const { id, tile: adapter } of tilesToActivate) {
@@ -97,12 +113,12 @@ export function createTileHost({ store, carousel, getRenderer, onFocusChange, on
     } else {
       // Carousel already active — add new tiles individually
       for (const id of added) {
-        const tileDesc = state.tiles[id];
+        const tileDesc = view.tiles[id];
         const renderer = getRenderer(tileDesc.type);
         if (!renderer) continue;
         const adapter = _createAdapter(id, tileDesc, renderer, store.dispatch);
         // Insert at the correct position in the carousel
-        const position = state.order.indexOf(id);
+        const position = view.order.indexOf(id);
         carousel.addCard(id, adapter, position >= 0 ? position : undefined);
         if (adapter._handle) handles.set(id, adapter._handle);
       }
@@ -113,20 +129,20 @@ export function createTileHost({ store, carousel, getRenderer, onFocusChange, on
     // activate (activate already sets the order).
     if (added.length === 0 || carousel.isActive()) {
       const currentCards = carousel.getCards();
-      if (!arraysEqual(currentCards, state.order)) {
-        carousel.reorderCards(state.order);
+      if (!arraysEqual(currentCards, view.order)) {
+        carousel.reorderCards(view.order);
       }
     }
 
     // ── Focus ──────────────────────────────────────────────────────
-    if (state.focusedId && state.focusedId !== carousel.getFocusedCard()) {
-      carousel.focusCard(state.focusedId);
+    if (view.focusedId && view.focusedId !== carousel.getFocusedCard()) {
+      carousel.focusCard(view.focusedId);
     }
 
     // Notify app.js of focus change so it can do WS bookkeeping
-    if (state.focusedId !== prev.focusedId && onFocusChange) {
-      const tile = state.tiles[state.focusedId];
-      onFocusChange(state.focusedId, tile?.type || null);
+    if (view.focusedId !== prev.focusedId && onFocusChange) {
+      const tile = view.tiles[view.focusedId];
+      onFocusChange(view.focusedId, tile?.type || null);
     }
   }
 

--- a/public/lib/ui-store.js
+++ b/public/lib/ui-store.js
@@ -1,69 +1,89 @@
 /**
  * UI Store — single source of truth for tile UI state
  *
- * See docs/tile-state-rewrite.md for the "why". Summary: previously
- * tile state was spread across the carousel, windowTabSet, and
- * sessionStore, each mutated at every call site. This collapses it
- * into one reducer-driven atom. Tab bar and carousel both derive from
- * it; persistence and URL sync are reactive subscriptions.
+ * See docs/tile-state-rewrite.md for the original "why", and
+ * docs/tile-clusters-design.md for the multi-cluster extension (FP1).
  *
- * State shape:
+ * State shape (v2):
  *   {
- *     version: 1,
- *     tiles:     { [id]: { id, type, props, x } },  // x = horizontal position
- *     order:     [id, id, ...],   // derived: tiles sorted by x
- *     focusedId: id | null,
+ *     version: 2,
+ *     activeClusterId: string,
+ *     clusters: { [id]: { id, name? } },
+ *     tiles: { [id]: { id, type, props, x, clusterId } },
+ *     focusedIdByCluster: { [clusterId]: id | null },
+ *
+ *     // Derived conveniences, scoped to the active cluster:
+ *     order: [id, ...],       // active cluster's tiles sorted by x
+ *     focusedId: id | null,   // = focusedIdByCluster[activeClusterId]
  *   }
  *
- * Position is a property of the tile itself (the `x` field) rather than
- * a separate array.  Today x is a 1-D integer; the clusters design
- * (docs/tile-clusters-design.md) will extend this to (cluster, x, y).
- * `state.order` is kept as a derived convenience so consumers that just
- * need "left-to-right list of ids" don't change.
+ * Each tile carries its own `clusterId` and `x`. `order`/`focusedId` at
+ * the top level are *derived* from the active cluster only, so consumers
+ * that don't care about clusters keep their existing contract.
+ *
+ * v1 → v2 migration: a persisted v1 store is treated as a single cluster
+ * named "default". All tiles get `clusterId: "default"`, and the old
+ * top-level `focusedId` becomes `focusedIdByCluster.default`.
  *
  * Invariants (enforced by the reducer):
- *   - order is derived from tiles sorted by x
- *   - focusedId is null or a key of tiles
- *   - ids are unique (tiles is a map, not a list)
- *   - every mutation returns a new state object (structural sharing)
+ *   - Every tile has a `clusterId` that exists in `clusters`.
+ *   - `activeClusterId` is always a key of `clusters`.
+ *   - `focusedIdByCluster[c]` is null or a tile whose `clusterId === c`.
+ *   - `order` is derived from tiles in activeCluster, sorted by x.
+ *   - Every mutation returns a new state object (structural sharing).
  */
 
 import { createStore } from "./store.js";
 
-const STORAGE_KEY = "katulong-ui-v1";
-const VERSION = 1;
+const STORAGE_KEY = "katulong-ui-v1"; // same key; version field discriminates
+const VERSION = 2;
+export const DEFAULT_CLUSTER_ID = "default";
 
 export const EMPTY_STATE = Object.freeze({
   version: VERSION,
+  activeClusterId: DEFAULT_CLUSTER_ID,
+  clusters: Object.freeze({ [DEFAULT_CLUSTER_ID]: Object.freeze({ id: DEFAULT_CLUSTER_ID }) }),
   tiles: Object.freeze({}),
+  focusedIdByCluster: Object.freeze({ [DEFAULT_CLUSTER_ID]: null }),
   order: Object.freeze([]),
   focusedId: null,
 });
 
 // ─── Helpers ─────────────────────────────────────────────────────────
-/** Derive the order array from tiles by sorting on x. */
-function deriveOrder(tiles) {
-  return Object.values(tiles)
+function clusterTiles(tiles, clusterId) {
+  return Object.values(tiles).filter(t => t.clusterId === clusterId);
+}
+
+function deriveOrder(tiles, clusterId) {
+  return clusterTiles(tiles, clusterId)
     .sort((a, b) => a.x - b.x)
     .map(t => t.id);
 }
 
-/** One past the highest x coordinate (or 0 if no tiles). */
-function nextX(tiles) {
+function nextX(tiles, clusterId) {
   let max = -1;
   for (const t of Object.values(tiles)) {
-    if (typeof t.x === "number" && t.x > max) max = t.x;
+    if (t.clusterId === clusterId && typeof t.x === "number" && t.x > max) max = t.x;
   }
   return max + 1;
 }
 
+function withDerived(state) {
+  const order = deriveOrder(state.tiles, state.activeClusterId);
+  const focusedId = state.focusedIdByCluster[state.activeClusterId] ?? null;
+  return { ...state, order, focusedId };
+}
+
 // ─── Action types ────────────────────────────────────────────────────
-export const ADD_TILE     = "ui/ADD_TILE";
-export const REMOVE_TILE  = "ui/REMOVE_TILE";
-export const REORDER      = "ui/REORDER";
-export const FOCUS_TILE   = "ui/FOCUS_TILE";
-export const UPDATE_PROPS = "ui/UPDATE_PROPS";
-export const RESET        = "ui/RESET";
+export const ADD_TILE       = "ui/ADD_TILE";
+export const REMOVE_TILE    = "ui/REMOVE_TILE";
+export const REORDER        = "ui/REORDER";
+export const FOCUS_TILE     = "ui/FOCUS_TILE";
+export const UPDATE_PROPS   = "ui/UPDATE_PROPS";
+export const RESET          = "ui/RESET";
+export const ADD_CLUSTER    = "ui/ADD_CLUSTER";
+export const REMOVE_CLUSTER = "ui/REMOVE_CLUSTER";
+export const SWITCH_CLUSTER = "ui/SWITCH_CLUSTER";
 
 // ─── Reducer ─────────────────────────────────────────────────────────
 function reducer(state = EMPTY_STATE, action) {
@@ -72,98 +92,158 @@ function reducer(state = EMPTY_STATE, action) {
       const { tile, focus = false, insertAt = "end", insertAfter } = action;
       if (!tile || !tile.id || !tile.type) return state;
       if (state.tiles[tile.id]) {
-        // Already present — optionally focus, but don't duplicate.
-        return focus ? { ...state, focusedId: tile.id } : state;
+        if (!focus) return state;
+        const existingCluster = state.tiles[tile.id].clusterId;
+        const focusedIdByCluster = { ...state.focusedIdByCluster, [existingCluster]: tile.id };
+        return withDerived({ ...state, focusedIdByCluster });
       }
-      const newTile = { id: tile.id, type: tile.type, props: { ...(tile.props || {}) } };
+      const clusterId = action.clusterId || state.activeClusterId;
+      if (!state.clusters[clusterId]) return state;
+      const newTile = {
+        id: tile.id,
+        type: tile.type,
+        props: { ...(tile.props || {}) },
+        clusterId,
+      };
       let newTiles;
-      // Determine the anchor tile for positional insertion:
-      //   insertAfter: <id>  — explicit tile to insert after (preferred)
-      //   insertAt: "afterFocus" — insert after the currently focused tile
-      const anchorId = insertAfter || (insertAt === "afterFocus" ? state.focusedId : null);
-      if (anchorId && state.tiles[anchorId]) {
+      let anchorId = insertAfter;
+      if (!anchorId && insertAt === "afterFocus") {
+        const focused = state.focusedIdByCluster[clusterId];
+        if (focused && state.tiles[focused]?.clusterId === clusterId) anchorId = focused;
+      }
+      if (anchorId && state.tiles[anchorId] && state.tiles[anchorId].clusterId === clusterId) {
         const insertX = state.tiles[anchorId].x + 1;
         newTile.x = insertX;
-        // Shift tiles at or past the insertion point to make room
         newTiles = {};
         for (const [id, t] of Object.entries(state.tiles)) {
-          newTiles[id] = t.x >= insertX ? { ...t, x: t.x + 1 } : t;
+          newTiles[id] = (t.clusterId === clusterId && t.x >= insertX)
+            ? { ...t, x: t.x + 1 }
+            : t;
         }
         newTiles[tile.id] = newTile;
       } else {
-        newTile.x = nextX(state.tiles);
+        newTile.x = nextX(state.tiles, clusterId);
         newTiles = { ...state.tiles, [tile.id]: newTile };
       }
-      return {
-        ...state,
-        tiles: newTiles,
-        order: deriveOrder(newTiles),
-        focusedId: focus ? tile.id : state.focusedId,
-      };
+      const focusedIdByCluster = focus
+        ? { ...state.focusedIdByCluster, [clusterId]: tile.id }
+        : state.focusedIdByCluster;
+      return withDerived({ ...state, tiles: newTiles, focusedIdByCluster });
     }
 
     case REMOVE_TILE: {
       const { id } = action;
-      if (!state.tiles[id]) return state;
+      const existing = state.tiles[id];
+      if (!existing) return state;
       const { [id]: _removed, ...restTiles } = state.tiles;
-      const newOrder = deriveOrder(restTiles);
-      let focusedId = state.focusedId;
-      if (focusedId === id) {
-        // Focus the neighbor to the right (or left if we removed the
-        // last card). Matches carousel's "focus right neighbor on
-        // close" behavior without needing the host to reimplement it.
-        const removedIdx = state.order.indexOf(id);
-        focusedId = newOrder[removedIdx] || newOrder[removedIdx - 1] || null;
+      const focusedIdByCluster = { ...state.focusedIdByCluster };
+      if (focusedIdByCluster[existing.clusterId] === id) {
+        const clusterOrder = deriveOrder(state.tiles, existing.clusterId);
+        const remainingOrder = deriveOrder(restTiles, existing.clusterId);
+        const removedIdx = clusterOrder.indexOf(id);
+        focusedIdByCluster[existing.clusterId] =
+          remainingOrder[removedIdx] || remainingOrder[removedIdx - 1] || null;
       }
-      return { ...state, tiles: restTiles, order: newOrder, focusedId };
+      return withDerived({ ...state, tiles: restTiles, focusedIdByCluster });
     }
 
     case REORDER: {
       const { order } = action;
       if (!Array.isArray(order)) return state;
-      // Defend against drops that omit ids or smuggle unknowns — fold
-      // in any missing tiles at the end so state never desyncs from
-      // `tiles`. Unknown ids are dropped.
-      const known = new Set(Object.keys(state.tiles));
+      const clusterId = action.clusterId || state.activeClusterId;
+      if (!state.clusters[clusterId]) return state;
+      const known = new Set(
+        Object.values(state.tiles)
+          .filter(t => t.clusterId === clusterId)
+          .map(t => t.id),
+      );
       const cleaned = order.filter(id => known.has(id));
       const seen = new Set(cleaned);
-      for (const id of state.order) {
+      const currentOrder = deriveOrder(state.tiles, clusterId);
+      for (const id of currentOrder) {
         if (!seen.has(id)) cleaned.push(id);
       }
-      // No-op if identical
-      if (cleaned.length === state.order.length && cleaned.every((id, i) => id === state.order[i])) {
+      if (cleaned.length === currentOrder.length
+          && cleaned.every((id, i) => id === currentOrder[i])) {
         return state;
       }
-      // Reassign x coordinates from the new order
       const newTiles = { ...state.tiles };
       cleaned.forEach((id, i) => {
         if (newTiles[id].x !== i) {
           newTiles[id] = { ...newTiles[id], x: i };
         }
       });
-      return { ...state, tiles: newTiles, order: cleaned };
+      return withDerived({ ...state, tiles: newTiles });
     }
 
     case FOCUS_TILE: {
       const { id } = action;
-      if (id !== null && !state.tiles[id]) return state;
-      if (state.focusedId === id) return state;
-      return { ...state, focusedId: id };
+      if (id === null) {
+        const current = state.focusedIdByCluster[state.activeClusterId];
+        if (current === null) return state;
+        const focusedIdByCluster = { ...state.focusedIdByCluster, [state.activeClusterId]: null };
+        return withDerived({ ...state, focusedIdByCluster });
+      }
+      const tile = state.tiles[id];
+      if (!tile) return state;
+      // A tile can only be focused within its own cluster. If the caller
+      // asks to focus a tile in a non-active cluster, no-op — they need
+      // to switchCluster first.
+      if (tile.clusterId !== state.activeClusterId) return state;
+      if (state.focusedIdByCluster[tile.clusterId] === id) return state;
+      const focusedIdByCluster = { ...state.focusedIdByCluster, [tile.clusterId]: id };
+      return withDerived({ ...state, focusedIdByCluster });
     }
 
     case UPDATE_PROPS: {
       const { id, patch } = action;
       const existing = state.tiles[id];
       if (!existing || !patch) return state;
-      // Shallow-merge patch into props. Bail if nothing actually
-      // changed — subscribers shouldn't fire on no-op UPDATE_PROPS.
       let changed = false;
       for (const k of Object.keys(patch)) {
         if (existing.props[k] !== patch[k]) { changed = true; break; }
       }
       if (!changed) return state;
       const newTile = { ...existing, props: { ...existing.props, ...patch } };
-      return { ...state, tiles: { ...state.tiles, [id]: newTile } };
+      return withDerived({ ...state, tiles: { ...state.tiles, [id]: newTile } });
+    }
+
+    case ADD_CLUSTER: {
+      const { cluster, switchTo = false } = action;
+      if (!cluster || !cluster.id) return state;
+      if (state.clusters[cluster.id]) return state;
+      const clusters = {
+        ...state.clusters,
+        [cluster.id]: { id: cluster.id, ...(cluster.name ? { name: cluster.name } : {}) },
+      };
+      const focusedIdByCluster = { ...state.focusedIdByCluster, [cluster.id]: null };
+      const next = { ...state, clusters, focusedIdByCluster };
+      if (switchTo) next.activeClusterId = cluster.id;
+      return withDerived(next);
+    }
+
+    case REMOVE_CLUSTER: {
+      const { id } = action;
+      if (!state.clusters[id]) return state;
+      if (Object.keys(state.clusters).length <= 1) return state;
+      const clusters = { ...state.clusters };
+      delete clusters[id];
+      const focusedIdByCluster = { ...state.focusedIdByCluster };
+      delete focusedIdByCluster[id];
+      const tiles = {};
+      for (const [tid, t] of Object.entries(state.tiles)) {
+        if (t.clusterId !== id) tiles[tid] = t;
+      }
+      let activeClusterId = state.activeClusterId;
+      if (activeClusterId === id) activeClusterId = Object.keys(clusters)[0];
+      return withDerived({ ...state, clusters, tiles, focusedIdByCluster, activeClusterId });
+    }
+
+    case SWITCH_CLUSTER: {
+      const { id } = action;
+      if (!state.clusters[id]) return state;
+      if (state.activeClusterId === id) return state;
+      return withDerived({ ...state, activeClusterId: id });
     }
 
     case RESET: {
@@ -176,55 +256,129 @@ function reducer(state = EMPTY_STATE, action) {
   }
 }
 
-/** Coerce an arbitrary object into a valid ui-store state.
- *  Handles migration: tiles may or may not carry `x`. When absent,
- *  position is backfilled from raw.order (the old persistence format). */
+// ─── Normalize (migration + coercion) ────────────────────────────────
+/**
+ * Coerce an arbitrary object into a valid v2 state. Handles:
+ *   - Null/invalid input (returns EMPTY_STATE).
+ *   - v1 → v2 migration: tiles without clusterId get DEFAULT_CLUSTER_ID,
+ *     and the old top-level focusedId becomes focusedIdByCluster.default.
+ *   - x backfill from raw.order for tiles that lack it (v1 format).
+ */
 export function normalize(raw) {
   if (!raw || typeof raw !== "object") return EMPTY_STATE;
-  const tiles = {};
-  if (raw.tiles && typeof raw.tiles === "object") {
-    for (const [id, t] of Object.entries(raw.tiles)) {
-      if (t && typeof t.type === "string") {
-        tiles[id] = { id, type: t.type, props: { ...(t.props || {}) } };
-        if (typeof t.x === "number") tiles[id].x = t.x;
+
+  const isV2 = typeof raw.activeClusterId === "string"
+    && raw.clusters && typeof raw.clusters === "object";
+
+  const clusters = {};
+  if (isV2) {
+    for (const [id, c] of Object.entries(raw.clusters)) {
+      if (c && typeof c === "object") {
+        clusters[id] = { id, ...(typeof c.name === "string" ? { name: c.name } : {}) };
       }
     }
   }
-  // Backfill x for tiles that lack it (old format or manual state).
-  const needsX = Object.keys(tiles).filter(id => typeof tiles[id].x !== "number");
-  if (needsX.length > 0) {
-    let pos = nextX(tiles); // start after highest existing x (0 if none)
-    const orderHint = Array.isArray(raw.order) ? raw.order : [];
-    const pending = new Set(needsX);
-    for (const id of orderHint) {
-      if (pending.has(id)) { tiles[id].x = pos++; pending.delete(id); }
-    }
-    for (const id of pending) { tiles[id].x = pos++; }
+  if (!clusters[DEFAULT_CLUSTER_ID]) {
+    clusters[DEFAULT_CLUSTER_ID] = { id: DEFAULT_CLUSTER_ID };
   }
-  const order = deriveOrder(tiles);
-  const focusedId = raw.focusedId && tiles[raw.focusedId] ? raw.focusedId : (order[0] || null);
-  return { version: VERSION, tiles, order, focusedId };
+
+  const tiles = {};
+  if (raw.tiles && typeof raw.tiles === "object") {
+    for (const [id, t] of Object.entries(raw.tiles)) {
+      if (!t || typeof t.type !== "string") continue;
+      const clusterId = (typeof t.clusterId === "string" && clusters[t.clusterId])
+        ? t.clusterId
+        : DEFAULT_CLUSTER_ID;
+      tiles[id] = {
+        id,
+        type: t.type,
+        props: { ...(t.props || {}) },
+        clusterId,
+      };
+      if (typeof t.x === "number") tiles[id].x = t.x;
+    }
+  }
+
+  // x backfill (per cluster) — v1 tiles don't carry x; reconstruct from
+  // raw.order (global for v1 — accurate since there's only one cluster).
+  const orderHint = Array.isArray(raw.order) ? raw.order : [];
+  const needsX = new Set(
+    Object.keys(tiles).filter(id => typeof tiles[id].x !== "number"),
+  );
+  if (needsX.size > 0) {
+    const perClusterNext = {};
+    for (const id of Object.keys(clusters)) perClusterNext[id] = nextX(tiles, id);
+    for (const id of orderHint) {
+      if (needsX.has(id)) {
+        const cid = tiles[id].clusterId;
+        tiles[id].x = perClusterNext[cid]++;
+        needsX.delete(id);
+      }
+    }
+    for (const id of needsX) {
+      const cid = tiles[id].clusterId;
+      tiles[id].x = perClusterNext[cid]++;
+    }
+  }
+
+  // focusedIdByCluster
+  const focusedIdByCluster = {};
+  for (const id of Object.keys(clusters)) focusedIdByCluster[id] = null;
+  if (isV2 && raw.focusedIdByCluster && typeof raw.focusedIdByCluster === "object") {
+    for (const [cid, fid] of Object.entries(raw.focusedIdByCluster)) {
+      if (!clusters[cid]) continue;
+      if (fid && tiles[fid] && tiles[fid].clusterId === cid) {
+        focusedIdByCluster[cid] = fid;
+      }
+    }
+  } else if (typeof raw.focusedId === "string") {
+    const fid = raw.focusedId;
+    if (tiles[fid] && tiles[fid].clusterId === DEFAULT_CLUSTER_ID) {
+      focusedIdByCluster[DEFAULT_CLUSTER_ID] = fid;
+    }
+  }
+  for (const cid of Object.keys(clusters)) {
+    if (focusedIdByCluster[cid]) continue;
+    const order = deriveOrder(tiles, cid);
+    focusedIdByCluster[cid] = order[0] || null;
+  }
+
+  const activeClusterId = (isV2 && clusters[raw.activeClusterId])
+    ? raw.activeClusterId
+    : DEFAULT_CLUSTER_ID;
+
+  return withDerived({
+    version: VERSION,
+    activeClusterId,
+    clusters,
+    tiles,
+    focusedIdByCluster,
+    order: [],
+    focusedId: null,
+  });
 }
 
 // ─── Persistence ─────────────────────────────────────────────────────
 /**
- * Serialize state for localStorage. Accepts an `isPersistable(type, props)`
- * predicate supplied by the host so this module never needs to know
- * about renderer internals. Props are forwarded for instance-level
- * persistence decisions (e.g. file-backed document tiles persist,
- * content-backed ones don't).
+ * Serialize state for localStorage. Derived fields (order, focusedId)
+ * are NOT written — they're re-derived on normalize.
  */
 export function serialize(state, isPersistable = () => true) {
   const tiles = {};
   for (const [id, t] of Object.entries(state.tiles)) {
     if (isPersistable(t.type, t.props || {})) tiles[id] = t;
   }
-  // Derive order from the persisted tiles' x coordinates. The order
-  // field is redundant (x is authoritative) but included for backward
-  // compat if the user ever rolls back to a pre-coordinate build.
-  const order = deriveOrder(tiles);
-  const focusedId = state.focusedId && tiles[state.focusedId] ? state.focusedId : (order[0] || null);
-  return { version: VERSION, tiles, order, focusedId };
+  const focusedIdByCluster = {};
+  for (const [cid, fid] of Object.entries(state.focusedIdByCluster)) {
+    focusedIdByCluster[cid] = (fid && tiles[fid]) ? fid : null;
+  }
+  return {
+    version: VERSION,
+    activeClusterId: state.activeClusterId,
+    clusters: state.clusters,
+    tiles,
+    focusedIdByCluster,
+  };
 }
 
 export function loadFromStorage() {
@@ -232,7 +386,8 @@ export function loadFromStorage() {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw);
-    if (!parsed || parsed.version !== VERSION) return null;
+    if (!parsed) return null;
+    if (parsed.version !== 1 && parsed.version !== VERSION) return null;
     return normalize(parsed);
   } catch (_) {
     return null;
@@ -246,28 +401,23 @@ export function saveToStorage(state, isPersistable) {
 }
 
 // ─── Store factory ───────────────────────────────────────────────────
-/**
- * Create a UI store. Pass `isPersistable(type)` so persistence can
- * filter non-persistable tile types without this module importing
- * the renderer registry.
- */
 export function createUiStore({ initialState = EMPTY_STATE, isPersistable = () => true, debug = false } = {}) {
   const store = createStore(normalize(initialState), reducer, { debug });
 
-  // Persist on every change. Cheap: JSON.stringify of a small object.
   store.subscribe((state) => saveToStorage(state, isPersistable));
 
   return {
     getState: store.getState,
     subscribe: store.subscribe,
     dispatch:  store.dispatch,
-    // Convenience action creators — call sites read more like a
-    // command API than raw dispatches, and typos throw at the source.
-    addTile:     (tile, opts = {}) => store.dispatch({ type: ADD_TILE, tile, ...opts }),
-    removeTile:  (id)              => store.dispatch({ type: REMOVE_TILE, id }),
-    reorder:     (order)           => store.dispatch({ type: REORDER, order }),
-    focusTile:   (id)              => store.dispatch({ type: FOCUS_TILE, id }),
-    updateProps: (id, patch)       => store.dispatch({ type: UPDATE_PROPS, id, patch }),
-    reset:       (state)           => store.dispatch({ type: RESET, state }),
+    addTile:       (tile, opts = {}) => store.dispatch({ type: ADD_TILE, tile, ...opts }),
+    removeTile:    (id)              => store.dispatch({ type: REMOVE_TILE, id }),
+    reorder:       (order, opts = {}) => store.dispatch({ type: REORDER, order, ...opts }),
+    focusTile:     (id)              => store.dispatch({ type: FOCUS_TILE, id }),
+    updateProps:   (id, patch)       => store.dispatch({ type: UPDATE_PROPS, id, patch }),
+    reset:         (state)           => store.dispatch({ type: RESET, state }),
+    addCluster:    (cluster, opts = {}) => store.dispatch({ type: ADD_CLUSTER, cluster, ...opts }),
+    removeCluster: (id)              => store.dispatch({ type: REMOVE_CLUSTER, id }),
+    switchCluster: (id)              => store.dispatch({ type: SWITCH_CLUSTER, id }),
   };
 }

--- a/test/add-target.test.js
+++ b/test/add-target.test.js
@@ -1,0 +1,125 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const {
+  decideAddTarget,
+  generateSessionName,
+  generateClusterId,
+  createAddHandler,
+} = await import(
+  new URL("../public/lib/add-target.js", import.meta.url).href
+);
+
+describe("decideAddTarget — level 1 (focused)", () => {
+  it("produces a tile target in the active cluster after the focused tile", () => {
+    const t = decideAddTarget({ level: 1, activeClusterId: "c1", focusedId: "t7" });
+    assert.deepStrictEqual(t, { kind: "tile", clusterId: "c1", insertAfter: "t7" });
+  });
+
+  it("produces a tile target with insertAfter=null when nothing is focused", () => {
+    const t = decideAddTarget({ level: 1, activeClusterId: "c1", focusedId: null });
+    assert.deepStrictEqual(t, { kind: "tile", clusterId: "c1", insertAfter: null });
+  });
+
+  it("defaults focusedId to null when omitted", () => {
+    const t = decideAddTarget({ level: 1, activeClusterId: "c1" });
+    assert.strictEqual(t.insertAfter, null);
+  });
+});
+
+describe("decideAddTarget — level 2 (overview)", () => {
+  it("produces a cluster target regardless of focused tile", () => {
+    assert.deepStrictEqual(
+      decideAddTarget({ level: 2, activeClusterId: "c1", focusedId: "t7" }),
+      { kind: "cluster" },
+    );
+    assert.deepStrictEqual(
+      decideAddTarget({ level: 2, activeClusterId: "c1", focusedId: null }),
+      { kind: "cluster" },
+    );
+  });
+
+  it("treats future Level 3+ as cluster target (safe default until L3 is designed)", () => {
+    assert.deepStrictEqual(
+      decideAddTarget({ level: 3, activeClusterId: "c1" }),
+      { kind: "cluster" },
+    );
+  });
+});
+
+describe("generateSessionName / generateClusterId", () => {
+  it("produces a `session-` prefix with base36-encoded clock", () => {
+    const name = generateSessionName(() => 0);
+    assert.strictEqual(name, "session-0");
+  });
+
+  it("produces a `cluster-` prefix with base36-encoded clock", () => {
+    const id = generateClusterId(() => 0);
+    assert.strictEqual(id, "cluster-0");
+  });
+
+  it("defaults to Date.now when no clock is injected", () => {
+    const name = generateSessionName();
+    assert.match(name, /^session-[a-z0-9]+$/);
+  });
+});
+
+describe("createAddHandler — dispatch", () => {
+  it("calls onAddTile with the tile target at level 1", () => {
+    const calls = [];
+    const handle = createAddHandler({
+      getLevel: () => 1,
+      getState: () => ({ activeClusterId: "c1", focusedId: "t7" }),
+      onAddTile: (t) => { calls.push(["tile", t]); },
+      onAddCluster: (t) => { calls.push(["cluster", t]); },
+    });
+    handle();
+    assert.deepStrictEqual(calls, [
+      ["tile", { kind: "tile", clusterId: "c1", insertAfter: "t7" }],
+    ]);
+  });
+
+  it("calls onAddCluster with the cluster target at level 2", () => {
+    const calls = [];
+    const handle = createAddHandler({
+      getLevel: () => 2,
+      getState: () => ({ activeClusterId: "c1", focusedId: "t7" }),
+      onAddTile: (t) => { calls.push(["tile", t]); },
+      onAddCluster: (t) => { calls.push(["cluster", t]); },
+    });
+    handle();
+    assert.deepStrictEqual(calls, [["cluster", { kind: "cluster" }]]);
+  });
+
+  it("reads fresh state at every call, not at factory creation time", () => {
+    let level = 1;
+    let focusedId = "t1";
+    const tileCalls = [];
+    const clusterCalls = [];
+    const handle = createAddHandler({
+      getLevel: () => level,
+      getState: () => ({ activeClusterId: "c1", focusedId }),
+      onAddTile: (t) => { tileCalls.push(t); },
+      onAddCluster: (t) => { clusterCalls.push(t); },
+    });
+    handle();
+    focusedId = "t2";
+    handle();
+    level = 2;
+    handle();
+    assert.strictEqual(tileCalls.length, 2);
+    assert.strictEqual(tileCalls[0].insertAfter, "t1");
+    assert.strictEqual(tileCalls[1].insertAfter, "t2");
+    assert.strictEqual(clusterCalls.length, 1);
+  });
+
+  it("returns the effect's return value (so async callers can await)", async () => {
+    const handle = createAddHandler({
+      getLevel: () => 1,
+      getState: () => ({ activeClusterId: "c1", focusedId: null }),
+      onAddTile: async () => "tile-result",
+      onAddCluster: async () => "cluster-result",
+    });
+    assert.strictEqual(await handle(), "tile-result");
+  });
+});

--- a/test/boot-state.test.js
+++ b/test/boot-state.test.js
@@ -1,0 +1,208 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+// Stub localStorage before loading ui-store (which is imported by
+// boot-state.js indirectly through normalize's subscribe path).
+const _storage = {};
+globalThis.localStorage = {
+  getItem: (k) => _storage[k] ?? null,
+  setItem: (k, v) => { _storage[k] = v; },
+  removeItem: (k) => { delete _storage[k]; },
+};
+
+const { buildBootState } = await import(
+  new URL("../public/lib/boot-state.js", import.meta.url).href
+);
+const { EMPTY_STATE } = await import(
+  new URL("../public/lib/ui-store.js", import.meta.url).href
+);
+
+describe("buildBootState — no sources", () => {
+  it("returns EMPTY_STATE when nothing is persisted and no URL hint", () => {
+    const { state, migratedLegacy } = buildBootState({});
+    assert.strictEqual(migratedLegacy, false);
+    assert.deepStrictEqual(state.tiles, {});
+    assert.strictEqual(state.focusedId, null);
+  });
+});
+
+describe("buildBootState — persisted state wins", () => {
+  it("uses persisted state when present, ignores legacy", () => {
+    const persisted = {
+      version: 2,
+      activeClusterId: "default",
+      clusters: { default: { id: "default" } },
+      tiles: {
+        a: { id: "a", type: "terminal", props: {}, x: 0, clusterId: "default" },
+      },
+      focusedIdByCluster: { default: "a" },
+      order: ["a"],
+      focusedId: "a",
+    };
+    const legacyCarousel = {
+      tiles: [{ id: "legacy", type: "terminal", sessionName: "legacy" }],
+      focused: "legacy",
+    };
+    const { state, migratedLegacy } = buildBootState({
+      persisted,
+      legacyCarousel,
+      getRenderer: () => ({}),
+    });
+    assert.strictEqual(migratedLegacy, false);
+    assert.ok(state.tiles.a);
+    assert.ok(!state.tiles.legacy);
+  });
+});
+
+describe("buildBootState — legacy migration", () => {
+  it("migrates legacy carousel state into default cluster", () => {
+    const { state, migratedLegacy } = buildBootState({
+      legacyCarousel: {
+        tiles: [
+          { id: "s1", type: "terminal", sessionName: "s1" },
+          { id: "s2", type: "terminal", sessionName: "s2" },
+        ],
+        focused: "s2",
+      },
+      getRenderer: () => ({ describe: () => ({}) }),
+    });
+    assert.strictEqual(migratedLegacy, true);
+    assert.strictEqual(state.tiles.s1.clusterId, "default");
+    assert.strictEqual(state.tiles.s2.clusterId, "default");
+    assert.strictEqual(state.tiles.s1.x, 0);
+    assert.strictEqual(state.tiles.s2.x, 1);
+    assert.strictEqual(state.focusedId, "s2");
+    // Props are stripped of id/type/cardWidth.
+    assert.strictEqual(state.tiles.s1.props.sessionName, "s1");
+    assert.strictEqual(state.tiles.s1.props.id, undefined);
+    assert.strictEqual(state.tiles.s1.props.type, undefined);
+  });
+
+  it("maps legacy 'dashboard' type to 'cluster'", () => {
+    const { state } = buildBootState({
+      legacyCarousel: {
+        tiles: [{ id: "d1", type: "dashboard" }],
+        focused: "d1",
+      },
+      getRenderer: (type) => (type === "cluster" ? { describe: () => ({}) } : null),
+    });
+    assert.strictEqual(state.tiles.d1.type, "cluster");
+  });
+
+  it("drops tiles whose type has no renderer", () => {
+    const { state } = buildBootState({
+      legacyCarousel: {
+        tiles: [
+          { id: "ok", type: "terminal" },
+          { id: "junk", type: "unknown-type" },
+        ],
+        focused: "ok",
+      },
+      getRenderer: (type) => (type === "terminal" ? { describe: () => ({}) } : null),
+    });
+    assert.ok(state.tiles.ok);
+    assert.ok(!state.tiles.junk);
+  });
+
+  it("does not flag migration when legacy has no tiles", () => {
+    const { migratedLegacy } = buildBootState({
+      legacyCarousel: { tiles: [], focused: null },
+    });
+    assert.strictEqual(migratedLegacy, false);
+  });
+});
+
+describe("buildBootState — URL session hint", () => {
+  it("adds a new terminal tile and focuses it", () => {
+    const { state } = buildBootState({ urlSession: "hello" });
+    assert.ok(state.tiles.hello);
+    assert.strictEqual(state.tiles.hello.type, "terminal");
+    assert.strictEqual(state.tiles.hello.props.sessionName, "hello");
+    assert.strictEqual(state.focusedId, "hello");
+  });
+
+  it("does not duplicate when the session is already present", () => {
+    const persisted = {
+      version: 2,
+      activeClusterId: "default",
+      clusters: { default: { id: "default" } },
+      tiles: {
+        existing: {
+          id: "existing", type: "terminal", props: { sessionName: "existing" },
+          x: 0, clusterId: "default",
+        },
+      },
+      focusedIdByCluster: { default: "existing" },
+      order: ["existing"],
+      focusedId: "existing",
+    };
+    const { state } = buildBootState({ persisted, urlSession: "existing" });
+    assert.strictEqual(Object.keys(state.tiles).length, 1);
+    assert.strictEqual(state.focusedId, "existing");
+  });
+
+  it("preserves persisted focusedId when URL session was already present", () => {
+    const persisted = {
+      version: 2,
+      activeClusterId: "default",
+      clusters: { default: { id: "default" } },
+      tiles: {
+        a: { id: "a", type: "terminal", props: {}, x: 0, clusterId: "default" },
+        b: { id: "b", type: "terminal", props: {}, x: 1, clusterId: "default" },
+      },
+      focusedIdByCluster: { default: "b" },
+      order: ["a", "b"],
+      focusedId: "b",
+    };
+    // User refreshed with ?s=a but b was focused last. Persisted wins.
+    const { state } = buildBootState({ persisted, urlSession: "a" });
+    assert.strictEqual(state.focusedId, "b");
+  });
+});
+
+describe("buildBootState — tab-set merge", () => {
+  it("folds in tab-set sessions without focusing them", () => {
+    const { state } = buildBootState({
+      urlSession: "main",
+      tabSetSessions: ["other"],
+    });
+    assert.ok(state.tiles.main);
+    assert.ok(state.tiles.other);
+    assert.strictEqual(state.focusedId, "main");
+  });
+
+  it("does not duplicate tab-set sessions that are already present", () => {
+    const persisted = {
+      version: 2,
+      activeClusterId: "default",
+      clusters: { default: { id: "default" } },
+      tiles: {
+        a: { id: "a", type: "terminal", props: {}, x: 0, clusterId: "default" },
+      },
+      focusedIdByCluster: { default: "a" },
+      order: ["a"],
+      focusedId: "a",
+    };
+    const { state } = buildBootState({ persisted, tabSetSessions: ["a"] });
+    assert.strictEqual(Object.keys(state.tiles).length, 1);
+  });
+});
+
+describe("buildBootState — pure function", () => {
+  it("does not mutate inputs", () => {
+    const persisted = {
+      version: 2,
+      activeClusterId: "default",
+      clusters: { default: { id: "default" } },
+      tiles: {
+        a: { id: "a", type: "terminal", props: {}, x: 0, clusterId: "default" },
+      },
+      focusedIdByCluster: { default: "a" },
+      order: ["a"],
+      focusedId: "a",
+    };
+    const snapshot = JSON.parse(JSON.stringify(persisted));
+    buildBootState({ persisted, urlSession: "b" });
+    assert.deepStrictEqual(persisted, snapshot);
+  });
+});

--- a/test/pinch-levels.test.js
+++ b/test/pinch-levels.test.js
@@ -1,0 +1,146 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const {
+  reducePinch,
+  diffPinchState,
+  PINCH_OUT_THRESHOLD,
+  PINCH_IN_THRESHOLD,
+  INITIAL_PINCH_STATE,
+} = await import(
+  new URL("../public/lib/pinch-levels.js", import.meta.url).href
+);
+
+describe("reducePinch — no-op zones", () => {
+  it("returns same state when scale is inside the dead zone", () => {
+    const s = { level: 1, mode: "carousel" };
+    assert.strictEqual(reducePinch(s, { scale: 1.0 }), s);
+    assert.strictEqual(reducePinch(s, { scale: 1.1 }), s);
+    assert.strictEqual(reducePinch(s, { scale: 0.95 }), s);
+  });
+
+  it("accepts injected custom thresholds", () => {
+    const s = { level: 1, mode: "carousel" };
+    // Default thresholds would fire at 1.15/0.87 — custom won't.
+    assert.strictEqual(reducePinch(s, { scale: 1.14 }), s);
+    // Custom out=1.10 fires at 1.14.
+    assert.deepStrictEqual(
+      reducePinch(s, { scale: 1.14, out: 1.10 }),
+      { level: 1, mode: "expose" },
+    );
+  });
+
+  it("handles missing action object (defensive)", () => {
+    const s = { level: 1, mode: "carousel" };
+    assert.strictEqual(reducePinch(s, undefined), s);
+  });
+});
+
+describe("reducePinch — pinch-out (zoom out)", () => {
+  it("level 1 carousel → level 1 expose", () => {
+    assert.deepStrictEqual(
+      reducePinch({ level: 1, mode: "carousel" }, { scale: 1.15 }),
+      { level: 1, mode: "expose" },
+    );
+  });
+
+  it("level 1 expose → level 2 expose (uniform mode inherited)", () => {
+    assert.deepStrictEqual(
+      reducePinch({ level: 1, mode: "expose" }, { scale: 1.2 }),
+      { level: 2, mode: "expose" },
+    );
+  });
+
+  it("level 2 is the ceiling — pinch-out at level 2 no-ops", () => {
+    const s = { level: 2, mode: "expose" };
+    assert.strictEqual(reducePinch(s, { scale: 2.0 }), s);
+  });
+
+  it("fires exactly at the threshold", () => {
+    assert.deepStrictEqual(
+      reducePinch({ level: 1, mode: "carousel" }, { scale: PINCH_OUT_THRESHOLD }),
+      { level: 1, mode: "expose" },
+    );
+  });
+});
+
+describe("reducePinch — pinch-in (zoom in)", () => {
+  it("level 1 expose → level 1 carousel", () => {
+    assert.deepStrictEqual(
+      reducePinch({ level: 1, mode: "expose" }, { scale: 0.8 }),
+      { level: 1, mode: "carousel" },
+    );
+  });
+
+  it("level 1 carousel is the floor — pinch-in at level 1 carousel no-ops", () => {
+    const s = { level: 1, mode: "carousel" };
+    assert.strictEqual(reducePinch(s, { scale: 0.5 }), s);
+  });
+
+  it("level 2 expose → level 1 expose (keeps uniform mode)", () => {
+    assert.deepStrictEqual(
+      reducePinch({ level: 2, mode: "expose" }, { scale: 0.8 }),
+      { level: 1, mode: "expose" },
+    );
+  });
+
+  it("fires exactly at the threshold", () => {
+    assert.deepStrictEqual(
+      reducePinch({ level: 1, mode: "expose" }, { scale: PINCH_IN_THRESHOLD }),
+      { level: 1, mode: "carousel" },
+    );
+  });
+});
+
+describe("reducePinch — round-trip", () => {
+  it("carousel → expose → L2 → expose → carousel", () => {
+    let s = INITIAL_PINCH_STATE;
+    s = reducePinch(s, { scale: 1.2 });
+    assert.deepStrictEqual(s, { level: 1, mode: "expose" });
+    s = reducePinch(s, { scale: 1.2 });
+    assert.deepStrictEqual(s, { level: 2, mode: "expose" });
+    s = reducePinch(s, { scale: 0.8 });
+    assert.deepStrictEqual(s, { level: 1, mode: "expose" });
+    s = reducePinch(s, { scale: 0.8 });
+    assert.deepStrictEqual(s, { level: 1, mode: "carousel" });
+  });
+
+  it("reducer is pure — doesn't mutate input", () => {
+    const s = { level: 1, mode: "carousel" };
+    const snap = JSON.parse(JSON.stringify(s));
+    reducePinch(s, { scale: 1.5 });
+    assert.deepStrictEqual(s, snap);
+  });
+});
+
+describe("diffPinchState", () => {
+  it("returns null when states are equal", () => {
+    const s = { level: 1, mode: "carousel" };
+    assert.strictEqual(diffPinchState(s, s), null);
+    assert.strictEqual(
+      diffPinchState({ level: 1, mode: "carousel" }, { level: 1, mode: "carousel" }),
+      null,
+    );
+  });
+
+  it("flags modeChanged when only mode differs", () => {
+    assert.deepStrictEqual(
+      diffPinchState({ level: 1, mode: "carousel" }, { level: 1, mode: "expose" }),
+      { levelChanged: false, modeChanged: true },
+    );
+  });
+
+  it("flags levelChanged when only level differs", () => {
+    assert.deepStrictEqual(
+      diffPinchState({ level: 1, mode: "expose" }, { level: 2, mode: "expose" }),
+      { levelChanged: true, modeChanged: false },
+    );
+  });
+
+  it("flags both when both differ", () => {
+    assert.deepStrictEqual(
+      diffPinchState({ level: 1, mode: "carousel" }, { level: 2, mode: "expose" }),
+      { levelChanged: true, modeChanged: true },
+    );
+  });
+});

--- a/test/selectors.test.js
+++ b/test/selectors.test.js
@@ -1,0 +1,130 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const { selectClusterView, getFocusedSession } = await import(
+  new URL("../public/lib/selectors.js", import.meta.url).href
+);
+
+function makeState(overrides = {}) {
+  return {
+    version: 2,
+    activeClusterId: "default",
+    clusters: { default: { id: "default" }, work: { id: "work" } },
+    tiles: {
+      a: { id: "a", type: "terminal", props: {}, x: 0, clusterId: "default" },
+      b: { id: "b", type: "terminal", props: {}, x: 1, clusterId: "default" },
+      w1: { id: "w1", type: "terminal", props: {}, x: 0, clusterId: "work" },
+    },
+    focusedIdByCluster: { default: "b", work: "w1" },
+    ...overrides,
+  };
+}
+
+describe("selectClusterView — basics", () => {
+  it("returns tiles and order filtered to the cluster", () => {
+    const view = selectClusterView(makeState(), "default");
+    assert.deepStrictEqual(Object.keys(view.tiles).sort(), ["a", "b"]);
+    assert.deepStrictEqual(view.order, ["a", "b"]);
+    assert.strictEqual(view.focusedId, "b");
+  });
+
+  it("returns a different view for a different cluster", () => {
+    const view = selectClusterView(makeState(), "work");
+    assert.deepStrictEqual(Object.keys(view.tiles), ["w1"]);
+    assert.deepStrictEqual(view.order, ["w1"]);
+    assert.strictEqual(view.focusedId, "w1");
+  });
+
+  it("orders tiles by x, not by insertion", () => {
+    const state = makeState({
+      tiles: {
+        t2: { id: "t2", type: "terminal", props: {}, x: 2, clusterId: "default" },
+        t0: { id: "t0", type: "terminal", props: {}, x: 0, clusterId: "default" },
+        t1: { id: "t1", type: "terminal", props: {}, x: 1, clusterId: "default" },
+      },
+      focusedIdByCluster: { default: "t0" },
+    });
+    assert.deepStrictEqual(selectClusterView(state, "default").order, ["t0", "t1", "t2"]);
+  });
+
+  it("treats missing x as 0 (sort-stable fallback)", () => {
+    const state = makeState({
+      tiles: {
+        b: { id: "b", type: "terminal", props: {}, x: 5, clusterId: "default" },
+        a: { id: "a", type: "terminal", props: {}, clusterId: "default" },
+      },
+      focusedIdByCluster: { default: "a" },
+    });
+    // `a` has no x (treated as 0), comes before `b` (x=5)
+    assert.deepStrictEqual(selectClusterView(state, "default").order, ["a", "b"]);
+  });
+});
+
+describe("selectClusterView — edge cases", () => {
+  it("returns empty view for unknown cluster id", () => {
+    assert.deepStrictEqual(
+      selectClusterView(makeState(), "nonexistent"),
+      { tiles: {}, order: [], focusedId: null },
+    );
+  });
+
+  it("returns empty view when cluster exists but has no tiles", () => {
+    const state = makeState({
+      clusters: { default: { id: "default" }, empty: { id: "empty" } },
+      focusedIdByCluster: { default: "b", empty: null },
+    });
+    assert.deepStrictEqual(
+      selectClusterView(state, "empty"),
+      { tiles: {}, order: [], focusedId: null },
+    );
+  });
+
+  it("handles missing focusedIdByCluster entry as null", () => {
+    const state = makeState({ focusedIdByCluster: { default: null, work: "w1" } });
+    assert.strictEqual(selectClusterView(state, "default").focusedId, null);
+  });
+
+  it("handles null/undefined state gracefully", () => {
+    assert.deepStrictEqual(
+      selectClusterView(null, "default"),
+      { tiles: {}, order: [], focusedId: null },
+    );
+    assert.deepStrictEqual(
+      selectClusterView(undefined, "default"),
+      { tiles: {}, order: [], focusedId: null },
+    );
+  });
+});
+
+describe("selectClusterView — purity", () => {
+  it("does not mutate the input state", () => {
+    const state = makeState();
+    const snap = JSON.parse(JSON.stringify(state));
+    selectClusterView(state, "default");
+    assert.deepStrictEqual(state, snap);
+  });
+
+  it("returns a fresh tiles object, not a reference into state", () => {
+    const state = makeState();
+    const view = selectClusterView(state, "default");
+    assert.notStrictEqual(view.tiles, state.tiles);
+  });
+});
+
+describe("getFocusedSession — unchanged", () => {
+  it("returns renderer-declared session for the focused tile", () => {
+    const state = makeState();
+    state.focusedId = "b"; // derived field (tile-host path still reads top-level)
+    const getRenderer = () => ({
+      describe: (props) => ({ session: props.sessionName || "b" }),
+    });
+    assert.strictEqual(getFocusedSession(state, getRenderer), "b");
+  });
+
+  it("returns null when renderer has no session", () => {
+    const state = makeState();
+    state.focusedId = "b";
+    const getRenderer = () => ({ describe: () => ({}) });
+    assert.strictEqual(getFocusedSession(state, getRenderer), null);
+  });
+});

--- a/test/tile-host.test.js
+++ b/test/tile-host.test.js
@@ -8,9 +8,33 @@ const { createTileHost } = await import(
 );
 
 // ── Minimal store ──────────────────────────────────────────────────────
-// Just enough to drive tile-host: getState, subscribe, dispatch.
-function createTestStore(initial = { tiles: {}, order: [], focusedId: null }) {
-  let state = { ...initial };
+// Uses the v2 multi-cluster shape tile-host now expects. `selectClusterView`
+// filters by clusterId; the test store keeps everything in a single
+// "default" cluster and derives legacy `order`/`focusedId` fields for tests
+// that assert on them.
+const DEFAULT_CLUSTER = "default";
+
+function withDerived(state) {
+  const tilesForCluster = Object.values(state.tiles)
+    .filter(t => t.clusterId === state.activeClusterId)
+    .sort((a, b) => (a.x ?? 0) - (b.x ?? 0));
+  const order = tilesForCluster.map(t => t.id);
+  const focusedId = state.focusedIdByCluster[state.activeClusterId] ?? null;
+  return { ...state, order, focusedId };
+}
+
+function emptyState() {
+  return withDerived({
+    version: 2,
+    activeClusterId: DEFAULT_CLUSTER,
+    clusters: { [DEFAULT_CLUSTER]: { id: DEFAULT_CLUSTER } },
+    tiles: {},
+    focusedIdByCluster: { [DEFAULT_CLUSTER]: null },
+  });
+}
+
+function createTestStore(initial = emptyState()) {
+  let state = initial;
   const subs = new Set();
 
   function notify() { subs.forEach(fn => fn(state)); }
@@ -19,33 +43,92 @@ function createTestStore(initial = { tiles: {}, order: [], focusedId: null }) {
     getState: () => state,
     subscribe(fn) { subs.add(fn); return () => subs.delete(fn); },
     dispatch(action) { /* not used by tile-host */ },
-    // Test helpers — mutate state and notify subscribers
-    setState(next) { state = next; notify(); },
+    setState(next) {
+      // Test-side convenience: accept both the v2 shape and the pre-v2 flat
+      // shape (`{tiles, order, focusedId}`) the original tests use. Flat
+      // input gets wrapped into the default cluster with x-positions taken
+      // from the order array.
+      if (next.clusters) {
+        // Normalize tiles that are missing clusterId/x. If the caller
+        // provided an `order` array, use it for x positions so legacy-style
+        // "spread state, set order" inserts still work.
+        const normalizedTiles = {};
+        const orderArr = next.order;
+        Object.entries(next.tiles || {}).forEach(([id, t]) => {
+          const idxInOrder = orderArr ? orderArr.indexOf(id) : -1;
+          // If the caller supplied an `order` array, trust it as the
+          // source of truth for x positions — overrides any existing
+          // x on the tile (the whole point of passing `order`).
+          const xFromOrder = idxInOrder >= 0 ? idxInOrder : undefined;
+          normalizedTiles[id] = {
+            ...t,
+            id: t.id ?? id,
+            clusterId: t.clusterId ?? DEFAULT_CLUSTER,
+            x: xFromOrder ?? t.x ?? 0,
+          };
+        });
+        const focusedIdByCluster = next.focusedIdByCluster
+          ? next.focusedIdByCluster
+          : { ...state.focusedIdByCluster, [DEFAULT_CLUSTER]: next.focusedId ?? null };
+        state = withDerived({ ...next, tiles: normalizedTiles, focusedIdByCluster });
+      } else {
+        const tiles = {};
+        const orderArr = next.order || Object.keys(next.tiles || {});
+        orderArr.forEach((id, x) => {
+          const t = next.tiles?.[id];
+          if (t) tiles[id] = { id, type: t.type, props: t.props || {}, x, clusterId: DEFAULT_CLUSTER };
+        });
+        state = withDerived({
+          version: 2,
+          activeClusterId: DEFAULT_CLUSTER,
+          clusters: { [DEFAULT_CLUSTER]: { id: DEFAULT_CLUSTER } },
+          tiles,
+          focusedIdByCluster: { [DEFAULT_CLUSTER]: next.focusedId ?? null },
+        });
+      }
+      notify();
+    },
     addTile(id, type, props, focus) {
-      state = {
+      const nextX = Object.values(state.tiles)
+        .filter(t => t.clusterId === DEFAULT_CLUSTER)
+        .reduce((m, t) => Math.max(m, (t.x ?? -1) + 1), 0);
+      state = withDerived({
         ...state,
-        tiles: { ...state.tiles, [id]: { id, type, props } },
-        order: [...state.order, id],
-        focusedId: focus ? id : state.focusedId,
-      };
+        tiles: {
+          ...state.tiles,
+          [id]: { id, type, props, x: nextX, clusterId: DEFAULT_CLUSTER },
+        },
+        focusedIdByCluster: focus
+          ? { ...state.focusedIdByCluster, [DEFAULT_CLUSTER]: id }
+          : state.focusedIdByCluster,
+      });
       notify();
     },
     removeTile(id) {
-      const { [id]: _, ...rest } = state.tiles;
-      state = {
-        ...state,
-        tiles: rest,
-        order: state.order.filter(x => x !== id),
-        focusedId: state.focusedId === id ? (state.order.filter(x => x !== id)[0] || null) : state.focusedId,
-      };
+      const { [id]: _removed, ...rest } = state.tiles;
+      const focusedIdByCluster = { ...state.focusedIdByCluster };
+      if (focusedIdByCluster[DEFAULT_CLUSTER] === id) {
+        const remaining = Object.values(rest)
+          .filter(t => t.clusterId === DEFAULT_CLUSTER)
+          .sort((a, b) => (a.x ?? 0) - (b.x ?? 0));
+        focusedIdByCluster[DEFAULT_CLUSTER] = remaining[0]?.id || null;
+      }
+      state = withDerived({ ...state, tiles: rest, focusedIdByCluster });
       notify();
     },
     focusTile(id) {
-      state = { ...state, focusedId: id };
+      state = withDerived({
+        ...state,
+        focusedIdByCluster: { ...state.focusedIdByCluster, [DEFAULT_CLUSTER]: id },
+      });
       notify();
     },
     reorder(order) {
-      state = { ...state, order };
+      const tiles = { ...state.tiles };
+      order.forEach((id, x) => {
+        if (tiles[id]) tiles[id] = { ...tiles[id], x };
+      });
+      state = withDerived({ ...state, tiles });
       notify();
     },
   };

--- a/test/ui-store.test.js
+++ b/test/ui-store.test.js
@@ -330,14 +330,20 @@ describe("RESET", () => {
 });
 
 describe("serialize", () => {
-  it("includes x on tiles and derives order", () => {
+  it("includes x + clusterId on tiles; drops derived order/focusedId", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: {} });
     store.addTile({ id: "b", type: "terminal", props: {} });
     const out = serialize(store.getState());
     assert.strictEqual(out.tiles.a.x, 0);
     assert.strictEqual(out.tiles.b.x, 1);
-    assert.deepStrictEqual(out.order, ["a", "b"]);
+    assert.strictEqual(out.tiles.a.clusterId, "default");
+    assert.strictEqual(out.tiles.b.clusterId, "default");
+    assert.strictEqual(out.order, undefined);
+    assert.strictEqual(out.focusedId, undefined);
+    assert.strictEqual(out.activeClusterId, "default");
+    assert.ok(out.clusters.default);
+    assert.ok("focusedIdByCluster" in out);
   });
 
   it("filters non-persistable tiles", () => {
@@ -347,7 +353,222 @@ describe("serialize", () => {
     const out = serialize(store.getState(), (type) => type === "terminal");
     assert.ok(out.tiles.a);
     assert.ok(!out.tiles.b);
-    assert.deepStrictEqual(out.order, ["a"]);
+  });
+
+  it("clears focusedIdByCluster entries that point to filtered tiles", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "ephemeral", props: {} }, { focus: true });
+    const out = serialize(store.getState(), (type) => type === "terminal");
+    assert.strictEqual(out.focusedIdByCluster.default, null);
+  });
+});
+
+// ── clusters ─────────────────────────────────────────────────────────
+
+describe("clusters: initial state", () => {
+  it("has a default cluster and active=default", () => {
+    const store = makeStore();
+    const s = store.getState();
+    assert.strictEqual(s.activeClusterId, "default");
+    assert.ok(s.clusters.default);
+    assert.deepStrictEqual(Object.keys(s.focusedIdByCluster), ["default"]);
+  });
+
+  it("new tiles are assigned clusterId = activeClusterId", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    assert.strictEqual(store.getState().tiles.a.clusterId, "default");
+  });
+});
+
+describe("ADD_CLUSTER", () => {
+  it("adds a cluster and initializes its focusedIdByCluster slot", () => {
+    const store = makeStore();
+    store.addCluster({ id: "work" });
+    const s = store.getState();
+    assert.ok(s.clusters.work);
+    assert.strictEqual(s.focusedIdByCluster.work, null);
+    // active is still default
+    assert.strictEqual(s.activeClusterId, "default");
+  });
+
+  it("can switch to the new cluster on creation", () => {
+    const store = makeStore();
+    store.addCluster({ id: "work", name: "Work" }, { switchTo: true });
+    const s = store.getState();
+    assert.strictEqual(s.activeClusterId, "work");
+    assert.strictEqual(s.clusters.work.name, "Work");
+  });
+
+  it("no-ops when cluster id already exists", () => {
+    const store = makeStore();
+    const before = store.getState();
+    store.addCluster({ id: "default" });
+    assert.strictEqual(store.getState(), before);
+  });
+
+  it("rejects cluster without an id", () => {
+    const store = makeStore();
+    const before = store.getState();
+    store.addCluster({});
+    assert.strictEqual(store.getState(), before);
+  });
+});
+
+describe("SWITCH_CLUSTER", () => {
+  it("updates activeClusterId and re-derives order/focusedId", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} }, { focus: true });
+    store.addCluster({ id: "work" });
+    store.switchCluster("work");
+    store.addTile({ id: "b", type: "terminal", props: {} }, { focus: true });
+    const s = store.getState();
+    assert.strictEqual(s.activeClusterId, "work");
+    assert.deepStrictEqual(s.order, ["b"]);
+    assert.strictEqual(s.focusedId, "b");
+
+    // Switch back — default's state is remembered
+    store.switchCluster("default");
+    const d = store.getState();
+    assert.deepStrictEqual(d.order, ["a"]);
+    assert.strictEqual(d.focusedId, "a");
+  });
+
+  it("no-ops for unknown cluster", () => {
+    const store = makeStore();
+    const before = store.getState();
+    store.switchCluster("ghost");
+    assert.strictEqual(store.getState(), before);
+  });
+
+  it("no-ops when already active", () => {
+    const store = makeStore();
+    const before = store.getState();
+    store.switchCluster("default");
+    assert.strictEqual(store.getState(), before);
+  });
+});
+
+describe("REMOVE_CLUSTER", () => {
+  it("removes the cluster and all its tiles", () => {
+    const store = makeStore();
+    store.addCluster({ id: "work" }, { switchTo: true });
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.addTile({ id: "b", type: "terminal", props: {} });
+    store.switchCluster("default");
+    store.removeCluster("work");
+    const s = store.getState();
+    assert.ok(!s.clusters.work);
+    assert.ok(!s.tiles.a);
+    assert.ok(!s.tiles.b);
+    assert.ok(!s.focusedIdByCluster.work);
+  });
+
+  it("refuses to remove the last cluster", () => {
+    const store = makeStore();
+    const before = store.getState();
+    store.removeCluster("default");
+    assert.strictEqual(store.getState(), before);
+  });
+
+  it("falls back to first remaining cluster when removing active", () => {
+    const store = makeStore();
+    store.addCluster({ id: "work" }, { switchTo: true });
+    store.removeCluster("work");
+    const s = store.getState();
+    assert.strictEqual(s.activeClusterId, "default");
+  });
+});
+
+describe("cluster-scoped actions", () => {
+  it("FOCUS_TILE rejects a tile in a non-active cluster", () => {
+    const store = makeStore();
+    store.addCluster({ id: "work" });
+    store.addTile({ id: "a", type: "terminal", props: {} }, { clusterId: "work" });
+    // active is still default; focusing "a" (in work) should no-op
+    const before = store.getState();
+    store.focusTile("a");
+    assert.strictEqual(store.getState(), before);
+  });
+
+  it("ADD_TILE can target a specific cluster via clusterId option", () => {
+    const store = makeStore();
+    store.addCluster({ id: "work" });
+    store.addTile({ id: "a", type: "terminal", props: {} }, { clusterId: "work" });
+    const s = store.getState();
+    assert.strictEqual(s.tiles.a.clusterId, "work");
+    // active cluster order is empty since "a" lives in "work"
+    assert.deepStrictEqual(s.order, []);
+  });
+
+  it("REORDER only touches tiles in the target cluster", () => {
+    const store = makeStore();
+    store.addCluster({ id: "work" });
+    store.addTile({ id: "a", type: "terminal", props: {} }); // default
+    store.addTile({ id: "b", type: "terminal", props: {} }); // default
+    store.addTile({ id: "w1", type: "terminal", props: {} }, { clusterId: "work" });
+    store.addTile({ id: "w2", type: "terminal", props: {} }, { clusterId: "work" });
+    store.reorder(["b", "a"]); // default cluster
+    const s = store.getState();
+    assert.deepStrictEqual(s.order, ["b", "a"]);
+    // work tiles keep their original order
+    assert.strictEqual(s.tiles.w1.x, 0);
+    assert.strictEqual(s.tiles.w2.x, 1);
+  });
+
+  it("REMOVE_TILE re-focuses within the removed tile's own cluster", () => {
+    const store = makeStore();
+    store.addCluster({ id: "work" });
+    store.addTile({ id: "a", type: "terminal", props: {} }, { focus: true });
+    store.addTile({ id: "w1", type: "terminal", props: {} }, { clusterId: "work" });
+    store.addTile({ id: "w2", type: "terminal", props: {} }, { clusterId: "work" });
+    // Focus the first work-tile by switching and focusing.
+    store.switchCluster("work");
+    store.focusTile("w1");
+    store.switchCluster("default");
+    // Now remove w1 while default is active — focus within work should
+    // fall back to w2 (the neighbor).
+    store.removeTile("w1");
+    assert.strictEqual(store.getState().focusedIdByCluster.work, "w2");
+    // Default's focus unchanged.
+    assert.strictEqual(store.getState().focusedIdByCluster.default, "a");
+  });
+});
+
+describe("v1 → v2 migration via normalize", () => {
+  it("wraps v1 tiles into the default cluster", () => {
+    const v1 = {
+      version: 1,
+      tiles: {
+        a: { id: "a", type: "terminal", props: {}, x: 0 },
+        b: { id: "b", type: "terminal", props: {}, x: 1 },
+      },
+      focusedId: "b",
+    };
+    const v2 = normalize(v1);
+    assert.strictEqual(v2.version, 2);
+    assert.strictEqual(v2.activeClusterId, "default");
+    assert.strictEqual(v2.tiles.a.clusterId, "default");
+    assert.strictEqual(v2.tiles.b.clusterId, "default");
+    assert.strictEqual(v2.focusedIdByCluster.default, "b");
+    assert.strictEqual(v2.focusedId, "b");
+    assert.deepStrictEqual(v2.order, ["a", "b"]);
+  });
+
+  it("migrates v1 tiles lacking x using the order hint", () => {
+    const v1 = {
+      version: 1,
+      tiles: {
+        a: { id: "a", type: "terminal", props: {} },
+        b: { id: "b", type: "terminal", props: {} },
+      },
+      order: ["b", "a"],
+      focusedId: "b",
+    };
+    const v2 = normalize(v1);
+    assert.strictEqual(v2.tiles.b.x, 0);
+    assert.strictEqual(v2.tiles.a.x, 1);
+    assert.deepStrictEqual(v2.order, ["b", "a"]);
   });
 });
 


### PR DESCRIPTION
## Summary

Functional-programming groundwork for the multi-cluster / virtual-desktop feature in `docs/tile-clusters-design.md`. Five PRs' worth of refactor landed on one branch — each commit is independently reviewable, with a mini-blog-post message explaining what / why / what was tried.

The goal across the chain is to **shift load off integration tests onto pure unit tests** so multi-cluster behavior is debuggable in milliseconds instead of needing full DOM harnesses. 41 new pure unit tests added across the chain; total unit suite is now 2150 tests (~16s).

### What's in the chain

- **FP1** `33aa3be` — `ui-store` v2 shape with clusters: `{version, activeClusterId, clusters, tiles (with clusterId), focusedIdByCluster}`. `buildBootState()` extracted to `public/lib/boot-state.js` as a pure function with v1→v2 legacy migration. _12 new pure tests for boot composition._
- **FP2** `509da16` — `pickRightNeighbor` reads ui-store `state.order`/`focusedId` instead of the imperative `carousel.isActive() ? carousel.getCards() : windowTabSet.getTabs()` branch. Stale cluster-aliasing docstring removed (focusedId is already the tile id, not session name).
- **FP3** `668a450` — pure `decideAddTarget({level, activeClusterId, focusedId})` + `createAddHandler` factory + id generators in `public/lib/add-target.js`. Sidebar-+ rewired through factory; Level-2 path wired to `uiStore.addCluster` so MC3 only swaps `getLevel()`. _12 pure tests._
- **FP4** `3cb0138` — pure `reducePinch(state, {scale})` for the L1↔L2 state machine + `diffPinchState` for minimal side-effects in `public/lib/pinch-levels.js`. App.js threads `pinchState` through the reducer; L2 transitions clamped until MC3. _17 pure tests._
- **FP5** `d39a96b` — `selectClusterView(state, clusterId)` pure selector. Tile-host accepts optional `getClusterId` (defaults to active cluster) and reconciles via the scoped view; `syncCarouselSubscriptions(clusterId?)` iterates ui-store order instead of carousel cards. Test store helper updated to v2 shape. _12 pure selector tests + 14 tile-host tests still passing._

### Why this shape

Today most app behavior is verified through integration tests that need a live DOM, ui-store, carousel, and timing. Each FP commit pulls one chunk of decision logic out into a pure module (zero I/O, no DOM, no timers). The integration tests still exist as a backstop, but the hard logic now has fast, deterministic, branch-by-branch coverage.

This also de-risks MC1-MC3 (the actual multi-cluster work): every action MC needs is already available as a pure function or testable factory. MC3 should be mostly a renderer + a `getLevel()` that's no longer hardcoded.

## Test plan

- [ ] Verify CI passes (full unit + integration + e2e)
- [ ] Smoke: refresh page in browser — single-cluster app still works (carousel shows, tiles persist, + button creates a session)
- [ ] Smoke: trigger pinch-out on iPad — carousel→expose still works; pinch-in returns to carousel
- [ ] Smoke: close a tab (Option+W) — focus lands on the right neighbor (the original bug `pickRightNeighbor` exists to handle)
- [ ] Smoke: refresh a page that had legacy `katulong-ui-store` v1 data — v1→v2 migration runs, tiles still appear in the default cluster
- [ ] Verify no regressions in the 2150-test unit suite