### PR TITLE
MC1e PR2: kat_<id> tmuxName + pane id capture + by-id routes

### DIFF
--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -17,6 +17,7 @@ import {
   parseCookies, getCsrfToken, escapeAttr, getCspHeaders,
 } from "../http-util.js";
 import { SessionName } from "../session-name.js";
+import { SESSION_ID_PATTERN } from "../id.js";
 import { loadShortcuts, saveShortcuts } from "../shortcuts.js";
 import { log } from "../log.js";
 import { rewriteVendorUrls } from "../static-files.js";
@@ -65,6 +66,29 @@ export function createAppRoutes(ctx) {
     getDraining, shortcutsPath,
     auth, csrf, topicBroker, getExternalUrl,
   } = ctx;
+
+  // Parse `/sessions/by-id/:id[/suffix]` route params. Returns either:
+  //   { session, suffix }       — session found (suffix is null for bare
+  //                                /sessions/by-id/:id, or the string after
+  //                                the next slash like "exec" / "status")
+  //   { error: { status, message } }
+  //
+  // Validating the id shape here means handlers never see a bogus id and
+  // don't need to catch a separate "invalid format" vs "not found" case.
+  // Suffix is kept as a raw opaque string; handlers compare it themselves.
+  function resolveByIdParam(param) {
+    const slash = param.indexOf("/");
+    const id = slash === -1 ? param : param.slice(0, slash);
+    const suffix = slash === -1 ? null : param.slice(slash + 1);
+    if (!SESSION_ID_PATTERN.test(id)) {
+      return { error: { status: 400, message: "Invalid session id" } };
+    }
+    const session = sessionManager.getSessionById(id);
+    if (!session) {
+      return { error: { status: 404, message: "Session not found" } };
+    }
+    return { session, suffix };
+  }
 
   // Narrative processor — transforms raw Claude events into a running blog-like narrative.
   // It owns all topic creation: topics are created lazily on the first published event
@@ -600,6 +624,109 @@ export function createAppRoutes(ctx) {
       const cwd = await sessionManager.getSessionCwd(name);
       json(res, cwd ? 200 : 404, cwd ? { cwd } : { error: "Session not found" });
     })},
+
+    // --- By-id session routes (MC1e PR2) ---
+    //
+    // These parallel the name-keyed `/sessions/:name/*` family below but
+    // look up sessions by the immutable `id` instead of the mutable
+    // friendly name. Name-keyed routes stay functional through PR2 so the
+    // client can migrate incrementally; PR3 removes them.
+    //
+    // Placed BEFORE the generic `/sessions/` prefix because the route
+    // matcher in server.js is first-match (see server.js:matchRoute).
+
+    { method: "POST", prefix: "/sessions/by-id/", handler: auth(csrf(async (req, res, param) => {
+      const { session, suffix, error } = resolveByIdParam(param);
+      if (error) return json(res, error.status, { error: error.message });
+      if (suffix === "exec") {
+        const { input } = await parseJSON(req);
+        if (typeof input !== "string") return json(res, 400, { error: "Missing input string" });
+        if (input.length > 65536) return json(res, 400, { error: "Input too large (max 64KB)" });
+        session.write(input + "\r");
+        return json(res, 200, { ok: true });
+      }
+      if (suffix === "input") {
+        let body;
+        try {
+          body = await parseJSON(req);
+        } catch (err) {
+          if (/too large/i.test(err.message)) return json(res, 413, { error: "Request body too large" });
+          return json(res, 400, { error: "Invalid JSON body" });
+        }
+        const data = body?.data;
+        if (typeof data !== "string") return json(res, 400, { error: "Missing data string" });
+        if (data.length === 0) return json(res, 400, { error: "Empty data" });
+        session.write(data);
+        return json(res, 200, { ok: true, bytes: Buffer.byteLength(data, "utf8") });
+      }
+      return json(res, 404, { error: "Not found" });
+    }))},
+
+    { method: "GET", prefix: "/sessions/by-id/", handler: auth(async (req, res, param) => {
+      const { session, suffix, error } = resolveByIdParam(param);
+      if (error) return json(res, error.status, { error: error.message });
+      if (suffix === "status") {
+        return json(res, 200, {
+          id: session.id,
+          name: session.name,
+          alive: session.alive,
+          hasChildProcesses: session.hasChildProcesses(),
+          childCount: session._childCount,
+        });
+      }
+      if (suffix !== "output") return json(res, 404, { error: "Not found" });
+
+      const url = new URL(req.url, "http://localhost");
+      const fromSeq = url.searchParams.get("fromSeq");
+      const lines = url.searchParams.get("lines");
+      const screen = url.searchParams.get("screen");
+
+      if (screen === "true") {
+        const snap = await session.snapshot();
+        return json(res, 200, { screen: snap.buffer, seq: snap.seq });
+      }
+      if (fromSeq !== null) {
+        const seq = parseInt(fromSeq, 10);
+        if (isNaN(seq) || seq < 0) return json(res, 400, { error: "Invalid fromSeq" });
+        const { data, cursor } = session.pullFrom(seq);
+        if (data === null) {
+          const snap = await session.snapshot();
+          return json(res, 200, { screen: snap.buffer, seq: snap.seq, evicted: true });
+        }
+        return json(res, 200, { data, seq: cursor, alive: session.alive });
+      }
+      if (lines !== null) {
+        const n = parseInt(lines, 10);
+        if (isNaN(n) || n < 1 || n > 1000) return json(res, 400, { error: "Invalid lines (1-1000)" });
+        const visible = await captureVisiblePane(session.tmuxName);
+        const allLines = (visible || "").split("\n");
+        const lastN = allLines.slice(-n).join("\n");
+        return json(res, 200, { data: lastN, seq: session.cursor });
+      }
+      const { data, cursor } = session.pullTail(4096);
+      json(res, 200, { data, seq: cursor });
+    })},
+
+    { method: "DELETE", prefix: "/sessions/by-id/", handler: auth(csrf((req, res, param) => {
+      const { session, suffix, error } = resolveByIdParam(param);
+      if (error) return json(res, error.status, { error: error.message });
+      if (suffix !== null) return json(res, 404, { error: "Not found" });
+      const url = new URL(req.url, "http://localhost");
+      const detachOnly = url.searchParams.get("action") === "detach";
+      const result = sessionManager.deleteSession(session.name, { detachOnly });
+      json(res, result.error ? 404 : 200, result.error ? { error: result.error } : { ok: true, action: result.action });
+    }))},
+
+    { method: "PUT", prefix: "/sessions/by-id/", handler: auth(csrf(async (req, res, param) => {
+      const { session, suffix, error } = resolveByIdParam(param);
+      if (error) return json(res, error.status, { error: error.message });
+      if (suffix !== null) return json(res, 404, { error: "Not found" });
+      const { name: newName } = await parseJSON(req);
+      const sessionName = SessionName.tryCreate(newName);
+      if (!sessionName) return json(res, 400, { error: "Invalid name" });
+      const result = await sessionManager.renameSession(session.name, sessionName.toString());
+      json(res, result.error ? 404 : 200, result.error ? { error: result.error } : { name: result.name, id: result.id });
+    }))},
 
     // --- Session I/O (exec + output) ---
 

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -23,10 +23,10 @@ import { startChildCountMonitor } from "./session-child-counter.js";
 import { Session } from "./session.js";
 import { sessionId, SESSION_ID_PATTERN } from "./id.js";
 import {
-  tmuxSessionName, tmuxExec, tmuxNewSession, tmuxHasSession,
+  tmuxExec, tmuxNewSession, tmuxHasSession,
   applyTmuxSessionOptions, captureVisiblePane, getCursorPosition, getPaneCwd, checkTmux,
   cleanTmuxServerEnv, setTmuxKatulongEnv, tmuxListSessions, tmuxKillSession, tmuxListSessionsDetailed,
-  tmuxSocketArgs,
+  tmuxSocketArgs, tmuxGetPaneId,
 } from "./tmux.js";
 import { DEFAULT_COLS, TERMINAL_ROWS_DEFAULT } from "./terminal-config.js";
 
@@ -54,17 +54,21 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
   // whatever plain object this callback returns, keeping the persistence
   // concern independent of the Session class.
   //
-  // Entry shape: { tmuxName, id }. Legacy entries (a raw tmuxName string)
-  // are accepted on load — see restoreSessions — and rewritten on the next
-  // scheduleSave(). The `id` field is the immutable surrogate introduced
-  // in MC1e; it lets ids survive server restart once client-side code
-  // starts consuming them (later MC1e steps).
+  // Entry shape: { tmuxName, id, tmuxPane }. Legacy entries (a raw tmuxName
+  // string or a `{ tmuxName, id }` object with no tmuxPane) are accepted on
+  // load — see restoreSessions — and rewritten on the next scheduleSave().
+  // `tmuxPane` is recaptured live on restore anyway, so persisting it is
+  // defense-in-depth for cases where the capture fails during startup.
   const store = createSessionStore({
     dataDir,
     serialize: () => {
       const obj = {};
       for (const [name, session] of sessions) {
-        obj[name] = { tmuxName: session.tmuxName, id: session.id };
+        obj[name] = {
+          tmuxName: session.tmuxName,
+          id: session.id,
+          tmuxPane: session.tmuxPane,
+        };
       }
       return obj;
     },
@@ -184,8 +188,17 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
     // new sessions already have them from tmuxNewSession().
     if (external) await applyTmuxSessionOptions(tmuxName);
 
+    // Capture the tmux pane id (`%N`) now — it's stable for the pane's
+    // lifetime and used by the claude hook pipeline to answer
+    // "which claude UUID is running in this katulong tile?". See
+    // docs/tile-claude-session-link.md. Failing to capture is not fatal:
+    // we fall back to null and the claude lookup simply won't match for
+    // this session until a restart or reattach.
+    const tmuxPane = await tmuxGetPaneId(tmuxName);
+
     const session = new Session(name, tmuxName, {
       id: id != null ? id : sessionId(),
+      tmuxPane,
       maxBufferBytes: MAX_BUFFER_BYTES,
       external,
       onData: (sessionName, fromSeq) => {
@@ -273,55 +286,43 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
 
   // --- Session operations ---
 
-  async function spawnSession(name, cols = DEFAULT_COLS, rows = DEFAULT_ROWS, cwd = null) {
-    // Serialize on tmux name (canonical form) so that spawn("foo bar") and
-    // adopt("foo_bar") cannot race — both map to the same tmux session.
-    const key = tmuxSessionName(name);
-    const pending = pendingOps.get(key);
+  async function spawnSession(name, cols = DEFAULT_COLS, rows = DEFAULT_ROWS, cwd = null, id = null) {
+    // Serialize on friendly name so concurrent spawns of the same name
+    // collapse into a single promise. Adopt also keys pendingOps on the
+    // friendly name it will store the session under (which equals the
+    // tmuxName for adoption), so a spawn and adopt targeting the same
+    // sessions-map key still serialize against each other.
+    const pending = pendingOps.get(name);
     if (pending) return pending;
 
-    const promise = doSpawnSession(name, cols, rows, cwd).finally(() => {
-      pendingOps.delete(key);
+    const promise = doSpawnSession(name, cols, rows, cwd, id).finally(() => {
+      pendingOps.delete(name);
     });
-    pendingOps.set(key, promise);
+    pendingOps.set(name, promise);
     return promise;
   }
 
-  async function doSpawnSession(name, cols, rows, cwd) {
-    const tmuxName = tmuxSessionName(name);
+  async function doSpawnSession(name, cols, rows, cwd, explicitId) {
+    // The surrogate id is the source of truth for the tmux session name
+    // from MC1e onward — `kat_<id>` uses only characters tmux already
+    // accepts (see lib/id.js), so no sanitization is needed.
+    const id = explicitId != null ? explicitId : sessionId();
+    const tmuxName = `kat_${id}`;
 
-    // Evict any discovered session that maps to the same tmux name
-    // (e.g., discovered "foo_bar" vs user creating "foo.bar" → both map to tmux "foo_bar")
-    let evicted = false;
-    for (const [key, s] of sessions) {
-      if (s.tmuxName === tmuxName && key !== name) {
-        s.detach();
-        sessions.delete(key);
-        evicted = true;
-        break;
-      }
-    }
+    const safeEnv = getSafeEnv();
+    const env = {
+      ...safeEnv,
+      TERM: "xterm-256color",
+      TERM_PROGRAM: "katulong",
+      COLORTERM: "truecolor",
+    };
+    await tmuxNewSession(tmuxName, cols, rows, shell, env, cwd || home);
 
-    // Only check tmux if we evicted a session (possible orphan) — skip
-    // for brand new names since tmuxNewSession will fail if it exists.
-    const exists = evicted ? await tmuxHasSession(tmuxName) : false;
-
-    if (!exists) {
-      const safeEnv = getSafeEnv();
-      const env = {
-        ...safeEnv,
-        TERM: "xterm-256color",
-        TERM_PROGRAM: "katulong",
-        COLORTERM: "truecolor",
-      };
-      await tmuxNewSession(tmuxName, cols, rows, shell, env, cwd || home);
-    }
-
-    const session = await adoptSession(name, tmuxName, cols, rows);
+    const session = await adoptSession(name, tmuxName, cols, rows, { id });
 
     sessions.set(name, session);
     detachedNames.delete(tmuxName);
-    log.info("Session created", { session: name, tmux: tmuxName, reattached: exists });
+    log.info("Session created", { session: name, tmux: tmuxName });
     return session;
   }
 
@@ -459,12 +460,6 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
       if (aliveSessionCount() >= MAX_SESSIONS) return { error: `Maximum session limit (${MAX_SESSIONS}) reached` };
       if (sessions.has(name)) return { error: "Session already exists" };
 
-      // Check for tmux name collision (e.g. "my session" vs "my_session" both map to "my_session")
-      const newTmuxName = tmuxSessionName(name);
-      for (const s of sessions.values()) {
-        if (s.tmuxName === newTmuxName) return { error: "Session name conflicts with existing session" };
-      }
-
       let cwd = null;
       if (copyFrom) {
         const source = sessions.get(copyFrom);
@@ -488,9 +483,17 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
 
     /**
      * Rename a session.
+     *
+     * MC1e: rename only updates the katulong-facing friendly name. The
+     * underlying tmux session (keyed by `kat_<id>` for new spawns or the
+     * user's external name for adopted sessions) is NOT renamed — that was
+     * the source of the rename-drift bugs documented in
+     * docs/session-identity.md. Downstream consumers that need a stable
+     * anchor should key by `id` or `tmuxPane`, not name.
+     *
      * @param {string} oldName
      * @param {string} newName
-     * @returns {{ name: string } | { error: string }}
+     * @returns {{ name: string, id: string } | { error: string }}
      */
     async renameSession(oldName, newName) {
       const session = sessions.get(oldName);
@@ -501,19 +504,7 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
       // would silently drop them).
       outputCoalescer.flush(oldName);
 
-      const newTmuxName = tmuxSessionName(newName);
-      for (const s of sessions.values()) {
-        if (s.tmuxName === newTmuxName && s !== session) return { error: "Session name conflicts with existing session" };
-      }
-      if (newTmuxName !== session.tmuxName) {
-        const tmuxExists = await tmuxHasSession(newTmuxName);
-        if (tmuxExists) return { error: "Session name conflicts with existing tmux session" };
-      }
-      const { code } = await tmuxExec(["rename-session", "-t", session.tmuxName, newTmuxName]);
-      if (code !== 0) return { error: "Failed to rename tmux session" };
-
       session.name = newName;
-      session.tmuxName = newTmuxName;
       sessions.delete(oldName);
       sessions.set(newName, session);
       tracker.renameSession(oldName, newName);
@@ -537,12 +528,6 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
 
       let session = sessions.get(name);
       if (!session) {
-        const newTmuxName = tmuxSessionName(name);
-        for (const s of sessions.values()) {
-          if (s.tmuxName === newTmuxName) {
-            throw new Error("Session name conflicts with existing session");
-          }
-        }
         session = await spawnSession(name, cols, rows);
       }
 
@@ -702,15 +687,37 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
     },
 
     /**
+     * Get a session by its immutable surrogate id.
+     *
+     * The id is assigned at spawn/adopt time and never changes, so it's
+     * the right key for the `/sessions/by-id/:id` route family introduced
+     * in MC1e PR2. Linear scan is fine at the MAX_SESSIONS=20 ceiling;
+     * indexing by id would add a second Map to keep in sync for no
+     * observable benefit.
+     *
+     * @param {string} id
+     * @returns {Session|undefined}
+     */
+    getSessionById(id) {
+      if (!id || typeof id !== "string") return undefined;
+      for (const session of sessions.values()) {
+        if (session.id === id) return session;
+      }
+      return undefined;
+    },
+
+    /**
      * Restore sessions from sessions.json, re-adopting tmux sessions that still exist.
      *
      * Accepts both persistence formats:
      *   - legacy: `{ [name]: tmuxName }` (string value)
-     *   - current: `{ [name]: { tmuxName, id } }` (object value with id)
+     *   - current: `{ [name]: { tmuxName, id, tmuxPane } }` (object value)
      *
      * A legacy entry is restored with a fresh id — there is no stable id
-     * in the old format to recover. The next scheduleSave() rewrites it in
-     * the current shape.
+     * in the old format to recover. `tmuxPane` is recaptured live by
+     * `adoptSession()` regardless of what was persisted, so a stale or
+     * missing value on disk is harmless. The next scheduleSave() rewrites
+     * the file in the current shape.
      */
     async restoreSessions() {
       const map = store.load();

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -46,7 +46,7 @@ const DEFAULT_ROWS = TERMINAL_ROWS_DEFAULT;
  */
 export function createSessionManager({ bridge, shell, home, dataDir }) {
   const sessions = new Map();
-  const pendingOps = new Map(); // tmuxName -> Promise<Session> (serializes concurrent spawns)
+  const pendingOps = new Map(); // friendly name (spawn) or tmuxName (adopt) -> Promise<Session>; key is whatever will end up as the sessions-map key, so spawn+adopt for the same slot serialize
   const detachedNames = new Set(); // tmux names of sessions detached from katulong
 
   // Session persistence — debounced writes to sessions.json.

--- a/lib/session.js
+++ b/lib/session.js
@@ -48,6 +48,10 @@ export class Session {
    * @param {string} [options.id] - Immutable surrogate id (MC1e). Session-manager
    *   always supplies one for new/adopted sessions; direct-construction tests
    *   may omit it.
+   * @param {string} [options.tmuxPane] - tmux pane id (e.g. `%3`) captured at
+   *   spawn/adopt time. Stable across rename/detach/reattach — used by the
+   *   tile → claude hook pipeline to locate the Claude session running in a
+   *   given katulong tile. See docs/tile-claude-session-link.md.
    * @param {number} [options.maxBufferItems]
    * @param {number} [options.maxBufferBytes]
    * @param {Function} [options.onData] - Callback: onData(sessionName, fromSeq)
@@ -67,6 +71,9 @@ export class Session {
     this.name = name;
     this.tmuxName = tmuxName;
     this.id = typeof options.id === "string" && options.id.length > 0 ? options.id : null;
+    this.tmuxPane = typeof options.tmuxPane === "string" && /^%\d+$/.test(options.tmuxPane)
+      ? options.tmuxPane
+      : null;
     this.state = Session.STATE_DETACHED;
     this.controlProc = null;
     this._childCount = 0;
@@ -696,6 +703,7 @@ export class Session {
       id: this.id,
       name: this.name,
       tmuxSession: this.tmuxName,
+      tmuxPane: this.tmuxPane,
       alive: this.alive,
       hasChildProcesses: this.hasChildProcesses(),
       external: this.external,

--- a/lib/session.js
+++ b/lib/session.js
@@ -42,8 +42,9 @@ export class Session {
   /**
    * Create a new Session backed by tmux control mode.
    * @param {string} name - Session display name (mutable)
-   * @param {string} tmuxName - tmux session name (currently derived from `name`;
-   *   becomes derived from `id` in a later MC1e step)
+   * @param {string} tmuxName - tmux session name. For katulong-spawned sessions
+   *   this is `kat_<id>` and never changes for the life of the session. For
+   *   externally adopted sessions this is the user's original tmux session name.
    * @param {object} options
    * @param {string} [options.id] - Immutable surrogate id (MC1e). Session-manager
    *   always supplies one for new/adopted sessions; direct-construction tests

--- a/lib/tmux.js
+++ b/lib/tmux.js
@@ -6,17 +6,6 @@ import { log } from "./log.js";
 // --- tmux control mode helpers ---
 
 /**
- * Sanitize a session name for tmux (disallows `.`, `:`, and spaces).
- * Katulong allows all printable ASCII in session names but tmux uses
- * some characters as delimiters (. : for window/pane addressing,
- * # for format strings).  These plus spaces are replaced with
- * underscores to keep tmux names safe for shell and tmux commands.
- */
-export function tmuxSessionName(name) {
-  return name.replace(/[.:#% ]/g, "_");
-}
-
-/**
  * Encode bytes as hex pairs for `tmux send-keys -H`.
  * @param {string|Buffer} data
  */
@@ -368,6 +357,27 @@ export async function getPaneCwd(name) {
   ]);
   if (code !== 0) return null;
   return stdout.trim() || null;
+}
+
+/**
+ * Get the tmux pane id (e.g. `%3`) for the first pane of a session.
+ *
+ * The pane id is assigned by tmux at pane creation and is stable across
+ * rename, detach, and reattach — only a tmux server restart changes it.
+ * MC1e uses it as the middle-end key for the tile → claude lookup (see
+ * docs/tile-claude-session-link.md): the hook pipeline stamps `%N` from
+ * `$TMUX_PANE`, and the server matches it against `session.tmuxPane`
+ * recorded here.
+ *
+ * Returns null on failure or when the output doesn't look like a pane id.
+ */
+export async function tmuxGetPaneId(name) {
+  const { code, stdout } = await tmuxExec([
+    "list-panes", "-t", name, "-F", "#{pane_id}",
+  ]);
+  if (code !== 0) return null;
+  const paneId = stdout.trim().split("\n")[0];
+  return /^%\d+$/.test(paneId) ? paneId : null;
 }
 
 /**

--- a/test/garble-octal-split.test.js
+++ b/test/garble-octal-split.test.js
@@ -43,7 +43,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
 
-import { unescapeTmuxOutputBytes, tmuxSessionName } from "../lib/tmux.js";
+import { unescapeTmuxOutputBytes } from "../lib/tmux.js";
 import { Session } from "../lib/session.js";
 
 // --- Helpers ---
@@ -115,7 +115,7 @@ class MockProc {
 }
 
 function createWiredSession(name) {
-  const session = new Session(name, tmuxSessionName(name));
+  const session = new Session(name, name);
   const proc = new MockProc();
   session.controlProc = proc;
   session.state = Session.STATE_ATTACHED;
@@ -320,7 +320,7 @@ describe("Session tmux output parser — partial octal escape across %output lin
     };
     const session = new Session(
       "reset-test",
-      tmuxSessionName("reset-test"),
+      "reset-test",
       { _spawn: spawnStub },
     );
 
@@ -374,7 +374,7 @@ describe("Session tmux output parser — partial octal escape across %output lin
     let onExitCalls = 0;
     const session = new Session(
       "stale-close-test",
-      tmuxSessionName("stale-close-test"),
+      "stale-close-test",
       { _spawn: spawnStub, onExit: () => { onExitCalls++; } },
     );
 

--- a/test/helpers/session-manager-fixture.js
+++ b/test/helpers/session-manager-fixture.js
@@ -71,6 +71,7 @@ export class BaseMockSession {
     this.name = name;
     this.tmuxName = tmuxName;
     this.id = options.id || null;
+    this.tmuxPane = options.tmuxPane || null;
     this.state = BaseMockSession.STATE_ATTACHED;
     this.external = options.external || false;
     this._options = options;
@@ -116,7 +117,13 @@ export class BaseMockSession {
   }
 
   toJSON() {
-    return { id: this.id, name: this.name, alive: this.alive, external: this.external };
+    return {
+      id: this.id,
+      name: this.name,
+      tmuxPane: this.tmuxPane,
+      alive: this.alive,
+      external: this.external,
+    };
   }
 }
 
@@ -141,22 +148,7 @@ export async function setupSessionManagerMocks(SessionClass = BaseMockSession) {
 
   mock.module(tmuxModuleUrl, {
     namedExports: {
-      tmuxSessionName: (name) => name.replace(/[.: ]/g, "_"),
-      // tmuxExec must support rename-session because session-manager.test.js
-      // exercises the rename path; other tests pass through harmlessly.
-      tmuxExec: async (args) => {
-        if (args[0] === "rename-session") {
-          const oldName = args[2];
-          const newName = args[3];
-          if (tmuxSessions.has(oldName)) {
-            tmuxSessions.delete(oldName);
-            tmuxSessions.set(newName, true);
-            return { code: 0 };
-          }
-          return { code: 1 };
-        }
-        return { code: 0 };
-      },
+      tmuxExec: async () => ({ code: 0 }),
       tmuxNewSession: async (tmuxName) => { tmuxSessions.set(tmuxName, true); },
       tmuxHasSession: async (tmuxName) => tmuxSessions.has(tmuxName),
       applyTmuxSessionOptions: async () => {},
@@ -170,6 +162,7 @@ export async function setupSessionManagerMocks(SessionClass = BaseMockSession) {
       tmuxKillSession: async (tmuxName) => { tmuxSessions.delete(tmuxName); },
       tmuxListSessionsDetailed: async () => new Map(),
       tmuxSocketArgs: () => [],
+      tmuxGetPaneId: async () => "%1",
     },
   });
 

--- a/test/session-exit-cleanup.test.js
+++ b/test/session-exit-cleanup.test.js
@@ -84,7 +84,6 @@ mock.module(sessionModuleUrl, {
 
 mock.module(tmuxModuleUrl, {
   namedExports: {
-    tmuxSessionName: (name) => name.replace(/[.: ]/g, "_"),
     tmuxExec: async () => ({ code: 0 }),
     tmuxNewSession: async (tmuxName) => { tmuxSessions.set(tmuxName, true); },
     tmuxHasSession: async (tmuxName) => tmuxSessions.has(tmuxName),
@@ -99,6 +98,7 @@ mock.module(tmuxModuleUrl, {
     tmuxKillSession: async (tmuxName) => { tmuxSessions.delete(tmuxName); },
     tmuxListSessionsDetailed: async () => new Map(),
     tmuxSocketArgs: () => [],
+    tmuxGetPaneId: async () => "%1",
   },
 });
 

--- a/test/session-manager.test.js
+++ b/test/session-manager.test.js
@@ -72,6 +72,26 @@ describe("session manager", () => {
       assert.strictEqual(result.id.length, 21);
     });
 
+    it("names the underlying tmux session `kat_<id>` (MC1e PR2)", async () => {
+      const { mgr } = makeManager();
+      const result = await mgr.createSession("display name with spaces");
+      const session = mgr.getSession("display name with spaces");
+      assert.strictEqual(session.tmuxName, `kat_${result.id}`,
+        "tmux name must derive from the immutable id, not the display name");
+      assert.ok(tmuxSessions.has(`kat_${result.id}`),
+        "tmux-new-session must be invoked with the kat_<id> name");
+    });
+
+    it("captures the tmux pane id on spawn (MC1e PR2)", async () => {
+      // The fixture's tmuxGetPaneId mock always returns "%1", so any
+      // spawned session should surface that value in listSessions().
+      const { mgr } = makeManager();
+      await mgr.createSession("paned");
+      const listed = mgr.listSessions().sessions[0];
+      assert.strictEqual(listed.tmuxPane, "%1",
+        "Session.toJSON must include the tmuxPane captured at spawn");
+    });
+
     it("rejects duplicate session names", async () => {
       const { mgr } = makeManager();
       await mgr.createSession("dup");
@@ -127,12 +147,12 @@ describe("session manager", () => {
 
     it("detaches a session without killing it", async () => {
       const { mgr } = makeManager();
-      await mgr.createSession("detach-me");
+      const created = await mgr.createSession("detach-me");
       const result = mgr.deleteSession("detach-me", { detachOnly: true });
       assert.deepStrictEqual(result, { ok: true, action: "detached" });
       assert.strictEqual(mgr.listSessions().sessions.length, 0);
-      // tmux session should still exist
-      assert.ok(tmuxSessions.has("detach-me"), "tmux session should remain after detach");
+      // tmux session should still exist (keyed by kat_<id> since MC1e PR2)
+      assert.ok(tmuxSessions.has(`kat_${created.id}`), "tmux session should remain after detach");
     });
 
     it("returns error for nonexistent session", () => {
@@ -172,6 +192,44 @@ describe("session manager", () => {
       const { mgr } = makeManager();
       const result = await mgr.renameSession("nope", "new");
       assert.ok(result.error);
+    });
+
+    it("does NOT rename the underlying tmux session (MC1e PR2)", async () => {
+      // The source of rename-drift bugs was that every rename forked a
+      // second name space (friendly name + tmux name) that slowly
+      // decohered. After PR2, tmuxName is `kat_<id>` and never changes.
+      const { mgr } = makeManager();
+      const created = await mgr.createSession("original");
+      await mgr.renameSession("original", "displayname");
+      const session = mgr.getSession("displayname");
+      assert.strictEqual(session.tmuxName, `kat_${created.id}`,
+        "rename must not touch the tmux session name");
+      assert.ok(tmuxSessions.has(`kat_${created.id}`),
+        "kat_<id> tmux session must still exist after rename");
+    });
+  });
+
+  describe("getSessionById", () => {
+    it("returns the session matching the id", async () => {
+      const { mgr } = makeManager();
+      const { id } = await mgr.createSession("find-me");
+      const session = mgr.getSessionById(id);
+      assert.ok(session, "should find a session");
+      assert.strictEqual(session.name, "find-me");
+      assert.strictEqual(session.id, id);
+    });
+
+    it("returns undefined for unknown id", async () => {
+      const { mgr } = makeManager();
+      await mgr.createSession("present");
+      assert.strictEqual(mgr.getSessionById("bogusid"), undefined);
+    });
+
+    it("returns undefined for falsy inputs", () => {
+      const { mgr } = makeManager();
+      assert.strictEqual(mgr.getSessionById(null), undefined);
+      assert.strictEqual(mgr.getSessionById(""), undefined);
+      assert.strictEqual(mgr.getSessionById(undefined), undefined);
     });
   });
 
@@ -266,12 +324,12 @@ describe("session manager", () => {
   describe("shutdown", () => {
     it("detaches all sessions without killing tmux", async () => {
       const { mgr } = makeManager();
-      await mgr.createSession("a");
-      await mgr.createSession("b");
+      const a = await mgr.createSession("a");
+      const b = await mgr.createSession("b");
       mgr.shutdown();
-      // tmux sessions should still exist
-      assert.ok(tmuxSessions.has("a"));
-      assert.ok(tmuxSessions.has("b"));
+      // tmux sessions should still exist (kat_<id> keys as of MC1e PR2)
+      assert.ok(tmuxSessions.has(`kat_${a.id}`));
+      assert.ok(tmuxSessions.has(`kat_${b.id}`));
     });
   });
 

--- a/test/session-persistence.test.js
+++ b/test/session-persistence.test.js
@@ -49,20 +49,7 @@ mock.module(sessionModuleUrl, {
 
 mock.module(tmuxModuleUrl, {
   namedExports: {
-    tmuxSessionName: (name) => name.replace(/[.: ]/g, "_"),
-    tmuxExec: async (args) => {
-      if (args[0] === "rename-session") {
-        const oldName = args[2];
-        const newName = args[3];
-        if (tmuxSessions.has(oldName)) {
-          tmuxSessions.delete(oldName);
-          tmuxSessions.set(newName, true);
-          return { code: 0 };
-        }
-        return { code: 1 };
-      }
-      return { code: 0 };
-    },
+    tmuxExec: async () => ({ code: 0 }),
     tmuxNewSession: async (tmuxName) => { tmuxSessions.set(tmuxName, true); },
     tmuxHasSession: async (tmuxName) => tmuxSessions.has(tmuxName),
     applyTmuxSessionOptions: async () => {},
@@ -76,6 +63,7 @@ mock.module(tmuxModuleUrl, {
     tmuxListSessionsDetailed: async () => new Map(),
     getCursorPosition: async () => ({ row: 0, col: 0 }),
     tmuxSocketArgs: () => [],
+    tmuxGetPaneId: async () => "%1",
   },
 });
 
@@ -103,21 +91,22 @@ describe("Session persistence", () => {
     const mgr1 = createSessionManager({
       bridge: makeBridge(), shell: "/bin/sh", home: "/tmp", dataDir,
     });
-    await mgr1.createSession("my session", 80, 24);
-    await mgr1.createSession("dev.server", 80, 24);
+    const a = await mgr1.createSession("my session", 80, 24);
+    const b = await mgr1.createSession("dev.server", 80, 24);
     mgr1.shutdown();
 
-    // Verify file was written — new shape is { tmuxName, id }.
+    // Verify file was written — new shape is { tmuxName, id, tmuxPane }.
+    // tmuxName is `kat_<id>` for new spawns (MC1e PR2).
     const saved = JSON.parse(readFileSync(join(dataDir, "sessions.json"), "utf-8"));
-    assert.strictEqual(saved["my session"].tmuxName, "my_session");
-    assert.strictEqual(saved["dev.server"].tmuxName, "dev_server");
-    assert.strictEqual(typeof saved["my session"].id, "string");
-    assert.strictEqual(typeof saved["dev.server"].id, "string");
+    assert.strictEqual(saved["my session"].tmuxName, `kat_${a.id}`);
+    assert.strictEqual(saved["dev.server"].tmuxName, `kat_${b.id}`);
+    assert.strictEqual(saved["my session"].id, a.id);
+    assert.strictEqual(saved["dev.server"].id, b.id);
 
     // tmux sessions still exist (shutdown detaches, doesn't kill)
     // Re-add them to our mock since MockSession.detach doesn't remove from tmuxSessions
-    tmuxSessions.set("my_session", true);
-    tmuxSessions.set("dev_server", true);
+    tmuxSessions.set(`kat_${a.id}`, true);
+    tmuxSessions.set(`kat_${b.id}`, true);
 
     // Create a new manager and restore
     const mgr2 = createSessionManager({
@@ -182,15 +171,15 @@ describe("Session persistence", () => {
     const mgr = createSessionManager({
       bridge: makeBridge(), shell: "/bin/sh", home: "/tmp", dataDir,
     });
-    await mgr.createSession("first", 80, 24);
-    await mgr.createSession("second", 80, 24);
+    const first = await mgr.createSession("first", 80, 24);
+    const second = await mgr.createSession("second", 80, 24);
 
     // Wait for debounce to fire (100ms + buffer)
     await new Promise((r) => setTimeout(r, 200));
 
     const saved = JSON.parse(readFileSync(join(dataDir, "sessions.json"), "utf-8"));
-    assert.strictEqual(saved["first"].tmuxName, "first");
-    assert.strictEqual(saved["second"].tmuxName, "second");
+    assert.strictEqual(saved["first"].tmuxName, `kat_${first.id}`);
+    assert.strictEqual(saved["second"].tmuxName, `kat_${second.id}`);
 
     mgr.shutdown();
     rmSync(dataDir, { recursive: true, force: true });
@@ -200,19 +189,20 @@ describe("Session persistence", () => {
     const mgr = createSessionManager({
       bridge: makeBridge(), shell: "/bin/sh", home: "/tmp", dataDir,
     });
-    await mgr.createSession("alpha", 80, 24);
+    const alpha = await mgr.createSession("alpha", 80, 24);
     await mgr.createSession("beta", 80, 24);
 
     // Delete one
     mgr.deleteSession("beta");
-    // Rename the other
+    // Rename the other — MC1e PR2: rename only changes the friendly key,
+    // tmuxName stays at kat_<id> (stable).
     await mgr.renameSession("alpha", "omega");
 
     // Wait for debounce
     await new Promise((r) => setTimeout(r, 200));
 
     const saved = JSON.parse(readFileSync(join(dataDir, "sessions.json"), "utf-8"));
-    assert.strictEqual(saved["omega"].tmuxName, "omega");
+    assert.strictEqual(saved["omega"].tmuxName, `kat_${alpha.id}`);
     assert.strictEqual(saved["beta"], undefined);
     assert.strictEqual(saved["alpha"], undefined);
 

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -4,7 +4,7 @@ import { Buffer } from "node:buffer";
 import { Session, SessionNotAliveError } from "../lib/session.js";
 import { RingBuffer } from "../lib/ring-buffer.js";
 import {
-  tmuxSessionName, encodeHexKeys, unescapeTmuxOutputBytes, stripDaResponses,
+  encodeHexKeys, unescapeTmuxOutputBytes, stripDaResponses,
 } from "../lib/tmux.js";
 
 /**
@@ -23,25 +23,6 @@ function unescapeTmuxOutput(s) {
 }
 
 // --- tmux control mode helper tests ---
-
-describe("tmuxSessionName", () => {
-  it("replaces tmux-incompatible characters with underscores", () => {
-    assert.strictEqual(tmuxSessionName("my.session"), "my_session");
-    assert.strictEqual(tmuxSessionName("host:port"), "host_port");
-    assert.strictEqual(tmuxSessionName("a.b:c"), "a_b_c");
-    assert.strictEqual(tmuxSessionName("my session"), "my_session");
-    assert.strictEqual(tmuxSessionName("a.b c:d"), "a_b_c_d");
-    assert.strictEqual(tmuxSessionName("test #1"), "test__1");
-    assert.strictEqual(tmuxSessionName("50%"), "50_");
-  });
-
-  it("preserves other printable ASCII", () => {
-    assert.strictEqual(tmuxSessionName("default"), "default");
-    assert.strictEqual(tmuxSessionName("my-session"), "my-session");
-    assert.strictEqual(tmuxSessionName("test!@$&"), "test!@$&");
-    assert.strictEqual(tmuxSessionName("(prod)"), "(prod)");
-  });
-});
 
 describe("encodeHexKeys", () => {
   it("encodes simple text", () => {
@@ -310,8 +291,7 @@ class MockReadable {
 }
 
 function createSimpleTestSession(name, options = {}) {
-  const tmuxName = tmuxSessionName(name);
-  const session = new Session(name, tmuxName, options);
+  const session = new Session(name, name, options);
   const mockProc = new MockControlProc();
   session.controlProc = mockProc;
   session.state = Session.STATE_ATTACHED;
@@ -766,7 +746,7 @@ describe("Session", () => {
 
       // Now simulate the child closing; kill-session should fire.
       mockProc.simulateClose(0);
-      assert.deepStrictEqual(callLog, ["detach-client", `kill-session:${tmuxSessionName("test")}`],
+      assert.deepStrictEqual(callLog, ["detach-client", "kill-session:test"],
         "kill-session must run only after the close event");
     });
   });
@@ -1008,7 +988,7 @@ describe("Session", () => {
 
     it("handles stdin error event by transitioning to DETACHED", () => {
       let exitCalled = false;
-      const session = new Session("stdin-error", tmuxSessionName("stdin-error"), {
+      const session = new Session("stdin-error", "stdin-error", {
         onExit: () => { exitCalled = true; },
       });
 
@@ -1030,7 +1010,7 @@ describe("Session", () => {
 
     it("ignores stdin error from superseded control process", () => {
       let exitCalled = false;
-      const session = new Session("stdin-stale", tmuxSessionName("stdin-stale"), {
+      const session = new Session("stdin-stale", "stdin-stale", {
         onExit: () => { exitCalled = true; },
       });
 


### PR DESCRIPTION
## Summary

- Spawned tmux sessions are now named `kat_<id>` (where `id` is the 21-char nanoid from PR1), eliminating `tmuxSessionName()` sanitization entirely. The name is derived from an immutable id so collisions and character-class filtering are structural non-issues.
- `Session` captures `tmuxPane` (e.g. `%1`) at spawn and adopt time via a new `tmuxGetPaneId()` helper. `tmuxPane` is exposed on `Session.toJSON()` and persisted. MC1f's claude-hook → tile wiring needs this stable pane handle.
- `renameSession()` no longer touches tmux — friendly-name changes only update the sessions-map key and persistence. The underlying `kat_<id>` name is stable for life, which makes the rename-drift bug class structurally impossible.
- New HTTP routes `/sessions/by-id/:id/{status,output,exec,input}` plus `PUT/DELETE /sessions/by-id/:id`. Name-keyed routes stay (removing them is PR3).
- `SessionManager.getSessionById(id)` for O(n) lookup — callers are rare; a second index isn't worth it.
- `pendingOps` is now keyed on the friendly name so concurrent spawn+adopt for the same sessions-map key serialize correctly.

## Test plan

- [x] `npm run test:unit` passes (2198/2198, 0 fail)
- [ ] Manual smoke: create, rename, delete via both name and by-id routes
- [ ] Verify `tmuxPane` field round-trips through persistence on restart

## Deferred to PR3

- Client-side localStorage v3→v4 migration
- Remove `?s=` query parameter usage
- Delete name-keyed routes entirely