### PR TITLE
Reconnect faster after laptop wake via focus/pageshow probes

### DIFF
--- a/public/lib/connection-manager.js
+++ b/public/lib/connection-manager.js
@@ -22,6 +22,7 @@ const BACKOFF_INITIAL    = 1000;
 const BACKOFF_MAX        = 10000;
 const BACKOFF_FACTOR     = 2;
 const BACKGROUND_THRESHOLD = 5000; // 5s — after this long in background, force reconnect
+const WAKE_PROBE_TIMEOUT   = 2000; // 2s — probe deadline on focus/pageshow (laptop wake)
 
 /**
  * Create a connection manager.
@@ -171,6 +172,31 @@ export function createConnectionManager({
     backoffDelay = Math.min(backoffDelay * BACKOFF_FACTOR, BACKOFF_MAX);
   }
 
+  /**
+   * Probe the connection after a wake event (focus, pageshow). If the
+   * socket is already closed, reconnect immediately. If it still looks
+   * open, send a ping and force a reconnect if no pong arrives within
+   * WAKE_PROBE_TIMEOUT — much faster than the normal 8s heartbeat.
+   */
+  function wakeProbe() {
+    if (!transport || transport.readyState !== 1) {
+      reconnectNow();
+      return;
+    }
+
+    const probeEpoch = epoch;
+    const pingResult = heartbeat.sendPing(heartbeatState, Date.now());
+    processEffects(pingResult);
+
+    setTimeout(() => {
+      if (disposed) return;
+      if (epoch !== probeEpoch) return;
+      if (heartbeatState.status === "waiting") {
+        handleDisconnect();
+      }
+    }, WAKE_PROBE_TIMEOUT);
+  }
+
   // ─── Public API ─────────────────────────────────────────────────
 
   function connect() {
@@ -295,6 +321,19 @@ export function createConnectionManager({
 
     addDomListener(window, "online", () => {
       if (!disposed) reconnectNow();
+    });
+
+    // Laptop wake / tab refocus — visibilitychange doesn't always fire on
+    // macOS lid-close, and even when it does the 8s heartbeat timeout is
+    // slow enough to look like a hang. `focus` and `pageshow` give us extra
+    // wake signals; wakeProbe() reconnects fast if the socket is dead and
+    // applies a tighter 2s deadline if it looks alive.
+    addDomListener(window, "focus", () => {
+      if (!disposed) wakeProbe();
+    });
+
+    addDomListener(window, "pageshow", () => {
+      if (!disposed) wakeProbe();
     });
 
     addDomListener(document, "visibilitychange", () => {

--- a/public/lib/connection-manager.js
+++ b/public/lib/connection-manager.js
@@ -51,6 +51,7 @@ export function createConnectionManager({
   let backoffDelay      = BACKOFF_INITIAL;
   let backgroundedAt    = null;
   let disposed          = false;
+  let wakeProbeTimer    = null;
 
   // DOM listeners stored for cleanup
   const domListeners    = [];
@@ -154,6 +155,11 @@ export function createConnectionManager({
     const { status } = connectionStore.getState();
     if (status === "disconnected") return;
 
+    if (wakeProbeTimer !== null) {
+      clearTimeout(wakeProbeTimer);
+      wakeProbeTimer = null;
+    }
+
     stopHeartbeat();
 
     if (transport) {
@@ -179,6 +185,14 @@ export function createConnectionManager({
    * WAKE_PROBE_TIMEOUT — much faster than the normal 8s heartbeat.
    */
   function wakeProbe() {
+    // Drop any probe from a prior wake event — focus + pageshow +
+    // visibilitychange can all fire in the same turn on laptop wake, and
+    // we only want one active probe at a time.
+    if (wakeProbeTimer !== null) {
+      clearTimeout(wakeProbeTimer);
+      wakeProbeTimer = null;
+    }
+
     if (!transport || transport.readyState !== 1) {
       reconnectNow();
       return;
@@ -187,13 +201,19 @@ export function createConnectionManager({
     const probeEpoch = epoch;
     const pingResult = heartbeat.sendPing(heartbeatState, Date.now());
     processEffects(pingResult);
+    // sendPing is idempotent — if the scheduled heartbeat had already
+    // flipped the machine to "waiting", sentAt belongs to that earlier
+    // ping, and we must not tear down a connection that might still
+    // answer it within the normal 8s window.
+    const probeSentAt = heartbeatState.sentAt;
 
-    setTimeout(() => {
+    wakeProbeTimer = setTimeout(() => {
+      wakeProbeTimer = null;
       if (disposed) return;
       if (epoch !== probeEpoch) return;
-      if (heartbeatState.status === "waiting") {
-        handleDisconnect();
-      }
+      if (heartbeatState.status !== "waiting") return;
+      if (heartbeatState.sentAt !== probeSentAt) return;
+      handleDisconnect();
     }, WAKE_PROBE_TIMEOUT);
   }
 
@@ -267,6 +287,11 @@ export function createConnectionManager({
     if (reconnectTimer !== null) {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
+    }
+
+    if (wakeProbeTimer !== null) {
+      clearTimeout(wakeProbeTimer);
+      wakeProbeTimer = null;
     }
 
     stopHeartbeat();
@@ -346,13 +371,14 @@ export function createConnectionManager({
         backgroundedAt = null;
 
         if (elapsed > BACKGROUND_THRESHOLD) {
-          // Extended background — connection is likely stale, force reconnect
-          disconnect();
-          connect();
+          // Extended background — connection is likely stale, force reconnect.
+          // reconnectNow() (vs. disconnect+connect) also resets backoffDelay,
+          // so a laptop waking into a previously failing reconnect cycle
+          // doesn't inherit the stale 8–10s backoff.
+          reconnectNow();
         } else {
-          // Brief background — probe with an immediate heartbeat ping
-          const result = heartbeat.sendPing(heartbeatState, Date.now());
-          processEffects(result);
+          // Brief background — same fast probe as focus/pageshow.
+          wakeProbe();
         }
       }
     });


### PR DESCRIPTION
## Summary

- After closing and reopening the laptop, Katulong sat on a stale tab for ~9s before reconnecting because `visibilitychange` doesn't reliably fire on macOS lid-close.
- Added `focus` and `pageshow` listeners that run a `wakeProbe()`: immediate reconnect if the socket isn't OPEN, otherwise a 2s ping-deadline that force-reconnects on timeout — vs. the 8s heartbeat timeout.
- Reuses existing heartbeat state + `handleDisconnect` re-entrancy guard, so stacking focus/pageshow/visibility events doesn't double-trigger.

## Test plan

- [x] `npm run test:unit` (all 2173 pass)
- [ ] Manual: close lid for 30s, reopen — connection indicator should recover within ~2s instead of ~9s
- [ ] Manual: alt-tab away and back with a healthy connection — no visible reconnect churn