### PR TITLE
feed-narrative: transcript drill-down endpoint (GET /api/claude-transcript/:session_id)

### DIFF
--- a/docs/claude-event-stream.md
+++ b/docs/claude-event-stream.md
@@ -24,9 +24,13 @@
 >   Claude topics now carry only `narrative` / `completion` / `attention`
 >   / `summary` statuses.
 >
-> This doc will be fully rewritten once the follow-on pieces land:
-> narrative processor reading transcript slices directly, and a
-> `GET /api/claude-transcript/:session_id` endpoint for on-demand detail.
+> Follow-on pieces have now landed: the narrative processor reads
+> transcript slices directly, and `GET /api/claude-transcript/:session_id`
+> serves on-demand detail (cursor-paginated via `fromLine` / `limit`,
+> returns `{ entries, nextCursor, hasMore }`). The transcript path is
+> stashed on the topic's server-only meta (`transcriptPath`) and stripped
+> from public responses by `publicMeta()` in `lib/routes/app-routes.js`.
+> This doc will be fully rewritten once the UI drill-down wiring lands.
 
 ## The problem we're solving
 

--- a/lib/claude-event-transform.js
+++ b/lib/claude-event-transform.js
@@ -11,10 +11,18 @@
  * for the feed tile's progress rendering strategy.
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
+
+// Hard cap on transcript file size to protect the server from being asked to
+// slurp a pathologically large JSONL into memory. 50 MB is well above any
+// real Claude Code session; beyond that we refuse rather than OOM the host.
+const MAX_TRANSCRIPT_BYTES = 50 * 1024 * 1024;
 
 const MAX_DETAIL_LENGTH = 200;
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// Anchored UUID: full-string match, used to validate session_id inputs.
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// Unanchored UUID: substring match, used to scrape a UUID from log output.
+export const UUID_SEARCH_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
 
 /**
  * Extract a short target description from tool_input.
@@ -217,6 +225,10 @@ export function readTranscriptEntries(transcriptPath, fromLine = 0, limit) {
 
   let raw;
   try {
+    const st = statSync(transcriptPath);
+    if (st.size > MAX_TRANSCRIPT_BYTES) {
+      return { entries: [], nextCursor: fromLine, hasMore: false };
+    }
     raw = readFileSync(transcriptPath, "utf8");
   } catch {
     return { entries: [], nextCursor: fromLine, hasMore: false };

--- a/lib/claude-event-transform.js
+++ b/lib/claude-event-transform.js
@@ -200,35 +200,48 @@ const TRANSCRIPT_RESULT_MAX = 500;
  *
  * @param {string} transcriptPath Absolute path to the JSONL transcript
  * @param {number} fromLine       Cursor: skip this many significant lines
- * @returns {{ entries: object[], nextCursor: number }}
+ * @param {number} [limit]        Stop after reading this many significant
+ *                                lines from `fromLine`. Omit for no cap.
+ *                                When set, `nextCursor` points at the next
+ *                                unread line so the caller can resume.
+ *                                `hasMore` is true when we stopped early.
+ * @returns {{ entries: object[], nextCursor: number, hasMore: boolean }}
  *   entries: normalized records with shape { role, text?, tools?, tool_result? }
  *   nextCursor: the new cursor value to persist for the next call
+ *   hasMore: true when the limit cut the read short
  */
-export function readTranscriptEntries(transcriptPath, fromLine = 0) {
+export function readTranscriptEntries(transcriptPath, fromLine = 0, limit) {
   if (!transcriptPath || typeof transcriptPath !== "string") {
-    return { entries: [], nextCursor: fromLine };
+    return { entries: [], nextCursor: fromLine, hasMore: false };
   }
 
   let raw;
   try {
     raw = readFileSync(transcriptPath, "utf8");
   } catch {
-    return { entries: [], nextCursor: fromLine };
+    return { entries: [], nextCursor: fromLine, hasMore: false };
   }
 
   const significant = raw.split("\n").filter(l => l.trim());
   if (fromLine >= significant.length) {
-    return { entries: [], nextCursor: significant.length };
+    return { entries: [], nextCursor: significant.length, hasMore: false };
   }
 
+  const hasLimit = typeof limit === "number" && limit > 0;
+  const end = hasLimit ? Math.min(significant.length, fromLine + limit) : significant.length;
+
   const entries = [];
-  for (let i = fromLine; i < significant.length; i++) {
+  for (let i = fromLine; i < end; i++) {
     let obj;
     try { obj = JSON.parse(significant[i]); } catch { continue; }
     const normalized = normalizeTranscriptEntry(obj);
     if (normalized) entries.push(normalized);
   }
-  return { entries, nextCursor: significant.length };
+  return {
+    entries,
+    nextCursor: end,
+    hasMore: end < significant.length,
+  };
 }
 
 /**

--- a/lib/claude-event-transform.js
+++ b/lib/claude-event-transform.js
@@ -230,6 +230,11 @@ export function readTranscriptEntries(transcriptPath, fromLine = 0, limit) {
       return { entries: [], nextCursor: fromLine, hasMore: false };
     }
     raw = readFileSync(transcriptPath, "utf8");
+    // Re-check after read to close the TOCTOU window between stat and read
+    // — the file could have grown past the cap between the two syscalls.
+    if (Buffer.byteLength(raw) > MAX_TRANSCRIPT_BYTES) {
+      return { entries: [], nextCursor: fromLine, hasMore: false };
+    }
   } catch {
     return { entries: [], nextCursor: fromLine, hasMore: false };
   }

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -23,8 +23,11 @@ import { rewriteVendorUrls } from "../static-files.js";
 import { captureVisiblePane, tmuxSocketArgs } from "../tmux.js";
 import { bridgeClipboardToContainers, bridgePaneContainer } from "../container-detect.js";
 import { readRawBody } from "../request-util.js";
-import { transformClaudeEvent, readTranscriptEntries } from "../claude-event-transform.js";
+import { transformClaudeEvent, readTranscriptEntries, UUID_RE, UUID_SEARCH_RE } from "../claude-event-transform.js";
 import { createNarrativeProcessor } from "../narrative-processor.js";
+import {
+  MAX_UPLOAD_BYTES, detectImage, imageMimeType, setClipboard,
+} from "./upload.js";
 
 // Server-only meta fields — filtered from any client-facing response.
 // transcriptPath is an absolute host filesystem path: we use it to read
@@ -42,10 +45,17 @@ export function publicMeta(meta) {
   return out;
 }
 
-const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-import {
-  MAX_UPLOAD_BYTES, detectImage, imageMimeType, setClipboard,
-} from "./upload.js";
+// Returns the first private key name found in caller-supplied meta, or null.
+// Callers turn a non-null return into a 400. Without this check a client
+// could forge `transcriptPath` via POST /pub or POST /api/topics/:topic/meta
+// and turn the transcript endpoint into an arbitrary file read.
+function hasPrivateKey(meta) {
+  if (!meta || typeof meta !== "object") return null;
+  for (const k of Object.keys(meta)) {
+    if (PRIVATE_META_KEYS.has(k)) return k;
+  }
+  return null;
+}
 
 export function createAppRoutes(ctx) {
   const {
@@ -323,6 +333,8 @@ export function createAppRoutes(ctx) {
       if (!/^[a-zA-Z0-9._\-/]+$/.test(topic) || /(^|\/)\.\.($|\/)/.test(topic)) return json(res, 400, { error: "Invalid topic (alphanumeric, dots, dashes, slashes)" });
       // Optional topic metadata — set once or update on publish
       if (data.meta && typeof data.meta === "object") {
+        const privateKey = hasPrivateKey(data.meta);
+        if (privateKey) return json(res, 400, { error: `Cannot set private key: ${privateKey}` });
         topicBroker.setMeta(topic, data.meta);
       }
       const delivered = topicBroker.publish(topic, message);
@@ -402,10 +414,8 @@ export function createAppRoutes(ctx) {
       if (!topic || !/^[a-zA-Z0-9._\-/]+$/.test(topic) || /(^|\/)\.\.($|\/)/.test(topic)) return json(res, 400, { error: "Invalid topic" });
       const data = await parseJSON(req);
       if (!data || typeof data !== "object") return json(res, 400, { error: "Body must be a JSON object" });
-      // Reject attempts to set private keys via the public meta endpoint.
-      for (const k of Object.keys(data)) {
-        if (PRIVATE_META_KEYS.has(k)) return json(res, 400, { error: `Cannot set private key: ${k}` });
-      }
+      const privateKey = hasPrivateKey(data);
+      if (privateKey) return json(res, 400, { error: `Cannot set private key: ${privateKey}` });
       topicBroker.setMeta(topic, data);
       json(res, 200, { ok: true, meta: publicMeta(topicBroker.getMeta(topic)) });
     }))},
@@ -453,18 +463,18 @@ export function createAppRoutes(ctx) {
     // Returns { entries, nextCursor, hasMore }.
     { method: "GET", prefix: "/api/claude-transcript/", handler: auth((req, res, sessionId) => {
       if (!topicBroker) return json(res, 503, { error: "Pub/sub not available" });
-      if (!SESSION_ID_RE.test(sessionId)) return json(res, 400, { error: "Invalid session_id" });
+      if (!UUID_RE.test(sessionId)) return json(res, 400, { error: "Invalid session_id" });
 
       const meta = topicBroker.getMeta(`claude/${sessionId}`);
-      const path = meta && typeof meta.transcriptPath === "string" ? meta.transcriptPath : null;
-      if (!path) return json(res, 404, { error: "No transcript recorded for session" });
+      const transcriptPath = meta && typeof meta.transcriptPath === "string" ? meta.transcriptPath : null;
+      if (!transcriptPath) return json(res, 404, { error: "No transcript recorded for session" });
 
       const url = new URL(req.url, "http://x");
       const fromLine = Math.max(0, parseInt(url.searchParams.get("fromLine") || "0", 10) || 0);
       const limitRaw = parseInt(url.searchParams.get("limit") || "200", 10) || 200;
       const limit = Math.min(1000, Math.max(1, limitRaw));
 
-      json(res, 200, readTranscriptEntries(path, fromLine, limit));
+      json(res, 200, readTranscriptEntries(transcriptPath, fromLine, limit));
     })},
 
     // Respond to a Claude session — sends text + Enter to the tmux pane
@@ -541,7 +551,6 @@ export function createAppRoutes(ctx) {
 
       // Extract Claude session UUID from open files of child processes
       let uuid = null;
-      const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
       for (const pid of claudePid) {
         const lsofOut = await new Promise(resolve => {
           execFile("lsof", ["-p", pid],
@@ -552,7 +561,7 @@ export function createAppRoutes(ctx) {
         // Look for .claude/ paths containing a UUID (session directory)
         for (const line of lsofOut.split("\n")) {
           if (!line.includes(".claude/")) continue;
-          const m = line.match(UUID_RE);
+          const m = line.match(UUID_SEARCH_RE);
           if (m) { uuid = m[0]; break; }
         }
         if (uuid) break;
@@ -564,7 +573,7 @@ export function createAppRoutes(ctx) {
       const meta = topicBroker.getMeta(topicName);
       if (!meta) return json(res, 404, { error: `Topic ${topicName} not found` });
 
-      json(res, 200, { topic: topicName, meta });
+      json(res, 200, { topic: topicName, meta: publicMeta(meta) });
     })},
 
     // --- Sessions ---

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -23,8 +23,26 @@ import { rewriteVendorUrls } from "../static-files.js";
 import { captureVisiblePane, tmuxSocketArgs } from "../tmux.js";
 import { bridgeClipboardToContainers, bridgePaneContainer } from "../container-detect.js";
 import { readRawBody } from "../request-util.js";
-import { transformClaudeEvent } from "../claude-event-transform.js";
+import { transformClaudeEvent, readTranscriptEntries } from "../claude-event-transform.js";
 import { createNarrativeProcessor } from "../narrative-processor.js";
+
+// Server-only meta fields — filtered from any client-facing response.
+// transcriptPath is an absolute host filesystem path: we use it to read
+// the transcript on the `/api/claude-transcript/:id` endpoint, but
+// leaking it to the client is an information disclosure we don't need.
+// Exported so route tests can audit the filter list directly.
+export const PRIVATE_META_KEYS = new Set(["transcriptPath"]);
+
+export function publicMeta(meta) {
+  if (!meta || typeof meta !== "object") return meta;
+  const out = {};
+  for (const [k, v] of Object.entries(meta)) {
+    if (!PRIVATE_META_KEYS.has(k)) out[k] = v;
+  }
+  return out;
+}
+
+const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 import {
   MAX_UPLOAD_BYTES, detectImage, imageMimeType, setClipboard,
 } from "./upload.js";
@@ -52,12 +70,21 @@ export function createAppRoutes(ctx) {
           sessionName: typeof payload.name === "string" ? payload.name.slice(0, 128) : null,
           cwd: typeof payload.cwd === "string" ? payload.cwd.slice(0, 512) : null,
           tmuxPane: typeof payload._tmuxPane === "string" ? payload._tmuxPane : null,
+          // Record the transcript path so the on-demand drill-down
+          // endpoint (/api/claude-transcript/:id) can read it back.
+          // Kept server-side — stripped from the client-facing broadcast
+          // and from /api/topics — so absolute host paths don't leak.
+          transcriptPath: typeof payload.transcript_path === "string" ? payload.transcript_path : null,
         };
         topicBroker.setMeta(topic, newMeta);
-        bridge.relay({ type: "topic-new", topic, meta: newMeta });
-      } else if (typeof payload._tmuxPane === "string" && !meta.tmuxPane) {
-        meta.tmuxPane = payload._tmuxPane;
-        topicBroker.setMeta(topic, meta);
+        bridge.relay({ type: "topic-new", topic, meta: publicMeta(newMeta) });
+      } else {
+        const patch = {};
+        if (typeof payload._tmuxPane === "string" && !meta.tmuxPane) patch.tmuxPane = payload._tmuxPane;
+        if (typeof payload.transcript_path === "string" && meta.transcriptPath !== payload.transcript_path) {
+          patch.transcriptPath = payload.transcript_path;
+        }
+        if (Object.keys(patch).length > 0) topicBroker.setMeta(topic, patch);
       }
     },
   }) : null;
@@ -340,9 +367,10 @@ export function createAppRoutes(ctx) {
       // ?all=1 to see the full list.
       const url = new URL(req.url, "http://x");
       const includeAll = url.searchParams.get("all") === "1";
-      const topics = includeAll
+      const raw = includeAll
         ? topicBroker.listTopics()
         : topicBroker.listTopics().filter(t => !t.name.endsWith("/output"));
+      const topics = raw.map(t => ({ ...t, meta: publicMeta(t.meta) }));
       json(res, 200, topics);
     })},
 
@@ -374,8 +402,12 @@ export function createAppRoutes(ctx) {
       if (!topic || !/^[a-zA-Z0-9._\-/]+$/.test(topic) || /(^|\/)\.\.($|\/)/.test(topic)) return json(res, 400, { error: "Invalid topic" });
       const data = await parseJSON(req);
       if (!data || typeof data !== "object") return json(res, 400, { error: "Body must be a JSON object" });
+      // Reject attempts to set private keys via the public meta endpoint.
+      for (const k of Object.keys(data)) {
+        if (PRIVATE_META_KEYS.has(k)) return json(res, 400, { error: `Cannot set private key: ${k}` });
+      }
       topicBroker.setMeta(topic, data);
-      json(res, 200, { ok: true, meta: topicBroker.getMeta(topic) });
+      json(res, 200, { ok: true, meta: publicMeta(topicBroker.getMeta(topic)) });
     }))},
 
     // --- Claude Event Stream ---
@@ -406,6 +438,34 @@ export function createAppRoutes(ctx) {
 
       json(res, 200, { ok: true });
     }))},
+
+    // On-demand transcript-slice drill-down. The pub/sub now carries only
+    // synthesized output (narrative / completion / attention / summary);
+    // raw tool-call detail lives in the Claude transcript JSONL on disk.
+    // This endpoint shields the frontend from the JSONL shape by routing
+    // through the shared `readTranscriptEntries` normalizer — same shape
+    // the narrative processor itself consumes.
+    //
+    // Query params:
+    //   ?fromLine=N  (default 0) — skip the first N significant lines
+    //   ?limit=N     (default 200, max 1000) — cap entries returned
+    //
+    // Returns { entries, nextCursor, hasMore }.
+    { method: "GET", prefix: "/api/claude-transcript/", handler: auth((req, res, sessionId) => {
+      if (!topicBroker) return json(res, 503, { error: "Pub/sub not available" });
+      if (!SESSION_ID_RE.test(sessionId)) return json(res, 400, { error: "Invalid session_id" });
+
+      const meta = topicBroker.getMeta(`claude/${sessionId}`);
+      const path = meta && typeof meta.transcriptPath === "string" ? meta.transcriptPath : null;
+      if (!path) return json(res, 404, { error: "No transcript recorded for session" });
+
+      const url = new URL(req.url, "http://x");
+      const fromLine = Math.max(0, parseInt(url.searchParams.get("fromLine") || "0", 10) || 0);
+      const limitRaw = parseInt(url.searchParams.get("limit") || "200", 10) || 200;
+      const limit = Math.min(1000, Math.max(1, limitRaw));
+
+      json(res, 200, readTranscriptEntries(path, fromLine, limit));
+    })},
 
     // Respond to a Claude session — sends text + Enter to the tmux pane
     // where Claude Code is running (matched by topic CWD → session CWD).

--- a/test/app-routes-meta.test.js
+++ b/test/app-routes-meta.test.js
@@ -1,0 +1,34 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { publicMeta, PRIVATE_META_KEYS } from "../lib/routes/app-routes.js";
+
+describe("publicMeta", () => {
+  it("strips known private keys", () => {
+    const out = publicMeta({
+      type: "progress",
+      cwd: "/Users/x/project",
+      transcriptPath: "/Users/x/.claude/projects/y/abc.jsonl",
+    });
+    assert.deepEqual(out, { type: "progress", cwd: "/Users/x/project" });
+  });
+
+  it("is a no-op when no private keys are present", () => {
+    const in_ = { type: "log", label: "CI" };
+    const out = publicMeta(in_);
+    assert.deepEqual(out, in_);
+    assert.notEqual(out, in_, "returns a fresh object, not the input");
+  });
+
+  it("returns non-object inputs unchanged", () => {
+    assert.equal(publicMeta(null), null);
+    assert.equal(publicMeta(undefined), undefined);
+    assert.equal(publicMeta("string"), "string");
+  });
+
+  it("PRIVATE_META_KEYS lists transcriptPath", () => {
+    // If this ever fails the filter has drifted — anyone adding a new
+    // server-only field should update both the set and the broadcast
+    // paths (see ensureTopicMeta / /api/topics / POST meta).
+    assert.ok(PRIVATE_META_KEYS.has("transcriptPath"));
+  });
+});

--- a/test/claude-event-transform.test.js
+++ b/test/claude-event-transform.test.js
@@ -286,12 +286,12 @@ describe("readTranscriptEntries", () => {
 
   it("returns empty result for missing path", () => {
     const result = readTranscriptEntries(null);
-    assert.deepEqual(result, { entries: [], nextCursor: 0 });
+    assert.deepEqual(result, { entries: [], nextCursor: 0, hasMore: false });
   });
 
   it("returns empty result when file does not exist", () => {
     const result = readTranscriptEntries(join(tmpDir, "does-not-exist.jsonl"));
-    assert.deepEqual(result, { entries: [], nextCursor: 0 });
+    assert.deepEqual(result, { entries: [], nextCursor: 0, hasMore: false });
   });
 
   it("normalizes an assistant text + tool_use turn into one entry", () => {
@@ -406,5 +406,35 @@ describe("readTranscriptEntries", () => {
     ]);
     const { entries } = readTranscriptEntries(path);
     assert.equal(entries.length, 0);
+  });
+
+  it("respects `limit` and reports hasMore when stopped short", () => {
+    const path = writeTranscript("paged.jsonl", [
+      { type: "user", message: { role: "user", content: "one" } },
+      { type: "user", message: { role: "user", content: "two" } },
+      { type: "user", message: { role: "user", content: "three" } },
+      { type: "user", message: { role: "user", content: "four" } },
+    ]);
+    const page1 = readTranscriptEntries(path, 0, 2);
+    assert.equal(page1.entries.length, 2);
+    assert.equal(page1.nextCursor, 2);
+    assert.equal(page1.hasMore, true);
+    assert.deepEqual(page1.entries.map(e => e.text), ["one", "two"]);
+
+    const page2 = readTranscriptEntries(path, page1.nextCursor, 2);
+    assert.equal(page2.entries.length, 2);
+    assert.equal(page2.nextCursor, 4);
+    assert.equal(page2.hasMore, false);
+    assert.deepEqual(page2.entries.map(e => e.text), ["three", "four"]);
+  });
+
+  it("`hasMore: false` when the limit exactly hits EOF", () => {
+    const path = writeTranscript("exact.jsonl", [
+      { type: "user", message: { role: "user", content: "a" } },
+      { type: "user", message: { role: "user", content: "b" } },
+    ]);
+    const result = readTranscriptEntries(path, 0, 2);
+    assert.equal(result.hasMore, false);
+    assert.equal(result.nextCursor, 2);
   });
 });


### PR DESCRIPTION
## Summary
- New authenticated route `GET /api/claude-transcript/:session_id?fromLine=N&limit=M` returns `{ entries, nextCursor, hasMore }` by reading the transcript path stashed on the topic's server-only meta.
- `readTranscriptEntries(path, fromLine, limit)` gains bounded pagination so cursor math stays in one place (significant-line counting, blank trailing lines don't shift the cursor).
- Server-only meta hygiene: new `PRIVATE_META_KEYS` + `publicMeta()` helper. `transcriptPath` is persisted but stripped from every client-facing path (bridge.relay broadcast, `GET /api/topics`, `POST /api/topics/:topic/meta`). POST also rejects attempts to set private keys with 400.

## Why
Third piece of the thin-event plan. The broker no longer persists raw tool detail — the Claude transcript JSONL on disk is the source of truth — so the feed tile needs an on-demand endpoint to drill into a narrative card. Persisting `transcriptPath` on topic meta means the endpoint survives restarts and there's no path-injection surface (we only read paths we previously recorded, and the session_id is UUID-validated).

Absolute host paths leak the user's home directory (`~/.claude/projects/...`) and must not reach browsers over the tunnel — `publicMeta` filters at every boundary so future private fields only need to be added to the set.

## Test plan
- [x] `npm run test:unit` — 2185 pass, 0 fail
- [x] New `test/app-routes-meta.test.js` covers `publicMeta` contract
- [x] `test/claude-event-transform.test.js` updated for new `hasMore` return field + two new pagination cases (limit cuts short, limit exactly at EOF)
- [x] Pre-push full suite (unit + integration + smoke E2E) passed
- [ ] Manual drill-down from the feed tile (UI wiring lands in a follow-on PR)