### PR TITLE
feat(file-browser): narrower default tile + scroll-to-column

### DIFF
--- a/public/lib/card-carousel.js
+++ b/public/lib/card-carousel.js
@@ -533,7 +533,7 @@ export function createCardCarousel({
     const savedWidths = readSavedCardWidths();
 
     // Store tile references and create contexts
-    for (const { id, tile, cardWidth } of tiles) {
+    for (const { id, tile, cardWidth, defaultWidth } of tiles) {
       const { wrapper, inner, frontFace, backFace } = createCardWrapper(id);
       const frontChrome = createTileChrome(frontFace);
       const entry = { wrapper, inner, frontFace, backFace, frontChrome, backChrome: null, tile, backTile: null, context: null, flipped: false, resizeHandles: null };
@@ -546,8 +546,8 @@ export function createCardCarousel({
       const handles = attachResizeHandles(id, entry);
       // Restore persisted width: explicit cardWidth (from the saved
       // tiles restore path) wins, else fall back to the per-id width
-      // we just read from localStorage.
-      const effectiveWidth = cardWidth ?? savedWidths.get(id);
+      // we just read from localStorage, else the tile-type default.
+      const effectiveWidth = cardWidth ?? savedWidths.get(id) ?? defaultWidth;
       if (effectiveWidth) handles.restore(effectiveWidth);
     }
 
@@ -606,7 +606,7 @@ export function createCardCarousel({
    *   is driven by the `cards` array order because positionCards() walks that
    *   array to compute translateX — the DOM child order does not matter.
    */
-  function addCard(tileId, tile, position) {
+  function addCard(tileId, tile, position, defaultWidth) {
     if (!active) return;
     if (cards.includes(tileId)) return;
 
@@ -624,7 +624,13 @@ export function createCardCarousel({
     cardEls.set(tileId, entry);
 
     container.appendChild(wrapper);
-    attachResizeHandles(tileId, entry);
+    const handles = attachResizeHandles(tileId, entry);
+    // Fall back to the tile-type default if no saved width exists for
+    // this id. A user-dragged width will already be in localStorage
+    // from a prior session; the default only applies on first open.
+    const savedWidth = readSavedCardWidths().get(tileId);
+    const effectiveWidth = savedWidth ?? defaultWidth;
+    if (effectiveWidth) handles.restore(effectiveWidth);
 
     positionCards(false);
     fitAll();

--- a/public/lib/file-browser/file-browser-component.js
+++ b/public/lib/file-browser/file-browser-component.js
@@ -137,7 +137,14 @@ export function createFileBrowserComponent(store, nav, options = {}) {
       }
 
       const row = e.target.closest(".fb-miller-row");
-      if (!row) return;
+      if (!row) {
+        // Click on column whitespace — scroll that column fully into view.
+        const col = e.target.closest(".fb-miller-col");
+        if (col) {
+          col.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "nearest" });
+        }
+        return;
+      }
       const colIndex = parseInt(row.dataset.col, 10);
       const name = row.dataset.name;
 

--- a/public/lib/tile-host.js
+++ b/public/lib/tile-host.js
@@ -21,6 +21,16 @@
 
 import { selectClusterView } from "./selectors.js";
 
+// Per-tile-type default card widths (px). Applied on first open only —
+// a user-dragged width saved in localStorage always wins.
+const DEFAULT_CARD_WIDTHS = {
+  "file-browser": 420,
+};
+
+function defaultCardWidthForType(type) {
+  return DEFAULT_CARD_WIDTHS[type];
+}
+
 /**
  * Create a tile host.
  *
@@ -101,7 +111,7 @@ export function createTileHost({ store, carousel, getRenderer, getClusterIdx, on
         if (!renderer) return null;
         // Create a thin tile adapter that carousel can mount
         const adapter = _createAdapter(id, tileDesc, renderer, store.dispatch);
-        return { id, tile: adapter };
+        return { id, tile: adapter, defaultWidth: defaultCardWidthForType(tileDesc.type) };
       }).filter(Boolean);
 
       carousel.activate(tilesToActivate, view.focusedId);
@@ -119,7 +129,7 @@ export function createTileHost({ store, carousel, getRenderer, getClusterIdx, on
         const adapter = _createAdapter(id, tileDesc, renderer, store.dispatch);
         // Insert at the correct position in the carousel
         const position = view.order.indexOf(id);
-        carousel.addCard(id, adapter, position >= 0 ? position : undefined);
+        carousel.addCard(id, adapter, position >= 0 ? position : undefined, defaultCardWidthForType(tileDesc.type));
         if (adapter._handle) handles.set(id, adapter._handle);
       }
     }


### PR DESCRIPTION
## Summary

- **File-browser tiles now default to 420px** on first open (vs the generic card default). Saved widths from drag-resize still win — the default only kicks in when no width has ever been persisted for that card.
- **Per-tile-type default widths** are now a one-line addition via `DEFAULT_CARD_WIDTHS` in `tile-host.js`, plumbed through `carousel.activate()` / `carousel.addCard()`.
- **Click on column whitespace** inside the file browser scrolls that column fully into view — useful now that a narrow tile can clip columns.

## Why

A full-width card showing a single ~260px Miller column wasted horizontal space. Previous attempt narrowed the inner columns instead; reverted after feedback that the tile itself is what should shrink.

## Test plan

- [x] `npm test` (2194 unit tests passing)
- [x] Smoke E2E + unit/integration passed via pre-push review
- [ ] Open a fresh file-browser tile → opens at 420px
- [ ] Drag-resize the tile → new width persists across reload
- [ ] Click empty space inside a partially-clipped Miller column → column scrolls into view