### PR TITLE
Feed narrative: thin-event model + transcript slices + topic purge

### DIFF
--- a/Formula/katulong.rb
+++ b/Formula/katulong.rb
@@ -53,6 +53,12 @@ class Katulong < Formula
         katulong start
 
       If the service is installed, brew upgrade restarts it automatically.
+
+      Upgrading from a pre-v0.56 build? The pub/sub directory may contain
+      stale topics left behind by retired releases (high-volume PTY output
+      streams, and pre-thin-event Claude session logs). Run:
+        katulong topics purge             # preview (dry-run, default)
+        katulong topics purge --yes       # delete the previewed topics
     EOS
   end
 

--- a/docs/claude-event-stream.md
+++ b/docs/claude-event-stream.md
@@ -1,5 +1,33 @@
 # Claude Event Stream — Live Agent Activity via Hooks
 
+> **⚠️ This document is mid-rewrite (as of 2026-04-14).**
+>
+> The architecture described below — "thin translator publishes every
+> transformed hook event to the topic broker" — has been superseded by a
+> **thin-event** model on the `worktree-feed-narrative` branch. In the new
+> model, the Claude transcript JSONL on disk is the source of truth, and
+> the pub/sub carries only *synthesized* output (narrative chunks,
+> completion / attention cards, session summaries) produced by a narrative
+> processor. Raw tool-call detail is fetched on demand from the transcript.
+>
+> Sections that are stale under the new model:
+> - Principle #3 ("thin translator") — the `/api/claude-events` handler no
+>   longer publishes; it ingests into the narrative processor, which owns
+>   all publishing *and* topic creation (lazy — topics only appear once
+>   something meaningful is synthesized, so `/clear` / `/resume` / empty
+>   sessions no longer clutter the picker).
+> - "Translation rules" table — those `step` / `status` mappings still
+>   exist inside `lib/claude-event-transform.js`, but they are no longer
+>   surfaced on the topic. They're only used as input to the narrative
+>   processor's Ollama prompt.
+> - "What stays as-is" → feed tile — the renderer code is unchanged, but
+>   Claude topics now carry only `narrative` / `completion` / `attention`
+>   / `summary` statuses.
+>
+> This doc will be fully rewritten once the follow-on pieces land:
+> narrative processor reading transcript slices directly, and a
+> `GET /api/claude-transcript/:session_id` endpoint for on-demand detail.
+
 ## The problem we're solving
 
 Claude Code sessions running inside katulong terminals are opaque.

--- a/lib/claude-event-transform.js
+++ b/lib/claude-event-transform.js
@@ -14,7 +14,6 @@
 import { readFileSync } from "node:fs";
 
 const MAX_DETAIL_LENGTH = 200;
-const MAX_TEXT_LENGTH = 500;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
@@ -108,6 +107,15 @@ export function transformClaudeEvent(payload) {
       break;
     }
 
+    case "PreToolUse": {
+      const tool = payload.tool_name || "Unknown";
+      const target = extractTarget(tool, payload.tool_input);
+      step = target ? `${tool} ${target}` : tool;
+      status = "pending";
+      detail = "";
+      break;
+    }
+
     case "PostToolUse": {
       const tool = payload.tool_name || "Unknown";
       const target = extractTarget(tool, payload.tool_input);
@@ -172,55 +180,113 @@ export function transformClaudeEvent(payload) {
   };
 }
 
-// --- Transcript text extraction ---
+// --- Transcript slice reading ---
 
-// Per-session tracking of how many assistant entries we've seen,
-// so we only emit new text blocks.
-const seenAssistantCounts = new Map();
+const TRANSCRIPT_TEXT_MAX = 1000;
+const TRANSCRIPT_RESULT_MAX = 500;
 
 /**
- * Extract new assistant text blocks from the transcript file.
+ * Read transcript JSONL entries starting from a given line index and
+ * return them as normalized, narrator-friendly records.
  *
- * Reads the JSONL transcript, finds assistant entries with text content
- * blocks, and returns only the ones we haven't seen before (tracked
- * per session_id).
+ * This is the primary hook the narrative processor uses under the
+ * thin-event model: the Claude transcript on disk is the source of
+ * truth for what happened in a session, and the pub/sub only carries
+ * synthesized output. Each flush advances a per-topic cursor, so we
+ * read only the new slice of the transcript.
  *
- * @param {string} transcriptPath - Path to the JSONL transcript
- * @param {string} sessionId - Claude session UUID
- * @returns {string[]} Array of text strings from new assistant entries
+ * Counting is by *significant* (non-blank) line number. Blank trailing
+ * lines from the JSONL writer don't shift the cursor.
+ *
+ * @param {string} transcriptPath Absolute path to the JSONL transcript
+ * @param {number} fromLine       Cursor: skip this many significant lines
+ * @returns {{ entries: object[], nextCursor: number }}
+ *   entries: normalized records with shape { role, text?, tools?, tool_result? }
+ *   nextCursor: the new cursor value to persist for the next call
  */
-export function extractNewAssistantText(transcriptPath, sessionId) {
-  if (!transcriptPath || typeof transcriptPath !== "string") return [];
+export function readTranscriptEntries(transcriptPath, fromLine = 0) {
+  if (!transcriptPath || typeof transcriptPath !== "string") {
+    return { entries: [], nextCursor: fromLine };
+  }
 
-  let lines;
+  let raw;
   try {
-    lines = readFileSync(transcriptPath, "utf8").split("\n");
+    raw = readFileSync(transcriptPath, "utf8");
   } catch {
-    return [];
+    return { entries: [], nextCursor: fromLine };
   }
 
-  // Collect all assistant text entries
-  const allTexts = [];
-  for (const line of lines) {
-    if (!line.trim()) continue;
+  const significant = raw.split("\n").filter(l => l.trim());
+  if (fromLine >= significant.length) {
+    return { entries: [], nextCursor: significant.length };
+  }
+
+  const entries = [];
+  for (let i = fromLine; i < significant.length; i++) {
     let obj;
-    try { obj = JSON.parse(line); } catch { continue; }
-    if (obj.type !== "assistant") continue;
-    const content = obj.message?.content;
-    if (!Array.isArray(content)) continue;
-    for (const block of content) {
-      if (block.type === "text" && block.text) {
-        allTexts.push(block.text);
-      }
+    try { obj = JSON.parse(significant[i]); } catch { continue; }
+    const normalized = normalizeTranscriptEntry(obj);
+    if (normalized) entries.push(normalized);
+  }
+  return { entries, nextCursor: significant.length };
+}
+
+/**
+ * Convert one raw transcript JSONL entry into a narrator-friendly record.
+ * Returns null for entries we don't care about (session metadata, pure
+ * thinking blocks, etc.) so the caller can ignore the noise.
+ *
+ * Shapes:
+ *   user prompt     → { role: "user", text }
+ *   tool result     → { role: "tool_result", text }
+ *   assistant turn  → { role: "assistant", text?, tools?: [{ name, input }] }
+ */
+function normalizeTranscriptEntry(obj) {
+  if (!obj || typeof obj !== "object") return null;
+  const type = obj.type;
+  const content = obj.message?.content;
+
+  if (type === "user") {
+    if (typeof content === "string") {
+      return { role: "user", text: truncate(content, TRANSCRIPT_TEXT_MAX) };
     }
+    if (!Array.isArray(content)) return null;
+
+    // tool_result blocks mean this "user" entry is actually a tool response
+    const toolResults = content.filter(b => b && b.type === "tool_result");
+    if (toolResults.length > 0) {
+      const text = toolResults.map(b => stringifyContent(b.content)).filter(Boolean).join("\n");
+      if (!text) return null;
+      return { role: "tool_result", text: truncate(text, TRANSCRIPT_RESULT_MAX) };
+    }
+
+    const text = content.filter(b => b && b.type === "text" && b.text)
+      .map(b => b.text).join("\n");
+    if (!text) return null;
+    return { role: "user", text: truncate(text, TRANSCRIPT_TEXT_MAX) };
   }
 
-  const prevCount = seenAssistantCounts.get(sessionId) || 0;
-  seenAssistantCounts.set(sessionId, allTexts.length);
+  if (type === "assistant") {
+    if (!Array.isArray(content)) return null;
+    const text = content.filter(b => b && b.type === "text" && b.text)
+      .map(b => b.text).join("\n");
+    const tools = content.filter(b => b && b.type === "tool_use")
+      .map(b => ({ name: b.name, input: b.input || {} }));
+    if (!text && tools.length === 0) return null;
+    const out = { role: "assistant" };
+    if (text) out.text = truncate(text, TRANSCRIPT_TEXT_MAX);
+    if (tools.length > 0) out.tools = tools;
+    return out;
+  }
 
-  // Return only new entries
-  if (allTexts.length <= prevCount) return [];
-  return allTexts.slice(prevCount).map(t =>
-    t.length > MAX_TEXT_LENGTH ? t.slice(0, MAX_TEXT_LENGTH - 1) + "\u2026" : t
-  );
+  return null;
+}
+
+function stringifyContent(c) {
+  if (typeof c === "string") return c;
+  if (Array.isArray(c)) {
+    return c.filter(b => b && b.type === "text" && b.text)
+      .map(b => b.text).join("\n");
+  }
+  return "";
 }

--- a/lib/cli/commands/topics.js
+++ b/lib/cli/commands/topics.js
@@ -1,14 +1,33 @@
 /**
  * CLI: katulong topics
  *
- * List active pub/sub topics and subscriber counts.
+ * Subcommands:
+ *   list              List active pub/sub topics (default)
+ *   purge [--yes]     Identify and optionally delete noise topics
+ *                     left over from retired releases.
  */
 
 import { ensureRunning, api } from "../api-client.js";
 
-export default async function topics(args) {
-  const jsonMode = args.includes("--json");
+const VALUABLE_STATUSES = new Set([
+  "narrative", "completion", "attention", "summary",
+]);
 
+export default async function topics(args) {
+  const hasSubcommand = args[0] && !args[0].startsWith("--");
+  const sub = hasSubcommand ? args[0] : "list";
+  const rest = hasSubcommand ? args.slice(1) : args;
+
+  if (sub === "list") return list(rest);
+  if (sub === "purge") return purge(rest);
+
+  console.error(`Unknown subcommand: ${sub}`);
+  console.error("Usage: katulong topics [list|purge] [options]");
+  process.exit(1);
+}
+
+async function list(args) {
+  const jsonMode = args.includes("--json");
   ensureRunning();
 
   try {
@@ -30,4 +49,98 @@ export default async function topics(args) {
     console.error(`✗ ${err.message}`);
     process.exit(1);
   }
+}
+
+async function purge(args) {
+  const confirm = args.includes("--yes");
+  ensureRunning();
+
+  let topics;
+  try {
+    // ?all=1 so retired `sessions/*/output` topics come through —
+    // `/api/topics` hides them from the feed-tile picker by default.
+    topics = await api.get("/api/topics?all=1");
+  } catch (err) {
+    console.error(`✗ ${err.message}`);
+    process.exit(1);
+  }
+
+  const drop = [];
+  const keep = [];
+
+  for (const t of topics) {
+    const name = t.name;
+    if (name.endsWith("/output")) {
+      drop.push({ name, reason: "retired /output topic" });
+      continue;
+    }
+    if (!name.startsWith("claude/")) {
+      keep.push({ name, reason: "not a claude topic" });
+      continue;
+    }
+    // Claude topic — inspect status counts
+    let stats;
+    try {
+      stats = await api.get(`/api/topics/${encodeTopic(name)}/stats`);
+    } catch (err) {
+      keep.push({ name, reason: `stats error: ${err.message}` });
+      continue;
+    }
+    const hasValue = Object.keys(stats.byStatus || {})
+      .some(s => VALUABLE_STATUSES.has(s));
+    if (!hasValue) {
+      const summary = summarizeStatuses(stats.byStatus);
+      drop.push({ name, reason: `no narrative/completion/attention (${summary})` });
+    } else {
+      const summary = summarizeStatuses(stats.byStatus);
+      keep.push({ name, reason: summary });
+    }
+  }
+
+  console.log(`\n${drop.length} topic${drop.length !== 1 ? "s" : ""} to delete:\n`);
+  for (const { name, reason } of drop) {
+    console.log(`  - ${name.padEnd(50)} ${reason}`);
+  }
+  console.log(`\n${keep.length} topic${keep.length !== 1 ? "s" : ""} to keep:\n`);
+  for (const { name, reason } of keep) {
+    console.log(`  = ${name.padEnd(50)} ${reason}`);
+  }
+
+  if (!confirm) {
+    console.log("\nDry run — re-run with --yes to delete.");
+    return;
+  }
+
+  if (drop.length === 0) {
+    console.log("\nNothing to delete.");
+    return;
+  }
+
+  console.log("");
+  let deleted = 0;
+  let failed = 0;
+  for (const { name } of drop) {
+    try {
+      await api.del(`/api/topics/${encodeTopic(name)}`);
+      deleted++;
+      console.log(`  ✓ deleted ${name}`);
+    } catch (err) {
+      failed++;
+      console.log(`  ✗ ${name} — ${err.message}`);
+    }
+  }
+  console.log(`\nDeleted ${deleted}, failed ${failed}.`);
+}
+
+function encodeTopic(name) {
+  // Topic names may contain "/"; encode each segment so the path
+  // reaches the prefix router intact.
+  return name.split("/").map(encodeURIComponent).join("/");
+}
+
+function summarizeStatuses(byStatus) {
+  if (!byStatus || Object.keys(byStatus).length === 0) return "empty log";
+  return Object.entries(byStatus)
+    .map(([s, n]) => `${s}:${n}`)
+    .join(", ");
 }

--- a/lib/narrative-processor.js
+++ b/lib/narrative-processor.js
@@ -1,34 +1,37 @@
 /**
  * Narrative Processor
  *
- * Transforms raw Claude Code hook events into a running narrative —
+ * Transforms a Claude Code session's transcript into a running narrative —
  * a conversational, blog-like stream with prose, code snippets, and
- * observations. Uses a local Ollama model to process batches of
- * accumulated events into markdown narrative chunks.
+ * observations. Uses a local Ollama model to process new transcript
+ * slices into markdown narrative chunks.
  *
- * Architecture:
- *   Raw events arrive one at a time via ingest(). They accumulate in
- *   a per-topic buffer. On trigger (Stop events, buffer threshold),
- *   the buffer is flushed to Ollama for narrative synthesis. The
- *   resulting markdown is published back to the same topic as a
- *   status="narrative" event that the feed tile renders as rich content.
+ * Architecture (thin-event model):
+ *   Hook events arrive via ingest() but are used only as triggers and for
+ *   synchronous attention/completion cards. The actual narrative material
+ *   is read from the Claude transcript JSONL on disk — that file is the
+ *   source of truth for what happened. Each topic maintains a cursor (a
+ *   line offset into the transcript) so every flush processes only the
+ *   slice since the last synthesis. This gives the narrator richer,
+ *   unlossy input than the hook payloads it used to receive.
  *
  * Conversation continuity:
  *   Each topic maintains a rolling summary so the model has context of
- *   the entire session, not just the latest batch. The summary is
+ *   the entire session, not just the latest slice. The summary is
  *   updated with each narrative chunk.
  */
 
 import { log as logger } from "./log.js";
+import { readTranscriptEntries } from "./claude-event-transform.js";
 
-const BATCH_THRESHOLD = 8;       // flush after N events
+const BATCH_THRESHOLD = 8;       // flush after N trigger events
 const FLUSH_DELAY_MS = 5000;     // debounce after trigger event
 const MAX_SUMMARY_LENGTH = 2000; // rolling summary cap
 const OLLAMA_TIMEOUT_MS = 60000; // max wait for ollama response
 const OLLAMA_URL = process.env.OLLAMA_URL || "http://localhost:11434";
 const OLLAMA_MODEL = process.env.OLLAMA_MODEL || "gemma4:31b-cloud";
 
-const SYSTEM_PROMPT = `You are a narrator for a live coding session. You receive batches of raw tool-use events from a Claude Code session and transform them into a running narrative — like a developer's blog post being written in real time.
+const SYSTEM_PROMPT = `You are a narrator for a live coding session. You receive slices of a Claude Code session transcript — user prompts, assistant reasoning and tool calls, and tool results — and transform them into a running narrative, like a developer's blog post being written in real time.
 
 Respond in EXACTLY this format — two sections separated by a "---" line:
 
@@ -63,15 +66,24 @@ You'll also receive a SUMMARY of the narrative so far for continuity. Continue n
 class TopicNarrative {
   constructor(topic) {
     this.topic = topic;
-    this.buffer = [];
     this.summary = "";
     this.objective = "";
     this.flushTimer = null;
     this.flushing = false;
     // Stash of the most recent hook payload — used by ensureTopicMeta
-    // when we lazily create the topic on first publish.
+    // when we lazily create the topic on first publish, and to resolve
+    // the transcript path.
     this.lastPayload = null;
     this.metaReady = false;
+    // Transcript cursor: index into the significant-line count of the
+    // JSONL transcript. Advances only after a successful Ollama call, so
+    // transient failures retry the same slice rather than dropping it.
+    this.transcriptPath = null;
+    this.transcriptCursor = 0;
+    // Trigger accumulator — how many hook events have landed since the
+    // last flush. We no longer keep the events themselves; the transcript
+    // is canonical.
+    this.pendingEvents = 0;
   }
 }
 
@@ -112,6 +124,9 @@ export function createNarrativeProcessor({ topicBroker, ensureTopicMeta, maxConc
 
     const tn = getOrCreate(topic);
     tn.lastPayload = payload;
+    if (!tn.transcriptPath && typeof payload.transcript_path === "string") {
+      tn.transcriptPath = payload.transcript_path;
+    }
 
     // PreToolUse events mean Claude is waiting for tool approval
     if (message.event === "PreToolUse" && payload.tool_name) {
@@ -135,30 +150,14 @@ export function createNarrativeProcessor({ topicBroker, ensureTopicMeta, maxConc
       publishStopCard(tn, text);
     }
 
-    // Build a compact event summary for the batch
-    const entry = {
-      event: message.event,
-      step: message.step,
-      status: message.status,
-      detail: message.detail || undefined,
-      tool: message.tool || undefined,
-    };
+    tn.pendingEvents += 1;
 
-    // Add extra context from payload when available
-    if (payload.tool_input && message.tool) {
-      entry.input = compactInput(message.tool, payload.tool_input);
-    }
-    if (payload.tool_response) {
-      const resp = compactResponse(payload.tool_response);
-      if (resp) entry.response = resp;
-    }
-
-    tn.buffer.push(entry);
-
-    // Trigger events flush immediately (with debounce)
+    // Trigger events schedule a flush (debounced). At flush time we read
+    // the transcript slice since the last cursor — the hook events
+    // themselves are not stored.
     const isTrigger = message.event === "Stop" ||
                       message.event === "SessionEnd" ||
-                      tn.buffer.length >= BATCH_THRESHOLD;
+                      tn.pendingEvents >= BATCH_THRESHOLD;
 
     if (isTrigger) {
       scheduleFlush(tn);
@@ -203,13 +202,13 @@ export function createNarrativeProcessor({ topicBroker, ensureTopicMeta, maxConc
   }
 
   async function flush(tn) {
-    if (tn.flushing || tn.buffer.length === 0) return;
+    if (tn.flushing) return;
 
-    // Global concurrency cap — drop this flush if at capacity.
-    // Events stay in the buffer and will be picked up next time.
+    // Global concurrency cap — skip this flush if at capacity. The cursor
+    // is not advanced and pendingEvents is preserved, so the slice will be
+    // picked up on the next scheduled flush.
     if (activeCalls >= maxConcurrent) {
       logger.info("narrative-processor", `Skipping flush for ${tn.topic} — ${activeCalls}/${maxConcurrent} calls active`);
-      // Reschedule so the buffer eventually drains
       scheduleFlush(tn);
       return;
     }
@@ -217,20 +216,31 @@ export function createNarrativeProcessor({ topicBroker, ensureTopicMeta, maxConc
     tn.flushing = true;
     tn.flushTimer = null;
 
-    const batch = tn.buffer.splice(0);
+    const startCursor = tn.transcriptCursor;
+    const { entries, nextCursor } = readTranscriptEntries(tn.transcriptPath, startCursor);
 
-    // Empty-session filter — a batch made entirely of SessionStart / SessionEnd
-    // (or bookkeeping events with no user prompt and no tool use) has nothing
-    // worth narrating. Skip the Ollama call so we don't spend tokens, and more
-    // importantly so we don't lazy-create a topic for a session that did
-    // nothing. This is what kills the /clear and /resume junk feeds.
-    if (!hasRealWork(batch)) {
+    // Nothing new on disk — nothing to narrate. Clear the trigger counter
+    // and exit without creating a topic.
+    if (entries.length === 0) {
+      tn.pendingEvents = 0;
+      tn.flushing = false;
+      return;
+    }
+
+    // Empty-session filter — a slice with no user prompt and no assistant
+    // tool use (e.g., /clear, /resume, cancelled turns) has nothing worth
+    // narrating. Advance the cursor past the junk so we don't re-examine
+    // these same entries forever, and exit without calling Ollama or
+    // creating a topic.
+    if (!hasRealWork(entries)) {
+      tn.transcriptCursor = nextCursor;
+      tn.pendingEvents = 0;
       tn.flushing = false;
       return;
     }
 
     activeCalls++;
-    const prompt = buildPrompt(batch, tn.summary);
+    const prompt = buildPrompt(entries, tn.summary);
 
     try {
       const raw = await callOllama(prompt);
@@ -238,10 +248,8 @@ export function createNarrativeProcessor({ topicBroker, ensureTopicMeta, maxConc
         const { objective, narrative } = parseResponse(raw.trim());
 
         if (narrative) {
-          // Extract unique file paths touched in this batch
-          const files = extractFiles(batch);
+          const files = extractFiles(entries);
 
-          // Publish the narrative chunk
           publish(tn, JSON.stringify({
             step: narrative,
             status: "narrative",
@@ -251,13 +259,11 @@ export function createNarrativeProcessor({ topicBroker, ensureTopicMeta, maxConc
             files,
           }));
 
-          // Update rolling summary
           tn.summary = updateSummary(tn.summary, narrative);
         }
 
         if (objective && objective !== tn.objective) {
           tn.objective = objective;
-          // Publish updated session objective as a sticky summary
           publish(tn, JSON.stringify({
             step: objective,
             status: "summary",
@@ -267,24 +273,30 @@ export function createNarrativeProcessor({ topicBroker, ensureTopicMeta, maxConc
           }));
         }
       }
+
+      // Advance cursor only on a successful round-trip. If Ollama returned
+      // an empty body we still advance — the model chose to say nothing
+      // about this slice and we shouldn't re-feed it indefinitely.
+      tn.transcriptCursor = nextCursor;
+      tn.pendingEvents = 0;
     } catch (err) {
       logger.warn("narrative-processor", `Failed to generate narrative for ${tn.topic}: ${err.message}`);
-      // Put events back so they're not lost
-      tn.buffer.unshift(...batch);
+      // Cursor is NOT advanced — the same slice will be retried on the
+      // next flush. pendingEvents is also preserved so a subsequent
+      // trigger event doesn't have to wait for a fresh threshold.
     } finally {
       activeCalls--;
       tn.flushing = false;
-      // If more events arrived while flushing, schedule another
-      if (tn.buffer.length > 0) scheduleFlush(tn);
+      if (tn.pendingEvents > 0) scheduleFlush(tn);
     }
   }
 
-  function buildPrompt(batch, summary) {
+  function buildPrompt(entries, summary) {
     const parts = [];
     if (summary) {
       parts.push(`NARRATIVE SO FAR:\n${summary}\n`);
     }
-    parts.push(`NEW EVENTS:\n${JSON.stringify(batch, null, 2)}`);
+    parts.push(`TRANSCRIPT SLICE:\n${JSON.stringify(entries, null, 2)}`);
     parts.push("\nWrite the next narrative chunk (2-6 sentences, markdown). Output ONLY the markdown, no preamble.");
     return parts.join("\n");
   }
@@ -371,16 +383,15 @@ function parseResponse(text) {
 }
 
 /**
- * Extract unique file paths (with optional line numbers) from a batch.
- * Returns Array<{ path: string, line?: number }>.
+ * Extract unique file paths (with optional line numbers) from the tool_use
+ * blocks inside a transcript slice. Returns Array<{ path, line? }>.
  *
- * Line numbers come from:
- *   - Read tool: input.offset (the starting line)
- *   - Edit tool: parse tool_response for line mentions
- *   - Grep response: "filename:linenum:" patterns
+ * We walk assistant entries' `tools` arrays — each tool_use carries its
+ * raw input, which is richer than any hook-payload-compacted form. Line
+ * numbers come from Read.offset where available.
  */
-function extractFiles(batch) {
-  // Map path → best line number seen (first wins)
+function extractFiles(entries) {
+  // Map path → first line number seen
   const seen = new Map();
 
   function add(path, line) {
@@ -390,36 +401,34 @@ function extractFiles(batch) {
     }
   }
 
-  for (const entry of batch) {
-    // File path from Read/Write/Edit tool input
-    const file = entry.input?.file;
-    if (file) {
-      add(file, entry.input?.line);
-      continue;
-    }
-    // Grep/Glob path
-    const path = entry.input?.path;
-    if (path && typeof path === "string" && !path.includes("*")) {
-      // Try to extract line from grep response ("filename:123:")
-      let grepLine;
-      if (entry.response && typeof entry.response === "string") {
-        const m = entry.response.match(/:(\d+):/);
-        if (m) grepLine = parseInt(m[1], 10);
+  for (const entry of entries) {
+    if (entry.role !== "assistant" || !Array.isArray(entry.tools)) continue;
+    for (const t of entry.tools) {
+      const input = t.input || {};
+      switch (t.name) {
+        case "Read":
+          add(input.file_path, input.offset);
+          break;
+        case "Write":
+        case "Edit":
+          add(input.file_path);
+          break;
+        case "Grep":
+        case "Glob":
+          if (typeof input.path === "string" && !input.path.includes("*")) {
+            add(input.path);
+          }
+          break;
+        case "Bash": {
+          // Pull a cd target out of the command if there is one
+          const cmd = typeof input.command === "string" ? input.command : "";
+          const cdMatch = cmd.match(/^cd\s+["']?([^"';&|]+)/);
+          if (cdMatch) add(cdMatch[1].trim());
+          break;
+        }
+        default:
+          break;
       }
-      add(path, grepLine);
-      continue;
-    }
-    // Bash commands that reference paths (cd, ls)
-    const cmd = entry.input?.cmd;
-    if (cmd && typeof cmd === "string") {
-      const cdMatch = cmd.match(/^cd\s+["']?([^"';&|]+)/);
-      if (cdMatch) { add(cdMatch[1].trim()); continue; }
-    }
-    // Fall back to step text like "Read feed.js" / "Edit index.html"
-    const step = entry.step;
-    if (step && typeof step === "string" && entry.tool) {
-      const m = step.match(/^(?:Read|Edit|Write)\s+(.+)/);
-      if (m) add(m[1].trim());
     }
   }
   return [...seen.entries()].map(([path, line]) =>
@@ -428,49 +437,18 @@ function extractFiles(batch) {
 }
 
 /**
- * Does this batch contain anything worth narrating? Sessions that only
- * emit SessionStart / SessionEnd (e.g., /clear, /resume, cancelled prompts)
- * or that emit a single Stop with no content are noise. We treat
- * UserPromptSubmit (non-empty) or any PostToolUse as evidence of real work.
+ * Does this slice contain anything worth narrating? Sessions that only
+ * emit session metadata (e.g., /clear, /resume, cancelled turns before
+ * any work) produce no user prompt and no assistant activity. We treat a
+ * user prompt with content or any assistant entry (text or tool use) as
+ * evidence of real work.
  */
-function hasRealWork(batch) {
-  for (const e of batch) {
-    if (e.event === "PostToolUse") return true;
-    if (e.event === "UserPromptSubmit" && e.step && !e.step.includes("(empty)")) return true;
+function hasRealWork(entries) {
+  for (const e of entries) {
+    if (e.role === "user" && e.text) return true;
+    if (e.role === "assistant" && (e.text || (e.tools && e.tools.length > 0))) return true;
   }
   return false;
-}
-
-// --- Helpers to compact payloads for the LLM ---
-
-function compactInput(tool, input) {
-  if (!input || typeof input !== "object") return undefined;
-  switch (tool) {
-    case "Read":
-      return { file: input.file_path, line: input.offset || undefined };
-    case "Write":
-      return { file: input.file_path };
-    case "Edit":
-      return { file: input.file_path };
-    case "Bash":
-      return { cmd: (input.command || "").slice(0, 200) };
-    case "Grep":
-      return { pattern: input.pattern, path: input.path };
-    case "Glob":
-      return { pattern: input.pattern };
-    case "Agent":
-      return { desc: input.description, type: input.subagent_type };
-    default:
-      return undefined;
-  }
-}
-
-function compactResponse(resp) {
-  if (!resp) return undefined;
-  const str = typeof resp === "string" ? resp
-    : resp.stdout || resp.content || resp.result || "";
-  if (!str || typeof str !== "string") return undefined;
-  return str.slice(0, 300);
 }
 
 /**

--- a/lib/narrative-processor.js
+++ b/lib/narrative-processor.js
@@ -1,0 +1,506 @@
+/**
+ * Narrative Processor
+ *
+ * Transforms raw Claude Code hook events into a running narrative —
+ * a conversational, blog-like stream with prose, code snippets, and
+ * observations. Uses a local Ollama model to process batches of
+ * accumulated events into markdown narrative chunks.
+ *
+ * Architecture:
+ *   Raw events arrive one at a time via ingest(). They accumulate in
+ *   a per-topic buffer. On trigger (Stop events, buffer threshold),
+ *   the buffer is flushed to Ollama for narrative synthesis. The
+ *   resulting markdown is published back to the same topic as a
+ *   status="narrative" event that the feed tile renders as rich content.
+ *
+ * Conversation continuity:
+ *   Each topic maintains a rolling summary so the model has context of
+ *   the entire session, not just the latest batch. The summary is
+ *   updated with each narrative chunk.
+ */
+
+import { log as logger } from "./log.js";
+
+const BATCH_THRESHOLD = 8;       // flush after N events
+const FLUSH_DELAY_MS = 5000;     // debounce after trigger event
+const MAX_SUMMARY_LENGTH = 2000; // rolling summary cap
+const OLLAMA_TIMEOUT_MS = 60000; // max wait for ollama response
+const OLLAMA_URL = process.env.OLLAMA_URL || "http://localhost:11434";
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL || "gemma4:31b-cloud";
+
+const SYSTEM_PROMPT = `You are a narrator for a live coding session. You receive batches of raw tool-use events from a Claude Code session and transform them into a running narrative — like a developer's blog post being written in real time.
+
+Respond in EXACTLY this format — two sections separated by a "---" line:
+
+OBJECTIVE: <one sentence describing the overall goal of this session — what are we trying to accomplish?>
+---
+<narrative chunk: 2-4 sentences continuing the story>
+
+Guidelines for the narrative chunk:
+- Focus on the WHY, not just the WHAT — "Reading the auth module to understand the session flow" not "Read auth.js"
+- When code is being edited, mention what changed and why (infer from context)
+- Group related tool calls into a single narrative beat — don't enumerate every file read
+- Use inline \`code\` for file names, function names, variables
+- Skip routine operations (cd, ls) unless they reveal something interesting
+- If the session is exploring/searching, say what it's looking for
+- If there's a bug being fixed, track the investigation arc
+- Keep each chunk short — this is a stream, not an essay
+- Never start with "The session" or "Claude" — vary your openings
+- Write in present tense
+- Use markdown formatting
+
+Guidelines for the OBJECTIVE line:
+- One sentence, plain text (no markdown)
+- Capture the high-level goal, not the current step
+- Update it as the session's focus evolves
+- Example: "Building a narrative feed that summarizes Claude Code sessions into blog-like updates"
+
+You'll also receive a SUMMARY of the narrative so far for continuity. Continue naturally from where it left off.`;
+
+/**
+ * Per-topic state for narrative processing.
+ */
+class TopicNarrative {
+  constructor(topic) {
+    this.topic = topic;
+    this.buffer = [];
+    this.summary = "";
+    this.objective = "";
+    this.flushTimer = null;
+    this.flushing = false;
+    // Stash of the most recent hook payload — used by ensureTopicMeta
+    // when we lazily create the topic on first publish.
+    this.lastPayload = null;
+    this.metaReady = false;
+  }
+}
+
+export function createNarrativeProcessor({ topicBroker, ensureTopicMeta, maxConcurrent = 1 }) {
+  const topics = new Map();
+  let enabled = true;
+  let activeCalls = 0;
+
+  function getOrCreate(topic) {
+    let tn = topics.get(topic);
+    if (!tn) {
+      tn = new TopicNarrative(topic);
+      topics.set(topic, tn);
+    }
+    return tn;
+  }
+
+  // Lazy publisher: creates the topic (via ensureTopicMeta) the first time
+  // something meaningful is about to be published. This is how sessions that
+  // never produce narrative / attention / completion stay invisible.
+  function publish(tn, message) {
+    if (!tn.metaReady && ensureTopicMeta && tn.lastPayload) {
+      ensureTopicMeta(tn.topic, tn.lastPayload);
+      tn.metaReady = true;
+    }
+    topicBroker.publish(tn.topic, message);
+  }
+
+  /**
+   * Ingest a raw event. Call this from the claude-events route handler.
+   *
+   * @param {string} topic - The topic name (e.g., "claude/{sessionId}")
+   * @param {object} message - The transformed event message (step/status/detail/event/tool)
+   * @param {object} payload - The original hook payload (for extra context)
+   */
+  function ingest(topic, message, payload) {
+    if (!enabled) return;
+
+    const tn = getOrCreate(topic);
+    tn.lastPayload = payload;
+
+    // PreToolUse events mean Claude is waiting for tool approval
+    if (message.event === "PreToolUse" && payload.tool_name) {
+      const tool = payload.tool_name;
+      const target = message.step || tool;
+      publish(tn, JSON.stringify({
+        step: `Approve **${tool}**: \`${target}\`?\n\n1. Yes\n2. No`,
+        status: "attention",
+        detail: "",
+        event: "Attention",
+        tool,
+      }));
+    }
+
+    // Stop events produce an immediate completion or attention card
+    // (separate from the Ollama narrative pipeline)
+    if (message.event === "Stop") {
+      const text = typeof payload.last_assistant_message === "string"
+        ? payload.last_assistant_message
+        : (message.detail || "");
+      publishStopCard(tn, text);
+    }
+
+    // Build a compact event summary for the batch
+    const entry = {
+      event: message.event,
+      step: message.step,
+      status: message.status,
+      detail: message.detail || undefined,
+      tool: message.tool || undefined,
+    };
+
+    // Add extra context from payload when available
+    if (payload.tool_input && message.tool) {
+      entry.input = compactInput(message.tool, payload.tool_input);
+    }
+    if (payload.tool_response) {
+      const resp = compactResponse(payload.tool_response);
+      if (resp) entry.response = resp;
+    }
+
+    tn.buffer.push(entry);
+
+    // Trigger events flush immediately (with debounce)
+    const isTrigger = message.event === "Stop" ||
+                      message.event === "SessionEnd" ||
+                      tn.buffer.length >= BATCH_THRESHOLD;
+
+    if (isTrigger) {
+      scheduleFlush(tn);
+    }
+  }
+
+  /**
+   * Publish an immediate completion or attention card from a Stop event.
+   * Determines whether Claude finished or is asking the user something.
+   * Returns early (without publishing, and thus without creating the topic)
+   * when Stop has no text — that's the /clear / empty-session case.
+   */
+  function publishStopCard(tn, text) {
+    if (!text) return;
+
+    const needsAttention = detectAttention(text);
+
+    if (needsAttention) {
+      publish(tn, JSON.stringify({
+        step: text,
+        status: "attention",
+        detail: "",
+        event: "Attention",
+        tool: null,
+      }));
+    } else {
+      // Truncate to a reasonable summary length
+      const summary = text.length > 500 ? text.slice(0, 497) + "…" : text;
+      publish(tn, JSON.stringify({
+        step: summary,
+        status: "completion",
+        detail: "",
+        event: "Completion",
+        tool: null,
+      }));
+    }
+  }
+
+  function scheduleFlush(tn) {
+    if (tn.flushTimer) clearTimeout(tn.flushTimer);
+    tn.flushTimer = setTimeout(() => flush(tn), FLUSH_DELAY_MS);
+  }
+
+  async function flush(tn) {
+    if (tn.flushing || tn.buffer.length === 0) return;
+
+    // Global concurrency cap — drop this flush if at capacity.
+    // Events stay in the buffer and will be picked up next time.
+    if (activeCalls >= maxConcurrent) {
+      logger.info("narrative-processor", `Skipping flush for ${tn.topic} — ${activeCalls}/${maxConcurrent} calls active`);
+      // Reschedule so the buffer eventually drains
+      scheduleFlush(tn);
+      return;
+    }
+
+    tn.flushing = true;
+    tn.flushTimer = null;
+
+    const batch = tn.buffer.splice(0);
+
+    // Empty-session filter — a batch made entirely of SessionStart / SessionEnd
+    // (or bookkeeping events with no user prompt and no tool use) has nothing
+    // worth narrating. Skip the Ollama call so we don't spend tokens, and more
+    // importantly so we don't lazy-create a topic for a session that did
+    // nothing. This is what kills the /clear and /resume junk feeds.
+    if (!hasRealWork(batch)) {
+      tn.flushing = false;
+      return;
+    }
+
+    activeCalls++;
+    const prompt = buildPrompt(batch, tn.summary);
+
+    try {
+      const raw = await callOllama(prompt);
+      if (raw && raw.trim()) {
+        const { objective, narrative } = parseResponse(raw.trim());
+
+        if (narrative) {
+          // Extract unique file paths touched in this batch
+          const files = extractFiles(batch);
+
+          // Publish the narrative chunk
+          publish(tn, JSON.stringify({
+            step: narrative,
+            status: "narrative",
+            detail: "",
+            event: "Narrative",
+            tool: null,
+            files,
+          }));
+
+          // Update rolling summary
+          tn.summary = updateSummary(tn.summary, narrative);
+        }
+
+        if (objective && objective !== tn.objective) {
+          tn.objective = objective;
+          // Publish updated session objective as a sticky summary
+          publish(tn, JSON.stringify({
+            step: objective,
+            status: "summary",
+            detail: "",
+            event: "Summary",
+            tool: null,
+          }));
+        }
+      }
+    } catch (err) {
+      logger.warn("narrative-processor", `Failed to generate narrative for ${tn.topic}: ${err.message}`);
+      // Put events back so they're not lost
+      tn.buffer.unshift(...batch);
+    } finally {
+      activeCalls--;
+      tn.flushing = false;
+      // If more events arrived while flushing, schedule another
+      if (tn.buffer.length > 0) scheduleFlush(tn);
+    }
+  }
+
+  function buildPrompt(batch, summary) {
+    const parts = [];
+    if (summary) {
+      parts.push(`NARRATIVE SO FAR:\n${summary}\n`);
+    }
+    parts.push(`NEW EVENTS:\n${JSON.stringify(batch, null, 2)}`);
+    parts.push("\nWrite the next narrative chunk (2-6 sentences, markdown). Output ONLY the markdown, no preamble.");
+    return parts.join("\n");
+  }
+
+  /**
+   * Call Ollama's /api/chat endpoint. Returns the markdown response text.
+   */
+  async function callOllama(userPrompt) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), OLLAMA_TIMEOUT_MS);
+
+    try {
+      const res = await fetch(`${OLLAMA_URL}/api/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: controller.signal,
+        body: JSON.stringify({
+          model: OLLAMA_MODEL,
+          stream: false,
+          messages: [
+            { role: "system", content: SYSTEM_PROMPT },
+            { role: "user", content: userPrompt },
+          ],
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`Ollama ${res.status}: ${body.slice(0, 200)}`);
+      }
+
+      const data = await res.json();
+      return data.message?.content || "";
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  function updateSummary(existing, newChunk) {
+    const combined = existing
+      ? `${existing}\n\n${newChunk}`
+      : newChunk;
+
+    // If under limit, keep as-is
+    if (combined.length <= MAX_SUMMARY_LENGTH) return combined;
+
+    // Truncate from the front, keeping the most recent content
+    return combined.slice(combined.length - MAX_SUMMARY_LENGTH);
+  }
+
+  function destroy() {
+    enabled = false;
+    for (const tn of topics.values()) {
+      if (tn.flushTimer) clearTimeout(tn.flushTimer);
+    }
+    topics.clear();
+  }
+
+  return { ingest, destroy };
+}
+
+/**
+ * Parse the model's response into objective + narrative.
+ * Expected format:
+ *   OBJECTIVE: <text>
+ *   ---
+ *   <markdown narrative>
+ */
+function parseResponse(text) {
+  const divider = text.indexOf("\n---");
+  if (divider === -1) {
+    // No divider — treat entire response as narrative
+    return { objective: null, narrative: text };
+  }
+
+  const top = text.slice(0, divider).trim();
+  const bottom = text.slice(divider + 4).trim();
+
+  let objective = null;
+  const objMatch = top.match(/^OBJECTIVE:\s*(.+)/i);
+  if (objMatch) objective = objMatch[1].trim();
+
+  return { objective, narrative: bottom || null };
+}
+
+/**
+ * Extract unique file paths (with optional line numbers) from a batch.
+ * Returns Array<{ path: string, line?: number }>.
+ *
+ * Line numbers come from:
+ *   - Read tool: input.offset (the starting line)
+ *   - Edit tool: parse tool_response for line mentions
+ *   - Grep response: "filename:linenum:" patterns
+ */
+function extractFiles(batch) {
+  // Map path → best line number seen (first wins)
+  const seen = new Map();
+
+  function add(path, line) {
+    if (!path || typeof path !== "string") return;
+    if (!seen.has(path)) {
+      seen.set(path, typeof line === "number" && line > 0 ? line : undefined);
+    }
+  }
+
+  for (const entry of batch) {
+    // File path from Read/Write/Edit tool input
+    const file = entry.input?.file;
+    if (file) {
+      add(file, entry.input?.line);
+      continue;
+    }
+    // Grep/Glob path
+    const path = entry.input?.path;
+    if (path && typeof path === "string" && !path.includes("*")) {
+      // Try to extract line from grep response ("filename:123:")
+      let grepLine;
+      if (entry.response && typeof entry.response === "string") {
+        const m = entry.response.match(/:(\d+):/);
+        if (m) grepLine = parseInt(m[1], 10);
+      }
+      add(path, grepLine);
+      continue;
+    }
+    // Bash commands that reference paths (cd, ls)
+    const cmd = entry.input?.cmd;
+    if (cmd && typeof cmd === "string") {
+      const cdMatch = cmd.match(/^cd\s+["']?([^"';&|]+)/);
+      if (cdMatch) { add(cdMatch[1].trim()); continue; }
+    }
+    // Fall back to step text like "Read feed.js" / "Edit index.html"
+    const step = entry.step;
+    if (step && typeof step === "string" && entry.tool) {
+      const m = step.match(/^(?:Read|Edit|Write)\s+(.+)/);
+      if (m) add(m[1].trim());
+    }
+  }
+  return [...seen.entries()].map(([path, line]) =>
+    line ? { path, line } : { path }
+  );
+}
+
+/**
+ * Does this batch contain anything worth narrating? Sessions that only
+ * emit SessionStart / SessionEnd (e.g., /clear, /resume, cancelled prompts)
+ * or that emit a single Stop with no content are noise. We treat
+ * UserPromptSubmit (non-empty) or any PostToolUse as evidence of real work.
+ */
+function hasRealWork(batch) {
+  for (const e of batch) {
+    if (e.event === "PostToolUse") return true;
+    if (e.event === "UserPromptSubmit" && e.step && !e.step.includes("(empty)")) return true;
+  }
+  return false;
+}
+
+// --- Helpers to compact payloads for the LLM ---
+
+function compactInput(tool, input) {
+  if (!input || typeof input !== "object") return undefined;
+  switch (tool) {
+    case "Read":
+      return { file: input.file_path, line: input.offset || undefined };
+    case "Write":
+      return { file: input.file_path };
+    case "Edit":
+      return { file: input.file_path };
+    case "Bash":
+      return { cmd: (input.command || "").slice(0, 200) };
+    case "Grep":
+      return { pattern: input.pattern, path: input.path };
+    case "Glob":
+      return { pattern: input.pattern };
+    case "Agent":
+      return { desc: input.description, type: input.subagent_type };
+    default:
+      return undefined;
+  }
+}
+
+function compactResponse(resp) {
+  if (!resp) return undefined;
+  const str = typeof resp === "string" ? resp
+    : resp.stdout || resp.content || resp.result || "";
+  if (!str || typeof str !== "string") return undefined;
+  return str.slice(0, 300);
+}
+
+/**
+ * Detect whether Claude's last message is asking the user for input.
+ * Returns true if the message looks like a question or choice prompt.
+ *
+ * Key insight: numbered lists alone are NOT attention — Claude often
+ * summarises work as numbered items. Attention requires a question
+ * signal (question mark, question phrase) alongside options.
+ */
+function detectAttention(text) {
+  if (!text) return false;
+  const trimmed = text.trimEnd();
+  const lower = trimmed.toLowerCase();
+
+  // Check for question signals
+  const lines = trimmed.split("\n").filter(l => l.trim());
+  const lastLine = lines[lines.length - 1] || "";
+  const endsWithQuestion = lastLine.trimEnd().endsWith("?");
+
+  const questionPhrases = [
+    "would you like", "do you want", "shall i", "should i",
+    "which option", "please choose", "please select",
+    "let me know", "what would you prefer", "which approach",
+    "what do you think",
+  ];
+  const hasQuestionPhrase = questionPhrases.some(p => lower.includes(p));
+
+  // A question mark or question phrase is sufficient
+  if (endsWithQuestion || hasQuestionPhrase) return true;
+
+  return false;
+}

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -334,10 +334,15 @@ export function createAppRoutes(ctx) {
 
     { method: "GET", path: "/api/topics", handler: auth((req, res) => {
       if (!topicBroker) return json(res, 200, []);
-      // Filter out internal PTY output streams — they're high-volume
-      // binary terminal data, not meaningful events for feed tiles.
-      const topics = topicBroker.listTopics()
-        .filter(t => !t.name.endsWith("/output"));
+      // By default, filter out internal PTY output streams — they're
+      // high-volume binary terminal data, not meaningful events for
+      // feed tiles. Admin tooling (cleanup, diagnostics) passes
+      // ?all=1 to see the full list.
+      const url = new URL(req.url, "http://x");
+      const includeAll = url.searchParams.get("all") === "1";
+      const topics = includeAll
+        ? topicBroker.listTopics()
+        : topicBroker.listTopics().filter(t => !t.name.endsWith("/output"));
       json(res, 200, topics);
     })},
 
@@ -347,6 +352,17 @@ export function createAppRoutes(ctx) {
       const existed = topicBroker.deleteTopic(topic);
       json(res, existed ? 200 : 404, { ok: existed });
     }))},
+
+    // GET /api/topics/:topic/stats — message counts grouped by status.
+    // Cleanup tooling uses this to classify a topic as noise vs. value
+    // without replaying the whole log via SSE.
+    { method: "GET", prefix: "/api/topics/", handler: auth((req, res, param) => {
+      if (!topicBroker) return json(res, 503, { error: "Pub/sub not available" });
+      if (!param.endsWith("/stats")) return json(res, 404, { error: "Not found" });
+      const topic = param.slice(0, -6); // strip "/stats"
+      if (!topic || !/^[a-zA-Z0-9._\-/]+$/.test(topic) || /(^|\/)\.\.($|\/)/.test(topic)) return json(res, 400, { error: "Invalid topic" });
+      json(res, 200, topicBroker.getTopicStats(topic));
+    })},
 
     // Topic names may contain slashes (e.g. "claude/session-abc"), so the
     // param from the prefix route will be "claude/session-abc/meta". We use

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -20,10 +20,11 @@ import { SessionName } from "../session-name.js";
 import { loadShortcuts, saveShortcuts } from "../shortcuts.js";
 import { log } from "../log.js";
 import { rewriteVendorUrls } from "../static-files.js";
-import { captureVisiblePane } from "../tmux.js";
+import { captureVisiblePane, tmuxSocketArgs } from "../tmux.js";
 import { bridgeClipboardToContainers, bridgePaneContainer } from "../container-detect.js";
 import { readRawBody } from "../request-util.js";
-import { transformClaudeEvent, extractNewAssistantText } from "../claude-event-transform.js";
+import { transformClaudeEvent } from "../claude-event-transform.js";
+import { createNarrativeProcessor } from "../narrative-processor.js";
 import {
   MAX_UPLOAD_BYTES, detectImage, imageMimeType, setClipboard,
 } from "./upload.js";
@@ -36,6 +37,30 @@ export function createAppRoutes(ctx) {
     getDraining, shortcutsPath,
     auth, csrf, topicBroker, getExternalUrl,
   } = ctx;
+
+  // Narrative processor — transforms raw Claude events into a running blog-like narrative.
+  // It owns all topic creation: topics are created lazily on the first published event
+  // (narrative / completion / attention / summary), so sessions that never produce
+  // meaningful output never clutter the picker.
+  const narrative = topicBroker ? createNarrativeProcessor({
+    topicBroker,
+    ensureTopicMeta: (topic, payload) => {
+      const meta = topicBroker.getMeta(topic);
+      if (!meta || !meta.type) {
+        const newMeta = {
+          type: "progress",
+          sessionName: typeof payload.name === "string" ? payload.name.slice(0, 128) : null,
+          cwd: typeof payload.cwd === "string" ? payload.cwd.slice(0, 512) : null,
+          tmuxPane: typeof payload._tmuxPane === "string" ? payload._tmuxPane : null,
+        };
+        topicBroker.setMeta(topic, newMeta);
+        bridge.relay({ type: "topic-new", topic, meta: newMeta });
+      } else if (typeof payload._tmuxPane === "string" && !meta.tmuxPane) {
+        meta.tmuxPane = payload._tmuxPane;
+        topicBroker.setMeta(topic, meta);
+      }
+    },
+  }) : null;
 
   function configPutRoute(path, fieldName, setter, getter) {
     return { method: "PUT", path, handler: auth(csrf(async (req, res) => {
@@ -309,7 +334,11 @@ export function createAppRoutes(ctx) {
 
     { method: "GET", path: "/api/topics", handler: auth((req, res) => {
       if (!topicBroker) return json(res, 200, []);
-      json(res, 200, topicBroker.listTopics());
+      // Filter out internal PTY output streams — they're high-volume
+      // binary terminal data, not meaningful events for feed tiles.
+      const topics = topicBroker.listTopics()
+        .filter(t => !t.name.endsWith("/output"));
+      json(res, 200, topics);
     })},
 
     { method: "DELETE", prefix: "/api/topics/", handler: auth(csrf((req, res, topic) => {
@@ -350,36 +379,117 @@ export function createAppRoutes(ctx) {
       const result = transformClaudeEvent(payload);
       if (!result) return json(res, 400, { error: "Missing session_id or hook_event_name" });
 
-      // Set topic meta on first publish so the feed tile uses progress rendering
-      const meta = topicBroker.getMeta(result.topic);
-      const isNewTopic = !meta || !meta.type;
-      if (isNewTopic) {
-        const newMeta = {
-          type: "progress",
-          sessionName: typeof payload.name === "string" ? payload.name.slice(0, 128) : null,
-          cwd: typeof payload.cwd === "string" ? payload.cwd.slice(0, 512) : null,
-        };
-        topicBroker.setMeta(result.topic, newMeta);
-        // Notify connected clients so feed tile pickers update live
-        bridge.relay({ type: "topic-new", topic: result.topic, meta: newMeta });
+      // Thin-event model: raw hook events are NOT published to the topic broker.
+      // The narrative processor decides what to publish (narrative / completion /
+      // attention / summary) and lazily creates the topic via ensureTopicMeta.
+      // Callers that want raw tool-call detail should read the Claude transcript
+      // JSONL directly — it's the source of truth, not the pub/sub log.
+      if (narrative) {
+        narrative.ingest(result.topic, result.message, payload);
       }
 
-      // Extract and publish any new assistant text from the transcript
-      // before the tool/stop event, so the feed shows reasoning in order.
-      const texts = extractNewAssistantText(payload.transcript_path, payload.session_id);
-      for (const text of texts) {
-        topicBroker.publish(result.topic, JSON.stringify({
-          step: text,
-          status: "text",
-          detail: "",
-          event: "AssistantText",
-          tool: null,
-        }));
-      }
-
-      const delivered = topicBroker.publish(result.topic, JSON.stringify(result.message));
-      json(res, 200, { ok: true, delivered });
+      json(res, 200, { ok: true });
     }))},
+
+    // Respond to a Claude session — sends text + Enter to the tmux pane
+    // where Claude Code is running (matched by topic CWD → session CWD).
+    { method: "POST", path: "/api/claude-respond", handler: auth(csrf(async (req, res) => {
+      if (!topicBroker) return json(res, 503, { error: "Pub/sub not available" });
+      let body;
+      try { body = await parseJSON(req, 8192); } catch (err) {
+        return json(res, 400, { error: err.message });
+      }
+      const { topic, text } = body;
+      if (!topic || typeof topic !== "string") return json(res, 400, { error: "Missing topic" });
+      if (!text || typeof text !== "string") return json(res, 400, { error: "Missing text" });
+      if (text.length > 2000) return json(res, 400, { error: "Response too long" });
+
+      const meta = topicBroker.getMeta(topic);
+      if (!meta?.cwd) return json(res, 404, { error: "Topic has no CWD metadata" });
+
+      // Find the Katulong session whose tmux pane CWD matches the topic CWD
+      const allSessions = sessionManager.listSessions().sessions;
+      let targetSession = null;
+      for (const s of allSessions) {
+        if (!s.alive) continue;
+        const cwd = await sessionManager.getSessionCwd(s.name);
+        if (cwd && (cwd === meta.cwd || meta.cwd.startsWith(cwd + "/"))) {
+          targetSession = s.name;
+          break;
+        }
+      }
+
+      if (!targetSession) return json(res, 404, { error: "No matching terminal session found" });
+
+      // Send the response text + Enter to the tmux pane
+      const session = sessionManager.getSession(targetSession);
+      if (!session?.alive) return json(res, 404, { error: "Session no longer alive" });
+      session.write(text + "\n");
+
+      json(res, 200, { ok: true, session: targetSession });
+    }))},
+
+    // Find the Claude topic running in a given Katulong session's tmux pane.
+    // Strategy: get the pane's shell PID → find child `claude` process →
+    // extract session UUID from its open files (lsof) → match to topic.
+    { method: "GET", prefix: "/sessions/claude-topic/", handler: auth(async (req, res, sessionName) => {
+      if (!topicBroker) return json(res, 503, { error: "Pub/sub not available" });
+      const { execFile } = await import("node:child_process");
+
+      // Get the pane's shell PID
+      const session = sessionManager.getSession(sessionName);
+      if (!session?.alive) return json(res, 404, { error: "Session not found" });
+
+      const tmuxName = session.tmuxName;
+      const panePid = await new Promise(resolve => {
+        execFile("tmux", [...tmuxSocketArgs(), "list-panes", "-t", tmuxName, "-F", "#{pane_pid}"],
+          { timeout: 3000 },
+          (err, stdout) => resolve(err ? null : stdout.trim().split("\n")[0] || null)
+        );
+      });
+      if (!panePid) return json(res, 404, { error: "Could not read pane PID" });
+
+      // Find `claude` child process
+      const claudePid = await new Promise(resolve => {
+        execFile("pgrep", ["-P", panePid],
+          { timeout: 3000 },
+          (err, stdout) => {
+            if (err || !stdout.trim()) return resolve(null);
+            // Could be multiple children — check each
+            const pids = stdout.trim().split("\n");
+            resolve(pids);
+          }
+        );
+      });
+      if (!claudePid) return json(res, 404, { error: "No child process in pane" });
+
+      // Extract Claude session UUID from open files of child processes
+      let uuid = null;
+      const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+      for (const pid of claudePid) {
+        const lsofOut = await new Promise(resolve => {
+          execFile("lsof", ["-p", pid],
+            { timeout: 5000, maxBuffer: 512 * 1024 },
+            (err, stdout) => resolve(err ? "" : stdout)
+          );
+        });
+        // Look for .claude/ paths containing a UUID (session directory)
+        for (const line of lsofOut.split("\n")) {
+          if (!line.includes(".claude/")) continue;
+          const m = line.match(UUID_RE);
+          if (m) { uuid = m[0]; break; }
+        }
+        if (uuid) break;
+      }
+
+      if (!uuid) return json(res, 404, { error: "No Claude session UUID found in pane" });
+
+      const topicName = `claude/${uuid}`;
+      const meta = topicBroker.getMeta(topicName);
+      if (!meta) return json(res, 404, { error: `Topic ${topicName} not found` });
+
+      json(res, 200, { topic: topicName, meta });
+    })},
 
     // --- Sessions ---
 

--- a/lib/topic-broker.js
+++ b/lib/topic-broker.js
@@ -370,5 +370,39 @@ export function createTopicBroker({ pubsubDir } = {}) {
     return existed;
   }
 
-  return { subscribe, publish, listTopics, getMeta, setMeta, deleteTopic };
+  /**
+   * Inspect a topic's log and return counts by message status.
+   * Used by cleanup tooling to classify topics as noise vs. value
+   * without re-streaming the whole log. Reads both the active log
+   * and the rotated `.1` file when present.
+   *
+   * Messages are typically stringified JSON with a `status` field
+   * (what our feed tiles use). We best-effort parse each envelope's
+   * `message`; malformed or non-JSON messages land in `_unparsed`.
+   *
+   * Returns { seq, total, byStatus: { [status]: n, _unparsed: n } }.
+   */
+  function getTopicStats(topic) {
+    const dir = topicDir(topic);
+    const byStatus = {};
+    let total = 0;
+
+    for (const name of ["log.jsonl.1", "log.jsonl"]) {
+      const envelopes = readEnvelopes(join(dir, name));
+      for (const env of envelopes) {
+        total++;
+        let status;
+        try {
+          const parsed = typeof env.message === "string" ? JSON.parse(env.message) : env.message;
+          status = parsed && typeof parsed === "object" ? parsed.status : undefined;
+        } catch { /* fall through */ }
+        const key = typeof status === "string" && status ? status : "_unparsed";
+        byStatus[key] = (byStatus[key] || 0) + 1;
+      }
+    }
+
+    return { seq: getSeq(topic), total, byStatus };
+  }
+
+  return { subscribe, publish, listTopics, getMeta, setMeta, deleteTopic, getTopicStats };
 }

--- a/test/claude-event-transform.test.js
+++ b/test/claude-event-transform.test.js
@@ -204,10 +204,10 @@ describe("transformClaudeEvent", () => {
   it("handles unknown event types as generic log entries", () => {
     const result = transformClaudeEvent({
       session_id: SESSION_ID,
-      hook_event_name: "PreToolUse",
+      hook_event_name: "SomeFutureHookEvent",
     });
 
-    assert.equal(result.message.step, "PreToolUse");
+    assert.equal(result.message.step, "SomeFutureHookEvent");
     assert.equal(result.message.status, "info");
   });
 

--- a/test/claude-event-transform.test.js
+++ b/test/claude-event-transform.test.js
@@ -1,6 +1,9 @@
-import { describe, it } from "node:test";
+import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { transformClaudeEvent } from "../lib/claude-event-transform.js";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { transformClaudeEvent, readTranscriptEntries } from "../lib/claude-event-transform.js";
 
 describe("transformClaudeEvent", () => {
   const SESSION_ID = "6bc4b919-90f6-484d-937d-d78e11aa1aa2";
@@ -267,5 +270,141 @@ describe("transformClaudeEvent", () => {
     });
 
     assert.equal(result.message.detail, "");
+  });
+});
+
+describe("readTranscriptEntries", () => {
+  let tmpDir;
+  before(() => { tmpDir = mkdtempSync(join(tmpdir(), "transcript-test-")); });
+  after(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  function writeTranscript(name, lines) {
+    const path = join(tmpDir, name);
+    writeFileSync(path, lines.map(l => typeof l === "string" ? l : JSON.stringify(l)).join("\n"));
+    return path;
+  }
+
+  it("returns empty result for missing path", () => {
+    const result = readTranscriptEntries(null);
+    assert.deepEqual(result, { entries: [], nextCursor: 0 });
+  });
+
+  it("returns empty result when file does not exist", () => {
+    const result = readTranscriptEntries(join(tmpDir, "does-not-exist.jsonl"));
+    assert.deepEqual(result, { entries: [], nextCursor: 0 });
+  });
+
+  it("normalizes an assistant text + tool_use turn into one entry", () => {
+    const path = writeTranscript("assistant.jsonl", [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Looking at the auth module." },
+            { type: "tool_use", name: "Read", input: { file_path: "/src/auth.js", offset: 42 } },
+          ],
+        },
+      },
+    ]);
+    const { entries, nextCursor } = readTranscriptEntries(path);
+    assert.equal(nextCursor, 1);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].role, "assistant");
+    assert.equal(entries[0].text, "Looking at the auth module.");
+    assert.deepEqual(entries[0].tools, [
+      { name: "Read", input: { file_path: "/src/auth.js", offset: 42 } },
+    ]);
+  });
+
+  it("normalizes a user string-content entry", () => {
+    const path = writeTranscript("user.jsonl", [
+      { type: "user", message: { role: "user", content: "Fix the login bug." } },
+    ]);
+    const { entries } = readTranscriptEntries(path);
+    assert.equal(entries.length, 1);
+    assert.deepEqual(entries[0], { role: "user", text: "Fix the login bug." });
+  });
+
+  it("distinguishes user text from tool_result user entries", () => {
+    const path = writeTranscript("mixed.jsonl", [
+      { type: "user", message: { role: "user", content: [{ type: "text", text: "Please fix it." }] } },
+      { type: "user", message: { role: "user", content: [{ type: "tool_result", content: "exit status 0" }] } },
+    ]);
+    const { entries } = readTranscriptEntries(path);
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].role, "user");
+    assert.equal(entries[1].role, "tool_result");
+    assert.equal(entries[1].text, "exit status 0");
+  });
+
+  it("skips metadata entries with no message", () => {
+    const path = writeTranscript("meta.jsonl", [
+      { type: "summary", operation: "compact", timestamp: "t", sessionId: "s", content: "summary text" },
+      { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "hi" }] } },
+    ]);
+    const { entries, nextCursor } = readTranscriptEntries(path);
+    assert.equal(nextCursor, 2, "cursor advances past skipped lines");
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].text, "hi");
+  });
+
+  it("advances cursor past blank trailing lines", () => {
+    const path = writeTranscript("trailing.jsonl", [
+      { type: "user", message: { role: "user", content: "a" } },
+      "",
+      "",
+    ]);
+    const { nextCursor } = readTranscriptEntries(path);
+    assert.equal(nextCursor, 1);
+  });
+
+  it("returns only the slice after fromLine", () => {
+    const path = writeTranscript("slice.jsonl", [
+      { type: "user", message: { role: "user", content: "first" } },
+      { type: "user", message: { role: "user", content: "second" } },
+      { type: "user", message: { role: "user", content: "third" } },
+    ]);
+    const { entries, nextCursor } = readTranscriptEntries(path, 1);
+    assert.equal(nextCursor, 3);
+    assert.deepEqual(entries.map(e => e.text), ["second", "third"]);
+  });
+
+  it("returns empty entries when cursor is already at end", () => {
+    const path = writeTranscript("end.jsonl", [
+      { type: "user", message: { role: "user", content: "only" } },
+    ]);
+    const { entries, nextCursor } = readTranscriptEntries(path, 5);
+    assert.deepEqual(entries, []);
+    assert.equal(nextCursor, 1);
+  });
+
+  it("skips malformed JSON lines without throwing", () => {
+    const path = writeTranscript("bad.jsonl", [
+      "not json",
+      { type: "user", message: { role: "user", content: "ok" } },
+    ]);
+    const { entries, nextCursor } = readTranscriptEntries(path);
+    assert.equal(nextCursor, 2);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].text, "ok");
+  });
+
+  it("truncates long assistant text", () => {
+    const longText = "x".repeat(2000);
+    const path = writeTranscript("long.jsonl", [
+      { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: longText }] } },
+    ]);
+    const { entries } = readTranscriptEntries(path);
+    assert.ok(entries[0].text.length <= 1000);
+    assert.ok(entries[0].text.endsWith("\u2026"));
+  });
+
+  it("skips assistant entries with only thinking blocks", () => {
+    const path = writeTranscript("think.jsonl", [
+      { type: "assistant", message: { role: "assistant", content: [{ type: "thinking", thinking: "deep thoughts" }] } },
+    ]);
+    const { entries } = readTranscriptEntries(path);
+    assert.equal(entries.length, 0);
   });
 });

--- a/test/topic-broker.test.js
+++ b/test/topic-broker.test.js
@@ -496,4 +496,51 @@ describe("Topic Broker", () => {
       assert.deepEqual(t.meta, { type: "progress", label: "Build" });
     });
   });
+
+  describe("getTopicStats", () => {
+    it("returns zero counts for an unknown topic", () => {
+      const broker = makeBroker();
+      const stats = broker.getTopicStats("nope");
+      assert.equal(stats.seq, 0);
+      assert.equal(stats.total, 0);
+      assert.deepEqual(stats.byStatus, {});
+    });
+
+    it("groups JSON-string messages by status field", () => {
+      const broker = makeBroker();
+      broker.publish("claude/x", JSON.stringify({ step: "a", status: "done" }));
+      broker.publish("claude/x", JSON.stringify({ step: "b", status: "done" }));
+      broker.publish("claude/x", JSON.stringify({ step: "c", status: "narrative" }));
+
+      const stats = broker.getTopicStats("claude/x");
+      assert.equal(stats.seq, 3);
+      assert.equal(stats.total, 3);
+      assert.deepEqual(stats.byStatus, { done: 2, narrative: 1 });
+    });
+
+    it("buckets non-JSON or status-less messages as _unparsed", () => {
+      const broker = makeBroker();
+      broker.publish("raw", "not json at all");
+      broker.publish("raw", JSON.stringify({ step: "x" })); // no status
+      broker.publish("raw", JSON.stringify({ status: "done" }));
+
+      const stats = broker.getTopicStats("raw");
+      assert.equal(stats.total, 3);
+      assert.equal(stats.byStatus._unparsed, 2);
+      assert.equal(stats.byStatus.done, 1);
+    });
+
+    it("includes rotated log entries", () => {
+      const broker = makeBroker();
+      // Seed many small messages to trigger rotation on event-sized topic
+      // (100KB cap). ~1000 bytes per message * 200 should roll over.
+      const big = "x".repeat(900);
+      for (let i = 0; i < 200; i++) {
+        broker.publish("rollover", JSON.stringify({ status: "done", pad: big }));
+      }
+      const stats = broker.getTopicStats("rollover");
+      assert.equal(stats.total, 200);
+      assert.equal(stats.byStatus.done, 200);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Reframes the `claude/*` pub/sub from event sourcing to a change-notification bus over the Claude transcript JSONL on disk. Four commits:

- **`323ce96` — Thin-event model**: `/api/claude-events` no longer republishes raw hook events. The narrative processor owns all publishing, topics are lazily created on first *meaningful* synthesis (so `/clear`, `/resume`, and cancelled turns stay invisible), and the feed tile now only sees synthesized output (narrative / completion / attention / summary).
- **`52b8d49` — Transcript slices**: Narrator reads transcript JSONL slices between flushes via a per-topic cursor. Richer input, retry-safe on Ollama failure, compactor code gone.
- **`e0bdc82` — `katulong topics purge`**: New CLI subcommand to delete leftover noise from retired architectures (`sessions/*/output` from PR #255999a, pre-thin-event `claude/*` topics). Dry-run by default, classifies via new `GET /api/topics/:topic/stats`.
- **`08b579f` — Formula caveat**: Points upgraders at `topics purge` in the brew caveats block so the one-time cleanup is discoverable.

## Why

Screenshots showed the feed-tile picker cluttered with junk `claude/<uuid>` topics containing empty `"[]"` / `"Claude responded"` messages. Root cause: eager topic creation on every hook event + raw events published to the same topic the narrator later publishes synthesized output to. Fixing the symptom (filter junk at render time) would leave disk bloat and noise in every subscriber. The deeper issue: the Claude transcript JSONL on disk is already canonical — the pub/sub should *react to change*, not hold a second copy of the timeline.

## Test plan
- [x] `npm run test:unit` — 2179 passing (4 new broker tests for `getTopicStats`, 12 new tests for `readTranscriptEntries`)
- [ ] Live smoke: after merge + release, run `katulong topics purge` on upgraded hosts to verify classifier picks up the expected drop set
- [ ] Feed tile behavior: confirm new `claude/*` topics only appear once narrative/completion/attention is synthesized, and that the picker no longer shows empty-session clutter

## Docs

`docs/claude-event-stream.md` got a mid-rewrite banner in `323ce96` explaining the superseded "thin translator" model. The full rewrite is held until the follow-on `GET /api/claude-transcript/:session_id` endpoint lands (next step after this PR).