### PR TITLE
MC1e PR3a: CLI speaks session ids internally

### DIFF
--- a/lib/cli/api-client.js
+++ b/lib/cli/api-client.js
@@ -89,16 +89,14 @@ export const api = {
 };
 
 /**
- * Resolve a friendly session name to its immutable surrogate id by listing
- * sessions and matching on name. Throws with a "Session not found: <name>"
- * error if no match exists, preserving the message shape that callers
- * already grep for (see e.g. crew output/wait 404 branches).
+ * Resolve a friendly session name to its surrogate id.
  *
- * The CLI previously addressed sessions by name (`/sessions/:name/...`).
- * Now that the server exposes id-keyed routes (`/sessions/by-id/:id/...`),
- * all CLI paths resolve name → id once and then speak ids to the server.
- * This keeps the CLI's user-facing surface (names as arguments) while
- * letting the server drop name-keyed routes in a later PR.
+ * The error message shape "Session not found: <name>" is grepped by the
+ * crew output/wait 404 branches — don't change it without updating them.
+ *
+ * @param {string} name - friendly session name
+ * @returns {Promise<string>} the session's immutable id
+ * @throws {Error} if no session with that name exists
  */
 export async function resolveSessionId(name) {
   const sessions = await api.get("/sessions");

--- a/lib/cli/api-client.js
+++ b/lib/cli/api-client.js
@@ -87,3 +87,23 @@ export const api = {
   put: (path, body) => request("PUT", path, body),
   del: (path) => request("DELETE", path),
 };
+
+/**
+ * Resolve a friendly session name to its immutable surrogate id by listing
+ * sessions and matching on name. Throws with a "Session not found: <name>"
+ * error if no match exists, preserving the message shape that callers
+ * already grep for (see e.g. crew output/wait 404 branches).
+ *
+ * The CLI previously addressed sessions by name (`/sessions/:name/...`).
+ * Now that the server exposes id-keyed routes (`/sessions/by-id/:id/...`),
+ * all CLI paths resolve name → id once and then speak ids to the server.
+ * This keeps the CLI's user-facing surface (names as arguments) while
+ * letting the server drop name-keyed routes in a later PR.
+ */
+export async function resolveSessionId(name) {
+  const sessions = await api.get("/sessions");
+  if (!Array.isArray(sessions)) throw new Error("Unexpected response from server.");
+  const match = sessions.find((s) => s.name === name);
+  if (!match) throw new Error(`Session not found: ${name}`);
+  return match.id;
+}

--- a/lib/cli/commands/crew.js
+++ b/lib/cli/commands/crew.js
@@ -6,7 +6,7 @@
  * monitored, and torn down per project.
  */
 
-import { ensureRunning, api, getBase } from "../api-client.js";
+import { ensureRunning, api, getBase, resolveSessionId } from "../api-client.js";
 import { formatTable } from "../format.js";
 
 // --- Naming helpers ---
@@ -158,11 +158,11 @@ async function spawn(args) {
     process.exit(1);
   }
 
-  await api.post("/sessions", { name: sessionName });
+  const created = await api.post("/sessions", { name: sessionName });
   console.log(`Spawned ${project}/${worker}`);
 
   if (cmd) {
-    await api.post(`/sessions/${encodeURIComponent(sessionName)}/exec`, { input: cmd });
+    await api.post(`/sessions/by-id/${encodeURIComponent(created.id)}/exec`, { input: cmd });
     console.log(`  cmd: ${cmd}`);
   }
 }
@@ -179,7 +179,8 @@ async function exec(args) {
 
   const command = cmdParts.join(" ");
   const sessionName = crewSessionName(project, worker);
-  await api.post(`/sessions/${encodeURIComponent(sessionName)}/exec`, { input: command });
+  const id = await resolveSessionId(sessionName);
+  await api.post(`/sessions/by-id/${encodeURIComponent(id)}/exec`, { input: command });
   console.log(`Sent to ${project}/${worker}: ${command}`);
 }
 
@@ -198,10 +199,11 @@ async function output(args) {
 
   const sessionName = crewSessionName(project, worker);
 
-  const encodedName = encodeURIComponent(sessionName);
+  const id = await resolveSessionId(sessionName);
+  const idPath = `/sessions/by-id/${encodeURIComponent(id)}`;
 
   // Initial fetch — get visible lines plus a sequence cursor for follow mode
-  const result = await api.get(`/sessions/${encodedName}/output?lines=${lines}`);
+  const result = await api.get(`${idPath}/output?lines=${lines}`);
   process.stdout.write((result.data || result.screen || "") + "\n");
 
   if (!follow) return;
@@ -214,7 +216,7 @@ async function output(args) {
   // Get initial cursor from a screen snapshot
   let seq;
   try {
-    const snap = await api.get(`/sessions/${encodedName}/output?screen=true`);
+    const snap = await api.get(`${idPath}/output?screen=true`);
     seq = snap.seq ?? 0;
   } catch {
     seq = 0;
@@ -225,7 +227,7 @@ async function output(args) {
 
     let chunk;
     try {
-      chunk = await api.get(`/sessions/${encodedName}/output?fromSeq=${seq}`);
+      chunk = await api.get(`${idPath}/output?fromSeq=${seq}`);
     } catch (err) {
       if (err.message.includes("404") || err.message.includes("Not found")) {
         console.error("\nSession ended.");
@@ -265,13 +267,14 @@ async function wait(args) {
   }
 
   const sessionName = crewSessionName(project, worker);
-  const encodedName = encodeURIComponent(sessionName);
+  const id = await resolveSessionId(sessionName);
+  const statusPath = `/sessions/by-id/${encodeURIComponent(id)}/status`;
 
   // Poll every 2 seconds until hasChildProcesses becomes false
   while (true) {
     let status;
     try {
-      status = await api.get(`/sessions/${encodedName}/status`);
+      status = await api.get(statusPath);
     } catch (err) {
       if (err.message.includes("404") || err.message.includes("Not found")) {
         console.error(`Session ${project}/${worker} not found.`);
@@ -308,7 +311,8 @@ async function kill(args) {
 
   if (worker) {
     const sessionName = crewSessionName(project, worker);
-    await api.del(`/sessions/${encodeURIComponent(sessionName)}`);
+    const id = await resolveSessionId(sessionName);
+    await api.del(`/sessions/by-id/${encodeURIComponent(id)}`);
     console.log(`Killed ${project}/${worker}`);
   } else {
     const sessions = await api.get("/sessions");
@@ -323,7 +327,7 @@ async function kill(args) {
     }
 
     for (const s of toKill) {
-      await api.del(`/sessions/${encodeURIComponent(s.name)}`);
+      await api.del(`/sessions/by-id/${encodeURIComponent(s.id)}`);
     }
     console.log(`Killed ${toKill.length} worker(s) in project "${project}".`);
   }

--- a/lib/cli/commands/crew.js
+++ b/lib/cli/commands/crew.js
@@ -159,6 +159,9 @@ async function spawn(args) {
   }
 
   const created = await api.post("/sessions", { name: sessionName });
+  if (!created?.id) {
+    throw new Error("Unexpected response from server: POST /sessions missing id");
+  }
   console.log(`Spawned ${project}/${worker}`);
 
   if (cmd) {
@@ -326,10 +329,27 @@ async function kill(args) {
       return;
     }
 
+    let killed = 0;
+    const failures = [];
     for (const s of toKill) {
-      await api.del(`/sessions/by-id/${encodeURIComponent(s.id)}`);
+      try {
+        await api.del(`/sessions/by-id/${encodeURIComponent(s.id)}`);
+        killed++;
+      } catch (err) {
+        // Tolerate 404 (session vanished between the list fetch and the
+        // delete, e.g. from a concurrent `session kill`). Record any other
+        // failure so the user knows the bulk op was partial.
+        if (!/not found/i.test(err.message)) {
+          failures.push({ name: s.name, error: err.message });
+        }
+      }
     }
-    console.log(`Killed ${toKill.length} worker(s) in project "${project}".`);
+    console.log(`Killed ${killed} worker(s) in project "${project}".`);
+    if (failures.length > 0) {
+      console.error(`${failures.length} worker(s) failed to kill:`);
+      for (const f of failures) console.error(`  ${f.name}: ${f.error}`);
+      process.exit(1);
+    }
   }
 }
 

--- a/lib/cli/commands/session.js
+++ b/lib/cli/commands/session.js
@@ -4,7 +4,7 @@
  * Manages PTY sessions via the local server API.
  */
 
-import { ensureRunning, api } from "../api-client.js";
+import { ensureRunning, api, resolveSessionId } from "../api-client.js";
 import { formatTable } from "../format.js";
 import { buildPayload } from "../key-map.js";
 
@@ -95,7 +95,8 @@ async function kill(args) {
   }
 
   ensureRunning();
-  const data = await api.del(`/sessions/${encodeURIComponent(name)}`);
+  const id = await resolveSessionId(name);
+  const data = await api.del(`/sessions/by-id/${encodeURIComponent(id)}`);
 
   if (jsonMode) {
     console.log(JSON.stringify(data, null, 2));
@@ -114,7 +115,8 @@ async function rename(args) {
   const [oldName, newName] = filtered;
 
   ensureRunning();
-  const data = await api.put(`/sessions/${encodeURIComponent(oldName)}`, { name: newName });
+  const id = await resolveSessionId(oldName);
+  const data = await api.put(`/sessions/by-id/${encodeURIComponent(id)}`, { name: newName });
 
   if (jsonMode) {
     console.log(JSON.stringify(data, null, 2));
@@ -162,7 +164,7 @@ async function prune(args) {
 
   const pruned = [];
   for (const s of orphans) {
-    await api.del(`/sessions/${encodeURIComponent(s.name)}`);
+    await api.del(`/sessions/by-id/${encodeURIComponent(s.id)}`);
     pruned.push(s.name);
   }
 
@@ -227,7 +229,8 @@ async function send(args) {
   ensureRunning();
   let data;
   try {
-    data = await api.post(`/sessions/${encodeURIComponent(name)}/input`, { data: payload });
+    const id = await resolveSessionId(name);
+    data = await api.post(`/sessions/by-id/${encodeURIComponent(id)}/input`, { data: payload });
   } catch (err) {
     if (/not found/i.test(err.message)) {
       console.error(`Error: ${err.message}`);

--- a/test/session-prune.test.js
+++ b/test/session-prune.test.js
@@ -3,7 +3,7 @@
  *
  * Mocks the API client to verify that prune correctly identifies orphaned
  * auto-generated sessions (session-XXXX pattern, alive, no child processes)
- * and kills them via DELETE /sessions/:name.
+ * and kills them via DELETE /sessions/by-id/:id.
  */
 
 import { describe, it, beforeEach, mock } from "node:test";
@@ -16,18 +16,37 @@ const apiClientUrl = new URL("../lib/cli/api-client.js", import.meta.url).href;
 let mockSessions = [];
 let deletedSessions = [];
 
+function synthId(name) {
+  // Deterministic pseudo-id so tests can map id → name when asserting.
+  return `id-${name}`;
+}
+
+// Inject synthetic ids into test fixtures so tests can keep using the
+// plain `{name, alive, hasChildProcesses}` shape — the prune command now
+// looks up `s.id` for the by-id DELETE route.
+function currentSessions() {
+  return mockSessions.map((s) => ({ ...s, id: s.id || synthId(s.name) }));
+}
+
 mock.module(apiClientUrl, {
   namedExports: {
     ensureRunning: () => {},
+    resolveSessionId: async (name) => {
+      const match = currentSessions().find((s) => s.name === name);
+      if (!match) throw new Error(`Session not found: ${name}`);
+      return match.id;
+    },
     api: {
       get: async (path) => {
-        if (path === "/sessions") return mockSessions;
+        if (path === "/sessions") return currentSessions();
         throw new Error(`Unexpected GET ${path}`);
       },
       del: async (path) => {
-        const match = path.match(/^\/sessions\/(.+)$/);
+        const match = path.match(/^\/sessions\/by-id\/(.+)$/);
         if (match) {
-          deletedSessions.push(decodeURIComponent(match[1]));
+          const id = decodeURIComponent(match[1]);
+          const session = currentSessions().find((s) => s.id === id);
+          deletedSessions.push(session ? session.name : id);
           return { ok: true, action: "deleted" };
         }
         throw new Error(`Unexpected DELETE ${path}`);


### PR DESCRIPTION
## Summary

- CLI commands (`session kill/rename/send/prune`, `crew spawn/exec/output/wait/kill`) now resolve name → id via `GET /sessions` and call `/sessions/by-id/:id/*`. User-facing surface unchanged.
- New `resolveSessionId(name)` helper in `lib/cli/api-client.js`.
- Unblocks PR3c (deletion of name-keyed server routes) and hardens CLI against rename races — once pinned to an id, a rename mid-command no longer causes a 404.

## Test plan

- [x] `npm run test:unit` passes (2198/2198)
- [ ] Manual smoke: `katulong session list`, `create`, `rename`, `kill`
- [ ] Manual smoke: `katulong crew spawn`, `exec`, `output --follow`, `wait`

## Related

- PR3b (follow-up): client localStorage v3→v4 + `?s=` → `?sid=`
- PR3c (follow-up): delete name-keyed routes