### PR TITLE
Live document viewer — auto-reload on disk changes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2200,6 +2200,11 @@
     .doc-tile-status-dirty { color: var(--warning); }
     .doc-tile-status-ok { color: var(--success); }
     .doc-tile-status-err { color: var(--danger); }
+    .doc-tile-conflict { display: flex; align-items: center; gap: var(--space-sm); padding: var(--space-xs) var(--space-sm); background: var(--bg-surface); border-bottom: 1px solid var(--warning, #d3b63b); color: var(--text); font-size: var(--text-xs); flex-shrink: 0; }
+    .doc-tile-conflict-msg { flex: 1; min-width: 0; color: var(--warning, #d3b63b); }
+    .doc-tile-conflict-btn { background: transparent; color: var(--text-muted); border: 1px solid var(--border); border-radius: var(--radius); padding: 2px var(--space-sm); font-size: var(--text-xs); font-family: var(--font-mono); cursor: pointer; transition: background 0.15s, color 0.15s, border-color 0.15s; }
+    .doc-tile-conflict-btn:hover { background: var(--accent); color: var(--text); border-color: var(--accent-active); }
+    .doc-tile-conflict-btn-primary { border-color: var(--warning, #d3b63b); color: var(--warning, #d3b63b); }
     .doc-tile-error { color: var(--text-error, #f66); }
     .doc-tile-error-page { display: flex; flex-direction: column; align-items: center; justify-content: center; flex: 1; gap: var(--space-md); padding: var(--space-lg); text-align: center; }
     .doc-tile-error-art { font-size: 3rem; line-height: 1; opacity: 0.7; user-select: none; }

--- a/public/lib/document-watcher.js
+++ b/public/lib/document-watcher.js
@@ -1,0 +1,35 @@
+/**
+ * Document Watcher — live file-sync for document-tile via SSE.
+ *
+ * Opens an EventSource to /api/files/watch for a single file path.
+ * When the server emits a change event, invokes onChange. The server
+ * already debounces, so we fire straight through.
+ *
+ * Mirrors the pattern in file-browser-watcher.js; factored out so
+ * document-tile.js can be wired for live reload without growing more
+ * inline fetch/watch plumbing, and so the behaviour is unit-testable.
+ */
+
+/**
+ * @param {object} opts
+ * @param {string} opts.filePath — path to watch
+ * @param {() => void} opts.onChange — called on each change notification
+ * @param {typeof EventSource} [opts.EventSourceImpl] — injectable for tests
+ * @returns {{ stop: () => void }}
+ */
+export function createDocumentWatcher({ filePath, onChange, EventSourceImpl }) {
+  const Impl = EventSourceImpl || globalThis.EventSource;
+  if (!filePath || typeof Impl !== "function") {
+    return { stop() {} };
+  }
+
+  const url = `/api/files/watch?paths=${encodeURIComponent(filePath)}`;
+  const es = new Impl(url);
+  es.onmessage = () => { try { onChange(); } catch { /* swallow */ } };
+
+  return {
+    stop() {
+      try { es.close(); } catch { /* already closed */ }
+    },
+  };
+}

--- a/public/lib/tiles/document-tile.js
+++ b/public/lib/tiles/document-tile.js
@@ -350,6 +350,7 @@ export function createDocumentTileFactory(_deps = {}) {
     let watcher = null;
     let conflictBarEl = null;
     let pendingDiskContent = null;
+    let headerEl = null;
 
     const isFileBacked = !!filePath;
     const ext = filePath
@@ -391,12 +392,12 @@ export function createDocumentTileFactory(_deps = {}) {
       }
     }
 
-    function showConflict(diskContent, rootEl, headerEl) {
+    function showConflict(diskContent) {
       // Always refresh the cached disk content so Revert applies the newest
       // version — the disk can change repeatedly while the banner is up.
       pendingDiskContent = diskContent;
       if (conflictBarEl) return;
-      if (!rootEl || !headerEl) return;
+      if (!headerEl) return;
 
       conflictBarEl = document.createElement("div");
       conflictBarEl.className = "doc-tile-conflict";
@@ -421,7 +422,7 @@ export function createDocumentTileFactory(_deps = {}) {
       overwrite.type = "button";
       overwrite.className = "doc-tile-conflict-btn doc-tile-conflict-btn-primary";
       overwrite.textContent = "Overwrite";
-      overwrite.addEventListener("click", () => { saveFile(); });
+      overwrite.addEventListener("click", saveFile);
       conflictBarEl.appendChild(overwrite);
 
       headerEl.insertAdjacentElement("afterend", conflictBarEl);
@@ -461,6 +462,7 @@ export function createDocumentTileFactory(_deps = {}) {
 
         const header = document.createElement("div");
         header.className = "doc-tile-header";
+        headerEl = header;
 
         const headerTitle = document.createElement("span");
         headerTitle.className = "doc-tile-header-title";
@@ -609,6 +611,9 @@ export function createDocumentTileFactory(_deps = {}) {
               api.get(`/api/files/read?path=${encodeURIComponent(filePath)}`)
                 .then((data) => {
                   if (!mounted || !editorView) return;
+                  // Guard against a malformed/empty response so we never
+                  // dispatch `undefined` into CodeMirror.
+                  if (typeof data?.content !== "string") return;
                   const currentDoc = editorView.state.doc.toString();
                   if (data.content === currentDoc) {
                     originalContent = data.content;
@@ -617,7 +622,7 @@ export function createDocumentTileFactory(_deps = {}) {
                   if (!dirty) {
                     applyDiskToEditor(data.content);
                   } else {
-                    showConflict(data.content, root, header);
+                    showConflict(data.content);
                   }
                 })
                 .catch(() => { /* transient read failure — wait for next event */ });
@@ -672,6 +677,7 @@ export function createDocumentTileFactory(_deps = {}) {
         }
         if (container) container.innerHTML = "";
         container = null;
+        headerEl = null;
         mounted = false;
         dirty = false;
         statusEl = null;

--- a/public/lib/tiles/document-tile.js
+++ b/public/lib/tiles/document-tile.js
@@ -10,11 +10,18 @@
  *
  * Markdown files (.md ext or format: "markdown") are rendered as HTML
  * via vendored marked.js. All other formats render in CodeMirror.
+ *
+ * File-backed tiles subscribe to /api/files/watch via createDocumentWatcher
+ * so the view auto-syncs with on-disk changes. For markdown the re-render
+ * is silent; for the code editor a VSCode-style conflict banner appears
+ * when the user has unsaved edits — they choose Revert (load disk) or
+ * Overwrite (save their buffer).
  */
 
 import { api } from "/lib/api-client.js";
 import { marked } from "/vendor/marked/marked.esm.js";
 import DOMPurify from "/vendor/dompurify/purify.es.mjs";
+import { createDocumentWatcher } from "/lib/document-watcher.js";
 
 /* ---------- cute animated error pages ---------- */
 
@@ -340,6 +347,9 @@ export function createDocumentTileFactory(_deps = {}) {
     let statusEl = null;
     let originalContent = "";
     let stopErrorAnim = null;
+    let watcher = null;
+    let conflictBarEl = null;
+    let pendingDiskContent = null;
 
     const isFileBacked = !!filePath;
     const ext = filePath
@@ -356,6 +366,67 @@ export function createDocumentTileFactory(_deps = {}) {
       statusEl.className = "doc-tile-status " + (className || "");
     }
 
+    /** Replace editor contents without triggering a dirty flag. */
+    function applyDiskToEditor(text) {
+      if (!editorView) return;
+      // Set originalContent first so the CM updateListener, which runs
+      // synchronously during dispatch, compares the new doc against the
+      // new baseline instead of the stale one.
+      originalContent = text;
+      dirty = false;
+      const prevHead = editorView.state.selection.main.head;
+      const newHead = Math.min(prevHead, text.length);
+      editorView.dispatch({
+        changes: { from: 0, to: editorView.state.doc.length, insert: text },
+        selection: { anchor: newHead },
+      });
+      updateStatus("", "");
+    }
+
+    function hideConflict() {
+      pendingDiskContent = null;
+      if (conflictBarEl) {
+        conflictBarEl.remove();
+        conflictBarEl = null;
+      }
+    }
+
+    function showConflict(diskContent, rootEl, headerEl) {
+      // Always refresh the cached disk content so Revert applies the newest
+      // version — the disk can change repeatedly while the banner is up.
+      pendingDiskContent = diskContent;
+      if (conflictBarEl) return;
+      if (!rootEl || !headerEl) return;
+
+      conflictBarEl = document.createElement("div");
+      conflictBarEl.className = "doc-tile-conflict";
+      conflictBarEl.setAttribute("role", "alert");
+
+      const msg = document.createElement("span");
+      msg.className = "doc-tile-conflict-msg";
+      msg.textContent = "File changed on disk. Your edits differ.";
+      conflictBarEl.appendChild(msg);
+
+      const revert = document.createElement("button");
+      revert.type = "button";
+      revert.className = "doc-tile-conflict-btn";
+      revert.textContent = "Revert";
+      revert.addEventListener("click", () => {
+        if (pendingDiskContent != null) applyDiskToEditor(pendingDiskContent);
+        hideConflict();
+      });
+      conflictBarEl.appendChild(revert);
+
+      const overwrite = document.createElement("button");
+      overwrite.type = "button";
+      overwrite.className = "doc-tile-conflict-btn doc-tile-conflict-btn-primary";
+      overwrite.textContent = "Overwrite";
+      overwrite.addEventListener("click", () => { saveFile(); });
+      conflictBarEl.appendChild(overwrite);
+
+      headerEl.insertAdjacentElement("afterend", conflictBarEl);
+    }
+
     async function saveFile() {
       if (!isFileBacked || !editorView || saving || !dirty) return;
       saving = true;
@@ -365,6 +436,7 @@ export function createDocumentTileFactory(_deps = {}) {
         await api.post("/api/files/write", { path: filePath, content: newContent });
         originalContent = newContent;
         dirty = false;
+        hideConflict();
         updateStatus("Saved", "doc-tile-status-ok");
         setTimeout(() => { if (!dirty && mounted) updateStatus("", ""); }, 2000);
       } catch (err) {
@@ -409,7 +481,7 @@ export function createDocumentTileFactory(_deps = {}) {
         root.appendChild(header);
 
         if (renderAsMarkdown) {
-          // --- Markdown rendering (unchanged) ---
+          // --- Markdown rendering ---
           const contentEl = document.createElement("div");
           contentEl.className = "doc-tile-content doc-tile-markdown";
           contentEl.tabIndex = 0;
@@ -417,6 +489,19 @@ export function createDocumentTileFactory(_deps = {}) {
           el.appendChild(root);
 
           if (isFileBacked) {
+            // Silent re-fetch used by the watcher — no "Loading…" flash,
+            // content replaced only on success so a transient fetch error
+            // doesn't blank out a working view.
+            const refreshMarkdown = () => {
+              api.get(`/api/files/read?path=${encodeURIComponent(filePath)}`)
+                .then((data) => {
+                  if (!mounted) return;
+                  contentEl.classList.remove("doc-tile-error");
+                  contentEl.innerHTML = DOMPurify.sanitize(marked.parse(data.content));
+                })
+                .catch(() => { /* keep previous content */ });
+            };
+
             const loadMarkdown = () => {
               if (stopErrorAnim) { stopErrorAnim(); stopErrorAnim = null; }
               contentEl.textContent = "Loading…";
@@ -426,6 +511,9 @@ export function createDocumentTileFactory(_deps = {}) {
                 .then((data) => {
                   if (!mounted) return;
                   contentEl.innerHTML = DOMPurify.sanitize(marked.parse(data.content));
+                  if (!watcher) {
+                    watcher = createDocumentWatcher({ filePath, onChange: refreshMarkdown });
+                  }
                 })
                 .catch((err) => {
                   if (!mounted) return;
@@ -497,6 +585,9 @@ export function createDocumentTileFactory(_deps = {}) {
                     dirty = newDirty;
                     updateStatus(dirty ? "Modified" : "", dirty ? "doc-tile-status-dirty" : "");
                   }
+                  // If the user edits back to the disk version while a conflict
+                  // banner is up, there's nothing left to reconcile.
+                  if (!dirty && conflictBarEl) hideConflict();
                 }
               }),
             ];
@@ -508,6 +599,30 @@ export function createDocumentTileFactory(_deps = {}) {
           };
 
           if (isFileBacked) {
+            // Called by the watcher on every fs change. Silent no-op when
+            // disk matches the buffer (including the common case where the
+            // change was our own save). If disk differs and the buffer is
+            // clean, sync silently; if the buffer is dirty, VSCode-style
+            // conflict banner lets the user choose Revert or Overwrite.
+            const handleDiskChange = () => {
+              if (!mounted || !editorView) return;
+              api.get(`/api/files/read?path=${encodeURIComponent(filePath)}`)
+                .then((data) => {
+                  if (!mounted || !editorView) return;
+                  const currentDoc = editorView.state.doc.toString();
+                  if (data.content === currentDoc) {
+                    originalContent = data.content;
+                    return;
+                  }
+                  if (!dirty) {
+                    applyDiskToEditor(data.content);
+                  } else {
+                    showConflict(data.content, root, header);
+                  }
+                })
+                .catch(() => { /* transient read failure — wait for next event */ });
+            };
+
             const loadFile = () => {
               if (stopErrorAnim) { stopErrorAnim(); stopErrorAnim = null; }
               editorContainer.textContent = "Loading…";
@@ -517,7 +632,12 @@ export function createDocumentTileFactory(_deps = {}) {
               api.get(`/api/files/read?path=${encodeURIComponent(filePath)}`)
                 .then((data) => {
                   if (!mounted) return;
-                  setupEditor(data.content);
+                  return setupEditor(data.content).then(() => {
+                    if (!mounted) return;
+                    if (!watcher) {
+                      watcher = createDocumentWatcher({ filePath, onChange: handleDiskChange });
+                    }
+                  });
                 })
                 .catch((err) => {
                   if (!mounted) return;
@@ -543,6 +663,8 @@ export function createDocumentTileFactory(_deps = {}) {
 
       unmount() {
         if (!mounted) return;
+        if (watcher) { watcher.stop(); watcher = null; }
+        hideConflict();
         if (stopErrorAnim) { stopErrorAnim(); stopErrorAnim = null; }
         if (editorView) {
           editorView.destroy();

--- a/test/document-watcher.test.js
+++ b/test/document-watcher.test.js
@@ -1,0 +1,105 @@
+/**
+ * Tests for document-watcher — the SSE wrapper used by document-tile to
+ * auto-sync with on-disk file changes.
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { createDocumentWatcher } from "../public/lib/document-watcher.js";
+
+class FakeEventSource {
+  constructor(url) {
+    this.url = url;
+    this.onmessage = null;
+    this.closed = false;
+    FakeEventSource.instances.push(this);
+  }
+  close() { this.closed = true; }
+  emit() { this.onmessage?.({ data: "{}" }); }
+}
+
+describe("createDocumentWatcher", () => {
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+  });
+
+  it("no-ops when filePath is empty", () => {
+    const w = createDocumentWatcher({
+      filePath: "",
+      onChange: () => { throw new Error("should not fire"); },
+      EventSourceImpl: FakeEventSource,
+    });
+    w.stop(); // must be safe
+    assert.equal(FakeEventSource.instances.length, 0);
+  });
+
+  it("no-ops when EventSource is unavailable", () => {
+    const w = createDocumentWatcher({
+      filePath: "/tmp/x.md",
+      onChange: () => {},
+      EventSourceImpl: null,
+    });
+    w.stop();
+  });
+
+  it("opens SSE to /api/files/watch with the encoded path", () => {
+    createDocumentWatcher({
+      filePath: "/tmp/foo bar.md",
+      onChange: () => {},
+      EventSourceImpl: FakeEventSource,
+    });
+    assert.equal(FakeEventSource.instances.length, 1);
+    assert.equal(
+      FakeEventSource.instances[0].url,
+      "/api/files/watch?paths=%2Ftmp%2Ffoo%20bar.md",
+    );
+  });
+
+  it("invokes onChange on each SSE message", () => {
+    let count = 0;
+    createDocumentWatcher({
+      filePath: "/tmp/x.md",
+      onChange: () => { count++; },
+      EventSourceImpl: FakeEventSource,
+    });
+    const es = FakeEventSource.instances[0];
+    es.emit();
+    es.emit();
+    es.emit();
+    assert.equal(count, 3);
+  });
+
+  it("swallows errors thrown inside onChange so one bad subscriber can't kill the connection", () => {
+    createDocumentWatcher({
+      filePath: "/tmp/x.md",
+      onChange: () => { throw new Error("boom"); },
+      EventSourceImpl: FakeEventSource,
+    });
+    const es = FakeEventSource.instances[0];
+    assert.doesNotThrow(() => es.emit());
+    assert.equal(es.closed, false);
+  });
+
+  it("stop() closes the EventSource", () => {
+    const w = createDocumentWatcher({
+      filePath: "/tmp/x.md",
+      onChange: () => {},
+      EventSourceImpl: FakeEventSource,
+    });
+    const es = FakeEventSource.instances[0];
+    assert.equal(es.closed, false);
+    w.stop();
+    assert.equal(es.closed, true);
+  });
+
+  it("stop() is idempotent", () => {
+    const w = createDocumentWatcher({
+      filePath: "/tmp/x.md",
+      onChange: () => {},
+      EventSourceImpl: FakeEventSource,
+    });
+    w.stop();
+    assert.doesNotThrow(() => w.stop());
+  });
+});


### PR DESCRIPTION
## Summary

- Wires `document-tile` to the existing `/api/files/watch` SSE endpoint so markdown and code viewers auto-sync when the underlying file changes (git pull, external editor, agent rewrites, etc.).
- Markdown re-renders silently. CodeMirror re-syncs silently when clean; when the buffer is dirty, a VSCode-style banner offers **Revert** (load disk) or **Overwrite** (save my version).
- Factors the SSE plumbing into `public/lib/document-watcher.js` (mirrors `file-browser-watcher.js`); new `test/document-watcher.test.js` covers URL encoding, fan-out, error isolation, and stop idempotency.

## Why

`document-tile` fetched once on mount and never re-checked. Viewers silently lost accuracy after any external edit, with no signal to the user. The watch infrastructure already existed — this PR is wiring, not infrastructure.

## Test plan

- [x] `npm run test:unit` — 2173 passing, 0 fail
- [x] New unit tests for \`createDocumentWatcher\` (7/7 passing)
- [ ] Manual: open a markdown tile, edit the file externally, confirm re-render
- [ ] Manual: open a code tile, confirm save round-trip is silent (no spurious conflict)
- [ ] Manual: open a code tile, edit the buffer, then edit the file externally, confirm conflict banner shows Revert/Overwrite
- [ ] Manual: Revert restores disk content; Overwrite saves buffer and dismisses banner