### PR TITLE
MC1 — 3D tile shape: position-as-identity workspace

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -958,7 +958,7 @@
         return { activeClusterIdx: st.activeClusterIdx, focusedId: st.focusedId };
       },
       onAddTile: () => createNewSession(),
-      onAddCluster: () => uiStore.addCluster({}, { switchTo: true }),
+      onAddCluster: () => uiStore.addCluster({ switchTo: true }),
     });
 
     if (sidebarAddBtn) {

--- a/public/app.js
+++ b/public/app.js
@@ -44,7 +44,7 @@
     import { dispatchNotification } from "/lib/notify.js";
     import { createUiStore, loadFromStorage, EMPTY_STATE } from "/lib/ui-store.js";
     import { buildBootState } from "/lib/boot-state.js";
-    import { createAddHandler, generateSessionName, generateClusterId } from "/lib/add-target.js";
+    import { createAddHandler, generateSessionName } from "/lib/add-target.js";
     import { reducePinch, diffPinchState, INITIAL_PINCH_STATE } from "/lib/pinch-levels.js";
     import { initRenderers, isPersistable, getRenderer } from "/lib/tile-renderers/index.js";
     import { createTileHost } from "/lib/tile-host.js";
@@ -592,10 +592,13 @@
      *  (Level 2) — each cluster's tiles are subscribed independently of
      *  whichever carousel is visually on screen.
      *
-     *  @param {string} [clusterId] — defaults to the active cluster. */
-    function syncCarouselSubscriptions(clusterId) {
+     *  @param {number} [clusterIdx] — defaults to the active cluster. */
+    function syncCarouselSubscriptions(clusterIdx) {
       const state = uiStore.getState();
-      const view = selectClusterView(state, clusterId || state.activeClusterId);
+      const view = selectClusterView(
+        state,
+        typeof clusterIdx === "number" ? clusterIdx : state.activeClusterIdx,
+      );
       if (view.order.length === 0) return;
       for (const tileId of view.order) {
         const handle = tileHost.getHandle(tileId);
@@ -952,10 +955,10 @@
       getLevel: () => 1,
       getState: () => {
         const st = uiStore.getState();
-        return { activeClusterId: st.activeClusterId, focusedId: st.focusedId };
+        return { activeClusterIdx: st.activeClusterIdx, focusedId: st.focusedId };
       },
       onAddTile: () => createNewSession(),
-      onAddCluster: () => uiStore.addCluster({ id: generateClusterId() }, { switchTo: true }),
+      onAddCluster: () => uiStore.addCluster({}, { switchTo: true }),
     });
 
     if (sidebarAddBtn) {

--- a/public/lib/add-target.js
+++ b/public/lib/add-target.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @typedef {{ kind: "tile", clusterId: string, insertAfter: string | null }} TileTarget
+ * @typedef {{ kind: "tile", clusterIdx: number, insertAfter: string | null }} TileTarget
  * @typedef {{ kind: "cluster" }} ClusterTarget
  * @typedef {TileTarget | ClusterTarget} AddTarget
  */
@@ -25,16 +25,16 @@
  * Decide what the + button should produce, given zoom level and state.
  *
  * @param {object} ctx
- * @param {number} ctx.level           Current zoom level (1 = focused, 2 = overview).
- * @param {string} ctx.activeClusterId Id of the currently-active cluster.
+ * @param {number} ctx.level            Current zoom level (1 = focused, 2 = overview).
+ * @param {number} ctx.activeClusterIdx Index of the currently-active cluster.
  * @param {string|null} [ctx.focusedId] Focused tile id, if any.
  * @returns {AddTarget}
  */
-export function decideAddTarget({ level, activeClusterId, focusedId = null }) {
+export function decideAddTarget({ level, activeClusterIdx, focusedId = null }) {
   if (level >= 2) return { kind: "cluster" };
   return {
     kind: "tile",
-    clusterId: activeClusterId,
+    clusterIdx: activeClusterIdx,
     insertAfter: focusedId,
   };
 }
@@ -50,16 +50,6 @@ export function generateSessionName(now = Date.now) {
 }
 
 /**
- * Unique cluster id. Same shape as generateSessionName so future
- * migration code can recognize "generated" ids vs. hand-named ones.
- *
- * @param {() => number} [now]
- */
-export function generateClusterId(now = Date.now) {
-  return `cluster-${now().toString(36)}`;
-}
-
-/**
  * Factory for a unified + handler. Both Level 1 and Level 2 add-buttons
  * call the returned function with no args; it reads fresh state, asks
  * `decideAddTarget` what to do, and dispatches to the right effect.
@@ -70,17 +60,17 @@ export function generateClusterId(now = Date.now) {
  *
  * @param {object} deps
  * @param {() => number} deps.getLevel
- * @param {() => { activeClusterId: string, focusedId: string|null }} deps.getState
+ * @param {() => { activeClusterIdx: number, focusedId: string|null }} deps.getState
  * @param {(target: TileTarget) => any} deps.onAddTile
  * @param {(target: ClusterTarget) => any} deps.onAddCluster
  * @returns {() => any} handleAdd
  */
 export function createAddHandler({ getLevel, getState, onAddTile, onAddCluster }) {
   return function handleAdd() {
-    const { activeClusterId, focusedId } = getState();
+    const { activeClusterIdx, focusedId } = getState();
     const target = decideAddTarget({
       level: getLevel(),
-      activeClusterId,
+      activeClusterIdx,
       focusedId,
     });
     if (target.kind === "cluster") return onAddCluster(target);

--- a/public/lib/boot-state.js
+++ b/public/lib/boot-state.js
@@ -3,29 +3,29 @@
  * ui-store state from all the sources the app needs at launch.
  *
  * Moved out of app.js to make it testable without a DOM, and so the
- * multi-cluster schema bump (FP1) has a single, reviewed place where
+ * multi-cluster schema bump has a single, reviewed place where
  * persistence + URL hints + window tabsets meet.
  *
  * Sources, in priority order:
- *   1. `persisted`       — result of ui-store `loadFromStorage()`.
+ *   1. `persisted`       — result of ui-store `loadFromStorage()` (already v3-normalized).
  *   2. `legacyCarousel`  — shape the pre-ui-store carousel persisted
  *                          (`{ tiles: [...], focused }`). Only used
  *                          when `persisted` is empty/missing, and
  *                          signals `migratedLegacy: true` so the
  *                          caller can clear the old storage key.
  *   3. `urlSession`      — the `?s=<name>` hint. Adds a new terminal
- *                          tile if the session isn't already present
- *                          and focuses it.
+ *                          tile to the active cluster if missing and
+ *                          focuses it.
  *   4. `tabSetSessions`  — legacy windowTabSet sessions. Folds in any
  *                          terminals that other windows know about
  *                          but weren't persisted here yet.
  */
 
-import { EMPTY_STATE, normalize, DEFAULT_CLUSTER_ID } from "./ui-store.js";
+import { EMPTY_STATE, normalize } from "./ui-store.js";
 
 /**
  * @param {object} deps
- * @param {object|null} [deps.persisted]         Normalized v2 state or null.
+ * @param {object|null} [deps.persisted]         Normalized v3 state or null.
  * @param {object|null} [deps.legacyCarousel]    Pre-ui-store carousel state or null.
  * @param {string|null} [deps.urlSession]        Value of ?s= URL param.
  * @param {string[]}    [deps.tabSetSessions]    Window tab-set session names.
@@ -40,33 +40,31 @@ export function buildBootState({
   tabSetSessions = [],
   getRenderer = () => ({}),
 } = {}) {
-  let state = persisted && Object.keys(persisted.tiles || {}).length > 0
-    ? persisted
-    : null;
+  const hasPersistedTiles = persisted
+    && Array.isArray(persisted.clusters)
+    && persisted.clusters.some(cluster => cluster.length > 0);
+
+  let state = hasPersistedTiles ? persisted : null;
   let migratedLegacy = false;
 
   if (!state && legacyCarousel?.tiles?.length) {
-    const tiles = {};
+    const cluster = [];
     for (const t of legacyCarousel.tiles) {
       const type = t.type === "dashboard" ? "cluster" : t.type;
       if (!getRenderer(type)) continue;
       const { id, type: _t, cardWidth: _cw, ...rest } = t;
-      tiles[t.id] = { id: t.id, type, props: rest, clusterId: DEFAULT_CLUSTER_ID };
+      cluster.push([{ id, type, props: rest }]);
     }
-    if (Object.keys(tiles).length > 0) {
-      // Assign x from the order of the legacy array.
-      let x = 0;
-      for (const t of legacyCarousel.tiles) {
-        if (tiles[t.id]) tiles[t.id].x = x++;
-      }
+    if (cluster.length > 0) {
+      const focusedRaw = legacyCarousel.focused;
+      const focused = cluster.some(col => col[0].id === focusedRaw)
+        ? focusedRaw
+        : cluster[0][0].id;
       state = normalize({
-        version: 2,
-        activeClusterId: DEFAULT_CLUSTER_ID,
-        clusters: { [DEFAULT_CLUSTER_ID]: { id: DEFAULT_CLUSTER_ID } },
-        tiles,
-        focusedIdByCluster: {
-          [DEFAULT_CLUSTER_ID]: legacyCarousel.focused || null,
-        },
+        version: 3,
+        clusters: [cluster],
+        activeClusterIdx: 0,
+        focusedTileIdByCluster: [focused],
       });
       migratedLegacy = true;
     }
@@ -79,26 +77,14 @@ export function buildBootState({
   // session. Otherwise the persisted focusedId wins — ?s= only tracks
   // terminals and goes stale when the user focuses a non-terminal
   // tile (e.g. file browser).
-  if (urlSession) {
-    if (!state.tiles[urlSession]) {
-      state = mergeTile(state, {
-        id: urlSession,
-        type: "terminal",
-        props: { sessionName: urlSession },
-        clusterId: state.activeClusterId,
-      }, { focus: true });
-    }
+  if (urlSession && !state.tiles[urlSession]) {
+    state = appendTerminalTile(state, urlSession, { focus: true });
   }
 
   // ── Merge windowTabSet sessions ─────────────────────────────────
   for (const name of tabSetSessions) {
     if (!state.tiles[name]) {
-      state = mergeTile(state, {
-        id: name,
-        type: "terminal",
-        props: { sessionName: name },
-        clusterId: state.activeClusterId,
-      }, { focus: false });
+      state = appendTerminalTile(state, name, { focus: false });
     }
   }
 
@@ -106,25 +92,33 @@ export function buildBootState({
 }
 
 /**
- * Add a tile to a v2 state (pure — returns a new state). Keeps the
- * boot-state composition isolated from the reducer so it doesn't need
- * a live store to compose initial state.
+ * Append a terminal tile as a new single-slot column at the end of the
+ * active cluster. Pure — returns a new state. Used for URL/tabset merge
+ * during boot only; runtime adds go through the reducer.
  */
-function mergeTile(state, tile, { focus = false } = {}) {
-  const { clusterId } = tile;
-  // nextX within the tile's cluster.
-  let maxX = -1;
-  for (const t of Object.values(state.tiles)) {
-    if (t.clusterId === clusterId && typeof t.x === "number" && t.x > maxX) maxX = t.x;
-  }
-  const nextTile = { ...tile, x: maxX + 1 };
-  const tiles = { ...state.tiles, [tile.id]: nextTile };
-  const focusedIdByCluster = focus
-    ? { ...state.focusedIdByCluster, [clusterId]: tile.id }
-    : state.focusedIdByCluster;
+function appendTerminalTile(state, sessionName, { focus = false } = {}) {
+  const c = state.activeClusterIdx;
+  const newCluster = state.clusters[c].slice();
+  newCluster.push([{
+    id: sessionName,
+    type: "terminal",
+    props: { sessionName },
+  }]);
+  const clusters = state.clusters.slice();
+  clusters[c] = newCluster;
+
+  const focusedTileIdByCluster = focus
+    ? (() => {
+      const next = state.focusedTileIdByCluster.slice();
+      next[c] = sessionName;
+      return next;
+    })()
+    : state.focusedTileIdByCluster;
+
   return normalize({
-    ...state,
-    tiles,
-    focusedIdByCluster,
+    version: 3,
+    clusters,
+    activeClusterIdx: c,
+    focusedTileIdByCluster,
   });
 }

--- a/public/lib/selectors.js
+++ b/public/lib/selectors.js
@@ -1,12 +1,11 @@
 /**
  * Selectors — pure functions that derive values from store state.
  *
- * These replace the mutable `state.session.name` pattern. Instead of
- * storing the "current session" as a side-effected variable, we derive
- * it on-demand from the ui-store's focusedId and the renderer registry.
+ * v3: clusters are stored as a 3D array `Tile[][][]` where position IS
+ * location. These selectors project views out of that shape for consumers
+ * that want map-access, a flat order, or the 2D per-cluster column view.
  *
- * Every function here is pure: (state, ...deps) => value.
- * No side effects, no mutations, no subscriptions.
+ * Every function here is pure: `(state, ...deps) => value`.
  */
 
 /**
@@ -14,8 +13,7 @@
  *
  * Only terminal and cluster tiles have a session — feed, file-browser,
  * localhost-browser, and progress tiles return null. Callers that need
- * to send WS messages (attach, switch, resize, subscribe) should use
- * this selector and guard against null.
+ * to send WS messages should use this selector and guard against null.
  *
  * @param {object} uiState — from uiStore.getState()
  * @param {function} getRenderer — from tile-renderers/index.js
@@ -33,30 +31,100 @@ export function getFocusedSession(uiState, getRenderer) {
  * Cluster-scoped view of ui-store state.
  *
  * Returns a `{ tiles, order, focusedId }` triple filtered to a single
- * cluster. Used by tile-host and WS-subscription code so each cluster
- * can drive its own carousel and bookkeep its own session subscriptions
- * independently.
+ * cluster, column-major top→bottom. Used by tile-host and WS-subscription
+ * code so each cluster can drive its own carousel and bookkeep its own
+ * session subscriptions independently.
  *
  * Pure: no dependency on renderer registry, no mutation of input. Given
- * an unknown or missing cluster id, returns an empty view.
+ * an out-of-range cluster index, returns an empty view.
  *
  * @param {object} uiState
- * @param {string} clusterId
+ * @param {number} clusterIdx
  * @returns {{ tiles: object, order: string[], focusedId: string|null }}
  */
-export function selectClusterView(uiState, clusterId) {
-  if (!uiState?.clusters?.[clusterId]) {
-    return { tiles: {}, order: [], focusedId: null };
-  }
+export function selectClusterView(uiState, clusterIdx) {
+  const cluster = uiState?.clusters?.[clusterIdx];
+  if (!cluster) return { tiles: {}, order: [], focusedId: null };
+
   const tiles = {};
-  const arr = [];
-  for (const t of Object.values(uiState.tiles)) {
-    if (t.clusterId !== clusterId) continue;
-    tiles[t.id] = t;
-    arr.push(t);
+  const order = [];
+  for (const column of cluster) {
+    for (const tile of column) {
+      tiles[tile.id] = tile;
+      order.push(tile.id);
+    }
   }
-  arr.sort((a, b) => (a.x ?? 0) - (b.x ?? 0));
-  const order = arr.map(t => t.id);
-  const focusedId = uiState.focusedIdByCluster?.[clusterId] ?? null;
+  const focusedId = uiState.focusedTileIdByCluster?.[clusterIdx] ?? null;
   return { tiles, order, focusedId };
+}
+
+/**
+ * 2D column view of a cluster, for Level-2 rendering and future drag-to-stack.
+ *
+ * Each column is identified by its head tile id (there is no separate
+ * "column id" entity — columns don't persist identity beyond their tiles).
+ * In MC1 single-slot, every column has length 1 so `id === tileIds[0]`.
+ *
+ * @param {object} uiState
+ * @param {number} clusterIdx
+ * @returns {{ id: string, tileIds: string[] }[]}
+ */
+export function selectColumns(uiState, clusterIdx) {
+  const cluster = uiState?.clusters?.[clusterIdx];
+  if (!cluster) return [];
+  return cluster.map((column) => ({
+    id: column[0].id,
+    tileIds: column.map(t => t.id),
+  }));
+}
+
+/**
+ * Build an O(1) tile-id → path locator for the whole workspace.
+ *
+ * With tiles stored positionally in a 3D array, finding a tile by id
+ * requires a traversal. This selector memoizes the index per state
+ * reference via WeakMap so repeated lookups (e.g., from WS message
+ * handlers, focus moves) are free.
+ *
+ * @param {object} uiState
+ * @returns {{
+ *   get: (id: string) => { c: number, col: number, row: number, tile: object } | null,
+ *   has: (id: string) => boolean,
+ *   ids: () => string[],
+ *   size: () => number,
+ * }}
+ */
+const _locatorCache = new WeakMap();
+const EMPTY_LOCATOR = Object.freeze({
+  get: () => null,
+  has: () => false,
+  ids: () => [],
+  size: () => 0,
+});
+
+export function tileLocator(uiState) {
+  if (!uiState || !Array.isArray(uiState.clusters)) return EMPTY_LOCATOR;
+  const cached = _locatorCache.get(uiState);
+  if (cached) return cached;
+
+  const index = new Map();
+  for (let c = 0; c < uiState.clusters.length; c++) {
+    const cluster = uiState.clusters[c];
+    for (let col = 0; col < cluster.length; col++) {
+      const column = cluster[col];
+      for (let row = 0; row < column.length; row++) {
+        const tile = column[row];
+        index.set(tile.id, { c, col, row, tile });
+      }
+    }
+  }
+
+  const locator = {
+    get: (id) => index.get(id) || null,
+    has: (id) => index.has(id),
+    ids: () => [...index.keys()],
+    size: () => index.size,
+  };
+  _locatorCache.set(uiState, locator);
+  return locator;
 }

--- a/public/lib/tile-host.js
+++ b/public/lib/tile-host.js
@@ -11,7 +11,7 @@
  * All tile lifecycle now flows through one subscription.
  *
  * Cluster isolation (FP5): each tile-host is scoped to a single cluster.
- * Reads go through `selectClusterView(state, clusterId)` so tile-host
+ * Reads go through `selectClusterView(state, clusterIdx)` so tile-host
  * only sees its cluster's tiles. A future MC3 Level-2 renderer can mount
  * one tile-host per cluster strip; today there's one tile-host bound to
  * the active cluster.
@@ -28,14 +28,14 @@ import { selectClusterView } from "./selectors.js";
  * @param {object} opts.store — ui-store instance (getState, subscribe, dispatch)
  * @param {object} opts.carousel — card-carousel instance
  * @param {function} opts.getRenderer — (type) → renderer object (from tile-renderers registry)
- * @param {function} [opts.getClusterId] — () → clusterId this host is scoped to.
- *   Defaults to reading `activeClusterId` from the store on every reconcile, so
+ * @param {function} [opts.getClusterIdx] — () → cluster index this host is scoped to.
+ *   Defaults to reading `activeClusterIdx` from the store on every reconcile, so
  *   today's single-cluster app behaves exactly like before.
  * @param {function} [opts.onFocusChange] — called after carousel focus settles,
  *   with (tileId, tileType). App.js uses this for WS subscription switching.
  */
-export function createTileHost({ store, carousel, getRenderer, getClusterId, onFocusChange, onTileRemoved }) {
-  const resolveClusterId = getClusterId || (() => store.getState().activeClusterId);
+export function createTileHost({ store, carousel, getRenderer, getClusterIdx, onFocusChange, onTileRemoved }) {
+  const resolveClusterIdx = getClusterIdx || (() => store.getState().activeClusterIdx);
   // Map<tileId, { unmount, focus, blur, resize, tile }>
   const handles = new Map();
   let prevState = null;
@@ -61,7 +61,7 @@ export function createTileHost({ store, carousel, getRenderer, getClusterId, onF
     // Scope to this host's cluster — every tile-host sees only its own
     // cluster's tiles. Today there's one tile-host bound to the active
     // cluster; MC3 can mount one per strip.
-    const view = selectClusterView(state, resolveClusterId());
+    const view = selectClusterView(state, resolveClusterIdx());
     const prev = prevState || { tiles: {}, order: [], focusedId: null };
     prevState = view;
 

--- a/public/lib/ui-store.js
+++ b/public/lib/ui-store.js
@@ -61,6 +61,11 @@ export const EMPTY_STATE = Object.freeze({
  * Rebuild `tiles`, `order`, `focusedId` from the 3D source-of-truth.
  * Called after every reducer step. O(N) across all tiles in all clusters.
  */
+// Reserved tile ids that would poison the derived `tiles` map prototype
+// if used as plain-object keys. Rejected at the boundary (normalize + ADD_TILE)
+// so no later consumer needs to guard against them.
+const RESERVED_IDS = new Set(["__proto__", "constructor", "prototype"]);
+
 function withDerived(state) {
   const tiles = {};
   for (const cluster of state.clusters) {
@@ -128,8 +133,8 @@ function removeTileAt(clusters, { c, col, row }) {
       next.splice(col, 1);
       return next;
     }
-    return replaceColumn(cluster, col, (col2) => {
-      const next = col2.slice();
+    return replaceColumn(cluster, col, (column) => {
+      const next = column.slice();
       next.splice(row, 1);
       return next;
     });
@@ -169,14 +174,20 @@ function reducer(state = EMPTY_STATE, action) {
     case ADD_TILE: {
       const { tile, focus = false, insertAt = "end", insertAfter } = action;
       if (!tile || !tile.id || !tile.type) return state;
+      if (RESERVED_IDS.has(tile.id)) return state;
 
       // Already present? Optionally shift focus and short-circuit — same
       // contract as v2, so callers that re-fire ADD_TILE as "focus this"
-      // keep working.
+      // keep working. Cross-cluster focus-via-ADD_TILE is a no-op: callers
+      // must switchCluster first. Without this, focusedTileIdByCluster
+      // would update in the background cluster but `state.focusedId`
+      // (the derived active-cluster field) would silently disagree.
       if (state.tiles[tile.id]) {
         if (!focus) return state;
         const existing = findPath(state.clusters, tile.id);
         if (!existing) return state;
+        if (existing.c !== state.activeClusterIdx) return state;
+        if (state.focusedTileIdByCluster[existing.c] === tile.id) return state;
         const focusedTileIdByCluster = state.focusedTileIdByCluster.slice();
         focusedTileIdByCluster[existing.c] = tile.id;
         return withDerived({ ...state, focusedTileIdByCluster });
@@ -429,6 +440,7 @@ function normalizeV3(raw) {
       const cleanColumn = [];
       for (const tile of column) {
         if (!tile || typeof tile.id !== "string" || typeof tile.type !== "string") continue;
+        if (RESERVED_IDS.has(tile.id)) continue;
         if (seenIds.has(tile.id)) continue;
         seenIds.add(tile.id);
         cleanColumn.push({ id: tile.id, type: tile.type, props: { ...(tile.props || {}) } });
@@ -441,11 +453,11 @@ function normalizeV3(raw) {
 
   const focusedTileIdByCluster = [];
   for (let c = 0; c < clusters.length; c++) {
-    const raw_f = Array.isArray(raw.focusedTileIdByCluster)
+    const rawFocusedId = Array.isArray(raw.focusedTileIdByCluster)
       ? raw.focusedTileIdByCluster[c]
       : null;
-    const inCluster = raw_f && clusters[c].some(col => col.some(t => t.id === raw_f));
-    focusedTileIdByCluster.push(inCluster ? raw_f : (clusters[c][0]?.[0]?.id ?? null));
+    const inCluster = rawFocusedId && clusters[c].some(col => col.some(t => t.id === rawFocusedId));
+    focusedTileIdByCluster.push(inCluster ? rawFocusedId : (clusters[c][0]?.[0]?.id ?? null));
   }
 
   let activeClusterIdx = typeof raw.activeClusterIdx === "number" ? raw.activeClusterIdx : 0;
@@ -484,15 +496,16 @@ function migrateV2(raw) {
       .sort((a, b) => (a.x ?? 0) - (b.x ?? 0));
     const cleaned = [];
     for (const t of tiles) {
+      if (RESERVED_IDS.has(t.id)) continue;
       if (seenIds.has(t.id)) continue;
       seenIds.add(t.id);
       cleaned.push([{ id: t.id, type: t.type, props: { ...(t.props || {}) } }]);
     }
     clusters.push(cleaned);
 
-    const raw_f = raw.focusedIdByCluster?.[cid];
-    const inCluster = raw_f && cleaned.some(col => col[0].id === raw_f);
-    focusedTileIdByCluster.push(inCluster ? raw_f : (cleaned[0]?.[0]?.id ?? null));
+    const rawFocusedId = raw.focusedIdByCluster?.[cid];
+    const inCluster = rawFocusedId && cleaned.some(col => col[0].id === rawFocusedId);
+    focusedTileIdByCluster.push(inCluster ? rawFocusedId : (cleaned[0]?.[0]?.id ?? null));
   }
 
   const activeClusterIdx = Math.max(0, clusterIds.indexOf(raw.activeClusterId));
@@ -515,12 +528,14 @@ function migrateV1(raw) {
   for (const id of order) {
     const t = raw.tiles[id];
     if (!t || typeof t.type !== "string") continue;
+    if (RESERVED_IDS.has(id)) continue;
     if (seenIds.has(id)) continue;
     seenIds.add(id);
     cluster.push([{ id, type: t.type, props: { ...(t.props || {}) } }]);
   }
   // Include tiles that weren't in raw.order.
   for (const [id, t] of Object.entries(raw.tiles)) {
+    if (RESERVED_IDS.has(id)) continue;
     if (seenIds.has(id)) continue;
     if (!t || typeof t.type !== "string") continue;
     cluster.push([{ id, type: t.type, props: { ...(t.props || {}) } }]);
@@ -620,7 +635,7 @@ export function createUiStore({ initialState = EMPTY_STATE, isPersistable = () =
     focusTile:     (id)              => store.dispatch({ type: FOCUS_TILE, id }),
     updateProps:   (id, patch)       => store.dispatch({ type: UPDATE_PROPS, id, patch }),
     reset:         (state)           => store.dispatch({ type: RESET, state }),
-    addCluster:    (cluster = {}, opts = {}) => store.dispatch({ type: ADD_CLUSTER, cluster, ...opts }),
+    addCluster:    (opts = {})       => store.dispatch({ type: ADD_CLUSTER, ...opts }),
     removeCluster: (clusterIdx)      => store.dispatch({ type: REMOVE_CLUSTER, clusterIdx }),
     switchCluster: (clusterIdx)      => store.dispatch({ type: SWITCH_CLUSTER, clusterIdx }),
   };

--- a/public/lib/ui-store.js
+++ b/public/lib/ui-store.js
@@ -1,77 +1,155 @@
 /**
- * UI Store — single source of truth for tile UI state
+ * UI Store — v3 spatial tile state.
  *
- * See docs/tile-state-rewrite.md for the original "why", and
- * docs/tile-clusters-design.md for the multi-cluster extension (FP1).
+ * See docs/tile-state-rewrite.md for the original "why" and
+ * docs/tile-clusters-design.md for the multi-cluster extension.
  *
- * State shape (v2):
+ * State shape (v3):
  *   {
- *     version: 2,
- *     activeClusterId: string,
- *     clusters: { [id]: { id, name? } },
- *     tiles: { [id]: { id, type, props, x, clusterId } },
- *     focusedIdByCluster: { [clusterId]: id | null },
+ *     version: 3,
+ *     clusters:               Tile[][][],           // SOURCE OF TRUTH: [c][col][row]
+ *     activeClusterIdx:       number,
+ *     focusedTileIdByCluster: (TileId | null)[],    // parallel to clusters
  *
- *     // Derived conveniences, scoped to the active cluster:
- *     order: [id, ...],       // active cluster's tiles sorted by x
- *     focusedId: id | null,   // = focusedIdByCluster[activeClusterId]
+ *     // Derived conveniences (rebuilt by withDerived after every mutation):
+ *     tiles:     { [id]: Tile },   // flattened across all clusters
+ *     order:     TileId[],         // active cluster, column-major top→bottom
+ *     focusedId: TileId | null,    // = focusedTileIdByCluster[activeClusterIdx]
  *   }
  *
- * Each tile carries its own `clusterId` and `x`. `order`/`focusedId` at
- * the top level are *derived* from the active cluster only, so consumers
- * that don't care about clusters keep their existing contract.
+ * A `Tile` is `{ id, type, props }` — nothing positional. Position in the
+ * 3D array IS location. Moving a tile is a splice-remove + splice-insert;
+ * there are no coordinate cascades, no `x` or `clusterId` fields to keep
+ * in sync.
  *
- * v1 → v2 migration: a persisted v1 store is treated as a single cluster
- * named "default". All tiles get `clusterId: "default"`, and the old
- * top-level `focusedId` becomes `focusedIdByCluster.default`.
+ * Persistence stores only the source-of-truth fields; the derived map and
+ * flat order are recomputed by `withDerived` on load.
  *
- * Invariants (enforced by the reducer):
- *   - Every tile has a `clusterId` that exists in `clusters`.
- *   - `activeClusterId` is always a key of `clusters`.
- *   - `focusedIdByCluster[c]` is null or a tile whose `clusterId === c`.
- *   - `order` is derived from tiles in activeCluster, sorted by x.
- *   - Every mutation returns a new state object (structural sharing).
+ * Migration:
+ *   v1 → v3: one cluster, single-slot columns in the v1 order.
+ *   v2 → v3: one cluster per v2 cluster (keys sorted), v2 tiles grouped by
+ *            `tile.x` into single-slot columns ordered by x ascending.
+ *
+ * Invariants (tested):
+ *   - clusters.length >= 1 and === focusedTileIdByCluster.length
+ *   - 0 ≤ activeClusterIdx < clusters.length
+ *   - No column is `[]` at rest (pruned after REMOVE_TILE).
+ *   - focusedTileIdByCluster[c] is null or appears somewhere in clusters[c].
+ *   - Tile ids are globally unique across the whole tree.
  */
 
 import { createStore } from "./store.js";
 
-const STORAGE_KEY = "katulong-ui-v1"; // same key; version field discriminates
-const VERSION = 2;
-export const DEFAULT_CLUSTER_ID = "default";
+const STORAGE_KEY = "katulong-ui-v1"; // unchanged; version field discriminates
+const VERSION = 3;
 
+// ─── Empty state ─────────────────────────────────────────────────────
+// One cluster always exists. The workspace can't be completely empty of
+// clusters — MC1 mirrors today's "there's always a default" invariant.
 export const EMPTY_STATE = Object.freeze({
   version: VERSION,
-  activeClusterId: DEFAULT_CLUSTER_ID,
-  clusters: Object.freeze({ [DEFAULT_CLUSTER_ID]: Object.freeze({ id: DEFAULT_CLUSTER_ID }) }),
+  clusters: Object.freeze([Object.freeze([])]),
+  activeClusterIdx: 0,
+  focusedTileIdByCluster: Object.freeze([null]),
   tiles: Object.freeze({}),
-  focusedIdByCluster: Object.freeze({ [DEFAULT_CLUSTER_ID]: null }),
   order: Object.freeze([]),
   focusedId: null,
 });
 
-// ─── Helpers ─────────────────────────────────────────────────────────
-function clusterTiles(tiles, clusterId) {
-  return Object.values(tiles).filter(t => t.clusterId === clusterId);
-}
-
-function deriveOrder(tiles, clusterId) {
-  return clusterTiles(tiles, clusterId)
-    .sort((a, b) => a.x - b.x)
-    .map(t => t.id);
-}
-
-function nextX(tiles, clusterId) {
-  let max = -1;
-  for (const t of Object.values(tiles)) {
-    if (t.clusterId === clusterId && typeof t.x === "number" && t.x > max) max = t.x;
-  }
-  return max + 1;
-}
-
+// ─── Derived-field recomputation ─────────────────────────────────────
+/**
+ * Rebuild `tiles`, `order`, `focusedId` from the 3D source-of-truth.
+ * Called after every reducer step. O(N) across all tiles in all clusters.
+ */
 function withDerived(state) {
-  const order = deriveOrder(state.tiles, state.activeClusterId);
-  const focusedId = state.focusedIdByCluster[state.activeClusterId] ?? null;
-  return { ...state, order, focusedId };
+  const tiles = {};
+  for (const cluster of state.clusters) {
+    for (const column of cluster) {
+      for (const tile of column) tiles[tile.id] = tile;
+    }
+  }
+  const activeCluster = state.clusters[state.activeClusterIdx] || [];
+  const order = [];
+  for (const column of activeCluster) {
+    for (const tile of column) order.push(tile.id);
+  }
+  const focusedId = state.focusedTileIdByCluster[state.activeClusterIdx] ?? null;
+  return { ...state, tiles, order, focusedId };
+}
+
+// ─── Path helpers (pure) ─────────────────────────────────────────────
+/** Find the 3D path of a tile by id, or null. O(total tiles). */
+function findPath(clusters, id) {
+  for (let c = 0; c < clusters.length; c++) {
+    const cluster = clusters[c];
+    for (let col = 0; col < cluster.length; col++) {
+      const column = cluster[col];
+      for (let row = 0; row < column.length; row++) {
+        if (column[row].id === id) return { c, col, row };
+      }
+    }
+  }
+  return null;
+}
+
+/** Structural-sharing splice: return a new `clusters` with `mutate(cluster[c])`. */
+function replaceCluster(clusters, c, mutate) {
+  const next = clusters.slice();
+  next[c] = mutate(clusters[c]);
+  return next;
+}
+
+function replaceColumn(cluster, col, mutate) {
+  const next = cluster.slice();
+  next[col] = mutate(cluster[col]);
+  return next;
+}
+
+/** Replace a tile at a known path. Pure. */
+function replaceTileAt(clusters, { c, col, row }, nextTile) {
+  return replaceCluster(clusters, c, (cluster) =>
+    replaceColumn(cluster, col, (column) => {
+      const next = column.slice();
+      next[row] = nextTile;
+      return next;
+    }),
+  );
+}
+
+/**
+ * Remove a tile at a known path. If the column becomes empty, prune it.
+ * Returns the new `clusters` array.
+ */
+function removeTileAt(clusters, { c, col, row }) {
+  return replaceCluster(clusters, c, (cluster) => {
+    const column = cluster[col];
+    if (column.length === 1) {
+      const next = cluster.slice();
+      next.splice(col, 1);
+      return next;
+    }
+    return replaceColumn(cluster, col, (col2) => {
+      const next = col2.slice();
+      next.splice(row, 1);
+      return next;
+    });
+  });
+}
+
+/** Append a new single-slot column to cluster c at `col`. */
+function insertColumnAt(clusters, c, col, tile) {
+  return replaceCluster(clusters, c, (cluster) => {
+    const next = cluster.slice();
+    next.splice(col, 0, [tile]);
+    return next;
+  });
+}
+
+/** Flatten one cluster column-major top→bottom. */
+function clusterOrder(cluster) {
+  const out = [];
+  for (const column of cluster) for (const t of column) out.push(t.id);
+  return out;
 }
 
 // ─── Action types ────────────────────────────────────────────────────
@@ -91,159 +169,210 @@ function reducer(state = EMPTY_STATE, action) {
     case ADD_TILE: {
       const { tile, focus = false, insertAt = "end", insertAfter } = action;
       if (!tile || !tile.id || !tile.type) return state;
+
+      // Already present? Optionally shift focus and short-circuit — same
+      // contract as v2, so callers that re-fire ADD_TILE as "focus this"
+      // keep working.
       if (state.tiles[tile.id]) {
         if (!focus) return state;
-        const existingCluster = state.tiles[tile.id].clusterId;
-        const focusedIdByCluster = { ...state.focusedIdByCluster, [existingCluster]: tile.id };
-        return withDerived({ ...state, focusedIdByCluster });
+        const existing = findPath(state.clusters, tile.id);
+        if (!existing) return state;
+        const focusedTileIdByCluster = state.focusedTileIdByCluster.slice();
+        focusedTileIdByCluster[existing.c] = tile.id;
+        return withDerived({ ...state, focusedTileIdByCluster });
       }
-      const clusterId = action.clusterId || state.activeClusterId;
-      if (!state.clusters[clusterId]) return state;
+
+      const clusterIdx = typeof action.clusterIdx === "number"
+        ? action.clusterIdx
+        : state.activeClusterIdx;
+      if (clusterIdx < 0 || clusterIdx >= state.clusters.length) return state;
+
       const newTile = {
         id: tile.id,
         type: tile.type,
         props: { ...(tile.props || {}) },
-        clusterId,
       };
-      let newTiles;
+
+      // Resolve insertion column.
       let anchorId = insertAfter;
       if (!anchorId && insertAt === "afterFocus") {
-        const focused = state.focusedIdByCluster[clusterId];
-        if (focused && state.tiles[focused]?.clusterId === clusterId) anchorId = focused;
-      }
-      if (anchorId && state.tiles[anchorId] && state.tiles[anchorId].clusterId === clusterId) {
-        const insertX = state.tiles[anchorId].x + 1;
-        newTile.x = insertX;
-        newTiles = {};
-        for (const [id, t] of Object.entries(state.tiles)) {
-          newTiles[id] = (t.clusterId === clusterId && t.x >= insertX)
-            ? { ...t, x: t.x + 1 }
-            : t;
+        const focusedHere = state.focusedTileIdByCluster[clusterIdx];
+        if (focusedHere && findPath(state.clusters, focusedHere)?.c === clusterIdx) {
+          anchorId = focusedHere;
         }
-        newTiles[tile.id] = newTile;
-      } else {
-        newTile.x = nextX(state.tiles, clusterId);
-        newTiles = { ...state.tiles, [tile.id]: newTile };
       }
-      const focusedIdByCluster = focus
-        ? { ...state.focusedIdByCluster, [clusterId]: tile.id }
-        : state.focusedIdByCluster;
-      return withDerived({ ...state, tiles: newTiles, focusedIdByCluster });
+
+      let targetCol;
+      if (anchorId) {
+        const p = findPath(state.clusters, anchorId);
+        targetCol = (p && p.c === clusterIdx) ? p.col + 1 : state.clusters[clusterIdx].length;
+      } else {
+        targetCol = state.clusters[clusterIdx].length;
+      }
+
+      const clusters = insertColumnAt(state.clusters, clusterIdx, targetCol, newTile);
+      const focusedTileIdByCluster = focus
+        ? (() => {
+          const next = state.focusedTileIdByCluster.slice();
+          next[clusterIdx] = tile.id;
+          return next;
+        })()
+        : state.focusedTileIdByCluster;
+
+      return withDerived({ ...state, clusters, focusedTileIdByCluster });
     }
 
     case REMOVE_TILE: {
       const { id } = action;
-      const existing = state.tiles[id];
-      if (!existing) return state;
-      const { [id]: _removed, ...restTiles } = state.tiles;
-      const focusedIdByCluster = { ...state.focusedIdByCluster };
-      if (focusedIdByCluster[existing.clusterId] === id) {
-        const clusterOrder = deriveOrder(state.tiles, existing.clusterId);
-        const remainingOrder = deriveOrder(restTiles, existing.clusterId);
-        const removedIdx = clusterOrder.indexOf(id);
-        focusedIdByCluster[existing.clusterId] =
-          remainingOrder[removedIdx] || remainingOrder[removedIdx - 1] || null;
+      const path = findPath(state.clusters, id);
+      if (!path) return state;
+
+      const prevClusterOrder = clusterOrder(state.clusters[path.c]);
+      const removedOrderIdx = prevClusterOrder.indexOf(id);
+      const clusters = removeTileAt(state.clusters, path);
+      const nextClusterOrder = clusterOrder(clusters[path.c]);
+
+      const focusedTileIdByCluster = state.focusedTileIdByCluster.slice();
+      if (focusedTileIdByCluster[path.c] === id) {
+        focusedTileIdByCluster[path.c] =
+          nextClusterOrder[removedOrderIdx] ||
+          nextClusterOrder[removedOrderIdx - 1] ||
+          null;
       }
-      return withDerived({ ...state, tiles: restTiles, focusedIdByCluster });
+
+      return withDerived({ ...state, clusters, focusedTileIdByCluster });
     }
 
     case REORDER: {
       const { order } = action;
       if (!Array.isArray(order)) return state;
-      const clusterId = action.clusterId || state.activeClusterId;
-      if (!state.clusters[clusterId]) return state;
-      const known = new Set(
-        Object.values(state.tiles)
-          .filter(t => t.clusterId === clusterId)
-          .map(t => t.id),
-      );
-      const cleaned = order.filter(id => known.has(id));
-      const seen = new Set(cleaned);
-      const currentOrder = deriveOrder(state.tiles, clusterId);
-      for (const id of currentOrder) {
-        if (!seen.has(id)) cleaned.push(id);
-      }
-      if (cleaned.length === currentOrder.length
-          && cleaned.every((id, i) => id === currentOrder[i])) {
-        return state;
-      }
-      const newTiles = { ...state.tiles };
-      cleaned.forEach((id, i) => {
-        if (newTiles[id].x !== i) {
-          newTiles[id] = { ...newTiles[id], x: i };
+      const clusterIdx = typeof action.clusterIdx === "number"
+        ? action.clusterIdx
+        : state.activeClusterIdx;
+      if (clusterIdx < 0 || clusterIdx >= state.clusters.length) return state;
+
+      const cluster = state.clusters[clusterIdx];
+      // Build a map from head-tile-id → column (column identity in single-slot
+      // is its head tile; multi-slot future will only reorder by head too).
+      const byHead = new Map();
+      for (const column of cluster) byHead.set(column[0].id, column);
+
+      const seen = new Set();
+      const newCluster = [];
+      for (const id of order) {
+        if (seen.has(id)) continue;
+        const col = byHead.get(id);
+        if (col) {
+          newCluster.push(col);
+          seen.add(id);
         }
-      });
-      return withDerived({ ...state, tiles: newTiles });
+      }
+      // Append any existing columns not mentioned in `order`.
+      for (const column of cluster) {
+        if (!seen.has(column[0].id)) {
+          newCluster.push(column);
+          seen.add(column[0].id);
+        }
+      }
+
+      // No-op if order unchanged.
+      let same = newCluster.length === cluster.length;
+      if (same) for (let i = 0; i < cluster.length; i++) {
+        if (cluster[i] !== newCluster[i]) { same = false; break; }
+      }
+      if (same) return state;
+
+      const clusters = state.clusters.slice();
+      clusters[clusterIdx] = newCluster;
+      return withDerived({ ...state, clusters });
     }
 
     case FOCUS_TILE: {
       const { id } = action;
       if (id === null) {
-        const current = state.focusedIdByCluster[state.activeClusterId];
+        const current = state.focusedTileIdByCluster[state.activeClusterIdx];
         if (current === null) return state;
-        const focusedIdByCluster = { ...state.focusedIdByCluster, [state.activeClusterId]: null };
-        return withDerived({ ...state, focusedIdByCluster });
+        const focusedTileIdByCluster = state.focusedTileIdByCluster.slice();
+        focusedTileIdByCluster[state.activeClusterIdx] = null;
+        return withDerived({ ...state, focusedTileIdByCluster });
       }
-      const tile = state.tiles[id];
-      if (!tile) return state;
+      const path = findPath(state.clusters, id);
+      if (!path) return state;
       // A tile can only be focused within its own cluster. If the caller
       // asks to focus a tile in a non-active cluster, no-op — they need
-      // to switchCluster first.
-      if (tile.clusterId !== state.activeClusterId) return state;
-      if (state.focusedIdByCluster[tile.clusterId] === id) return state;
-      const focusedIdByCluster = { ...state.focusedIdByCluster, [tile.clusterId]: id };
-      return withDerived({ ...state, focusedIdByCluster });
+      // to switchCluster first. Mirrors v2 semantics.
+      if (path.c !== state.activeClusterIdx) return state;
+      if (state.focusedTileIdByCluster[path.c] === id) return state;
+      const focusedTileIdByCluster = state.focusedTileIdByCluster.slice();
+      focusedTileIdByCluster[path.c] = id;
+      return withDerived({ ...state, focusedTileIdByCluster });
     }
 
     case UPDATE_PROPS: {
       const { id, patch } = action;
-      const existing = state.tiles[id];
-      if (!existing || !patch) return state;
+      if (!patch) return state;
+      const path = findPath(state.clusters, id);
+      if (!path) return state;
+      const existing = state.clusters[path.c][path.col][path.row];
       let changed = false;
       for (const k of Object.keys(patch)) {
         if (existing.props[k] !== patch[k]) { changed = true; break; }
       }
       if (!changed) return state;
-      const newTile = { ...existing, props: { ...existing.props, ...patch } };
-      return withDerived({ ...state, tiles: { ...state.tiles, [id]: newTile } });
+      const nextTile = { ...existing, props: { ...existing.props, ...patch } };
+      const clusters = replaceTileAt(state.clusters, path, nextTile);
+      return withDerived({ ...state, clusters });
     }
 
     case ADD_CLUSTER: {
-      const { cluster, switchTo = false } = action;
-      if (!cluster || !cluster.id) return state;
-      if (state.clusters[cluster.id]) return state;
-      const clusters = {
-        ...state.clusters,
-        [cluster.id]: { id: cluster.id, ...(cluster.name ? { name: cluster.name } : {}) },
-      };
-      const focusedIdByCluster = { ...state.focusedIdByCluster, [cluster.id]: null };
-      const next = { ...state, clusters, focusedIdByCluster };
-      if (switchTo) next.activeClusterId = cluster.id;
-      return withDerived(next);
+      const { switchTo = false, position } = action;
+      const insertAt = (typeof position === "number"
+        && position >= 0
+        && position <= state.clusters.length)
+        ? position
+        : state.clusters.length;
+
+      const clusters = state.clusters.slice();
+      clusters.splice(insertAt, 0, []);
+      const focusedTileIdByCluster = state.focusedTileIdByCluster.slice();
+      focusedTileIdByCluster.splice(insertAt, 0, null);
+
+      let activeClusterIdx = state.activeClusterIdx;
+      // Keep the active index pointing at the same cluster the user was
+      // looking at — if we inserted at or before it, shift by 1.
+      if (insertAt <= activeClusterIdx) activeClusterIdx += 1;
+      if (switchTo) activeClusterIdx = insertAt;
+
+      return withDerived({ ...state, clusters, focusedTileIdByCluster, activeClusterIdx });
     }
 
     case REMOVE_CLUSTER: {
-      const { id } = action;
-      if (!state.clusters[id]) return state;
-      if (Object.keys(state.clusters).length <= 1) return state;
-      const clusters = { ...state.clusters };
-      delete clusters[id];
-      const focusedIdByCluster = { ...state.focusedIdByCluster };
-      delete focusedIdByCluster[id];
-      const tiles = {};
-      for (const [tid, t] of Object.entries(state.tiles)) {
-        if (t.clusterId !== id) tiles[tid] = t;
+      const { clusterIdx } = action;
+      if (typeof clusterIdx !== "number") return state;
+      if (clusterIdx < 0 || clusterIdx >= state.clusters.length) return state;
+      if (state.clusters.length <= 1) return state; // always keep at least one
+
+      const clusters = state.clusters.slice();
+      clusters.splice(clusterIdx, 1);
+      const focusedTileIdByCluster = state.focusedTileIdByCluster.slice();
+      focusedTileIdByCluster.splice(clusterIdx, 1);
+
+      let activeClusterIdx = state.activeClusterIdx;
+      if (activeClusterIdx > clusterIdx) activeClusterIdx -= 1;
+      else if (activeClusterIdx === clusterIdx) {
+        // Clamp to new bounds; prefer the same position (now the "next" cluster).
+        activeClusterIdx = Math.min(activeClusterIdx, clusters.length - 1);
       }
-      let activeClusterId = state.activeClusterId;
-      if (activeClusterId === id) activeClusterId = Object.keys(clusters)[0];
-      return withDerived({ ...state, clusters, tiles, focusedIdByCluster, activeClusterId });
+
+      return withDerived({ ...state, clusters, focusedTileIdByCluster, activeClusterIdx });
     }
 
     case SWITCH_CLUSTER: {
-      const { id } = action;
-      if (!state.clusters[id]) return state;
-      if (state.activeClusterId === id) return state;
-      return withDerived({ ...state, activeClusterId: id });
+      const { clusterIdx } = action;
+      if (typeof clusterIdx !== "number") return state;
+      if (clusterIdx < 0 || clusterIdx >= state.clusters.length) return state;
+      if (state.activeClusterIdx === clusterIdx) return state;
+      return withDerived({ ...state, activeClusterIdx: clusterIdx });
     }
 
     case RESET: {
@@ -258,101 +387,156 @@ function reducer(state = EMPTY_STATE, action) {
 
 // ─── Normalize (migration + coercion) ────────────────────────────────
 /**
- * Coerce an arbitrary object into a valid v2 state. Handles:
- *   - Null/invalid input (returns EMPTY_STATE).
- *   - v1 → v2 migration: tiles without clusterId get DEFAULT_CLUSTER_ID,
- *     and the old top-level focusedId becomes focusedIdByCluster.default.
- *   - x backfill from raw.order for tiles that lack it (v1 format).
+ * Coerce an arbitrary object into a valid v3 state.
+ *
+ * Accepts:
+ *   - v3: passed through (after structural validation).
+ *   - v2: tiles grouped by clusterId + x into single-slot columns.
+ *   - v1: flat order → single cluster, single-slot columns.
+ *   - null / invalid → EMPTY_STATE.
  */
 export function normalize(raw) {
   if (!raw || typeof raw !== "object") return EMPTY_STATE;
 
-  const isV2 = typeof raw.activeClusterId === "string"
-    && raw.clusters && typeof raw.clusters === "object";
-
-  const clusters = {};
-  if (isV2) {
-    for (const [id, c] of Object.entries(raw.clusters)) {
-      if (c && typeof c === "object") {
-        clusters[id] = { id, ...(typeof c.name === "string" ? { name: c.name } : {}) };
-      }
-    }
-  }
-  if (!clusters[DEFAULT_CLUSTER_ID]) {
-    clusters[DEFAULT_CLUSTER_ID] = { id: DEFAULT_CLUSTER_ID };
+  // v3: already in the target shape.
+  if (raw.version === 3 && Array.isArray(raw.clusters)) {
+    return normalizeV3(raw);
   }
 
-  const tiles = {};
+  // v2: tiles are a map with clusterId + x.
+  if (typeof raw.activeClusterId === "string" && raw.clusters && typeof raw.clusters === "object") {
+    return migrateV2(raw);
+  }
+
+  // v1: a map of tiles, plus a flat order array.
   if (raw.tiles && typeof raw.tiles === "object") {
-    for (const [id, t] of Object.entries(raw.tiles)) {
-      if (!t || typeof t.type !== "string") continue;
-      const clusterId = (typeof t.clusterId === "string" && clusters[t.clusterId])
-        ? t.clusterId
-        : DEFAULT_CLUSTER_ID;
-      tiles[id] = {
-        id,
-        type: t.type,
-        props: { ...(t.props || {}) },
-        clusterId,
-      };
-      if (typeof t.x === "number") tiles[id].x = t.x;
-    }
+    return migrateV1(raw);
   }
 
-  // x backfill (per cluster) — v1 tiles don't carry x; reconstruct from
-  // raw.order (global for v1 — accurate since there's only one cluster).
-  const orderHint = Array.isArray(raw.order) ? raw.order : [];
-  const needsX = new Set(
-    Object.keys(tiles).filter(id => typeof tiles[id].x !== "number"),
-  );
-  if (needsX.size > 0) {
-    const perClusterNext = {};
-    for (const id of Object.keys(clusters)) perClusterNext[id] = nextX(tiles, id);
-    for (const id of orderHint) {
-      if (needsX.has(id)) {
-        const cid = tiles[id].clusterId;
-        tiles[id].x = perClusterNext[cid]++;
-        needsX.delete(id);
+  return EMPTY_STATE;
+}
+
+function normalizeV3(raw) {
+  // Validate 3D array + drop malformed tiles. Unknown fields on tiles are
+  // stripped to keep persistence canonical ({id, type, props} only).
+  const seenIds = new Set();
+  const clusters = [];
+  for (const cluster of raw.clusters) {
+    if (!Array.isArray(cluster)) { clusters.push([]); continue; }
+    const cleanCluster = [];
+    for (const column of cluster) {
+      if (!Array.isArray(column) || column.length === 0) continue;
+      const cleanColumn = [];
+      for (const tile of column) {
+        if (!tile || typeof tile.id !== "string" || typeof tile.type !== "string") continue;
+        if (seenIds.has(tile.id)) continue;
+        seenIds.add(tile.id);
+        cleanColumn.push({ id: tile.id, type: tile.type, props: { ...(tile.props || {}) } });
       }
+      if (cleanColumn.length > 0) cleanCluster.push(cleanColumn);
     }
-    for (const id of needsX) {
-      const cid = tiles[id].clusterId;
-      tiles[id].x = perClusterNext[cid]++;
-    }
+    clusters.push(cleanCluster);
+  }
+  if (clusters.length === 0) clusters.push([]);
+
+  const focusedTileIdByCluster = [];
+  for (let c = 0; c < clusters.length; c++) {
+    const raw_f = Array.isArray(raw.focusedTileIdByCluster)
+      ? raw.focusedTileIdByCluster[c]
+      : null;
+    const inCluster = raw_f && clusters[c].some(col => col.some(t => t.id === raw_f));
+    focusedTileIdByCluster.push(inCluster ? raw_f : (clusters[c][0]?.[0]?.id ?? null));
   }
 
-  // focusedIdByCluster
-  const focusedIdByCluster = {};
-  for (const id of Object.keys(clusters)) focusedIdByCluster[id] = null;
-  if (isV2 && raw.focusedIdByCluster && typeof raw.focusedIdByCluster === "object") {
-    for (const [cid, fid] of Object.entries(raw.focusedIdByCluster)) {
-      if (!clusters[cid]) continue;
-      if (fid && tiles[fid] && tiles[fid].clusterId === cid) {
-        focusedIdByCluster[cid] = fid;
-      }
-    }
-  } else if (typeof raw.focusedId === "string") {
-    const fid = raw.focusedId;
-    if (tiles[fid] && tiles[fid].clusterId === DEFAULT_CLUSTER_ID) {
-      focusedIdByCluster[DEFAULT_CLUSTER_ID] = fid;
-    }
-  }
-  for (const cid of Object.keys(clusters)) {
-    if (focusedIdByCluster[cid]) continue;
-    const order = deriveOrder(tiles, cid);
-    focusedIdByCluster[cid] = order[0] || null;
-  }
-
-  const activeClusterId = (isV2 && clusters[raw.activeClusterId])
-    ? raw.activeClusterId
-    : DEFAULT_CLUSTER_ID;
+  let activeClusterIdx = typeof raw.activeClusterIdx === "number" ? raw.activeClusterIdx : 0;
+  if (activeClusterIdx < 0 || activeClusterIdx >= clusters.length) activeClusterIdx = 0;
 
   return withDerived({
     version: VERSION,
-    activeClusterId,
     clusters,
-    tiles,
-    focusedIdByCluster,
+    activeClusterIdx,
+    focusedTileIdByCluster,
+    tiles: {},
+    order: [],
+    focusedId: null,
+  });
+}
+
+function migrateV2(raw) {
+  // Collect cluster ids in a stable order: active cluster first, then the
+  // rest by insertion order of raw.clusters. This keeps the active cluster
+  // at activeClusterIdx=0 by default if nothing else pins it.
+  const clusterIds = [];
+  if (raw.clusters[raw.activeClusterId]) clusterIds.push(raw.activeClusterId);
+  for (const id of Object.keys(raw.clusters)) {
+    if (!clusterIds.includes(id)) clusterIds.push(id);
+  }
+  if (clusterIds.length === 0) clusterIds.push("default");
+
+  const clusters = [];
+  const focusedTileIdByCluster = [];
+  const seenIds = new Set();
+
+  for (const cid of clusterIds) {
+    // Tiles in this cluster, sorted by x ascending.
+    const tiles = Object.values(raw.tiles || {})
+      .filter(t => t && typeof t.type === "string" && t.clusterId === cid)
+      .sort((a, b) => (a.x ?? 0) - (b.x ?? 0));
+    const cleaned = [];
+    for (const t of tiles) {
+      if (seenIds.has(t.id)) continue;
+      seenIds.add(t.id);
+      cleaned.push([{ id: t.id, type: t.type, props: { ...(t.props || {}) } }]);
+    }
+    clusters.push(cleaned);
+
+    const raw_f = raw.focusedIdByCluster?.[cid];
+    const inCluster = raw_f && cleaned.some(col => col[0].id === raw_f);
+    focusedTileIdByCluster.push(inCluster ? raw_f : (cleaned[0]?.[0]?.id ?? null));
+  }
+
+  const activeClusterIdx = Math.max(0, clusterIds.indexOf(raw.activeClusterId));
+
+  return withDerived({
+    version: VERSION,
+    clusters,
+    activeClusterIdx,
+    focusedTileIdByCluster,
+    tiles: {},
+    order: [],
+    focusedId: null,
+  });
+}
+
+function migrateV1(raw) {
+  const order = Array.isArray(raw.order) ? raw.order : Object.keys(raw.tiles);
+  const seenIds = new Set();
+  const cluster = [];
+  for (const id of order) {
+    const t = raw.tiles[id];
+    if (!t || typeof t.type !== "string") continue;
+    if (seenIds.has(id)) continue;
+    seenIds.add(id);
+    cluster.push([{ id, type: t.type, props: { ...(t.props || {}) } }]);
+  }
+  // Include tiles that weren't in raw.order.
+  for (const [id, t] of Object.entries(raw.tiles)) {
+    if (seenIds.has(id)) continue;
+    if (!t || typeof t.type !== "string") continue;
+    cluster.push([{ id, type: t.type, props: { ...(t.props || {}) } }]);
+  }
+
+  const focusedRaw = typeof raw.focusedId === "string" ? raw.focusedId : null;
+  const focused = cluster.some(col => col[0].id === focusedRaw)
+    ? focusedRaw
+    : (cluster[0]?.[0]?.id ?? null);
+
+  return withDerived({
+    version: VERSION,
+    clusters: [cluster],
+    activeClusterIdx: 0,
+    focusedTileIdByCluster: [focused],
+    tiles: {},
     order: [],
     focusedId: null,
   });
@@ -360,24 +544,43 @@ export function normalize(raw) {
 
 // ─── Persistence ─────────────────────────────────────────────────────
 /**
- * Serialize state for localStorage. Derived fields (order, focusedId)
- * are NOT written — they're re-derived on normalize.
+ * Serialize state for localStorage. Derived fields (tiles, order, focusedId)
+ * are NOT written — they're re-derived on normalize. Non-persistable tiles
+ * are stripped per the caller-provided predicate.
  */
 export function serialize(state, isPersistable = () => true) {
-  const tiles = {};
-  for (const [id, t] of Object.entries(state.tiles)) {
-    if (isPersistable(t.type, t.props || {})) tiles[id] = t;
+  const clusters = [];
+  const seenIds = new Set();
+  for (const cluster of state.clusters) {
+    const cleanCluster = [];
+    for (const column of cluster) {
+      const cleanColumn = [];
+      for (const tile of column) {
+        if (!isPersistable(tile.type, tile.props || {})) continue;
+        if (seenIds.has(tile.id)) continue;
+        seenIds.add(tile.id);
+        cleanColumn.push(tile);
+      }
+      if (cleanColumn.length > 0) cleanCluster.push(cleanColumn);
+    }
+    clusters.push(cleanCluster);
   }
-  const focusedIdByCluster = {};
-  for (const [cid, fid] of Object.entries(state.focusedIdByCluster)) {
-    focusedIdByCluster[cid] = (fid && tiles[fid]) ? fid : null;
+
+  const focusedTileIdByCluster = [];
+  for (let c = 0; c < clusters.length; c++) {
+    const f = state.focusedTileIdByCluster[c];
+    const inCluster = f && clusters[c].some(col => col.some(t => t.id === f));
+    focusedTileIdByCluster.push(inCluster ? f : null);
   }
+
+  let activeClusterIdx = state.activeClusterIdx;
+  if (activeClusterIdx < 0 || activeClusterIdx >= clusters.length) activeClusterIdx = 0;
+
   return {
     version: VERSION,
-    activeClusterId: state.activeClusterId,
-    clusters: state.clusters,
-    tiles,
-    focusedIdByCluster,
+    clusters,
+    activeClusterIdx,
+    focusedTileIdByCluster,
   };
 }
 
@@ -387,7 +590,8 @@ export function loadFromStorage() {
     if (!raw) return null;
     const parsed = JSON.parse(raw);
     if (!parsed) return null;
-    if (parsed.version !== 1 && parsed.version !== VERSION) return null;
+    // Accept v1, v2, and v3 shapes — normalize handles all three.
+    if (parsed.version !== 1 && parsed.version !== 2 && parsed.version !== VERSION) return null;
     return normalize(parsed);
   } catch (_) {
     return null;
@@ -416,8 +620,8 @@ export function createUiStore({ initialState = EMPTY_STATE, isPersistable = () =
     focusTile:     (id)              => store.dispatch({ type: FOCUS_TILE, id }),
     updateProps:   (id, patch)       => store.dispatch({ type: UPDATE_PROPS, id, patch }),
     reset:         (state)           => store.dispatch({ type: RESET, state }),
-    addCluster:    (cluster, opts = {}) => store.dispatch({ type: ADD_CLUSTER, cluster, ...opts }),
-    removeCluster: (id)              => store.dispatch({ type: REMOVE_CLUSTER, id }),
-    switchCluster: (id)              => store.dispatch({ type: SWITCH_CLUSTER, id }),
+    addCluster:    (cluster = {}, opts = {}) => store.dispatch({ type: ADD_CLUSTER, cluster, ...opts }),
+    removeCluster: (clusterIdx)      => store.dispatch({ type: REMOVE_CLUSTER, clusterIdx }),
+    switchCluster: (clusterIdx)      => store.dispatch({ type: SWITCH_CLUSTER, clusterIdx }),
   };
 }

--- a/test/add-target.test.js
+++ b/test/add-target.test.js
@@ -4,7 +4,6 @@ import assert from "node:assert";
 const {
   decideAddTarget,
   generateSessionName,
-  generateClusterId,
   createAddHandler,
 } = await import(
   new URL("../public/lib/add-target.js", import.meta.url).href
@@ -12,17 +11,17 @@ const {
 
 describe("decideAddTarget — level 1 (focused)", () => {
   it("produces a tile target in the active cluster after the focused tile", () => {
-    const t = decideAddTarget({ level: 1, activeClusterId: "c1", focusedId: "t7" });
-    assert.deepStrictEqual(t, { kind: "tile", clusterId: "c1", insertAfter: "t7" });
+    const t = decideAddTarget({ level: 1, activeClusterIdx: 0, focusedId: "t7" });
+    assert.deepStrictEqual(t, { kind: "tile", clusterIdx: 0, insertAfter: "t7" });
   });
 
   it("produces a tile target with insertAfter=null when nothing is focused", () => {
-    const t = decideAddTarget({ level: 1, activeClusterId: "c1", focusedId: null });
-    assert.deepStrictEqual(t, { kind: "tile", clusterId: "c1", insertAfter: null });
+    const t = decideAddTarget({ level: 1, activeClusterIdx: 2, focusedId: null });
+    assert.deepStrictEqual(t, { kind: "tile", clusterIdx: 2, insertAfter: null });
   });
 
   it("defaults focusedId to null when omitted", () => {
-    const t = decideAddTarget({ level: 1, activeClusterId: "c1" });
+    const t = decideAddTarget({ level: 1, activeClusterIdx: 0 });
     assert.strictEqual(t.insertAfter, null);
   });
 });
@@ -30,32 +29,27 @@ describe("decideAddTarget — level 1 (focused)", () => {
 describe("decideAddTarget — level 2 (overview)", () => {
   it("produces a cluster target regardless of focused tile", () => {
     assert.deepStrictEqual(
-      decideAddTarget({ level: 2, activeClusterId: "c1", focusedId: "t7" }),
+      decideAddTarget({ level: 2, activeClusterIdx: 0, focusedId: "t7" }),
       { kind: "cluster" },
     );
     assert.deepStrictEqual(
-      decideAddTarget({ level: 2, activeClusterId: "c1", focusedId: null }),
+      decideAddTarget({ level: 2, activeClusterIdx: 0, focusedId: null }),
       { kind: "cluster" },
     );
   });
 
   it("treats future Level 3+ as cluster target (safe default until L3 is designed)", () => {
     assert.deepStrictEqual(
-      decideAddTarget({ level: 3, activeClusterId: "c1" }),
+      decideAddTarget({ level: 3, activeClusterIdx: 0 }),
       { kind: "cluster" },
     );
   });
 });
 
-describe("generateSessionName / generateClusterId", () => {
+describe("generateSessionName", () => {
   it("produces a `session-` prefix with base36-encoded clock", () => {
     const name = generateSessionName(() => 0);
     assert.strictEqual(name, "session-0");
-  });
-
-  it("produces a `cluster-` prefix with base36-encoded clock", () => {
-    const id = generateClusterId(() => 0);
-    assert.strictEqual(id, "cluster-0");
   });
 
   it("defaults to Date.now when no clock is injected", () => {
@@ -69,13 +63,13 @@ describe("createAddHandler — dispatch", () => {
     const calls = [];
     const handle = createAddHandler({
       getLevel: () => 1,
-      getState: () => ({ activeClusterId: "c1", focusedId: "t7" }),
+      getState: () => ({ activeClusterIdx: 0, focusedId: "t7" }),
       onAddTile: (t) => { calls.push(["tile", t]); },
       onAddCluster: (t) => { calls.push(["cluster", t]); },
     });
     handle();
     assert.deepStrictEqual(calls, [
-      ["tile", { kind: "tile", clusterId: "c1", insertAfter: "t7" }],
+      ["tile", { kind: "tile", clusterIdx: 0, insertAfter: "t7" }],
     ]);
   });
 
@@ -83,7 +77,7 @@ describe("createAddHandler — dispatch", () => {
     const calls = [];
     const handle = createAddHandler({
       getLevel: () => 2,
-      getState: () => ({ activeClusterId: "c1", focusedId: "t7" }),
+      getState: () => ({ activeClusterIdx: 1, focusedId: "t7" }),
       onAddTile: (t) => { calls.push(["tile", t]); },
       onAddCluster: (t) => { calls.push(["cluster", t]); },
     });
@@ -94,29 +88,33 @@ describe("createAddHandler — dispatch", () => {
   it("reads fresh state at every call, not at factory creation time", () => {
     let level = 1;
     let focusedId = "t1";
+    let activeClusterIdx = 0;
     const tileCalls = [];
     const clusterCalls = [];
     const handle = createAddHandler({
       getLevel: () => level,
-      getState: () => ({ activeClusterId: "c1", focusedId }),
+      getState: () => ({ activeClusterIdx, focusedId }),
       onAddTile: (t) => { tileCalls.push(t); },
       onAddCluster: (t) => { clusterCalls.push(t); },
     });
     handle();
     focusedId = "t2";
+    activeClusterIdx = 1;
     handle();
     level = 2;
     handle();
     assert.strictEqual(tileCalls.length, 2);
     assert.strictEqual(tileCalls[0].insertAfter, "t1");
+    assert.strictEqual(tileCalls[0].clusterIdx, 0);
     assert.strictEqual(tileCalls[1].insertAfter, "t2");
+    assert.strictEqual(tileCalls[1].clusterIdx, 1);
     assert.strictEqual(clusterCalls.length, 1);
   });
 
   it("returns the effect's return value (so async callers can await)", async () => {
     const handle = createAddHandler({
       getLevel: () => 1,
-      getState: () => ({ activeClusterId: "c1", focusedId: null }),
+      getState: () => ({ activeClusterIdx: 0, focusedId: null }),
       onAddTile: async () => "tile-result",
       onAddCluster: async () => "cluster-result",
     });

--- a/test/boot-state.test.js
+++ b/test/boot-state.test.js
@@ -13,9 +13,22 @@ globalThis.localStorage = {
 const { buildBootState } = await import(
   new URL("../public/lib/boot-state.js", import.meta.url).href
 );
-const { EMPTY_STATE } = await import(
+const { normalize } = await import(
   new URL("../public/lib/ui-store.js", import.meta.url).href
 );
+
+// ── Helpers ────────────────────────────────────────────────────────────
+// Build a v3-shape "already persisted" input. boot-state expects persisted
+// to be the output of ui-store.loadFromStorage(), which runs `normalize` —
+// so derived fields (tiles, order, focusedId) are present. We mimic that.
+function persistedV3({ clusters, activeClusterIdx = 0, focusedTileIdByCluster }) {
+  return normalize({
+    version: 3,
+    clusters,
+    activeClusterIdx,
+    focusedTileIdByCluster,
+  });
+}
 
 describe("buildBootState — no sources", () => {
   it("returns EMPTY_STATE when nothing is persisted and no URL hint", () => {
@@ -23,22 +36,17 @@ describe("buildBootState — no sources", () => {
     assert.strictEqual(migratedLegacy, false);
     assert.deepStrictEqual(state.tiles, {});
     assert.strictEqual(state.focusedId, null);
+    assert.strictEqual(state.clusters.length, 1);
+    assert.deepStrictEqual(state.clusters[0], []);
   });
 });
 
 describe("buildBootState — persisted state wins", () => {
   it("uses persisted state when present, ignores legacy", () => {
-    const persisted = {
-      version: 2,
-      activeClusterId: "default",
-      clusters: { default: { id: "default" } },
-      tiles: {
-        a: { id: "a", type: "terminal", props: {}, x: 0, clusterId: "default" },
-      },
-      focusedIdByCluster: { default: "a" },
-      order: ["a"],
-      focusedId: "a",
-    };
+    const persisted = persistedV3({
+      clusters: [[[{ id: "a", type: "terminal", props: {} }]]],
+      focusedTileIdByCluster: ["a"],
+    });
     const legacyCarousel = {
       tiles: [{ id: "legacy", type: "terminal", sessionName: "legacy" }],
       focused: "legacy",
@@ -52,10 +60,27 @@ describe("buildBootState — persisted state wins", () => {
     assert.ok(state.tiles.a);
     assert.ok(!state.tiles.legacy);
   });
+
+  it("treats persisted state with no tiles as empty and falls back to legacy", () => {
+    const persisted = persistedV3({
+      clusters: [[]],
+      focusedTileIdByCluster: [null],
+    });
+    const { state, migratedLegacy } = buildBootState({
+      persisted,
+      legacyCarousel: {
+        tiles: [{ id: "s1", type: "terminal", sessionName: "s1" }],
+        focused: "s1",
+      },
+      getRenderer: () => ({ describe: () => ({}) }),
+    });
+    assert.strictEqual(migratedLegacy, true);
+    assert.ok(state.tiles.s1);
+  });
 });
 
 describe("buildBootState — legacy migration", () => {
-  it("migrates legacy carousel state into default cluster", () => {
+  it("migrates legacy carousel state into a single cluster of single-slot columns", () => {
     const { state, migratedLegacy } = buildBootState({
       legacyCarousel: {
         tiles: [
@@ -67,11 +92,12 @@ describe("buildBootState — legacy migration", () => {
       getRenderer: () => ({ describe: () => ({}) }),
     });
     assert.strictEqual(migratedLegacy, true);
-    assert.strictEqual(state.tiles.s1.clusterId, "default");
-    assert.strictEqual(state.tiles.s2.clusterId, "default");
-    assert.strictEqual(state.tiles.s1.x, 0);
-    assert.strictEqual(state.tiles.s2.x, 1);
+    assert.strictEqual(state.clusters.length, 1);
+    assert.strictEqual(state.clusters[0].length, 2);
+    assert.strictEqual(state.clusters[0][0][0].id, "s1");
+    assert.strictEqual(state.clusters[0][1][0].id, "s2");
     assert.strictEqual(state.focusedId, "s2");
+    assert.strictEqual(state.focusedTileIdByCluster[0], "s2");
     // Props are stripped of id/type/cardWidth.
     assert.strictEqual(state.tiles.s1.props.sessionName, "s1");
     assert.strictEqual(state.tiles.s1.props.id, undefined);
@@ -110,6 +136,17 @@ describe("buildBootState — legacy migration", () => {
     });
     assert.strictEqual(migratedLegacy, false);
   });
+
+  it("falls back focused to first tile when legacy focus is unknown", () => {
+    const { state } = buildBootState({
+      legacyCarousel: {
+        tiles: [{ id: "s1", type: "terminal", sessionName: "s1" }],
+        focused: "ghost",
+      },
+      getRenderer: () => ({ describe: () => ({}) }),
+    });
+    assert.strictEqual(state.focusedId, "s1");
+  });
 });
 
 describe("buildBootState — URL session hint", () => {
@@ -122,41 +159,43 @@ describe("buildBootState — URL session hint", () => {
   });
 
   it("does not duplicate when the session is already present", () => {
-    const persisted = {
-      version: 2,
-      activeClusterId: "default",
-      clusters: { default: { id: "default" } },
-      tiles: {
-        existing: {
-          id: "existing", type: "terminal", props: { sessionName: "existing" },
-          x: 0, clusterId: "default",
-        },
-      },
-      focusedIdByCluster: { default: "existing" },
-      order: ["existing"],
-      focusedId: "existing",
-    };
+    const persisted = persistedV3({
+      clusters: [[[{ id: "existing", type: "terminal", props: { sessionName: "existing" } }]]],
+      focusedTileIdByCluster: ["existing"],
+    });
     const { state } = buildBootState({ persisted, urlSession: "existing" });
     assert.strictEqual(Object.keys(state.tiles).length, 1);
     assert.strictEqual(state.focusedId, "existing");
   });
 
   it("preserves persisted focusedId when URL session was already present", () => {
-    const persisted = {
-      version: 2,
-      activeClusterId: "default",
-      clusters: { default: { id: "default" } },
-      tiles: {
-        a: { id: "a", type: "terminal", props: {}, x: 0, clusterId: "default" },
-        b: { id: "b", type: "terminal", props: {}, x: 1, clusterId: "default" },
-      },
-      focusedIdByCluster: { default: "b" },
-      order: ["a", "b"],
-      focusedId: "b",
-    };
+    const persisted = persistedV3({
+      clusters: [[
+        [{ id: "a", type: "terminal", props: {} }],
+        [{ id: "b", type: "terminal", props: {} }],
+      ]],
+      focusedTileIdByCluster: ["b"],
+    });
     // User refreshed with ?s=a but b was focused last. Persisted wins.
     const { state } = buildBootState({ persisted, urlSession: "a" });
     assert.strictEqual(state.focusedId, "b");
+  });
+
+  it("appends the URL tile to the active cluster", () => {
+    const persisted = persistedV3({
+      clusters: [
+        [[{ id: "a", type: "terminal", props: {} }]],
+        [[{ id: "w1", type: "terminal", props: {} }]],
+      ],
+      activeClusterIdx: 1,
+      focusedTileIdByCluster: ["a", "w1"],
+    });
+    const { state } = buildBootState({ persisted, urlSession: "new" });
+    assert.strictEqual(state.activeClusterIdx, 1);
+    assert.strictEqual(state.focusedId, "new");
+    // tile lives in the active cluster (index 1), not the first one.
+    assert.ok(state.clusters[1].some(col => col.some(t => t.id === "new")));
+    assert.ok(!state.clusters[0].some(col => col.some(t => t.id === "new")));
   });
 });
 
@@ -172,17 +211,10 @@ describe("buildBootState — tab-set merge", () => {
   });
 
   it("does not duplicate tab-set sessions that are already present", () => {
-    const persisted = {
-      version: 2,
-      activeClusterId: "default",
-      clusters: { default: { id: "default" } },
-      tiles: {
-        a: { id: "a", type: "terminal", props: {}, x: 0, clusterId: "default" },
-      },
-      focusedIdByCluster: { default: "a" },
-      order: ["a"],
-      focusedId: "a",
-    };
+    const persisted = persistedV3({
+      clusters: [[[{ id: "a", type: "terminal", props: {} }]]],
+      focusedTileIdByCluster: ["a"],
+    });
     const { state } = buildBootState({ persisted, tabSetSessions: ["a"] });
     assert.strictEqual(Object.keys(state.tiles).length, 1);
   });
@@ -190,17 +222,10 @@ describe("buildBootState — tab-set merge", () => {
 
 describe("buildBootState — pure function", () => {
   it("does not mutate inputs", () => {
-    const persisted = {
-      version: 2,
-      activeClusterId: "default",
-      clusters: { default: { id: "default" } },
-      tiles: {
-        a: { id: "a", type: "terminal", props: {}, x: 0, clusterId: "default" },
-      },
-      focusedIdByCluster: { default: "a" },
-      order: ["a"],
-      focusedId: "a",
-    };
+    const persisted = persistedV3({
+      clusters: [[[{ id: "a", type: "terminal", props: {} }]]],
+      focusedTileIdByCluster: ["a"],
+    });
     const snapshot = JSON.parse(JSON.stringify(persisted));
     buildBootState({ persisted, urlSession: "b" });
     assert.deepStrictEqual(persisted, snapshot);

--- a/test/selectors.test.js
+++ b/test/selectors.test.js
@@ -1,96 +1,124 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 
-const { selectClusterView, getFocusedSession } = await import(
+const { selectClusterView, selectColumns, tileLocator, getFocusedSession } = await import(
   new URL("../public/lib/selectors.js", import.meta.url).href
 );
 
-function makeState(overrides = {}) {
+// ── Helpers ────────────────────────────────────────────────────────────
+// Build a v3 state directly (no need to go through reducers for selector
+// tests). `withDerived` is inlined here to keep selector tests independent
+// of ui-store internals.
+function v3State({ clusters, activeClusterIdx = 0, focusedTileIdByCluster }) {
+  const tiles = {};
+  for (const cluster of clusters) {
+    for (const column of cluster) {
+      for (const tile of column) tiles[tile.id] = tile;
+    }
+  }
+  const active = clusters[activeClusterIdx] || [];
+  const order = [];
+  for (const column of active) for (const tile of column) order.push(tile.id);
   return {
-    version: 2,
-    activeClusterId: "default",
-    clusters: { default: { id: "default" }, work: { id: "work" } },
-    tiles: {
-      a: { id: "a", type: "terminal", props: {}, x: 0, clusterId: "default" },
-      b: { id: "b", type: "terminal", props: {}, x: 1, clusterId: "default" },
-      w1: { id: "w1", type: "terminal", props: {}, x: 0, clusterId: "work" },
-    },
-    focusedIdByCluster: { default: "b", work: "w1" },
-    ...overrides,
+    version: 3,
+    clusters,
+    activeClusterIdx,
+    focusedTileIdByCluster,
+    tiles,
+    order,
+    focusedId: focusedTileIdByCluster[activeClusterIdx] ?? null,
   };
+}
+
+function tile(id, extraProps = {}) {
+  return { id, type: "terminal", props: { sessionName: id, ...extraProps } };
 }
 
 describe("selectClusterView — basics", () => {
   it("returns tiles and order filtered to the cluster", () => {
-    const view = selectClusterView(makeState(), "default");
+    const state = v3State({
+      clusters: [
+        [[tile("a")], [tile("b")]],
+        [[tile("w1")]],
+      ],
+      focusedTileIdByCluster: ["b", "w1"],
+    });
+    const view = selectClusterView(state, 0);
     assert.deepStrictEqual(Object.keys(view.tiles).sort(), ["a", "b"]);
     assert.deepStrictEqual(view.order, ["a", "b"]);
     assert.strictEqual(view.focusedId, "b");
   });
 
   it("returns a different view for a different cluster", () => {
-    const view = selectClusterView(makeState(), "work");
+    const state = v3State({
+      clusters: [
+        [[tile("a")], [tile("b")]],
+        [[tile("w1")]],
+      ],
+      focusedTileIdByCluster: ["b", "w1"],
+    });
+    const view = selectClusterView(state, 1);
     assert.deepStrictEqual(Object.keys(view.tiles), ["w1"]);
     assert.deepStrictEqual(view.order, ["w1"]);
     assert.strictEqual(view.focusedId, "w1");
   });
 
-  it("orders tiles by x, not by insertion", () => {
-    const state = makeState({
-      tiles: {
-        t2: { id: "t2", type: "terminal", props: {}, x: 2, clusterId: "default" },
-        t0: { id: "t0", type: "terminal", props: {}, x: 0, clusterId: "default" },
-        t1: { id: "t1", type: "terminal", props: {}, x: 1, clusterId: "default" },
-      },
-      focusedIdByCluster: { default: "t0" },
+  it("orders tiles column-major top→bottom within multi-row columns", () => {
+    const state = v3State({
+      clusters: [[
+        [tile("c0r0"), tile("c0r1")],
+        [tile("c1r0")],
+        [tile("c2r0"), tile("c2r1"), tile("c2r2")],
+      ]],
+      focusedTileIdByCluster: ["c0r0"],
     });
-    assert.deepStrictEqual(selectClusterView(state, "default").order, ["t0", "t1", "t2"]);
-  });
-
-  it("treats missing x as 0 (sort-stable fallback)", () => {
-    const state = makeState({
-      tiles: {
-        b: { id: "b", type: "terminal", props: {}, x: 5, clusterId: "default" },
-        a: { id: "a", type: "terminal", props: {}, clusterId: "default" },
-      },
-      focusedIdByCluster: { default: "a" },
-    });
-    // `a` has no x (treated as 0), comes before `b` (x=5)
-    assert.deepStrictEqual(selectClusterView(state, "default").order, ["a", "b"]);
+    assert.deepStrictEqual(
+      selectClusterView(state, 0).order,
+      ["c0r0", "c0r1", "c1r0", "c2r0", "c2r1", "c2r2"],
+    );
   });
 });
 
 describe("selectClusterView — edge cases", () => {
-  it("returns empty view for unknown cluster id", () => {
+  it("returns empty view for out-of-range cluster index", () => {
+    const state = v3State({
+      clusters: [[[tile("a")]]],
+      focusedTileIdByCluster: ["a"],
+    });
     assert.deepStrictEqual(
-      selectClusterView(makeState(), "nonexistent"),
+      selectClusterView(state, 5),
       { tiles: {}, order: [], focusedId: null },
     );
   });
 
   it("returns empty view when cluster exists but has no tiles", () => {
-    const state = makeState({
-      clusters: { default: { id: "default" }, empty: { id: "empty" } },
-      focusedIdByCluster: { default: "b", empty: null },
+    const state = v3State({
+      clusters: [[[tile("a")]], []],
+      focusedTileIdByCluster: ["a", null],
     });
     assert.deepStrictEqual(
-      selectClusterView(state, "empty"),
+      selectClusterView(state, 1),
       { tiles: {}, order: [], focusedId: null },
     );
   });
 
-  it("handles missing focusedIdByCluster entry as null", () => {
-    const state = makeState({ focusedIdByCluster: { default: null, work: "w1" } });
-    assert.strictEqual(selectClusterView(state, "default").focusedId, null);
+  it("handles missing focusedTileIdByCluster entry as null", () => {
+    const state = {
+      version: 3,
+      clusters: [[[tile("a")]]],
+      activeClusterIdx: 0,
+      focusedTileIdByCluster: [],
+    };
+    assert.strictEqual(selectClusterView(state, 0).focusedId, null);
   });
 
   it("handles null/undefined state gracefully", () => {
     assert.deepStrictEqual(
-      selectClusterView(null, "default"),
+      selectClusterView(null, 0),
       { tiles: {}, order: [], focusedId: null },
     );
     assert.deepStrictEqual(
-      selectClusterView(undefined, "default"),
+      selectClusterView(undefined, 0),
       { tiles: {}, order: [], focusedId: null },
     );
   });
@@ -98,32 +126,153 @@ describe("selectClusterView — edge cases", () => {
 
 describe("selectClusterView — purity", () => {
   it("does not mutate the input state", () => {
-    const state = makeState();
+    const state = v3State({
+      clusters: [[[tile("a")], [tile("b")]]],
+      focusedTileIdByCluster: ["b"],
+    });
     const snap = JSON.parse(JSON.stringify(state));
-    selectClusterView(state, "default");
+    selectClusterView(state, 0);
     assert.deepStrictEqual(state, snap);
   });
 
   it("returns a fresh tiles object, not a reference into state", () => {
-    const state = makeState();
-    const view = selectClusterView(state, "default");
+    const state = v3State({
+      clusters: [[[tile("a")]]],
+      focusedTileIdByCluster: ["a"],
+    });
+    const view = selectClusterView(state, 0);
     assert.notStrictEqual(view.tiles, state.tiles);
+  });
+});
+
+describe("selectColumns", () => {
+  it("returns one entry per column, each keyed by its head tile id", () => {
+    const state = v3State({
+      clusters: [[
+        [tile("c0head"), tile("c0row1")],
+        [tile("c1only")],
+      ]],
+      focusedTileIdByCluster: ["c0head"],
+    });
+    assert.deepStrictEqual(selectColumns(state, 0), [
+      { id: "c0head", tileIds: ["c0head", "c0row1"] },
+      { id: "c1only", tileIds: ["c1only"] },
+    ]);
+  });
+
+  it("returns [] for out-of-range cluster index", () => {
+    const state = v3State({
+      clusters: [[[tile("a")]]],
+      focusedTileIdByCluster: ["a"],
+    });
+    assert.deepStrictEqual(selectColumns(state, 3), []);
+  });
+
+  it("returns [] for null/undefined state", () => {
+    assert.deepStrictEqual(selectColumns(null, 0), []);
+    assert.deepStrictEqual(selectColumns(undefined, 0), []);
+  });
+});
+
+describe("tileLocator", () => {
+  it("resolves tile ids to {c, col, row, tile} paths", () => {
+    const state = v3State({
+      clusters: [
+        [[tile("a")], [tile("b"), tile("c")]],
+        [[tile("w1")]],
+      ],
+      focusedTileIdByCluster: ["a", "w1"],
+    });
+    const loc = tileLocator(state);
+    assert.deepStrictEqual(
+      { ...loc.get("a"), tile: undefined },
+      { c: 0, col: 0, row: 0, tile: undefined },
+    );
+    assert.strictEqual(loc.get("a").tile.id, "a");
+    assert.deepStrictEqual(
+      { ...loc.get("c"), tile: undefined },
+      { c: 0, col: 1, row: 1, tile: undefined },
+    );
+    assert.deepStrictEqual(
+      { ...loc.get("w1"), tile: undefined },
+      { c: 1, col: 0, row: 0, tile: undefined },
+    );
+  });
+
+  it("returns null for unknown ids", () => {
+    const state = v3State({
+      clusters: [[[tile("a")]]],
+      focusedTileIdByCluster: ["a"],
+    });
+    const loc = tileLocator(state);
+    assert.strictEqual(loc.get("nope"), null);
+    assert.strictEqual(loc.has("nope"), false);
+    assert.strictEqual(loc.has("a"), true);
+  });
+
+  it("memoizes per state reference (same state → same locator)", () => {
+    const state = v3State({
+      clusters: [[[tile("a")]]],
+      focusedTileIdByCluster: ["a"],
+    });
+    assert.strictEqual(tileLocator(state), tileLocator(state));
+  });
+
+  it("rebuilds for a new state reference", () => {
+    const s1 = v3State({
+      clusters: [[[tile("a")]]],
+      focusedTileIdByCluster: ["a"],
+    });
+    const s2 = v3State({
+      clusters: [[[tile("a")], [tile("b")]]],
+      focusedTileIdByCluster: ["a"],
+    });
+    const l1 = tileLocator(s1);
+    const l2 = tileLocator(s2);
+    assert.notStrictEqual(l1, l2);
+    assert.strictEqual(l1.has("b"), false);
+    assert.strictEqual(l2.has("b"), true);
+  });
+
+  it("ids() and size() reflect the whole workspace", () => {
+    const state = v3State({
+      clusters: [
+        [[tile("a")], [tile("b")]],
+        [[tile("w1")]],
+      ],
+      focusedTileIdByCluster: ["a", "w1"],
+    });
+    const loc = tileLocator(state);
+    assert.deepStrictEqual(loc.ids().sort(), ["a", "b", "w1"]);
+    assert.strictEqual(loc.size(), 3);
+  });
+
+  it("returns an empty locator for null/undefined state", () => {
+    const loc = tileLocator(null);
+    assert.strictEqual(loc.get("x"), null);
+    assert.strictEqual(loc.has("x"), false);
+    assert.strictEqual(loc.size(), 0);
+    assert.deepStrictEqual(loc.ids(), []);
   });
 });
 
 describe("getFocusedSession — unchanged", () => {
   it("returns renderer-declared session for the focused tile", () => {
-    const state = makeState();
-    state.focusedId = "b"; // derived field (tile-host path still reads top-level)
+    const state = v3State({
+      clusters: [[[tile("a")], [tile("b")]]],
+      focusedTileIdByCluster: ["b"],
+    });
     const getRenderer = () => ({
-      describe: (props) => ({ session: props.sessionName || "b" }),
+      describe: (props) => ({ session: props.sessionName }),
     });
     assert.strictEqual(getFocusedSession(state, getRenderer), "b");
   });
 
   it("returns null when renderer has no session", () => {
-    const state = makeState();
-    state.focusedId = "b";
+    const state = v3State({
+      clusters: [[[tile("a")]]],
+      focusedTileIdByCluster: ["a"],
+    });
     const getRenderer = () => ({ describe: () => ({}) });
     assert.strictEqual(getFocusedSession(state, getRenderer), null);
   });

--- a/test/tile-host.test.js
+++ b/test/tile-host.test.js
@@ -1,35 +1,35 @@
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert";
 
-// tile-host has zero imports now (getRenderer is injected), so the
-// file:// URL import works without a custom Node loader.
 const { createTileHost } = await import(
   new URL("../public/lib/tile-host.js", import.meta.url).href
 );
 
-// ── Minimal store ──────────────────────────────────────────────────────
-// Uses the v2 multi-cluster shape tile-host now expects. `selectClusterView`
-// filters by clusterId; the test store keeps everything in a single
-// "default" cluster and derives legacy `order`/`focusedId` fields for tests
-// that assert on them.
-const DEFAULT_CLUSTER = "default";
+// ── Minimal v3-shape store ──────────────────────────────────────────────
+// tile-host reads via `selectClusterView`, which expects the v3 3D shape.
+// This store keeps a single cluster and maintains derived `tiles`/`order`/
+// `focusedId` fields for consumers that peek at top-level state.
 
 function withDerived(state) {
-  const tilesForCluster = Object.values(state.tiles)
-    .filter(t => t.clusterId === state.activeClusterId)
-    .sort((a, b) => (a.x ?? 0) - (b.x ?? 0));
-  const order = tilesForCluster.map(t => t.id);
-  const focusedId = state.focusedIdByCluster[state.activeClusterId] ?? null;
-  return { ...state, order, focusedId };
+  const tiles = {};
+  for (const cluster of state.clusters) {
+    for (const column of cluster) {
+      for (const tile of column) tiles[tile.id] = tile;
+    }
+  }
+  const active = state.clusters[state.activeClusterIdx] || [];
+  const order = [];
+  for (const column of active) for (const tile of column) order.push(tile.id);
+  const focusedId = state.focusedTileIdByCluster[state.activeClusterIdx] ?? null;
+  return { ...state, tiles, order, focusedId };
 }
 
 function emptyState() {
   return withDerived({
-    version: 2,
-    activeClusterId: DEFAULT_CLUSTER,
-    clusters: { [DEFAULT_CLUSTER]: { id: DEFAULT_CLUSTER } },
-    tiles: {},
-    focusedIdByCluster: { [DEFAULT_CLUSTER]: null },
+    version: 3,
+    clusters: [[]],
+    activeClusterIdx: 0,
+    focusedTileIdByCluster: [null],
   });
 }
 
@@ -39,96 +39,108 @@ function createTestStore(initial = emptyState()) {
 
   function notify() { subs.forEach(fn => fn(state)); }
 
+  // Build a v3 state from legacy {tiles, order, focusedId} test input.
+  // Each tile becomes a single-slot column, preserving `order`.
+  function fromFlat({ tiles = {}, order, focusedId = null }) {
+    const orderArr = order || Object.keys(tiles);
+    const cluster = [];
+    const seen = new Set();
+    for (const id of orderArr) {
+      if (seen.has(id) || !tiles[id]) continue;
+      seen.add(id);
+      const t = tiles[id];
+      cluster.push([{ id, type: t.type, props: t.props || {} }]);
+    }
+    for (const [id, t] of Object.entries(tiles)) {
+      if (seen.has(id) || !t) continue;
+      seen.add(id);
+      cluster.push([{ id, type: t.type, props: t.props || {} }]);
+    }
+    return withDerived({
+      version: 3,
+      clusters: [cluster],
+      activeClusterIdx: 0,
+      focusedTileIdByCluster: [focusedId],
+    });
+  }
+
   return {
     getState: () => state,
     subscribe(fn) { subs.add(fn); return () => subs.delete(fn); },
-    dispatch(action) { /* not used by tile-host */ },
+    dispatch(_action) { /* not used by tile-host */ },
     setState(next) {
-      // Test-side convenience: accept both the v2 shape and the pre-v2 flat
-      // shape (`{tiles, order, focusedId}`) the original tests use. Flat
-      // input gets wrapped into the default cluster with x-positions taken
-      // from the order array.
+      // Accept either v3 ({clusters, ...}) or flat ({tiles, order, focusedId}).
       if (next.clusters) {
-        // Normalize tiles that are missing clusterId/x. If the caller
-        // provided an `order` array, use it for x positions so legacy-style
-        // "spread state, set order" inserts still work.
-        const normalizedTiles = {};
-        const orderArr = next.order;
-        Object.entries(next.tiles || {}).forEach(([id, t]) => {
-          const idxInOrder = orderArr ? orderArr.indexOf(id) : -1;
-          // If the caller supplied an `order` array, trust it as the
-          // source of truth for x positions — overrides any existing
-          // x on the tile (the whole point of passing `order`).
-          const xFromOrder = idxInOrder >= 0 ? idxInOrder : undefined;
-          normalizedTiles[id] = {
-            ...t,
-            id: t.id ?? id,
-            clusterId: t.clusterId ?? DEFAULT_CLUSTER,
-            x: xFromOrder ?? t.x ?? 0,
-          };
-        });
-        const focusedIdByCluster = next.focusedIdByCluster
-          ? next.focusedIdByCluster
-          : { ...state.focusedIdByCluster, [DEFAULT_CLUSTER]: next.focusedId ?? null };
-        state = withDerived({ ...next, tiles: normalizedTiles, focusedIdByCluster });
-      } else {
-        const tiles = {};
-        const orderArr = next.order || Object.keys(next.tiles || {});
-        orderArr.forEach((id, x) => {
-          const t = next.tiles?.[id];
-          if (t) tiles[id] = { id, type: t.type, props: t.props || {}, x, clusterId: DEFAULT_CLUSTER };
-        });
         state = withDerived({
-          version: 2,
-          activeClusterId: DEFAULT_CLUSTER,
-          clusters: { [DEFAULT_CLUSTER]: { id: DEFAULT_CLUSTER } },
-          tiles,
-          focusedIdByCluster: { [DEFAULT_CLUSTER]: next.focusedId ?? null },
+          version: 3,
+          activeClusterIdx: 0,
+          focusedTileIdByCluster: [null],
+          ...next,
         });
+      } else {
+        state = fromFlat(next);
       }
       notify();
     },
     addTile(id, type, props, focus) {
-      const nextX = Object.values(state.tiles)
-        .filter(t => t.clusterId === DEFAULT_CLUSTER)
-        .reduce((m, t) => Math.max(m, (t.x ?? -1) + 1), 0);
+      const cluster = state.clusters[0].slice();
+      cluster.push([{ id, type, props }]);
+      const focusedTileIdByCluster = focus
+        ? [id]
+        : state.focusedTileIdByCluster.slice();
       state = withDerived({
         ...state,
-        tiles: {
-          ...state.tiles,
-          [id]: { id, type, props, x: nextX, clusterId: DEFAULT_CLUSTER },
-        },
-        focusedIdByCluster: focus
-          ? { ...state.focusedIdByCluster, [DEFAULT_CLUSTER]: id }
-          : state.focusedIdByCluster,
+        clusters: [cluster],
+        focusedTileIdByCluster,
       });
       notify();
     },
     removeTile(id) {
-      const { [id]: _removed, ...rest } = state.tiles;
-      const focusedIdByCluster = { ...state.focusedIdByCluster };
-      if (focusedIdByCluster[DEFAULT_CLUSTER] === id) {
-        const remaining = Object.values(rest)
-          .filter(t => t.clusterId === DEFAULT_CLUSTER)
-          .sort((a, b) => (a.x ?? 0) - (b.x ?? 0));
-        focusedIdByCluster[DEFAULT_CLUSTER] = remaining[0]?.id || null;
+      const cluster = state.clusters[0];
+      const orderPrev = [];
+      for (const col of cluster) for (const t of col) orderPrev.push(t.id);
+      const removedIdx = orderPrev.indexOf(id);
+      const newCluster = [];
+      for (const col of cluster) {
+        const filtered = col.filter(t => t.id !== id);
+        if (filtered.length > 0) newCluster.push(filtered);
       }
-      state = withDerived({ ...state, tiles: rest, focusedIdByCluster });
+      const nextOrder = [];
+      for (const col of newCluster) for (const t of col) nextOrder.push(t.id);
+      const focusedTileIdByCluster = state.focusedTileIdByCluster.slice();
+      if (focusedTileIdByCluster[0] === id) {
+        focusedTileIdByCluster[0] =
+          nextOrder[removedIdx] || nextOrder[removedIdx - 1] || null;
+      }
+      state = withDerived({
+        ...state,
+        clusters: [newCluster],
+        focusedTileIdByCluster,
+      });
       notify();
     },
     focusTile(id) {
       state = withDerived({
         ...state,
-        focusedIdByCluster: { ...state.focusedIdByCluster, [DEFAULT_CLUSTER]: id },
+        focusedTileIdByCluster: [id],
       });
       notify();
     },
     reorder(order) {
-      const tiles = { ...state.tiles };
-      order.forEach((id, x) => {
-        if (tiles[id]) tiles[id] = { ...tiles[id], x };
-      });
-      state = withDerived({ ...state, tiles });
+      const cluster = state.clusters[0];
+      const byHead = new Map();
+      for (const col of cluster) byHead.set(col[0].id, col);
+      const seen = new Set();
+      const newCluster = [];
+      for (const id of order) {
+        if (seen.has(id)) continue;
+        const col = byHead.get(id);
+        if (col) { newCluster.push(col); seen.add(id); }
+      }
+      for (const col of cluster) {
+        if (!seen.has(col[0].id)) { newCluster.push(col); seen.add(col[0].id); }
+      }
+      state = withDerived({ ...state, clusters: [newCluster] });
       notify();
     },
   };
@@ -232,6 +244,7 @@ describe("tile-host", () => {
       carousel,
       getRenderer: renderer.getRenderer,
       onFocusChange: opts.onFocusChange || (() => {}),
+      onTileRemoved: opts.onTileRemoved,
     });
     return host;
   }
@@ -241,8 +254,8 @@ describe("tile-host", () => {
     it("activates carousel with all tiles from store", () => {
       store.setState({
         tiles: {
-          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
-          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+          s1: { type: "terminal", props: { sessionName: "s1" } },
+          s2: { type: "terminal", props: { sessionName: "s2" } },
         },
         order: ["s1", "s2"],
         focusedId: "s1",
@@ -260,7 +273,7 @@ describe("tile-host", () => {
     it("mounts every tile via the renderer", () => {
       store.setState({
         tiles: {
-          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
+          s1: { type: "terminal", props: { sessionName: "s1" } },
         },
         order: ["s1"],
         focusedId: "s1",
@@ -314,11 +327,12 @@ describe("tile-host", () => {
       store.addTile("s1", "terminal", { sessionName: "s1" }, true);
       store.addTile("s2", "terminal", { sessionName: "s2" }, false);
 
-      // Now insert fb between s1 and s2 (afterFocus on s1)
-      const s = store.getState();
       store.setState({
-        ...s,
-        tiles: { ...s.tiles, fb: { id: "fb", type: "terminal", props: { sessionName: "fb" } } },
+        tiles: {
+          s1: { type: "terminal", props: { sessionName: "s1" } },
+          fb: { type: "terminal", props: { sessionName: "fb" } },
+          s2: { type: "terminal", props: { sessionName: "s2" } },
+        },
         order: ["s1", "fb", "s2"],
         focusedId: "fb",
       });
@@ -328,7 +342,6 @@ describe("tile-host", () => {
       assert.ok(fbOp, "addCard must be called for fb");
       assert.strictEqual(fbOp.position, 1, "fb must be inserted at index 1 (right of s1)");
 
-      // Carousel order should reflect the store order
       assert.deepStrictEqual(carousel.getCards(), ["s1", "fb", "s2"]);
     });
   });
@@ -338,8 +351,8 @@ describe("tile-host", () => {
     it("calls carousel.removeCard", () => {
       store.setState({
         tiles: {
-          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
-          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+          s1: { type: "terminal", props: { sessionName: "s1" } },
+          s2: { type: "terminal", props: { sessionName: "s2" } },
         },
         order: ["s1", "s2"],
         focusedId: "s1",
@@ -358,7 +371,7 @@ describe("tile-host", () => {
     it("unmounts the renderer handle", () => {
       store.setState({
         tiles: {
-          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
+          s1: { type: "terminal", props: { sessionName: "s1" } },
         },
         order: ["s1"],
         focusedId: "s1",
@@ -370,9 +383,6 @@ describe("tile-host", () => {
       assert.strictEqual(renderer.mounts[0].mounted, true);
 
       store.removeTile("s1");
-      // removeCard is called — the carousel is responsible for
-      // calling adapter.unmount(), which the real carousel does.
-      // Our mock doesn't, but the handle tracking should clear.
       assert.strictEqual(host.getHandle("s1"), null);
     });
   });
@@ -382,8 +392,8 @@ describe("tile-host", () => {
     it("calls carousel.focusCard", () => {
       store.setState({
         tiles: {
-          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
-          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+          s1: { type: "terminal", props: { sessionName: "s1" } },
+          s2: { type: "terminal", props: { sessionName: "s2" } },
         },
         order: ["s1", "s2"],
         focusedId: "s1",
@@ -404,8 +414,8 @@ describe("tile-host", () => {
       const changes = [];
       store.setState({
         tiles: {
-          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
-          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+          s1: { type: "terminal", props: { sessionName: "s1" } },
+          s2: { type: "terminal", props: { sessionName: "s2" } },
         },
         order: ["s1", "s2"],
         focusedId: "s1",
@@ -429,8 +439,8 @@ describe("tile-host", () => {
     it("calls carousel.reorderCards", () => {
       store.setState({
         tiles: {
-          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
-          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+          s1: { type: "terminal", props: { sessionName: "s1" } },
+          s2: { type: "terminal", props: { sessionName: "s2" } },
         },
         order: ["s1", "s2"],
         focusedId: "s1",
@@ -466,21 +476,22 @@ describe("tile-host", () => {
   // ── Re-entrancy guard ──────────────────────────────────────────────
   describe("re-entrancy", () => {
     it("does not double-mount when onFocusChange triggers a dispatch", () => {
-      // Simulate what happens when a renderer dispatches UPDATE_PROPS
-      // from inside the focus callback — the store fires subscribers
-      // synchronously, which would re-enter reconcile without the guard.
       createHost({
         onFocusChange: (id) => {
           const s = store.getState();
           if (s.tiles[id]) {
-            // Mutate state from inside the callback
-            store.setState({
-              ...s,
-              tiles: {
-                ...s.tiles,
-                [id]: { ...s.tiles[id], props: { ...s.tiles[id].props, touched: true } },
-              },
-            });
+            // Mutate state from inside the callback via flat setState
+            const tiles = {};
+            for (const tid of s.order) {
+              const existing = s.tiles[tid];
+              tiles[tid] = {
+                type: existing.type,
+                props: tid === id
+                  ? { ...existing.props, touched: true }
+                  : existing.props,
+              };
+            }
+            store.setState({ tiles, order: s.order, focusedId: s.focusedId });
           }
         },
       });
@@ -498,18 +509,14 @@ describe("tile-host", () => {
       const removed = [];
       store.setState({
         tiles: {
-          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
-          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+          s1: { type: "terminal", props: { sessionName: "s1" } },
+          s2: { type: "terminal", props: { sessionName: "s2" } },
         },
         order: ["s1", "s2"],
         focusedId: "s1",
       });
 
-      host = createTileHost({
-        store,
-        carousel,
-        getRenderer: renderer.getRenderer,
-        onFocusChange: () => {},
+      createHost({
         onTileRemoved: (id, handle) => removed.push({ id, sessions: handle.getSessions?.() }),
       });
       host.init();
@@ -525,18 +532,14 @@ describe("tile-host", () => {
       const removed = [];
       store.setState({
         tiles: {
-          s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
-          s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
+          s1: { type: "terminal", props: { sessionName: "s1" } },
+          s2: { type: "terminal", props: { sessionName: "s2" } },
         },
         order: ["s1", "s2"],
         focusedId: "s1",
       });
 
-      host = createTileHost({
-        store,
-        carousel,
-        getRenderer: renderer.getRenderer,
-        onFocusChange: () => {},
+      createHost({
         onTileRemoved: (id, handle) => removed.push({ id, sessions: handle.getSessions?.() }),
       });
       host.init();

--- a/test/ui-store.test.js
+++ b/test/ui-store.test.js
@@ -102,6 +102,23 @@ describe("normalize", () => {
     assert.deepStrictEqual(s.order, ["dup"]);
     assert.strictEqual(s.clusters[0].length, 1);
   });
+
+  it("rejects reserved ids that would poison the derived tile map prototype", () => {
+    const s = normalize({
+      version: 3,
+      clusters: [[
+        [{ id: "__proto__", type: "terminal", props: {} }],
+        [{ id: "ok", type: "terminal", props: {} }],
+      ]],
+      activeClusterIdx: 0,
+      focusedTileIdByCluster: ["__proto__"],
+    });
+    assert.deepStrictEqual(s.order, ["ok"]);
+    // If the reserved id had been accepted, `tiles.__proto__` would be the
+    // tile object; untouched, it remains the native prototype.
+    assert.strictEqual(Object.getPrototypeOf(s.tiles), Object.prototype);
+    assert.strictEqual(s.clusters[0].length, 1);
+  });
 });
 
 // ── ADD_TILE ─────────────────────────────────────────────────────────
@@ -423,7 +440,7 @@ describe("ADD_CLUSTER", () => {
 
   it("can switch to the new cluster on creation", () => {
     const store = makeStore();
-    store.addCluster({}, { switchTo: true });
+    store.addCluster({ switchTo: true });
     assert.strictEqual(store.getState().activeClusterIdx, 1);
   });
 
@@ -431,7 +448,7 @@ describe("ADD_CLUSTER", () => {
     const store = makeStore();
     store.addCluster(); // now [0, 1]
     store.switchCluster(1); // active = 1
-    store.addCluster({}, { position: 0 }); // inserts before the active
+    store.addCluster({ position: 0 }); // inserts before the active
     const s = store.getState();
     assert.strictEqual(s.clusters.length, 3);
     assert.strictEqual(s.activeClusterIdx, 2); // shifted from 1 to 2
@@ -475,7 +492,7 @@ describe("SWITCH_CLUSTER", () => {
 describe("REMOVE_CLUSTER", () => {
   it("removes the cluster and all its tiles", () => {
     const store = makeStore();
-    store.addCluster({}, { switchTo: true });
+    store.addCluster({ switchTo: true });
     store.addTile({ id: "w1", type: "terminal", props: {} });
     store.addTile({ id: "w2", type: "terminal", props: {} });
     store.switchCluster(0);
@@ -495,14 +512,14 @@ describe("REMOVE_CLUSTER", () => {
 
   it("clamps activeClusterIdx when removing the active cluster", () => {
     const store = makeStore();
-    store.addCluster({}, { switchTo: true }); // active = 1
+    store.addCluster({ switchTo: true }); // active = 1
     store.removeCluster(1);
     assert.strictEqual(store.getState().activeClusterIdx, 0);
   });
 
   it("shifts activeClusterIdx down when removing a lower-indexed cluster", () => {
     const store = makeStore();
-    store.addCluster({}, { switchTo: true }); // active = 1
+    store.addCluster({ switchTo: true }); // active = 1
     store.removeCluster(0);
     assert.strictEqual(store.getState().activeClusterIdx, 0);
     assert.strictEqual(store.getState().clusters.length, 1);

--- a/test/ui-store.test.js
+++ b/test/ui-store.test.js
@@ -1,100 +1,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 
-const { normalize, serialize, EMPTY_STATE } = await import(
+const { normalize, serialize, EMPTY_STATE, createUiStore } = await import(
   new URL("../public/lib/ui-store.js", import.meta.url).href
 );
 
-// ── normalize ───────────────────────────────────────────────────────
-
-describe("normalize", () => {
-  it("returns EMPTY_STATE for null/undefined", () => {
-    assert.deepStrictEqual(normalize(null), EMPTY_STATE);
-    assert.deepStrictEqual(normalize(undefined), EMPTY_STATE);
-    assert.deepStrictEqual(normalize(42), EMPTY_STATE);
-  });
-
-  it("assigns x from order array when tiles lack x (migration)", () => {
-    const raw = {
-      version: 1,
-      tiles: {
-        a: { id: "a", type: "terminal", props: {} },
-        b: { id: "b", type: "terminal", props: {} },
-        c: { id: "c", type: "terminal", props: {} },
-      },
-      order: ["b", "a", "c"],
-      focusedId: "a",
-    };
-    const result = normalize(raw);
-    assert.strictEqual(result.tiles.b.x, 0);
-    assert.strictEqual(result.tiles.a.x, 1);
-    assert.strictEqual(result.tiles.c.x, 2);
-    assert.deepStrictEqual(result.order, ["b", "a", "c"]);
-    assert.strictEqual(result.focusedId, "a");
-  });
-
-  it("preserves x when tiles already have it", () => {
-    const raw = {
-      version: 1,
-      tiles: {
-        a: { id: "a", type: "terminal", props: {}, x: 5 },
-        b: { id: "b", type: "terminal", props: {}, x: 2 },
-      },
-      focusedId: "a",
-    };
-    const result = normalize(raw);
-    assert.strictEqual(result.tiles.a.x, 5);
-    assert.strictEqual(result.tiles.b.x, 2);
-    assert.deepStrictEqual(result.order, ["b", "a"]);
-  });
-
-  it("backfills missing tiles not in order array (corrupt save)", () => {
-    const raw = {
-      version: 1,
-      tiles: {
-        a: { id: "a", type: "terminal", props: {} },
-        b: { id: "b", type: "terminal", props: {} },
-        orphan: { id: "orphan", type: "terminal", props: {} },
-      },
-      order: ["a", "b"], // orphan missing from order
-      focusedId: "a",
-    };
-    const result = normalize(raw);
-    assert.strictEqual(result.tiles.a.x, 0);
-    assert.strictEqual(result.tiles.b.x, 1);
-    assert.strictEqual(result.tiles.orphan.x, 2);
-    assert.deepStrictEqual(result.order, ["a", "b", "orphan"]);
-  });
-
-  it("defaults focusedId to first tile when missing", () => {
-    const raw = {
-      tiles: { z: { id: "z", type: "terminal", props: {}, x: 0 } },
-    };
-    const result = normalize(raw);
-    assert.strictEqual(result.focusedId, "z");
-  });
-
-  it("rejects tiles with invalid type", () => {
-    const raw = {
-      tiles: {
-        good: { id: "good", type: "terminal", props: {} },
-        bad: { id: "bad", props: {} }, // no type
-      },
-      order: ["good", "bad"],
-    };
-    const result = normalize(raw);
-    assert.ok(result.tiles.good);
-    assert.ok(!result.tiles.bad);
-    assert.deepStrictEqual(result.order, ["good"]);
-  });
-});
-
-// ── reducer (via createUiStore) ─────────────────────────────────────
-
-// createUiStore calls normalize on initialState and wraps the reducer.
-// We test through it to exercise the real dispatch path.
-
-// Stub localStorage — ui-store calls saveToStorage on every change
+// Stub localStorage — ui-store calls saveToStorage on every change.
 const _storage = {};
 globalThis.localStorage = {
   getItem: (k) => _storage[k] ?? null,
@@ -102,62 +13,162 @@ globalThis.localStorage = {
   removeItem: (k) => { delete _storage[k]; },
 };
 
-const { createUiStore } = await import(
-  new URL("../public/lib/ui-store.js", import.meta.url).href
-);
-
 function makeStore(initial) {
   return createUiStore({ initialState: initial });
 }
 
+// ── normalize (v3 shape + migrations) ────────────────────────────────
+
+describe("normalize", () => {
+  it("returns EMPTY_STATE for null/undefined/non-object", () => {
+    assert.deepStrictEqual(normalize(null), EMPTY_STATE);
+    assert.deepStrictEqual(normalize(undefined), EMPTY_STATE);
+    assert.deepStrictEqual(normalize(42), EMPTY_STATE);
+  });
+
+  it("passes v3 through, dropping empty columns", () => {
+    const v3 = {
+      version: 3,
+      clusters: [[
+        [{ id: "a", type: "terminal", props: {} }],
+        [], // should be pruned
+        [{ id: "b", type: "terminal", props: {} }],
+      ]],
+      activeClusterIdx: 0,
+      focusedTileIdByCluster: ["a"],
+    };
+    const s = normalize(v3);
+    assert.strictEqual(s.version, 3);
+    assert.strictEqual(s.clusters.length, 1);
+    assert.strictEqual(s.clusters[0].length, 2);
+    assert.deepStrictEqual(s.order, ["a", "b"]);
+  });
+
+  it("strips unknown fields on v3 tiles (keeps only id/type/props)", () => {
+    const v3 = {
+      version: 3,
+      clusters: [[[{ id: "a", type: "terminal", props: {}, x: 99, clusterId: "legacy" }]]],
+      activeClusterIdx: 0,
+      focusedTileIdByCluster: ["a"],
+    };
+    const s = normalize(v3);
+    const t = s.clusters[0][0][0];
+    assert.deepStrictEqual(Object.keys(t).sort(), ["id", "props", "type"]);
+  });
+
+  it("clamps out-of-range activeClusterIdx", () => {
+    const s = normalize({
+      version: 3,
+      clusters: [[[{ id: "a", type: "terminal", props: {} }]]],
+      activeClusterIdx: 99,
+      focusedTileIdByCluster: ["a"],
+    });
+    assert.strictEqual(s.activeClusterIdx, 0);
+  });
+
+  it("picks head of first column when focused id is missing/invalid", () => {
+    const s = normalize({
+      version: 3,
+      clusters: [[[{ id: "a", type: "terminal", props: {} }]]],
+      activeClusterIdx: 0,
+      focusedTileIdByCluster: ["ghost"],
+    });
+    assert.strictEqual(s.focusedId, "a");
+  });
+
+  it("rejects tiles without a valid type (but keeps neighbors)", () => {
+    const s = normalize({
+      version: 3,
+      clusters: [[
+        [{ id: "good", type: "terminal", props: {} }],
+        [{ id: "bad", props: {} }], // no type — whole column drops
+      ]],
+      activeClusterIdx: 0,
+      focusedTileIdByCluster: ["good"],
+    });
+    assert.deepStrictEqual(s.order, ["good"]);
+  });
+
+  it("dedups duplicate tile ids across columns", () => {
+    const s = normalize({
+      version: 3,
+      clusters: [[
+        [{ id: "dup", type: "terminal", props: {} }],
+        [{ id: "dup", type: "terminal", props: {} }],
+      ]],
+      activeClusterIdx: 0,
+      focusedTileIdByCluster: ["dup"],
+    });
+    assert.deepStrictEqual(s.order, ["dup"]);
+    assert.strictEqual(s.clusters[0].length, 1);
+  });
+});
+
+// ── ADD_TILE ─────────────────────────────────────────────────────────
+
 describe("ADD_TILE", () => {
-  it("assigns x = 0 to the first tile", () => {
+  it("adds the first tile as a single-slot column", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: {} });
     const s = store.getState();
-    assert.strictEqual(s.tiles.a.x, 0);
     assert.deepStrictEqual(s.order, ["a"]);
+    assert.strictEqual(s.clusters[0].length, 1);
+    assert.strictEqual(s.clusters[0][0][0].id, "a");
+    assert.ok(s.tiles.a);
   });
 
-  it("appends at end by default (x = nextX)", () => {
+  it("appends a new column at the end by default", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: {} });
     store.addTile({ id: "b", type: "terminal", props: {} });
     store.addTile({ id: "c", type: "terminal", props: {} });
     const s = store.getState();
-    assert.strictEqual(s.tiles.a.x, 0);
-    assert.strictEqual(s.tiles.b.x, 1);
-    assert.strictEqual(s.tiles.c.x, 2);
     assert.deepStrictEqual(s.order, ["a", "b", "c"]);
+    assert.strictEqual(s.clusters[0].length, 3);
   });
 
-  it("inserts afterFocus — shifts tiles to the right", () => {
+  it("inserts afterFocus — new column immediately after focused tile's", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: {} }, { focus: true });
     store.addTile({ id: "b", type: "terminal", props: {} });
-    // Focus is on "a" (x=0). Insert "mid" after focus.
     store.addTile({ id: "mid", type: "terminal", props: {} }, { insertAt: "afterFocus" });
     const s = store.getState();
-    assert.strictEqual(s.tiles.a.x, 0);
-    assert.strictEqual(s.tiles.mid.x, 1);
-    assert.strictEqual(s.tiles.b.x, 2); // shifted from 1 → 2
     assert.deepStrictEqual(s.order, ["a", "mid", "b"]);
   });
 
-  it("does not duplicate — optionally focuses existing tile", () => {
+  it("inserts after an explicit tile id via insertAfter", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.addTile({ id: "b", type: "terminal", props: {} });
+    store.addTile({ id: "c", type: "terminal", props: {} });
+    store.addTile({ id: "mid", type: "terminal", props: {} }, { insertAfter: "a" });
+    assert.deepStrictEqual(store.getState().order, ["a", "mid", "b", "c"]);
+  });
+
+  it("does not duplicate existing ids — can shift focus", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: {} });
     store.addTile({ id: "b", type: "terminal", props: {} }, { focus: true });
-    // Try to add "a" again with focus
     store.addTile({ id: "a", type: "terminal", props: {} }, { focus: true });
     const s = store.getState();
-    assert.strictEqual(Object.keys(s.tiles).length, 2);
+    assert.strictEqual(s.clusters[0].length, 2);
     assert.strictEqual(s.focusedId, "a");
+  });
+
+  it("rejects invalid tile payloads", () => {
+    const store = makeStore();
+    const before = store.getState();
+    store.addTile(null);
+    store.addTile({});
+    store.addTile({ id: "x" });
+    assert.strictEqual(store.getState(), before);
   });
 });
 
+// ── REMOVE_TILE ──────────────────────────────────────────────────────
+
 describe("REMOVE_TILE", () => {
-  it("removes tile and derives new order", () => {
+  it("removes the tile and prunes its now-empty column", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: {} });
     store.addTile({ id: "b", type: "terminal", props: {} });
@@ -166,6 +177,7 @@ describe("REMOVE_TILE", () => {
     const s = store.getState();
     assert.ok(!s.tiles.b);
     assert.deepStrictEqual(s.order, ["a", "c"]);
+    assert.strictEqual(s.clusters[0].length, 2);
   });
 
   it("focuses right neighbor when removing focused tile", () => {
@@ -173,12 +185,11 @@ describe("REMOVE_TILE", () => {
     store.addTile({ id: "a", type: "terminal", props: {} });
     store.addTile({ id: "b", type: "terminal", props: {} }, { focus: true });
     store.addTile({ id: "c", type: "terminal", props: {} });
-    // b is focused, remove it — should focus c (right neighbor)
     store.removeTile("b");
     assert.strictEqual(store.getState().focusedId, "c");
   });
 
-  it("focuses left neighbor when removing last tile", () => {
+  it("focuses left neighbor when removing the last tile", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: {} });
     store.addTile({ id: "b", type: "terminal", props: {} });
@@ -204,18 +215,16 @@ describe("REMOVE_TILE", () => {
   });
 });
 
+// ── REORDER ──────────────────────────────────────────────────────────
+
 describe("REORDER", () => {
-  it("reassigns x coordinates to match new order", () => {
+  it("reorders columns by head-tile id", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: {} });
     store.addTile({ id: "b", type: "terminal", props: {} });
     store.addTile({ id: "c", type: "terminal", props: {} });
     store.reorder(["c", "a", "b"]);
-    const s = store.getState();
-    assert.strictEqual(s.tiles.c.x, 0);
-    assert.strictEqual(s.tiles.a.x, 1);
-    assert.strictEqual(s.tiles.b.x, 2);
-    assert.deepStrictEqual(s.order, ["c", "a", "b"]);
+    assert.deepStrictEqual(store.getState().order, ["c", "a", "b"]);
   });
 
   it("no-ops when order is unchanged", () => {
@@ -227,18 +236,13 @@ describe("REORDER", () => {
     assert.strictEqual(store.getState(), before);
   });
 
-  it("appends missing tiles at the end", () => {
+  it("appends missing columns at the end in their original order", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: {} });
     store.addTile({ id: "b", type: "terminal", props: {} });
     store.addTile({ id: "c", type: "terminal", props: {} });
-    // Only specify a,c — b should be appended
     store.reorder(["a", "c"]);
-    const s = store.getState();
-    assert.deepStrictEqual(s.order, ["a", "c", "b"]);
-    assert.strictEqual(s.tiles.a.x, 0);
-    assert.strictEqual(s.tiles.c.x, 1);
-    assert.strictEqual(s.tiles.b.x, 2);
+    assert.deepStrictEqual(store.getState().order, ["a", "c", "b"]);
   });
 
   it("drops unknown ids", () => {
@@ -248,6 +252,8 @@ describe("REORDER", () => {
     assert.deepStrictEqual(store.getState().order, ["a"]);
   });
 });
+
+// ── FOCUS_TILE ───────────────────────────────────────────────────────
 
 describe("FOCUS_TILE", () => {
   it("changes focusedId", () => {
@@ -273,17 +279,25 @@ describe("FOCUS_TILE", () => {
     store.focusTile("ghost");
     assert.strictEqual(store.getState(), before);
   });
+
+  it("clears focus when passed null", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} }, { focus: true });
+    store.focusTile(null);
+    assert.strictEqual(store.getState().focusedId, null);
+  });
 });
 
+// ── UPDATE_PROPS ─────────────────────────────────────────────────────
+
 describe("UPDATE_PROPS", () => {
-  it("shallow-merges patch into props, preserves x", () => {
+  it("shallow-merges patch into props", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: { sessionName: "s1" } });
     store.updateProps("a", { title: "hello" });
     const t = store.getState().tiles.a;
     assert.strictEqual(t.props.sessionName, "s1");
     assert.strictEqual(t.props.title, "hello");
-    assert.strictEqual(t.x, 0); // x preserved
   });
 
   it("no-ops when patch values are identical", () => {
@@ -293,158 +307,167 @@ describe("UPDATE_PROPS", () => {
     store.updateProps("a", { sessionName: "s1" });
     assert.strictEqual(store.getState(), before);
   });
+
+  it("keeps the tile's position across updates", () => {
+    const store = makeStore();
+    store.addTile({ id: "a", type: "terminal", props: {} });
+    store.addTile({ id: "b", type: "terminal", props: {} });
+    store.addTile({ id: "c", type: "terminal", props: {} });
+    store.updateProps("b", { title: "renamed" });
+    assert.deepStrictEqual(store.getState().order, ["a", "b", "c"]);
+  });
 });
 
+// ── RESET ────────────────────────────────────────────────────────────
+
 describe("RESET", () => {
-  it("normalizes the provided state (backfills x from order)", () => {
+  it("replaces state via normalize", () => {
     const store = makeStore();
     store.reset({
-      tiles: {
-        x: { id: "x", type: "terminal", props: {} },
-        y: { id: "y", type: "terminal", props: {} },
-      },
-      order: ["y", "x"],
-      focusedId: "y",
+      version: 3,
+      clusters: [[
+        [{ id: "x", type: "terminal", props: {} }],
+        [{ id: "y", type: "terminal", props: {} }],
+      ]],
+      activeClusterIdx: 0,
+      focusedTileIdByCluster: ["y"],
     });
     const s = store.getState();
-    assert.strictEqual(s.tiles.y.x, 0);
-    assert.strictEqual(s.tiles.x.x, 1);
-    assert.deepStrictEqual(s.order, ["y", "x"]);
+    assert.deepStrictEqual(s.order, ["x", "y"]);
     assert.strictEqual(s.focusedId, "y");
   });
 
-  it("preserves x when tiles already have it", () => {
+  it("accepts legacy v1 shape and migrates to v3", () => {
     const store = makeStore();
     store.reset({
+      version: 1,
       tiles: {
-        a: { id: "a", type: "terminal", props: {}, x: 10 },
-        b: { id: "b", type: "terminal", props: {}, x: 3 },
+        a: { id: "a", type: "terminal", props: {} },
+        b: { id: "b", type: "terminal", props: {} },
       },
+      order: ["b", "a"],
       focusedId: "b",
     });
     const s = store.getState();
-    assert.strictEqual(s.tiles.a.x, 10);
-    assert.strictEqual(s.tiles.b.x, 3);
+    assert.strictEqual(s.version, 3);
     assert.deepStrictEqual(s.order, ["b", "a"]);
+    assert.strictEqual(s.focusedId, "b");
   });
 });
 
+// ── serialize ────────────────────────────────────────────────────────
+
 describe("serialize", () => {
-  it("includes x + clusterId on tiles; drops derived order/focusedId", () => {
+  it("emits a clean v3 shape (no derived fields, tiles are dumb)", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: {} });
     store.addTile({ id: "b", type: "terminal", props: {} });
     const out = serialize(store.getState());
-    assert.strictEqual(out.tiles.a.x, 0);
-    assert.strictEqual(out.tiles.b.x, 1);
-    assert.strictEqual(out.tiles.a.clusterId, "default");
-    assert.strictEqual(out.tiles.b.clusterId, "default");
+    assert.strictEqual(out.version, 3);
+    assert.strictEqual(out.activeClusterIdx, 0);
+    assert.ok(Array.isArray(out.clusters));
+    assert.deepStrictEqual(out.clusters[0].map(col => col[0].id), ["a", "b"]);
+    assert.strictEqual(out.tiles, undefined);
     assert.strictEqual(out.order, undefined);
     assert.strictEqual(out.focusedId, undefined);
-    assert.strictEqual(out.activeClusterId, "default");
-    assert.ok(out.clusters.default);
-    assert.ok("focusedIdByCluster" in out);
+    // Tiles carry only {id, type, props} — no clusterId/x/y.
+    assert.deepStrictEqual(Object.keys(out.clusters[0][0][0]).sort(), ["id", "props", "type"]);
   });
 
-  it("filters non-persistable tiles", () => {
+  it("filters non-persistable tiles and prunes empty columns", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: {} });
     store.addTile({ id: "b", type: "ephemeral", props: {} });
     const out = serialize(store.getState(), (type) => type === "terminal");
-    assert.ok(out.tiles.a);
-    assert.ok(!out.tiles.b);
+    assert.strictEqual(out.clusters[0].length, 1);
+    assert.strictEqual(out.clusters[0][0][0].id, "a");
   });
 
-  it("clears focusedIdByCluster entries that point to filtered tiles", () => {
+  it("nulls out focused entries that point to filtered tiles", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "ephemeral", props: {} }, { focus: true });
     const out = serialize(store.getState(), (type) => type === "terminal");
-    assert.strictEqual(out.focusedIdByCluster.default, null);
+    assert.strictEqual(out.focusedTileIdByCluster[0], null);
   });
 });
 
 // ── clusters ─────────────────────────────────────────────────────────
 
 describe("clusters: initial state", () => {
-  it("has a default cluster and active=default", () => {
+  it("has exactly one empty cluster with active index 0", () => {
     const store = makeStore();
     const s = store.getState();
-    assert.strictEqual(s.activeClusterId, "default");
-    assert.ok(s.clusters.default);
-    assert.deepStrictEqual(Object.keys(s.focusedIdByCluster), ["default"]);
+    assert.strictEqual(s.activeClusterIdx, 0);
+    assert.strictEqual(s.clusters.length, 1);
+    assert.deepStrictEqual(s.clusters[0], []);
+    assert.deepStrictEqual(s.focusedTileIdByCluster, [null]);
   });
 
-  it("new tiles are assigned clusterId = activeClusterId", () => {
+  it("ADD_TILE targets the active cluster by default", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: {} });
-    assert.strictEqual(store.getState().tiles.a.clusterId, "default");
+    assert.strictEqual(store.getState().clusters[0][0][0].id, "a");
   });
 });
 
 describe("ADD_CLUSTER", () => {
-  it("adds a cluster and initializes its focusedIdByCluster slot", () => {
+  it("appends an empty cluster and a null focus slot in parallel", () => {
     const store = makeStore();
-    store.addCluster({ id: "work" });
+    store.addCluster();
     const s = store.getState();
-    assert.ok(s.clusters.work);
-    assert.strictEqual(s.focusedIdByCluster.work, null);
-    // active is still default
-    assert.strictEqual(s.activeClusterId, "default");
+    assert.strictEqual(s.clusters.length, 2);
+    assert.deepStrictEqual(s.clusters[1], []);
+    assert.strictEqual(s.focusedTileIdByCluster[1], null);
+    assert.strictEqual(s.activeClusterIdx, 0); // unchanged
   });
 
   it("can switch to the new cluster on creation", () => {
     const store = makeStore();
-    store.addCluster({ id: "work", name: "Work" }, { switchTo: true });
+    store.addCluster({}, { switchTo: true });
+    assert.strictEqual(store.getState().activeClusterIdx, 1);
+  });
+
+  it("can insert at an explicit position, shifting the active index", () => {
+    const store = makeStore();
+    store.addCluster(); // now [0, 1]
+    store.switchCluster(1); // active = 1
+    store.addCluster({}, { position: 0 }); // inserts before the active
     const s = store.getState();
-    assert.strictEqual(s.activeClusterId, "work");
-    assert.strictEqual(s.clusters.work.name, "Work");
-  });
-
-  it("no-ops when cluster id already exists", () => {
-    const store = makeStore();
-    const before = store.getState();
-    store.addCluster({ id: "default" });
-    assert.strictEqual(store.getState(), before);
-  });
-
-  it("rejects cluster without an id", () => {
-    const store = makeStore();
-    const before = store.getState();
-    store.addCluster({});
-    assert.strictEqual(store.getState(), before);
+    assert.strictEqual(s.clusters.length, 3);
+    assert.strictEqual(s.activeClusterIdx, 2); // shifted from 1 to 2
   });
 });
 
 describe("SWITCH_CLUSTER", () => {
-  it("updates activeClusterId and re-derives order/focusedId", () => {
+  it("updates activeClusterIdx and re-derives order/focusedId", () => {
     const store = makeStore();
     store.addTile({ id: "a", type: "terminal", props: {} }, { focus: true });
-    store.addCluster({ id: "work" });
-    store.switchCluster("work");
+    store.addCluster();
+    store.switchCluster(1);
     store.addTile({ id: "b", type: "terminal", props: {} }, { focus: true });
     const s = store.getState();
-    assert.strictEqual(s.activeClusterId, "work");
+    assert.strictEqual(s.activeClusterIdx, 1);
     assert.deepStrictEqual(s.order, ["b"]);
     assert.strictEqual(s.focusedId, "b");
 
-    // Switch back — default's state is remembered
-    store.switchCluster("default");
+    // Switch back — cluster 0's state is remembered.
+    store.switchCluster(0);
     const d = store.getState();
     assert.deepStrictEqual(d.order, ["a"]);
     assert.strictEqual(d.focusedId, "a");
   });
 
-  it("no-ops for unknown cluster", () => {
+  it("no-ops for out-of-range index", () => {
     const store = makeStore();
     const before = store.getState();
-    store.switchCluster("ghost");
+    store.switchCluster(99);
     assert.strictEqual(store.getState(), before);
   });
 
   it("no-ops when already active", () => {
     const store = makeStore();
     const before = store.getState();
-    store.switchCluster("default");
+    store.switchCluster(0);
     assert.strictEqual(store.getState(), before);
   });
 });
@@ -452,110 +475,92 @@ describe("SWITCH_CLUSTER", () => {
 describe("REMOVE_CLUSTER", () => {
   it("removes the cluster and all its tiles", () => {
     const store = makeStore();
-    store.addCluster({ id: "work" }, { switchTo: true });
-    store.addTile({ id: "a", type: "terminal", props: {} });
-    store.addTile({ id: "b", type: "terminal", props: {} });
-    store.switchCluster("default");
-    store.removeCluster("work");
+    store.addCluster({}, { switchTo: true });
+    store.addTile({ id: "w1", type: "terminal", props: {} });
+    store.addTile({ id: "w2", type: "terminal", props: {} });
+    store.switchCluster(0);
+    store.removeCluster(1);
     const s = store.getState();
-    assert.ok(!s.clusters.work);
-    assert.ok(!s.tiles.a);
-    assert.ok(!s.tiles.b);
-    assert.ok(!s.focusedIdByCluster.work);
+    assert.strictEqual(s.clusters.length, 1);
+    assert.ok(!s.tiles.w1);
+    assert.ok(!s.tiles.w2);
   });
 
   it("refuses to remove the last cluster", () => {
     const store = makeStore();
     const before = store.getState();
-    store.removeCluster("default");
+    store.removeCluster(0);
     assert.strictEqual(store.getState(), before);
   });
 
-  it("falls back to first remaining cluster when removing active", () => {
+  it("clamps activeClusterIdx when removing the active cluster", () => {
     const store = makeStore();
-    store.addCluster({ id: "work" }, { switchTo: true });
-    store.removeCluster("work");
-    const s = store.getState();
-    assert.strictEqual(s.activeClusterId, "default");
+    store.addCluster({}, { switchTo: true }); // active = 1
+    store.removeCluster(1);
+    assert.strictEqual(store.getState().activeClusterIdx, 0);
+  });
+
+  it("shifts activeClusterIdx down when removing a lower-indexed cluster", () => {
+    const store = makeStore();
+    store.addCluster({}, { switchTo: true }); // active = 1
+    store.removeCluster(0);
+    assert.strictEqual(store.getState().activeClusterIdx, 0);
+    assert.strictEqual(store.getState().clusters.length, 1);
   });
 });
 
 describe("cluster-scoped actions", () => {
   it("FOCUS_TILE rejects a tile in a non-active cluster", () => {
     const store = makeStore();
-    store.addCluster({ id: "work" });
-    store.addTile({ id: "a", type: "terminal", props: {} }, { clusterId: "work" });
-    // active is still default; focusing "a" (in work) should no-op
+    store.addCluster();
+    store.addTile({ id: "w1", type: "terminal", props: {} }, { clusterIdx: 1 });
     const before = store.getState();
-    store.focusTile("a");
+    store.focusTile("w1");
     assert.strictEqual(store.getState(), before);
   });
 
-  it("ADD_TILE can target a specific cluster via clusterId option", () => {
+  it("ADD_TILE can target a specific cluster via clusterIdx option", () => {
     const store = makeStore();
-    store.addCluster({ id: "work" });
-    store.addTile({ id: "a", type: "terminal", props: {} }, { clusterId: "work" });
+    store.addCluster();
+    store.addTile({ id: "w1", type: "terminal", props: {} }, { clusterIdx: 1 });
     const s = store.getState();
-    assert.strictEqual(s.tiles.a.clusterId, "work");
-    // active cluster order is empty since "a" lives in "work"
+    // Active cluster (0) is empty; w1 lives in cluster 1.
     assert.deepStrictEqual(s.order, []);
+    assert.strictEqual(s.clusters[1][0][0].id, "w1");
   });
 
-  it("REORDER only touches tiles in the target cluster", () => {
+  it("REORDER only touches columns in the target cluster", () => {
     const store = makeStore();
-    store.addCluster({ id: "work" });
-    store.addTile({ id: "a", type: "terminal", props: {} }); // default
-    store.addTile({ id: "b", type: "terminal", props: {} }); // default
-    store.addTile({ id: "w1", type: "terminal", props: {} }, { clusterId: "work" });
-    store.addTile({ id: "w2", type: "terminal", props: {} }, { clusterId: "work" });
-    store.reorder(["b", "a"]); // default cluster
+    store.addCluster();
+    store.addTile({ id: "a", type: "terminal", props: {} }); // cluster 0
+    store.addTile({ id: "b", type: "terminal", props: {} }); // cluster 0
+    store.addTile({ id: "w1", type: "terminal", props: {} }, { clusterIdx: 1 });
+    store.addTile({ id: "w2", type: "terminal", props: {} }, { clusterIdx: 1 });
+    store.reorder(["b", "a"]); // cluster 0
     const s = store.getState();
     assert.deepStrictEqual(s.order, ["b", "a"]);
-    // work tiles keep their original order
-    assert.strictEqual(s.tiles.w1.x, 0);
-    assert.strictEqual(s.tiles.w2.x, 1);
+    assert.deepStrictEqual(s.clusters[1].map(c => c[0].id), ["w1", "w2"]);
   });
 
   it("REMOVE_TILE re-focuses within the removed tile's own cluster", () => {
     const store = makeStore();
-    store.addCluster({ id: "work" });
+    store.addCluster();
     store.addTile({ id: "a", type: "terminal", props: {} }, { focus: true });
-    store.addTile({ id: "w1", type: "terminal", props: {} }, { clusterId: "work" });
-    store.addTile({ id: "w2", type: "terminal", props: {} }, { clusterId: "work" });
-    // Focus the first work-tile by switching and focusing.
-    store.switchCluster("work");
+    store.addTile({ id: "w1", type: "terminal", props: {} }, { clusterIdx: 1 });
+    store.addTile({ id: "w2", type: "terminal", props: {} }, { clusterIdx: 1 });
+    store.switchCluster(1);
     store.focusTile("w1");
-    store.switchCluster("default");
-    // Now remove w1 while default is active — focus within work should
-    // fall back to w2 (the neighbor).
+    store.switchCluster(0);
     store.removeTile("w1");
-    assert.strictEqual(store.getState().focusedIdByCluster.work, "w2");
-    // Default's focus unchanged.
-    assert.strictEqual(store.getState().focusedIdByCluster.default, "a");
+    assert.strictEqual(store.getState().focusedTileIdByCluster[1], "w2");
+    assert.strictEqual(store.getState().focusedTileIdByCluster[0], "a");
   });
 });
 
-describe("v1 → v2 migration via normalize", () => {
-  it("wraps v1 tiles into the default cluster", () => {
-    const v1 = {
-      version: 1,
-      tiles: {
-        a: { id: "a", type: "terminal", props: {}, x: 0 },
-        b: { id: "b", type: "terminal", props: {}, x: 1 },
-      },
-      focusedId: "b",
-    };
-    const v2 = normalize(v1);
-    assert.strictEqual(v2.version, 2);
-    assert.strictEqual(v2.activeClusterId, "default");
-    assert.strictEqual(v2.tiles.a.clusterId, "default");
-    assert.strictEqual(v2.tiles.b.clusterId, "default");
-    assert.strictEqual(v2.focusedIdByCluster.default, "b");
-    assert.strictEqual(v2.focusedId, "b");
-    assert.deepStrictEqual(v2.order, ["a", "b"]);
-  });
+// ── Migrations ───────────────────────────────────────────────────────
 
-  it("migrates v1 tiles lacking x using the order hint", () => {
+describe("v1 → v3 migration via normalize", () => {
+  it("wraps v1 tiles into single-slot columns in the v1 order", () => {
     const v1 = {
       version: 1,
       tiles: {
@@ -565,10 +570,58 @@ describe("v1 → v2 migration via normalize", () => {
       order: ["b", "a"],
       focusedId: "b",
     };
-    const v2 = normalize(v1);
-    assert.strictEqual(v2.tiles.b.x, 0);
-    assert.strictEqual(v2.tiles.a.x, 1);
-    assert.deepStrictEqual(v2.order, ["b", "a"]);
+    const v3 = normalize(v1);
+    assert.strictEqual(v3.version, 3);
+    assert.strictEqual(v3.activeClusterIdx, 0);
+    assert.deepStrictEqual(v3.order, ["b", "a"]);
+    assert.strictEqual(v3.focusedId, "b");
+    assert.strictEqual(v3.clusters[0].length, 2);
+  });
+
+  it("backfills missing tiles not in order array (corrupt save)", () => {
+    const v1 = {
+      version: 1,
+      tiles: {
+        a: { id: "a", type: "terminal", props: {} },
+        b: { id: "b", type: "terminal", props: {} },
+        orphan: { id: "orphan", type: "terminal", props: {} },
+      },
+      order: ["a", "b"],
+    };
+    const v3 = normalize(v1);
+    assert.deepStrictEqual(v3.order, ["a", "b", "orphan"]);
+  });
+});
+
+describe("v2 → v3 migration via normalize", () => {
+  it("promotes v2 clusters to v3 3D array, preserving x order as columns", () => {
+    const v2 = {
+      version: 2,
+      activeClusterId: "default",
+      clusters: {
+        default: { id: "default" },
+        work: { id: "work", name: "Work" },
+      },
+      tiles: {
+        a: { id: "a", type: "terminal", props: {}, clusterId: "default", x: 0 },
+        b: { id: "b", type: "terminal", props: {}, clusterId: "default", x: 1 },
+        w1: { id: "w1", type: "terminal", props: {}, clusterId: "work", x: 0 },
+      },
+      focusedIdByCluster: { default: "b", work: "w1" },
+    };
+    const v3 = normalize(v2);
+    assert.strictEqual(v3.version, 3);
+    // Active cluster lands at index 0 in the v3 output.
+    assert.strictEqual(v3.activeClusterIdx, 0);
+    assert.deepStrictEqual(v3.order, ["a", "b"]);
+    assert.strictEqual(v3.focusedId, "b");
+    assert.strictEqual(v3.clusters.length, 2);
+    // Each v2 tile becomes its own single-slot column.
+    assert.deepStrictEqual(v3.clusters[0].map(c => c[0].id), ["a", "b"]);
+    assert.deepStrictEqual(v3.clusters[1].map(c => c[0].id), ["w1"]);
+    // Tiles are dumb: no clusterId or x fields survive.
+    const t = v3.clusters[0][0][0];
+    assert.deepStrictEqual(Object.keys(t).sort(), ["id", "props", "type"]);
   });
 });
 
@@ -582,26 +635,5 @@ describe("round-trip: serialize → normalize", () => {
     const restored = normalize(serialized);
     assert.deepStrictEqual(restored.order, store.getState().order);
     assert.strictEqual(restored.focusedId, store.getState().focusedId);
-    for (const id of restored.order) {
-      assert.strictEqual(restored.tiles[id].x, store.getState().tiles[id].x);
-    }
-  });
-
-  it("old format (no x) round-trips through normalize correctly", () => {
-    // Simulate what loadFromStorage returns for pre-coordinate persistence
-    const oldFormat = {
-      version: 1,
-      tiles: {
-        s1: { id: "s1", type: "terminal", props: { sessionName: "s1" } },
-        s2: { id: "s2", type: "terminal", props: { sessionName: "s2" } },
-      },
-      order: ["s2", "s1"],
-      focusedId: "s2",
-    };
-    const restored = normalize(oldFormat);
-    assert.deepStrictEqual(restored.order, ["s2", "s1"]);
-    assert.strictEqual(restored.tiles.s2.x, 0);
-    assert.strictEqual(restored.tiles.s1.x, 1);
-    assert.strictEqual(restored.focusedId, "s2");
   });
 });


### PR DESCRIPTION
## Summary

- Tile state is now a pure 3D array `clusters[c][col][row] = tile`. Position IS location — tiles carry no `x`, `y`, or `clusterId`; cluster identity is an array index, not a string ID.
- Reducer rewritten around structural-sharing splices: ADD/REMOVE/REORDER operate on the 3D shape directly; derived `tiles`/`order`/`focusedId` are rebuilt after every step so existing consumers (tile-tab-bar, app.js) keep working unchanged.
- Adds `selectColumns` (2D column view for Level-2) and `tileLocator` (WeakMap-memoized O(1) id→path lookup), plus v1/v2/v3 migrations in `normalize`.

## Why this shape

v2 had tiles with `{id, x, clusterId}` plus a clusters map keyed by cluster-id. Every reorder cascaded x updates; every cluster add/remove needed an ID generator and sync. Moving to pure 3D means splice-remove + splice-insert for moves, positional array splices for clusters, and zero coordinate cascades. Tile IDs remain stable (WS subs, DOM keys, focus-survives-splice), but tiles themselves are dumb `{id, type, props}`.

## Test plan

- [x] `npm run test:unit` — 2165 pass, 3 pre-existing skips
- [x] `npm run test:integration` — all suites marked flaky/skip per pre-existing markers (no regression)
- [ ] Manual verification: boot, add/remove tiles, reorder, refresh, `?s=` URL session, tab-set merge, add cluster, switch cluster