### PR TITLE
ipad bar: trim stacked vertical padding

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -831,7 +831,7 @@
     /* Tab row: [+] and tabs side by side */
     .bar-tab-row {
       display: flex; align-items: center; gap: var(--space-xs);
-      padding-bottom: var(--space-sm);
+      padding-bottom: var(--space-xs);
     }
 
     /* Inline text input row (between tabs and tool row) */
@@ -873,7 +873,7 @@
 
     /* Tool row — docked as second row inside #shortcut-bar */
     #key-island {
-      display: flex; gap: 0.375rem; padding: var(--space-sm) 0.375rem var(--space-xs);
+      display: flex; gap: 0.375rem; padding: var(--space-xs) 0.375rem 0;
       align-items: center;
       width: 100%;
       border-top: 1px solid var(--border);
@@ -964,7 +964,7 @@
       flex-grow: 0;
       flex-direction: column;
       align-items: stretch;
-      padding: var(--space-sm) var(--space-sm) calc(var(--space-xs) + env(safe-area-inset-bottom, 0px)) var(--space-sm);
+      padding: var(--space-xs) var(--space-sm) calc(var(--space-xs) + env(safe-area-inset-bottom, 0px)) var(--space-sm);
       gap: 0;
     }
     /* Tabs: taller for touch, shrink to fit */


### PR DESCRIPTION
## Summary

- Three stacked vertical paddings on `#shortcut-bar.bar-ipad` were eating ~16px of dead space above/below the tab + tool rows.
- Tightened outer top padding, `.bar-tab-row` bottom padding, and `#key-island` top/bottom padding from 8/8/8/4px to 4/4/4/0px.
- Touch-target button heights are unchanged — only inter-row gaps shrink, so the bar is ~16px shorter while keeping tap areas intact.

## Test plan

- [x] `npm test` (pre-push hook ran unit + integration + smoke e2e)
- [ ] Manual verification on iPad: confirm the bottom bar is shorter and the iPadOS floating keyboard accessory pill sits with roughly equal space above/below.