### PR TITLE
MC1e PR1: server-side surrogate session id (additive)

### DIFF
--- a/docs/mc1e-implementation-plan.md
+++ b/docs/mc1e-implementation-plan.md
@@ -1,0 +1,151 @@
+# MC1e — Implementation Plan
+
+Companion to `docs/tile-clusters-design.md` MC1e entry and `docs/session-identity.md`.
+
+The MC1e doc says "combine persistence move + surrogate id so there is exactly one migration." That framing is correct for **client-side** work (both parts re-key the same client stores, so one schema bump is cheaper than two). But a **server-side additive id** can land before either client migration without any user-visible change — ids become available and unused until a later PR consumes them.
+
+Split MC1e into 3 PRs. Each ships independently; each is reviewable in one sitting.
+
+## Decisions to confirm with user before PR1
+
+1. **ID format.** Options: `crypto.randomUUID()` (36 chars, already in Node), nanoid (21 chars, need dep), base36 timestamp+counter (short, ordered, no dep). Recommendation: **`crypto.randomUUID()`** — zero deps, universally recognized, collision-resistant. Length isn't a user-visible problem since it lives in data, not UI.
+
+2. **tmuxName derivation.** `kat_<id>` where id is the full UUID (`kat_550e8400-e29b-41d4-a716-446655440000`). tmux accepts this — dots and dashes pass validation. **No sanitization dance.**
+
+3. **Persistence of id across server restart.** Options:
+   - (a) Regenerate on every start — old clients' `?s=<id>` URLs break across restarts.
+   - (b) Persist a tmuxName→id map to disk (`~/.katulong/sessions.json`).
+   - (c) Derive id from tmuxName on adoption (`tmuxName = "kat_<uuid>"` → strip prefix).
+   - Recommendation: **(c) for new sessions, fall back to (a) for adopted-external sessions.** When server adopts a tmux session whose name starts with `kat_`, extract the trailing uuid as id. For foreign tmux sessions (unlikely but possible), synthesize a fresh id. No persistence layer needed; id is encoded in tmuxName.
+
+4. **Migration window.** URL `?s=<name>` → `?s=<id>` redirect lives for how long? Recommendation: **indefinite.** It's a server-side redirect with a O(1) lookup, and removing it breaks every bookmark users have. Cost to maintain is ~10 lines.
+
+5. **WebSocket contract.** `session-renamed` → `session-updated { id, displayName }` per the doc. Only one client version talks to one server version (no protocol backward-compat obligation for WS), so the old message type can be deleted in the same PR that introduces the new one.
+
+---
+
+## PR1 — Server-side id (additive, no client changes, no migration)
+
+**Scope.** Introduce `Session.id` as an immutable field. Do not change tmuxName derivation yet (existing sessions keep their current sanitized names; new sessions also get sanitized names). Expose `id` in JSON responses and WebSocket broadcasts alongside existing `name`-keyed fields. Clients ignore `id`.
+
+**Why ship alone.** Zero behavior change. Establishes the field shape the migration will consume. Gives the client-side PRs something to ingest.
+
+**Files to change.**
+
+- `lib/session.js`
+  - Constructor takes `id` arg. Stores `this.id`.
+  - `toJSON()` includes `id`.
+  - `stats()` includes `id`.
+
+- `lib/session-manager.js`
+  - `spawnSession(name, ...)`: generate `id = crypto.randomUUID()`. Pass into `new Session(name, tmuxName, { id, ... })`.
+  - `sessions` Map still keyed by `name` — don't migrate internal lookup structure yet.
+  - Add secondary `sessionsById` Map for id→Session lookup. Keep in sync with `sessions`.
+  - `attachClient` / `subscribeClient` / any public method that takes `name`: unchanged signature. Internal lookup still via `name`.
+  - On adoption path (server restart detects existing `kat_*` tmux session): if tmux session name is `kat_<uuid>` (36-char uuid pattern), extract id from suffix. Otherwise generate fresh id.
+
+- `lib/routes.js`
+  - `GET /sessions` already returns array of `toJSON()` — picks up `id` automatically.
+  - `POST /sessions` (create): response includes `id`.
+  - No new routes in this PR.
+
+- `server.js` / WebSocket bridge
+  - `session-added`, `session-removed`, `session-renamed`, `session-updated` broadcasts: include `id` alongside existing fields. Do not remove existing fields.
+
+- `test/session.test.js`, `test/session-manager.test.js`
+  - Assert id is generated on `spawnSession`.
+  - Assert id survives `renameSession` (name changes, id does not).
+  - Assert adopting a `kat_<uuid>` tmux session recovers the same id.
+  - Assert adopting a foreign-named tmux session synthesizes a fresh id.
+
+**Out of scope for PR1.**
+- No URL routing changes.
+- No client-side consumption.
+- No tmuxName changes (still sanitized display name).
+- No `/sessions/:id` HTTP routes.
+- No removal of rename-as-key machinery.
+
+**Risk.** Very low. Additive only. The `sessionsById` Map doubles memory for session metadata (negligible).
+
+**Estimate.** 1 day including tests.
+
+---
+
+## PR2 — Server-side id becomes load-bearing
+
+**Scope.** New sessions use `kat_<uuid>` tmuxName. `tmuxSessionName` sanitization function becomes dead code and is deleted. `/sessions/:id` endpoints added as aliases of `/sessions/:name` (both work). WebSocket session messages switch to id-first, with name as a derived field. Server-side redirect `GET /?s=<name>` → `?s=<id>`. Still no client migration — existing client code keeps using `name` everywhere.
+
+**Why ship separately from PR1.** This is where internal behavior changes (new tmuxName format, routing redirect). Isolating it from the additive PR makes rollback surgical if the new tmuxName format exposes a tmux edge case.
+
+**Files to change.**
+
+- `lib/tmux.js`
+  - Delete `tmuxSessionName()`. Replace callers with `"kat_" + id`.
+  - Delete conflict-check loop in `session-manager.js:62` (tmuxName is now structurally unique per id).
+
+- `lib/session-manager.js`
+  - `spawnSession`: `tmuxName = "kat_" + id`, no sanitization call.
+  - Adoption path: existing sessions keep their current tmuxName (may be `kat_<sanitized-name>` from pre-PR2 state). Treat tmuxName as opaque after adoption.
+
+- `lib/routes.js`
+  - Add `/sessions/:id` routes for GET/PUT/DELETE. Resolve via `sessionsById`. Keep `/sessions/:name` routes for backward-compat inside the current release.
+  - `GET /?s=<name>`: if a session matches name, 302 to `?s=<id>`. Otherwise serve index.html as-is (client handles unknown names).
+
+- `server.js` WebSocket
+  - Outgoing messages: send `{ type: "session-updated", id, displayName }` instead of `session-renamed`. Keep the server accepting legacy outgoing field names for one release if any internal producer still emits them.
+  - Incoming messages: accept either `id` or `name` where relevant (same release transition).
+
+- `test/`
+  - `/sessions/:id` endpoints work end-to-end.
+  - `/?s=<name>` redirects to `/?s=<id>`.
+  - Rename via `PUT /sessions/:id { displayName }` does not touch tmux.
+  - `tmuxSessionName` deleted — assert the import is gone (grep test).
+
+**Out of scope for PR2.**
+- No client-side migration.
+- No removal of `/sessions/:name` routes.
+
+**Risk.** Medium. Deleting the sanitization function is the scariest part — if any call site is missed, runtime error. Mitigated by grep test + full test suite.
+
+**Estimate.** 2 days.
+
+---
+
+## PR3 — Client-side migration (the "big" PR)
+
+**Scope.** Persistence move + client re-keying, per the MC1e doc's "combine the two" framing. All client stores re-key by `id`. localStorage schema bumps v3 → v4. Migration reducer reads old name-keyed state and issues fresh ids (or consumes server's `id` mapping if the client has a live WS connection at migration time). Delete `rename()` methods on `terminalPool`, `carousel`, `notepad`, `windowTabSet`, `iconStore`, `sessionStore` — they become no-ops that derive from `uiStore`. Shortcut-bar and `<tile-tab-bar>` read displayName from store, not from tile id. `state.session.name` closure deleted.
+
+**Why ship separately from PR2.** This is the large, risky one. Isolating it means the server-side scaffolding (PR1 + PR2) is already stable; the only new variable is the client migration.
+
+**Files to change.** (abbreviated — final list from diff)
+
+- `public/lib/ui-store.js` — migration reducer v3→v4. Tile ids become session ids, not session names.
+- `public/lib/tile-locator.js` — ids are now opaque strings (were display names); no changes except doc.
+- `public/lib/card-carousel.js` — cards map keyed by id; `renameCard()` deleted.
+- `public/lib/terminal-pool.js` — keyed by id; `rename()` deleted.
+- `public/lib/notepad.js`, `public/lib/window-tab-set.js`, `public/lib/icon-store.js`, `public/lib/session-store.js` — same pattern.
+- `public/lib/ws-message-handlers.js` — `session-updated` replaces `session-renamed`. One-field update to `uiStore.tiles[id].props.displayName`.
+- `public/app.js` — `applyLocalRename` deleted (or reduced to a single `uiStore` dispatch). `tab-rename` event handler becomes a two-liner: API call + dispatch. `state.session.name` deleted; selectors derive from uiStore.
+- `public/index.html` / URL handling — `?s=<id>` preferred; falls back to server redirect for `?s=<name>`.
+
+**Tests.**
+- Migration reducer: v3 state with known tile names migrates to v4 with synthesized ids; focus preserved; order preserved.
+- Rename across all 5 entry points (shortcut-bar, `<tile-tab-bar>`, session-list, Option+R, WS echo): exactly one server-side tmux session afterward (the test from session-identity.md).
+- Multi-window rename: BroadcastChannel message carries id; receiving window updates displayName without key migration.
+
+**Risk.** Large. Load-bearing migration. Parallel read path (accept v3 state, rewrite to v4 on load) through one release helps the rollback story.
+
+**Estimate.** 3-5 days including migration testing.
+
+---
+
+## Sequencing and MC3
+
+MC3 (Level 2 cluster strips) is blocked on PR3, not PR1 or PR2. If MC3 gains schedule pressure, PR1 and PR2 can ship first and MC3 can start against the id-aware server API while PR3 is in flight — but MC3's client-side work must not add new name-keyed stores (otherwise PR3 grows).
+
+## Open questions (need user input)
+
+1. Confirm `crypto.randomUUID()` over nanoid — any preference for shorter ids in logs / URLs?
+2. Is the adoption heuristic (`kat_<uuid>` → extract id, else synthesize) acceptable, or should the server refuse to adopt non-`kat_` sessions?
+3. How long does `/sessions/:name` stick around after PR3? Recommendation: delete immediately (WS has no backward-compat obligation, HTTP likewise since URL redirects handle bookmarks).
+4. Should PR1 include the `renameSession()` helper extraction (the MC1e doc's transitional helper), or is that PR3-only?

--- a/docs/mc1e-implementation-plan.md
+++ b/docs/mc1e-implementation-plan.md
@@ -6,21 +6,15 @@ The MC1e doc says "combine persistence move + surrogate id so there is exactly o
 
 Split MC1e into 3 PRs. Each ships independently; each is reviewable in one sitting.
 
-## Decisions to confirm with user before PR1
+## Decisions (confirmed 2026-04-14)
 
-1. **ID format.** Options: `crypto.randomUUID()` (36 chars, already in Node), nanoid (21 chars, need dep), base36 timestamp+counter (short, ordered, no dep). Recommendation: **`crypto.randomUUID()`** — zero deps, universally recognized, collision-resistant. Length isn't a user-visible problem since it lives in data, not UI.
-
-2. **tmuxName derivation.** `kat_<id>` where id is the full UUID (`kat_550e8400-e29b-41d4-a716-446655440000`). tmux accepts this — dots and dashes pass validation. **No sanitization dance.**
-
-3. **Persistence of id across server restart.** Options:
-   - (a) Regenerate on every start — old clients' `?s=<id>` URLs break across restarts.
-   - (b) Persist a tmuxName→id map to disk (`~/.katulong/sessions.json`).
-   - (c) Derive id from tmuxName on adoption (`tmuxName = "kat_<uuid>"` → strip prefix).
-   - Recommendation: **(c) for new sessions, fall back to (a) for adopted-external sessions.** When server adopts a tmux session whose name starts with `kat_`, extract the trailing uuid as id. For foreign tmux sessions (unlikely but possible), synthesize a fresh id. No persistence layer needed; id is encoded in tmuxName.
-
-4. **Migration window.** URL `?s=<name>` → `?s=<id>` redirect lives for how long? Recommendation: **indefinite.** It's a server-side redirect with a O(1) lookup, and removing it breaks every bookmark users have. Cost to maintain is ~10 lines.
-
-5. **WebSocket contract.** `session-renamed` → `session-updated { id, displayName }` per the doc. Only one client version talks to one server version (no protocol backward-compat obligation for WS), so the old message type can be deleted in the same PR that introduces the new one.
+1. **ID format: nanoid.** 21-char url-safe id. Adds `nanoid` dep.
+2. **tmuxName: `kat_<nanoid>`.** No sanitization.
+3. **`?s=` URL param is deleted entirely, not redirected.** It predates tiles and no longer fits the UI model. PR2 removes both query handling and the server-side redirect idea.
+4. **`/sessions/:name` routes deleted on the spot in PR3.** No transition window.
+5. **`renameSession()` helper: TBD during PR3.** Decide when the call-site shape is visible.
+6. **WebSocket contract.** `session-renamed` → `session-updated { id, displayName }`. Old message type deleted in the same PR that introduces the new one — no protocol backward-compat obligation for WS.
+7. **Adoption heuristic.** When adopting an existing `kat_*` tmux session, try to match the suffix against nanoid's alphabet + length; on match, reuse that id. On non-match (pre-PR2 sanitized names, foreign sessions), synthesize a fresh nanoid.
 
 ---
 
@@ -88,8 +82,8 @@ Split MC1e into 3 PRs. Each ships independently; each is reviewable in one sitti
   - Adoption path: existing sessions keep their current tmuxName (may be `kat_<sanitized-name>` from pre-PR2 state). Treat tmuxName as opaque after adoption.
 
 - `lib/routes.js`
-  - Add `/sessions/:id` routes for GET/PUT/DELETE. Resolve via `sessionsById`. Keep `/sessions/:name` routes for backward-compat inside the current release.
-  - `GET /?s=<name>`: if a session matches name, 302 to `?s=<id>`. Otherwise serve index.html as-is (client handles unknown names).
+  - Add `/sessions/:id` routes for GET/PUT/DELETE. Resolve via `sessionsById`. Keep `/sessions/:name` routes for the PR2→PR3 transition; deleted in PR3.
+  - **Delete `?s=` URL param handling entirely.** It predates tiles. No redirect replaces it. `?s=<anything>` is simply ignored after PR2.
 
 - `server.js` WebSocket
   - Outgoing messages: send `{ type: "session-updated", id, displayName }` instead of `session-renamed`. Keep the server accepting legacy outgoing field names for one release if any internal producer still emits them.
@@ -126,7 +120,7 @@ Split MC1e into 3 PRs. Each ships independently; each is reviewable in one sitti
 - `public/lib/notepad.js`, `public/lib/window-tab-set.js`, `public/lib/icon-store.js`, `public/lib/session-store.js` — same pattern.
 - `public/lib/ws-message-handlers.js` — `session-updated` replaces `session-renamed`. One-field update to `uiStore.tiles[id].props.displayName`.
 - `public/app.js` — `applyLocalRename` deleted (or reduced to a single `uiStore` dispatch). `tab-rename` event handler becomes a two-liner: API call + dispatch. `state.session.name` deleted; selectors derive from uiStore.
-- `public/index.html` / URL handling — `?s=<id>` preferred; falls back to server redirect for `?s=<name>`.
+- `public/index.html` / URL handling — remove all `?s=` reading code. Session selection is driven by uiStore/persistence, not URL.
 
 **Tests.**
 - Migration reducer: v3 state with known tile names migrates to v4 with synthesized ids; focus preserved; order preserved.
@@ -143,9 +137,4 @@ Split MC1e into 3 PRs. Each ships independently; each is reviewable in one sitti
 
 MC3 (Level 2 cluster strips) is blocked on PR3, not PR1 or PR2. If MC3 gains schedule pressure, PR1 and PR2 can ship first and MC3 can start against the id-aware server API while PR3 is in flight — but MC3's client-side work must not add new name-keyed stores (otherwise PR3 grows).
 
-## Open questions (need user input)
-
-1. Confirm `crypto.randomUUID()` over nanoid — any preference for shorter ids in logs / URLs?
-2. Is the adoption heuristic (`kat_<uuid>` → extract id, else synthesize) acceptable, or should the server refuse to adopt non-`kat_` sessions?
-3. How long does `/sessions/:name` stick around after PR3? Recommendation: delete immediately (WS has no backward-compat obligation, HTTP likewise since URL redirects handle bookmarks).
-4. Should PR1 include the `renameSession()` helper extraction (the MC1e doc's transitional helper), or is that PR3-only?
+## Resolved decisions — see "Decisions" section above.

--- a/lib/id.js
+++ b/lib/id.js
@@ -1,0 +1,25 @@
+/**
+ * Stable, URL-safe session identifier generator.
+ *
+ * Same alphabet and default length as the nanoid package (21 chars ≈ 126
+ * bits of entropy, collision-resistant for the session lifetimes we care
+ * about), inlined here to avoid a runtime dep. The alphabet (A–Z, a–z,
+ * 0–9, `-`, `_`) is a superset of what tmux accepts in session names, so
+ * a `kat_<id>` tmuxName needs no sanitization.
+ *
+ * Uses WebCrypto's `getRandomValues` (available in Node 20+) via the
+ * module-scoped `crypto` global. Bytes are masked to the alphabet via
+ * `byte & 63` — unbiased because the alphabet is exactly 64 symbols.
+ */
+
+const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+export function sessionId(size = 21) {
+  const bytes = new Uint8Array(size);
+  crypto.getRandomValues(bytes);
+  let id = "";
+  for (let i = 0; i < size; i++) id += ALPHABET[bytes[i] & 63];
+  return id;
+}
+
+export const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{21}$/;

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -593,7 +593,7 @@ export function createAppRoutes(ctx) {
         const session = sessionManager.getSession(result.name);
         if (session) session.setIcon("robot");
       }
-      json(res, result.error ? 409 : 201, result.error ? { error: result.error } : { name: result.name });
+      json(res, result.error ? 409 : 201, result.error ? { error: result.error } : { name: result.name, id: result.id });
     }))},
 
     { method: "GET", prefix: "/sessions/cwd/", handler: auth(async (req, res, name) => {
@@ -711,7 +711,7 @@ export function createAppRoutes(ctx) {
       const sessionName = SessionName.tryCreate(newName);
       if (!sessionName) return json(res, 400, { error: "Invalid name" });
       const result = await sessionManager.renameSession(name, sessionName.toString());
-      json(res, result.error ? 404 : 200, result.error ? { error: result.error } : { name: result.name });
+      json(res, result.error ? 404 : 200, result.error ? { error: result.error } : { name: result.name, id: result.id });
     }))},
 
     // --- tmux session browser ---

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -21,6 +21,7 @@ import { driftLog, driftLogLevel } from "./drift-log.js";
 import { createSessionStore } from "./session-persistence.js";
 import { startChildCountMonitor } from "./session-child-counter.js";
 import { Session } from "./session.js";
+import { sessionId } from "./id.js";
 import {
   tmuxSessionName, tmuxExec, tmuxNewSession, tmuxHasSession,
   applyTmuxSessionOptions, captureVisiblePane, getCursorPosition, getPaneCwd, checkTmux,
@@ -52,11 +53,19 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
   // The store is a thin wrapper around fs; it only knows how to serialize
   // whatever plain object this callback returns, keeping the persistence
   // concern independent of the Session class.
+  //
+  // Entry shape: { tmuxName, id }. Legacy entries (a raw tmuxName string)
+  // are accepted on load — see restoreSessions — and rewritten on the next
+  // scheduleSave(). The `id` field is the immutable surrogate introduced
+  // in MC1e; it lets ids survive server restart once client-side code
+  // starts consuming them (later MC1e steps).
   const store = createSessionStore({
     dataDir,
     serialize: () => {
       const obj = {};
-      for (const [name, session] of sessions) obj[name] = session.tmuxName;
+      for (const [name, session] of sessions) {
+        obj[name] = { tmuxName: session.tmuxName, id: session.id };
+      }
       return obj;
     },
   });
@@ -170,12 +179,13 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
 
   // --- Shared helper: adopt an existing tmux session ---
 
-  async function adoptSession(name, tmuxName, cols = DEFAULT_COLS, rows = DEFAULT_ROWS, { external = false } = {}) {
+  async function adoptSession(name, tmuxName, cols = DEFAULT_COLS, rows = DEFAULT_ROWS, { external = false, id = null } = {}) {
     // Only apply tmux options for externally adopted sessions —
     // new sessions already have them from tmuxNewSession().
     if (external) await applyTmuxSessionOptions(tmuxName);
 
     const session = new Session(name, tmuxName, {
+      id: id || sessionId(),
       maxBufferBytes: MAX_BUFFER_BYTES,
       external,
       onData: (sessionName, fromSeq) => {
@@ -336,7 +346,7 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
     sessions.set(tmuxName, session);
     detachedNames.delete(tmuxName);
     log.info("Adopted tmux session", { tmuxName });
-    return { name: tmuxName };
+    return { name: tmuxName, id: session.id };
   }
 
   // --- Public API ---
@@ -469,9 +479,9 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
         }
       }
 
-      await spawnSession(name, cols, rows, cwd);
+      const session = await spawnSession(name, cols, rows, cwd);
       scheduleSave();
-      return { name };
+      return { name, id: session.id };
     },
 
     deleteSession: deleteSession,
@@ -507,10 +517,10 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
       sessions.delete(oldName);
       sessions.set(newName, session);
       tracker.renameSession(oldName, newName);
-      bridge.relay({ type: "session-renamed", session: oldName, newName });
+      bridge.relay({ type: "session-renamed", session: oldName, newName, id: session.id });
       log.info("Session renamed", { from: oldName, to: newName });
       scheduleSave();
-      return { name: newName };
+      return { name: newName, id: session.id };
     },
 
     /**
@@ -693,32 +703,49 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
 
     /**
      * Restore sessions from sessions.json, re-adopting tmux sessions that still exist.
+     *
+     * Accepts both persistence formats:
+     *   - legacy: `{ [name]: tmuxName }` (string value)
+     *   - current: `{ [name]: { tmuxName, id } }` (object value with id)
+     *
+     * A legacy entry is restored with a fresh id — there is no stable id
+     * in the old format to recover. The next scheduleSave() rewrites it in
+     * the current shape.
      */
     async restoreSessions() {
       const map = store.load();
       if (!map) return;
 
-      // Filter candidates synchronously, then restore in parallel.
-      const candidates = Object.entries(map).filter(
-        ([friendlyName, tmuxName]) =>
-          typeof tmuxName === "string" &&
-          !sessions.has(friendlyName) &&
-          !isAlreadyManaged(tmuxName)
-      );
+      // Normalize to `{ friendlyName, tmuxName, id }`. Filter candidates
+      // synchronously, then restore in parallel.
+      const candidates = [];
+      for (const [friendlyName, entry] of Object.entries(map)) {
+        let tmuxName = null;
+        let persistedId = null;
+        if (typeof entry === "string") {
+          tmuxName = entry;
+        } else if (entry && typeof entry === "object" && typeof entry.tmuxName === "string") {
+          tmuxName = entry.tmuxName;
+          if (typeof entry.id === "string") persistedId = entry.id;
+        }
+        if (!tmuxName) continue;
+        if (sessions.has(friendlyName)) continue;
+        if (isAlreadyManaged(tmuxName)) continue;
+        candidates.push({ friendlyName, tmuxName, persistedId });
+      }
 
       await Promise.allSettled(
-        candidates.map(async ([friendlyName, tmuxName]) => {
+        candidates.map(async ({ friendlyName, tmuxName, persistedId }) => {
           const exists = await tmuxHasSession(tmuxName);
           if (!exists) return;
-          const session = await adoptSession(friendlyName, tmuxName);
+          const session = await adoptSession(friendlyName, tmuxName, DEFAULT_COLS, DEFAULT_ROWS, { id: persistedId });
           sessions.set(friendlyName, session);
           log.info("Restored session", { session: friendlyName, tmux: tmuxName });
         })
       ).then(results => {
         for (let i = 0; i < results.length; i++) {
           if (results[i].status === "rejected") {
-            const [friendlyName] = candidates[i];
-            log.warn("Failed to restore session", { session: friendlyName, error: results[i].reason?.message });
+            log.warn("Failed to restore session", { session: candidates[i].friendlyName, error: results[i].reason?.message });
           }
         }
       });

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -21,7 +21,7 @@ import { driftLog, driftLogLevel } from "./drift-log.js";
 import { createSessionStore } from "./session-persistence.js";
 import { startChildCountMonitor } from "./session-child-counter.js";
 import { Session } from "./session.js";
-import { sessionId } from "./id.js";
+import { sessionId, SESSION_ID_PATTERN } from "./id.js";
 import {
   tmuxSessionName, tmuxExec, tmuxNewSession, tmuxHasSession,
   applyTmuxSessionOptions, captureVisiblePane, getCursorPosition, getPaneCwd, checkTmux,
@@ -185,7 +185,7 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
     if (external) await applyTmuxSessionOptions(tmuxName);
 
     const session = new Session(name, tmuxName, {
-      id: id || sessionId(),
+      id: id != null ? id : sessionId(),
       maxBufferBytes: MAX_BUFFER_BYTES,
       external,
       onData: (sessionName, fromSeq) => {
@@ -726,7 +726,9 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
           tmuxName = entry;
         } else if (entry && typeof entry === "object" && typeof entry.tmuxName === "string") {
           tmuxName = entry.tmuxName;
-          if (typeof entry.id === "string") persistedId = entry.id;
+          if (typeof entry.id === "string" && SESSION_ID_PATTERN.test(entry.id)) {
+            persistedId = entry.id;
+          }
         }
         if (!tmuxName) continue;
         if (sessions.has(friendlyName)) continue;
@@ -788,6 +790,12 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
         }
         scheduleSave();
       }
+
+      // Always rewrite sessions.json after restore. If any legacy
+      // string-valued entries were loaded, they were restored with fresh
+      // ids — persisting now seals those ids into the file so subsequent
+      // restarts keep them stable. No-op when the shape is already current.
+      scheduleSave();
     },
 
     /**

--- a/lib/session.js
+++ b/lib/session.js
@@ -41,9 +41,13 @@ export class SessionNotAliveError extends Error {
 export class Session {
   /**
    * Create a new Session backed by tmux control mode.
-   * @param {string} name - Session name
-   * @param {string} tmuxName - Sanitized tmux session name
+   * @param {string} name - Session display name (mutable)
+   * @param {string} tmuxName - tmux session name (currently derived from `name`;
+   *   becomes derived from `id` in a later MC1e step)
    * @param {object} options
+   * @param {string} [options.id] - Immutable surrogate id (MC1e). Session-manager
+   *   always supplies one for new/adopted sessions; direct-construction tests
+   *   may omit it.
    * @param {number} [options.maxBufferItems]
    * @param {number} [options.maxBufferBytes]
    * @param {Function} [options.onData] - Callback: onData(sessionName, fromSeq)
@@ -62,6 +66,7 @@ export class Session {
   constructor(name, tmuxName, options = {}) {
     this.name = name;
     this.tmuxName = tmuxName;
+    this.id = options.id || null;
     this.state = Session.STATE_DETACHED;
     this.controlProc = null;
     this._childCount = 0;
@@ -688,6 +693,7 @@ export class Session {
    */
   toJSON() {
     return {
+      id: this.id,
       name: this.name,
       tmuxSession: this.tmuxName,
       alive: this.alive,

--- a/lib/session.js
+++ b/lib/session.js
@@ -66,7 +66,7 @@ export class Session {
   constructor(name, tmuxName, options = {}) {
     this.name = name;
     this.tmuxName = tmuxName;
-    this.id = options.id || null;
+    this.id = typeof options.id === "string" && options.id.length > 0 ? options.id : null;
     this.state = Session.STATE_DETACHED;
     this.controlProc = null;
     this._childCount = 0;

--- a/lib/ws-manager.js
+++ b/lib/ws-manager.js
@@ -187,7 +187,7 @@ export function createWebSocketManager({ bridge, sessionManager, pluginWsHandler
         break;
       case "session-renamed":
         // Tracker already renamed clients before relay, so route via newName
-        sendToSession(msg.newName, { type: "session-renamed", name: msg.newName });
+        sendToSession(msg.newName, { type: "session-renamed", name: msg.newName, id: msg.id });
         break;
       case "resize-sync":
         sendToSessionExcluding(msg.session, msg.activeClientId, {

--- a/test/helpers/session-manager-fixture.js
+++ b/test/helpers/session-manager-fixture.js
@@ -70,6 +70,7 @@ export class BaseMockSession {
   constructor(name, tmuxName, options = {}) {
     this.name = name;
     this.tmuxName = tmuxName;
+    this.id = options.id || null;
     this.state = BaseMockSession.STATE_ATTACHED;
     this.external = options.external || false;
     this._options = options;
@@ -115,7 +116,7 @@ export class BaseMockSession {
   }
 
   toJSON() {
-    return { name: this.name, alive: this.alive, external: this.external };
+    return { id: this.id, name: this.name, alive: this.alive, external: this.external };
   }
 }
 

--- a/test/session-id.test.js
+++ b/test/session-id.test.js
@@ -1,0 +1,148 @@
+/**
+ * Session surrogate-id tests (MC1e PR1 — additive server-side id).
+ *
+ * These assertions are load-bearing for the later MC1e steps that migrate
+ * client stores to key by id. If any of them regress, the client-side work
+ * can't rely on id being present/stable/persisted.
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { sessionId, SESSION_ID_PATTERN } from "../lib/id.js";
+import {
+  setupSessionManagerMocks,
+  BaseMockSession,
+  makeBridge,
+  tmuxSessions,
+} from "./helpers/session-manager-fixture.js";
+
+const { createSessionManager } = await setupSessionManagerMocks(BaseMockSession);
+
+function makeManager(overrides = {}) {
+  return createSessionManager({
+    bridge: makeBridge(),
+    shell: "/bin/sh",
+    home: "/tmp",
+    ...overrides,
+  });
+}
+
+describe("sessionId()", () => {
+  it("returns a 21-char url-safe id by default", () => {
+    const id = sessionId();
+    assert.strictEqual(id.length, 21);
+    assert.match(id, SESSION_ID_PATTERN);
+  });
+
+  it("generates distinct ids across many calls", () => {
+    const ids = new Set();
+    for (let i = 0; i < 10000; i++) ids.add(sessionId());
+    assert.strictEqual(ids.size, 10000, "10k sessionIds should all be unique");
+  });
+
+  it("supports a custom size", () => {
+    assert.strictEqual(sessionId(5).length, 5);
+    assert.strictEqual(sessionId(40).length, 40);
+  });
+});
+
+describe("session manager — id lifecycle", () => {
+  beforeEach(() => {
+    tmuxSessions.clear();
+  });
+
+  it("createSession generates an id", async () => {
+    const mgr = makeManager();
+    const result = await mgr.createSession("s1");
+    assert.match(result.id, SESSION_ID_PATTERN);
+  });
+
+  it("listSessions surfaces the id", async () => {
+    const mgr = makeManager();
+    const { id } = await mgr.createSession("s1");
+    const { sessions } = mgr.listSessions();
+    assert.strictEqual(sessions[0].id, id);
+  });
+
+  it("renameSession preserves the id", async () => {
+    const mgr = makeManager();
+    const { id } = await mgr.createSession("original");
+    const renamed = await mgr.renameSession("original", "updated");
+    assert.strictEqual(renamed.id, id, "id must not change on rename");
+    const { sessions } = mgr.listSessions();
+    assert.strictEqual(sessions[0].id, id);
+  });
+
+  it("ids are distinct across concurrently-created sessions", async () => {
+    const mgr = makeManager();
+    const results = await Promise.all(
+      Array.from({ length: 8 }, (_, i) => mgr.createSession(`s${i}`)),
+    );
+    const ids = new Set(results.map(r => r.id));
+    assert.strictEqual(ids.size, 8);
+  });
+
+  it("session-renamed relay carries the id", async () => {
+    const bridge = makeBridge();
+    const mgr = createSessionManager({ bridge, shell: "/bin/sh", home: "/tmp" });
+    const { id } = await mgr.createSession("a");
+    await mgr.renameSession("a", "b");
+    const renamed = bridge.messages.find(m => m.type === "session-renamed");
+    assert.strictEqual(renamed.id, id);
+  });
+});
+
+describe("session manager — id persistence", () => {
+  let dataDir;
+
+  beforeEach(() => {
+    tmuxSessions.clear();
+    dataDir = mkdtempSync(join(tmpdir(), "katulong-id-test-"));
+  });
+
+  it("persists id to sessions.json", async () => {
+    const mgr = makeManager({ dataDir });
+    const { id } = await mgr.createSession("persisted");
+    mgr.shutdown();
+    const saved = JSON.parse(readFileSync(join(dataDir, "sessions.json"), "utf-8"));
+    assert.strictEqual(saved["persisted"].id, id);
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("restores the id across a fresh manager", async () => {
+    const mgr1 = makeManager({ dataDir });
+    const { id } = await mgr1.createSession("keep-me");
+    mgr1.shutdown();
+    // tmux session still alive (real shutdown detaches; our mock kept it)
+    tmuxSessions.set("keep-me", true);
+
+    const mgr2 = makeManager({ dataDir });
+    await mgr2.restoreSessions();
+    const restored = mgr2.listSessions().sessions.find(s => s.name === "keep-me");
+    assert.ok(restored, "session should restore");
+    assert.strictEqual(restored.id, id, "restored id must match persisted id");
+    mgr2.shutdown();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("accepts legacy string-valued sessions.json and synthesizes ids", async () => {
+    // Pre-MC1e shape: { name: "tmuxName" } with no id.
+    writeFileSync(
+      join(dataDir, "sessions.json"),
+      JSON.stringify({ "legacy-session": "legacy_session" }),
+    );
+    tmuxSessions.set("legacy_session", true);
+
+    const mgr = makeManager({ dataDir });
+    await mgr.restoreSessions();
+    const restored = mgr.listSessions().sessions.find(s => s.name === "legacy-session");
+    assert.ok(restored, "legacy-format session should restore");
+    assert.match(restored.id, SESSION_ID_PATTERN, "legacy entries should get a fresh nanoid");
+    mgr.shutdown();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+});

--- a/test/session-manager.test.js
+++ b/test/session-manager.test.js
@@ -64,10 +64,12 @@ describe("session manager", () => {
   });
 
   describe("createSession", () => {
-    it("creates a session and returns its name", async () => {
+    it("creates a session and returns its name and id", async () => {
       const { mgr } = makeManager();
       const result = await mgr.createSession("test1");
-      assert.deepStrictEqual(result, { name: "test1" });
+      assert.strictEqual(result.name, "test1");
+      assert.strictEqual(typeof result.id, "string");
+      assert.strictEqual(result.id.length, 21);
     });
 
     it("rejects duplicate session names", async () => {
@@ -141,18 +143,21 @@ describe("session manager", () => {
   });
 
   describe("renameSession", () => {
-    it("renames a session", async () => {
+    it("renames a session and preserves id", async () => {
       const { mgr, bridge } = makeManager();
-      await mgr.createSession("old");
+      const created = await mgr.createSession("old");
       const result = await mgr.renameSession("old", "new");
-      assert.deepStrictEqual(result, { name: "new" });
+      assert.strictEqual(result.name, "new");
+      assert.strictEqual(result.id, created.id, "rename must preserve id");
       assert.strictEqual(mgr.listSessions().sessions.length, 1);
       assert.strictEqual(mgr.listSessions().sessions[0].name, "new");
+      assert.strictEqual(mgr.listSessions().sessions[0].id, created.id);
 
       const renamed = bridge.messages.find(m => m.type === "session-renamed");
       assert.ok(renamed);
       assert.strictEqual(renamed.session, "old");
       assert.strictEqual(renamed.newName, "new");
+      assert.strictEqual(renamed.id, created.id);
     });
 
     it("rejects rename to existing name", async () => {

--- a/test/session-persistence.test.js
+++ b/test/session-persistence.test.js
@@ -23,6 +23,7 @@ class MockSession {
   constructor(name, tmuxName, options = {}) {
     this.name = name;
     this.tmuxName = tmuxName;
+    this.id = options.id || null;
     this._alive = true;
     this._cols = 0;
     this._rows = 0;
@@ -39,7 +40,7 @@ class MockSession {
   detach() { this._alive = false; }
   kill() { this._alive = false; tmuxSessions.delete(this.tmuxName); }
   serializeScreen() { return ""; }
-  toJSON() { return { name: this.name, alive: this.alive }; }
+  toJSON() { return { id: this.id, name: this.name, alive: this.alive }; }
 }
 
 mock.module(sessionModuleUrl, {
@@ -106,10 +107,12 @@ describe("Session persistence", () => {
     await mgr1.createSession("dev.server", 80, 24);
     mgr1.shutdown();
 
-    // Verify file was written
+    // Verify file was written — new shape is { tmuxName, id }.
     const saved = JSON.parse(readFileSync(join(dataDir, "sessions.json"), "utf-8"));
-    assert.strictEqual(saved["my session"], "my_session");
-    assert.strictEqual(saved["dev.server"], "dev_server");
+    assert.strictEqual(saved["my session"].tmuxName, "my_session");
+    assert.strictEqual(saved["dev.server"].tmuxName, "dev_server");
+    assert.strictEqual(typeof saved["my session"].id, "string");
+    assert.strictEqual(typeof saved["dev.server"].id, "string");
 
     // tmux sessions still exist (shutdown detaches, doesn't kill)
     // Re-add them to our mock since MockSession.detach doesn't remove from tmuxSessions
@@ -186,8 +189,8 @@ describe("Session persistence", () => {
     await new Promise((r) => setTimeout(r, 200));
 
     const saved = JSON.parse(readFileSync(join(dataDir, "sessions.json"), "utf-8"));
-    assert.strictEqual(saved["first"], "first");
-    assert.strictEqual(saved["second"], "second");
+    assert.strictEqual(saved["first"].tmuxName, "first");
+    assert.strictEqual(saved["second"].tmuxName, "second");
 
     mgr.shutdown();
     rmSync(dataDir, { recursive: true, force: true });
@@ -209,7 +212,7 @@ describe("Session persistence", () => {
     await new Promise((r) => setTimeout(r, 200));
 
     const saved = JSON.parse(readFileSync(join(dataDir, "sessions.json"), "utf-8"));
-    assert.strictEqual(saved["omega"], "omega");
+    assert.strictEqual(saved["omega"].tmuxName, "omega");
     assert.strictEqual(saved["beta"], undefined);
     assert.strictEqual(saved["alpha"], undefined);
 


### PR DESCRIPTION
## Summary

First of three PRs implementing MC1e. Adds an immutable `id` field to `Session` alongside the existing mutable `name`. Purely additive — no behavior change, no client consumption yet. Establishes the field shape later PRs will migrate onto.

## What changes

- **`lib/id.js`** — 21-char url-safe id generator (inline nanoid alphabet, no new runtime dep). Uses WebCrypto `getRandomValues`.
- **Session** constructor accepts `options.id`; `toJSON()` includes it.
- **session-manager**:
  - `adoptSession()` generates an id (or uses a persisted one).
  - `sessions.json` entry shape: `{ tmuxName, id }` instead of a raw `tmuxName` string. Legacy string entries still load; they get a fresh id on restore and are rewritten in the current shape on next `scheduleSave()`.
  - `createSession` / `renameSession` / `adoptTmuxSession` include id in their return value.
  - `session-renamed` bridge relay carries id.
- **ws-manager** — `session-renamed` WS message carries id (clients ignore it until PR3).
- **Tests** — new `test/session-id.test.js` (11 assertions): generator uniqueness, id propagation through create/rename/list, persistence round-trip, legacy-format acceptance. Existing rename + persistence tests updated to the new `{ tmuxName, id }` shape.

## Out of scope

- tmuxName still derived from name (`kat_<id>` change is PR2).
- `tmuxSessionName` sanitization stays (deleted in PR2).
- No `/sessions/:id` routes yet.
- No client-side consumption (PR3).

See `docs/mc1e-implementation-plan.md` for the full multi-PR plan.

## Test plan

- [x] `npm test` — 2193 pass, 0 fail
- [x] New `test/session-id.test.js` — 11 new assertions
- [x] Updated rename + persistence tests pass
- [ ] Manual verification: create session, rename it, confirm id is stable across the rename in server logs