### PR TITLE
MC1e PR3b: client API callsites → /sessions/by-id/:id

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -6,7 +6,7 @@
       createShortcutsStore, loadShortcuts as reloadShortcuts,
     } from "/lib/stores.js";
     import { createSessionListComponent, updateSnapshot } from "/lib/session-list-component.js";
-    import { api } from "/lib/api-client.js";
+    import { api, resolveSessionId, invalidateSessionIdCache } from "/lib/api-client.js";
     import { createTokenListComponent } from "/lib/token-list-component.js";
     import { createTokenFormManager } from "/lib/token-form.js";
     import { createShortcutsPopup, createShortcutsEditPanel, createAddShortcutModal } from "/lib/shortcuts-components.js";
@@ -396,7 +396,7 @@
         // Partial failure — roll back any sessions we did create so the
         // server isn't left with orphaned tmux sessions that no UI owns.
         await Promise.allSettled(
-          created.map(s => api.delete(`/sessions/${encodeURIComponent(s.name)}`))
+          created.map(s => api.delete(`/sessions/by-id/${encodeURIComponent(s.id)}`))
         );
         const first = failures[0];
         console.error("Failed to create cluster:", first);
@@ -1028,8 +1028,9 @@
       if (!sessionName) return;
       // Kill on server (best-effort — may fail if disconnected)
       try {
-        await api.delete(`/sessions/${encodeURIComponent(sessionName)}`);
-      } catch { /* disconnected or already dead — that's fine */ }
+        const id = await resolveSessionId(sessionName);
+        await api.delete(`/sessions/by-id/${encodeURIComponent(id)}`);
+      } catch { /* disconnected, already dead, or never existed — that's fine */ }
     }
 
     function toggleKeyboardHelp() {
@@ -1459,8 +1460,13 @@
 
       // Persist to the server. If the server canonicalized the name, apply
       // a second rename pass. On failure, roll back the optimistic update.
-      api.put(`/sessions/${encodeURIComponent(oldName)}`, { name: newName })
+      // Rename via the stable id so we don't race our own optimistic update.
+      resolveSessionId(oldName)
+        .then((sid) => api.put(`/sessions/by-id/${encodeURIComponent(sid)}`, { name: newName }))
         .then((result) => {
+          // Rename changes the friendly name → invalidate both keys in the cache
+          invalidateSessionIdCache(oldName);
+          invalidateSessionIdCache(newName);
           const canonical = result?.name || newName;
           if (canonical !== newName) {
             const st = uiStore.getState();
@@ -1492,14 +1498,25 @@
         }});
       }
       if (desc.session) {
-        // Session-backed tiles: detach (keep server session), kill, tear-off
+        // Session-backed tiles: detach (keep server session), kill, tear-off.
+        // `id` is the tile id (== session friendly name today) — resolve to
+        // the stable session id before hitting the server so rename races
+        // don't matter.
         items.push({ icon: "eject", label: "Detach", action: async () => {
-          try { await api.delete(`/sessions/${encodeURIComponent(id)}?action=detach`); } catch (_) {}
+          try {
+            const sid = await resolveSessionId(desc.session);
+            await api.delete(`/sessions/by-id/${encodeURIComponent(sid)}?action=detach`);
+            invalidateSessionIdCache(desc.session);
+          } catch (_) {}
           uiStore.removeTile(id);
         }});
         items.push({ icon: "x-circle", label: "Kill session", danger: true, action: async () => {
           if (!confirm(`Kill session "${id}"?\n\nThis will terminate the tmux session and all its processes.`)) return;
-          try { await api.delete(`/sessions/${encodeURIComponent(id)}`); } catch (_) {}
+          try {
+            const sid = await resolveSessionId(desc.session);
+            await api.delete(`/sessions/by-id/${encodeURIComponent(sid)}`);
+            invalidateSessionIdCache(desc.session);
+          } catch (_) {}
           uiStore.removeTile(id);
           if (windowTabSet) windowTabSet.onSessionKilled(id);
         }});

--- a/public/app.js
+++ b/public/app.js
@@ -1028,8 +1028,9 @@
       if (!sessionName) return;
       // Kill on server (best-effort — may fail if disconnected)
       try {
-        const id = await resolveSessionId(sessionName);
-        await api.delete(`/sessions/by-id/${encodeURIComponent(id)}`);
+        const sid = await resolveSessionId(sessionName);
+        await api.delete(`/sessions/by-id/${encodeURIComponent(sid)}`);
+        invalidateSessionIdCache(sessionName);
       } catch { /* disconnected, already dead, or never existed — that's fine */ }
     }
 

--- a/public/lib/api-client.js
+++ b/public/lib/api-client.js
@@ -40,3 +40,40 @@ export const api = {
   patch: (url, data) => request("PATCH", url, data),
   delete: (url, data) => request("DELETE", url, data),
 };
+
+// ─── Session id resolver ──────────────────────────────────────────────
+// Callsites still hold friendly names (tile ids, URL params, etc.) but
+// the server's name-keyed routes are being retired. Resolve name → id
+// once and let callers hit /sessions/by-id/:id/*. Cache is in-memory
+// only, and we only cache individual name→id hits — renames invalidate
+// the entry via invalidateSessionIdCache(name). Deletes do the same.
+const sessionIdByName = new Map();
+
+/**
+ * Resolve a session friendly name to its surrogate id.
+ * Throws if the session does not exist.
+ *
+ * @param {string} name
+ * @returns {Promise<string>}
+ */
+export async function resolveSessionId(name) {
+  if (sessionIdByName.has(name)) return sessionIdByName.get(name);
+  const sessions = await api.get("/sessions");
+  if (!Array.isArray(sessions)) throw new Error("Unexpected /sessions response");
+  // Repopulate the whole cache from this fetch so follow-up lookups are free.
+  sessionIdByName.clear();
+  for (const s of sessions) {
+    if (s && typeof s.name === "string" && typeof s.id === "string") {
+      sessionIdByName.set(s.name, s.id);
+    }
+  }
+  const id = sessionIdByName.get(name);
+  if (!id) throw new Error(`Session not found: ${name}`);
+  return id;
+}
+
+/** Drop cache entries — call after rename/delete so stale names don't resolve. */
+export function invalidateSessionIdCache(name) {
+  if (name === undefined) sessionIdByName.clear();
+  else sessionIdByName.delete(name);
+}

--- a/public/lib/session-list-component.js
+++ b/public/lib/session-list-component.js
@@ -8,7 +8,7 @@
 
 import { createComponent } from '/lib/component.js';
 import { invalidateSessions } from '/lib/stores.js';
-import { api } from '/lib/api-client.js';
+import { api, invalidateSessionIdCache } from '/lib/api-client.js';
 
 const DIVIDER_CLASS = "session-list-divider";
 const LONG_PRESS_MS = 300;
@@ -324,7 +324,10 @@ export function createSessionListComponent(store, options = {}) {
           return;
         }
         try {
-          await api.put(`/sessions/${encodeURIComponent(originalName)}`, { name: newName });
+          // List render has s.id in scope — rename via the stable id
+          await api.put(`/sessions/by-id/${encodeURIComponent(s.id)}`, { name: newName });
+          invalidateSessionIdCache(originalName);
+          invalidateSessionIdCache(newName);
           invalidateSessions(store, state.currentSession);
         } catch {
           nameInput.value = originalName;
@@ -375,7 +378,8 @@ export function createSessionListComponent(store, options = {}) {
       detachBtn.addEventListener("click", async (e) => {
         e.stopPropagation();
         try {
-          await api.delete(`/sessions/${encodeURIComponent(s.name)}?action=detach`);
+          await api.delete(`/sessions/by-id/${encodeURIComponent(s.id)}?action=detach`);
+          invalidateSessionIdCache(s.name);
           if (windowTabSet) windowTabSet.removeTab(s.name);
           switchAfterRemove(s.name);
         } catch (err) {
@@ -396,7 +400,8 @@ export function createSessionListComponent(store, options = {}) {
           : `Delete session "${s.name}"?\n\nThis will kill the tmux session.`;
         if (!confirm(message)) return;
         try {
-          await api.delete(`/sessions/${encodeURIComponent(s.name)}`);
+          await api.delete(`/sessions/by-id/${encodeURIComponent(s.id)}`);
+          invalidateSessionIdCache(s.name);
           if (windowTabSet) windowTabSet.onSessionKilled(s.name);
           switchAfterRemove(s.name);
         } catch (err) {

--- a/public/lib/session-status-watcher.js
+++ b/public/lib/session-status-watcher.js
@@ -12,8 +12,9 @@
  * This module centralizes that polling. The tile that "owns" the
  * session (terminal-tile) creates the watcher at mount time and
  * destroys it at unmount. The back tile subscribes instead of
- * running its own interval. Rename is plumbed through
- * `setSessionName()` so subsequent polls hit the new URL.
+ * running its own interval. Since the watcher polls the by-id route
+ * (`/sessions/by-id/:id/status`), renames don't change the URL — the
+ * surrogate id is stable for the life of the session.
  *
  * The watcher never decides *what* should happen on a transition —
  * subscribers do. The watcher just reports:
@@ -36,22 +37,21 @@
 
 /**
  * @param {object} options
- * @param {string} options.sessionName — session to poll
+ * @param {string} options.sessionId — session id (stable surrogate) to poll
  * @param {number} [options.interval=5000] — poll interval in ms
  * @param {typeof fetch} [options.fetchImpl] — injectable for tests
  * @returns {{
  *   subscribe: (fn: (event) => void) => () => void,
- *   setSessionName: (newName: string) => void,
  *   destroy: () => void,
  *   poll: () => Promise<void>,
+ *   sessionId: string,
  * }}
  */
 export function createSessionStatusWatcher({
-  sessionName,
+  sessionId,
   interval = 5000,
   fetchImpl,
 } = {}) {
-  let currentSessionName = sessionName;
   const doFetch = fetchImpl || ((url) => globalThis.fetch(url));
   const subscribers = new Set();
   let destroyed = false;
@@ -63,7 +63,7 @@ export function createSessionStatusWatcher({
     if (destroyed) return;
     let status = null;
     try {
-      const res = await doFetch(`/sessions/${encodeURIComponent(currentSessionName)}/status`);
+      const res = await doFetch(`/sessions/by-id/${encodeURIComponent(sessionId)}/status`);
       if (destroyed) return;
       if (!res.ok) {
         notify({ status: null, transitions: {}, error: new Error(`HTTP ${res.status}`) });
@@ -118,10 +118,6 @@ export function createSessionStatusWatcher({
       };
     },
 
-    setSessionName(newName) {
-      currentSessionName = newName;
-    },
-
     destroy() {
       destroyed = true;
       stop();
@@ -131,6 +127,6 @@ export function createSessionStatusWatcher({
     /** Manual poll — used by tests and by eager first-poll on mount. */
     poll,
 
-    get sessionName() { return currentSessionName; },
+    get sessionId() { return sessionId; },
   };
 }

--- a/public/lib/shortcut-bar.js
+++ b/public/lib/shortcut-bar.js
@@ -213,7 +213,7 @@ export function createShortcutBar(options = {}) {
           },
           deleteAction: () => {
             if (!confirm(`Kill session "${s.name}"?\n\nThis will terminate the tmux session and all its processes.`)) return false;
-            api.delete(`/sessions/${encodeURIComponent(s.name)}`).then(() => {
+            api.delete(`/sessions/by-id/${encodeURIComponent(s.id)}`).then(() => {
               if (windowTabSet) windowTabSet.onSessionKilled(s.name);
               if (sessionStore) {
                 const focusedId = uiStore?.getState?.().focusedId ?? null;

--- a/public/lib/shortcut-bar.js
+++ b/public/lib/shortcut-bar.js
@@ -9,7 +9,7 @@
  */
 
 import { invalidateSessions } from "/lib/stores.js";
-import { api } from "/lib/api-client.js";
+import { api, invalidateSessionIdCache } from "/lib/api-client.js";
 import { detectPlatform } from "/lib/platform.js";
 import { renderKeyIsland } from "/lib/key-island.js";
 import "/lib/tile-tab-bar.js"; // registers <tile-tab-bar> custom element
@@ -214,6 +214,7 @@ export function createShortcutBar(options = {}) {
           deleteAction: () => {
             if (!confirm(`Kill session "${s.name}"?\n\nThis will terminate the tmux session and all its processes.`)) return false;
             api.delete(`/sessions/by-id/${encodeURIComponent(s.id)}`).then(() => {
+              invalidateSessionIdCache(s.name);
               if (windowTabSet) windowTabSet.onSessionKilled(s.name);
               if (sessionStore) {
                 const focusedId = uiStore?.getState?.().focusedId ?? null;

--- a/public/lib/tiles/dashboard-back-tile.js
+++ b/public/lib/tiles/dashboard-back-tile.js
@@ -9,7 +9,7 @@
  * carousel surface; the container exposes `ctx.faceStack` instead.)
  */
 
-import { api } from "../api-client.js";
+import { api, invalidateSessionIdCache } from "../api-client.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -208,6 +208,7 @@ export function createDashboardBackTile({ sessionName, sessionId, watcher } = {}
       case "kill":
         try {
           await api.delete(`/sessions/by-id/${encodeURIComponent(sessionId)}`);
+          invalidateSessionIdCache(currentSessionName);
           addEvent(`Killed session ${currentSessionName}`);
           updateStatus("exited");
         } catch (err) {
@@ -218,6 +219,7 @@ export function createDashboardBackTile({ sessionName, sessionId, watcher } = {}
       case "restart":
         try {
           await api.delete(`/sessions/by-id/${encodeURIComponent(sessionId)}`);
+          invalidateSessionIdCache(currentSessionName);
           if (destroyed) return;
           addEvent(`Killed session ${currentSessionName}`);
           // Brief delay then recreate. The destroyed guard must fire on
@@ -228,6 +230,7 @@ export function createDashboardBackTile({ sessionName, sessionId, watcher } = {}
             if (destroyed) return;
             try {
               await api.post("/sessions", { name: currentSessionName });
+              invalidateSessionIdCache(currentSessionName);
               if (destroyed) return;
               addEvent(`Restarted session ${currentSessionName}`);
               startTime = Date.now();
@@ -250,7 +253,7 @@ export function createDashboardBackTile({ sessionName, sessionId, watcher } = {}
 
       case "copy-output":
         try {
-          const data = await api.get(`/sessions/${encodeURIComponent(currentSessionName)}/buffer?lines=50`);
+          const data = await api.get(`/sessions/by-id/${encodeURIComponent(sessionId)}/output?lines=50`);
           const text = Array.isArray(data) ? data.join("\n") : (data.output || data.buffer || "");
           await navigator.clipboard.writeText(text);
           addEvent("Copied last 50 lines to clipboard");

--- a/public/lib/tiles/dashboard-back-tile.js
+++ b/public/lib/tiles/dashboard-back-tile.js
@@ -299,9 +299,10 @@ export function createDashboardBackTile({ sessionName, sessionId, watcher } = {}
   return {
     type: "dashboard-back",
 
-    /** Update the session name after a tab rename. Mirrors terminal-tile's
-     *  setSessionName so the dashboard's polling and actions stay aligned
-     *  with the carousel key. */
+    /** Update the displayed session name after a tab rename. API calls
+     *  route through the immutable sessionId, so this only refreshes
+     *  display surfaces — the .db-session-name DOM node and the chrome
+     *  toolbar title. */
     setSessionName(newName) {
       currentSessionName = newName;
       if (rootEl) {

--- a/public/lib/tiles/dashboard-back-tile.js
+++ b/public/lib/tiles/dashboard-back-tile.js
@@ -45,17 +45,18 @@ function statusLabel(status) {
 
 /**
  * @param {object} options
- * @param {string} options.sessionName — primary session name
+ * @param {string} options.sessionName — primary session name (for display)
+ * @param {string} options.sessionId — stable session id (used for API calls)
  * @param {object} [options.watcher] — optional shared SessionStatusWatcher.
  *   Terminal tile passes its watcher in so the front and back faces share
  *   a single poller instead of running duplicate intervals. When omitted
  *   (e.g. in tests that render the back tile in isolation) the back tile
  *   is inert — no polling, no status updates beyond what's set manually.
  */
-export function createDashboardBackTile({ sessionName, watcher } = {}) {
-  // Mutable: kept in sync with the carousel's tile ID via setSessionName().
-  // The carousel calls this from renameCard() so polling, action APIs,
-  // and rendering all use the current name after a tab rename.
+export function createDashboardBackTile({ sessionName, sessionId, watcher } = {}) {
+  // Mutable display name (updated on rename via setSessionName). API calls
+  // route through `sessionId`, which is stable for the life of the session
+  // and does NOT change on rename.
   let currentSessionName = sessionName;
   let container = null;
   let ctx = null;
@@ -206,7 +207,7 @@ export function createDashboardBackTile({ sessionName, watcher } = {}) {
     switch (action) {
       case "kill":
         try {
-          await api.delete(`/sessions/${encodeURIComponent(currentSessionName)}`);
+          await api.delete(`/sessions/by-id/${encodeURIComponent(sessionId)}`);
           addEvent(`Killed session ${currentSessionName}`);
           updateStatus("exited");
         } catch (err) {
@@ -216,7 +217,7 @@ export function createDashboardBackTile({ sessionName, watcher } = {}) {
 
       case "restart":
         try {
-          await api.delete(`/sessions/${encodeURIComponent(currentSessionName)}`);
+          await api.delete(`/sessions/by-id/${encodeURIComponent(sessionId)}`);
           if (destroyed) return;
           addEvent(`Killed session ${currentSessionName}`);
           // Brief delay then recreate. The destroyed guard must fire on

--- a/public/lib/tiles/terminal-tile.js
+++ b/public/lib/tiles/terminal-tile.js
@@ -9,6 +9,7 @@
 
 import { createDashboardBackTile } from "./dashboard-back-tile.js";
 import { createSessionStatusWatcher } from "../session-status-watcher.js";
+import { resolveSessionId } from "../api-client.js";
 
 /**
  * Create the terminal tile factory. Call once at startup with shared deps,
@@ -52,10 +53,11 @@ export function createTerminalTileFactory(deps) {
 
       /** Update the session name after a tab rename. The carousel calls
        *  this from renameCard() so that subsequent lookups (findCard,
-       *  serialize, etc.) see the new name instead of the original. */
+       *  serialize, etc.) see the new name instead of the original.
+       *  The watcher polls by id and needs no update; the back tile
+       *  still tracks the friendly name for display. */
       setSessionName(newName) {
         currentSessionName = newName;
-        watcher?.setSessionName(newName);
         backTile?.setSessionName(newName);
       },
 
@@ -69,54 +71,53 @@ export function createTerminalTileFactory(deps) {
         mounted = true;
 
         // ── Shared status watcher ──────────────────────────────────
-        // One poller per session, not one per tile face. Terminal tile
-        // owns the watcher; the back tile subscribes instead of running
-        // its own interval. See public/lib/session-status-watcher.js.
-        watcher = createSessionStatusWatcher({ sessionName: currentSessionName });
-
-        // ── Register dashboard back-face via faceStack ─────────────
-        // `ctx.faceStack` is the container-provided affordance that
-        // replaced `a carousel dep.setBackTile` in Tier 1 T1a. The tile
-        // doesn't know or care whether the container is a carousel, an
-        // exposé pack, or a Level 2 mini-strip — it just says "here's
-        // my secondary face, show it when I tell you to".
+        // Status polling is keyed on the immutable session id, not the
+        // friendly name — the id is resolved asynchronously at mount
+        // and doesn't change on rename. Back tile + auto-flip wiring
+        // wait until the id is known; if resolution fails (session was
+        // killed externally between persist and mount) the tile stays
+        // in its "no status" baseline state, which is harmless — the
+        // terminal pool still shows the last known screen.
         const faceStack = ctx?.faceStack;
-        if (faceStack) {
-          backTile = createDashboardBackTile({ sessionName: currentSessionName, watcher });
-          faceStack.setSecondary(backTile);
-        }
-
-        // ── Auto-flip on child process exit ────────────────────────
-        // When the watcher reports a had-children → no-children
-        // transition, schedule a 1.5s debounce then re-poll and flip
-        // if still idle. The debounce absorbs brief pauses between
-        // commands. The watcher's own destroyed guard covers the fetch
-        // side; the `destroyed` flag here covers the setTimeout side.
-        //
-        // The `destroyed` guard remains load-bearing even though the
-        // tile now owns its affordance cleanly: the 1.5s debounce and
-        // the re-poll inside it are both async hops that can land
-        // after unmount(). Removing the guard would let a late
-        // setTimeout flip a stale faceStack reference.
-        watcherUnsubscribe = watcher.subscribe((event) => {
+        resolveSessionId(currentSessionName).then((sessionId) => {
           if (destroyed) return;
-          if (!event.transitions?.idle) return;
-          if (!faceStack || faceStack.isShowingSecondary()) return;
-          if (autoFlipTimer) clearTimeout(autoFlipTimer);
-          autoFlipTimer = setTimeout(() => {
+          watcher = createSessionStatusWatcher({ sessionId });
+
+          if (faceStack) {
+            backTile = createDashboardBackTile({
+              sessionName: currentSessionName,
+              sessionId,
+              watcher,
+            });
+            faceStack.setSecondary(backTile);
+          }
+
+          // ── Auto-flip on child process exit ────────────────────────
+          // When the watcher reports a had-children → no-children
+          // transition, schedule a 1.5s debounce then re-poll and flip
+          // if still idle. The debounce absorbs brief pauses between
+          // commands. The watcher's own destroyed guard covers the fetch
+          // side; the `destroyed` flag here covers the setTimeout side.
+          watcherUnsubscribe = watcher.subscribe((event) => {
             if (destroyed) return;
-            if (faceStack.isShowingSecondary()) return;
-            // Re-check via an immediate poll so we don't flip on a
-            // momentary pause between commands. If that poll reports
-            // child processes are back, the flip is cancelled.
-            watcher.poll().then(() => {
+            if (!event.transitions?.idle) return;
+            if (!faceStack || faceStack.isShowingSecondary()) return;
+            if (autoFlipTimer) clearTimeout(autoFlipTimer);
+            autoFlipTimer = setTimeout(() => {
               if (destroyed) return;
               if (faceStack.isShowingSecondary()) return;
-              if (backTile?.addEvent) backTile.addEvent("Agent work completed");
-              faceStack.showSecondary(true);
-            }).catch(() => {});
-          }, 1500);
-        });
+              // Re-check via an immediate poll so we don't flip on a
+              // momentary pause between commands. If that poll reports
+              // child processes are back, the flip is cancelled.
+              watcher.poll().then(() => {
+                if (destroyed) return;
+                if (faceStack.isShowingSecondary()) return;
+                if (backTile?.addEvent) backTile.addEvent("Agent work completed");
+                faceStack.showSecondary(true);
+              }).catch(() => {});
+            }, 1500);
+          });
+        }).catch(() => { /* session missing — baseline state is fine */ });
       },
 
       unmount() {

--- a/test/auto-flip.test.js
+++ b/test/auto-flip.test.js
@@ -101,10 +101,16 @@ async function importTerminalTile() {
   return mod.createTerminalTileFactory;
 }
 
-// Poll-response script helper: step through a sequence of statuses
+// Poll-response script helper: step through a sequence of statuses.
+// Requests to `/sessions` (the name→id resolver lookup triggered at
+// mount time) are answered separately so they don't consume a slot in
+// the status script.
 function makeFetchScript(statuses) {
   let i = 0;
-  return mock.fn(async (_url) => {
+  return mock.fn(async (url) => {
+    if (typeof url === "string" && /\/sessions($|\?)/.test(url)) {
+      return { ok: true, json: async () => [{ id: "idDev", name: "dev" }] };
+    }
     const s = statuses[Math.min(i, statuses.length - 1)];
     i++;
     return { ok: true, json: async () => s };
@@ -149,6 +155,10 @@ describe('terminal-tile auto-flip on idle', () => {
     const container = createMockElement("div");
 
     tile.mount(container, { flip: () => {}, faceStack });
+    // mount() resolves the session id asynchronously before creating
+    // the watcher — flush microtasks so the watcher is wired before
+    // we advance mock timers.
+    await flush();
 
     // Tick the 5s status poll interval to trigger first poll (active)
     timers.tick(5000);
@@ -182,6 +192,7 @@ describe('terminal-tile auto-flip on idle', () => {
     const container = createMockElement("div");
 
     tile.mount(container, { flip: () => {}, faceStack });
+    await flush();
     timers.tick(5000);
     await flush();
     timers.tick(5000);
@@ -211,6 +222,7 @@ describe('terminal-tile auto-flip on idle', () => {
     const container = createMockElement("div");
 
     tile.mount(container, { flip: () => {}, faceStack });
+    await flush();
     timers.tick(5000);
     await flush();
     timers.tick(5000);

--- a/test/session-status-watcher.test.js
+++ b/test/session-status-watcher.test.js
@@ -41,7 +41,7 @@ describe('SessionStatusWatcher', () => {
       { alive: true, hasChildProcesses: true },
       { alive: true, hasChildProcesses: false },
     ]);
-    const watcher = createSessionStatusWatcher({ sessionName: "dev", fetchImpl });
+    const watcher = createSessionStatusWatcher({ sessionId: "idDev", fetchImpl });
     const a = mock.fn();
     const b = mock.fn();
     const c = mock.fn();
@@ -65,7 +65,7 @@ describe('SessionStatusWatcher', () => {
       { alive: true, hasChildProcesses: true },
       { alive: true, hasChildProcesses: false },
     ]);
-    const watcher = createSessionStatusWatcher({ sessionName: "dev", fetchImpl });
+    const watcher = createSessionStatusWatcher({ sessionId: "idDev", fetchImpl });
     const events = [];
     watcher.subscribe(e => events.push(e));
 
@@ -87,7 +87,7 @@ describe('SessionStatusWatcher', () => {
       { alive: true, hasChildProcesses: false },
       { alive: false, hasChildProcesses: false },
     ]);
-    const watcher = createSessionStatusWatcher({ sessionName: "dev", fetchImpl });
+    const watcher = createSessionStatusWatcher({ sessionId: "idDev", fetchImpl });
     const events = [];
     watcher.subscribe(e => events.push(e));
 
@@ -102,7 +102,7 @@ describe('SessionStatusWatcher', () => {
 
   it('stops polling when last subscriber unsubscribes', async () => {
     const fetchImpl = makeFetchScript([{ alive: true, hasChildProcesses: false }]);
-    const watcher = createSessionStatusWatcher({ sessionName: "dev", fetchImpl });
+    const watcher = createSessionStatusWatcher({ sessionId: "idDev", fetchImpl });
     const unsubscribe = watcher.subscribe(() => {});
     timers.tick(5000);
     await flush();
@@ -119,7 +119,7 @@ describe('SessionStatusWatcher', () => {
   it('destroy() prevents any further notifications even if a fetch is in flight', async () => {
     let resolveFetch;
     const fetchImpl = mock.fn(() => new Promise(r => { resolveFetch = r; }));
-    const watcher = createSessionStatusWatcher({ sessionName: "dev", fetchImpl });
+    const watcher = createSessionStatusWatcher({ sessionId: "idDev", fetchImpl });
     const events = [];
     watcher.subscribe(e => events.push(e));
 
@@ -132,28 +132,26 @@ describe('SessionStatusWatcher', () => {
     assert.strictEqual(events.length, 0);
   });
 
-  it('setSessionName updates the URL for subsequent polls', async () => {
+  it('polls the by-id URL for the session id it was created with', async () => {
     const fetchImpl = makeFetchScript([
       { alive: true, hasChildProcesses: false },
       { alive: true, hasChildProcesses: false },
     ]);
-    const watcher = createSessionStatusWatcher({ sessionName: "old", fetchImpl });
+    const watcher = createSessionStatusWatcher({ sessionId: "idOld", fetchImpl });
     watcher.subscribe(() => {});
     timers.tick(5000);
     await flush();
-
-    watcher.setSessionName("new");
     timers.tick(5000);
     await flush();
 
-    assert.strictEqual(fetchImpl.mock.calls[0].arguments[0], "/sessions/old/status");
-    assert.strictEqual(fetchImpl.mock.calls[1].arguments[0], "/sessions/new/status");
+    assert.strictEqual(fetchImpl.mock.calls[0].arguments[0], "/sessions/by-id/idOld/status");
+    assert.strictEqual(fetchImpl.mock.calls[1].arguments[0], "/sessions/by-id/idOld/status");
     watcher.destroy();
   });
 
   it('swallows subscriber errors without blocking other subscribers', async () => {
     const fetchImpl = makeFetchScript([{ alive: true, hasChildProcesses: false }]);
-    const watcher = createSessionStatusWatcher({ sessionName: "dev", fetchImpl });
+    const watcher = createSessionStatusWatcher({ sessionId: "idDev", fetchImpl });
     const bad = mock.fn(() => { throw new Error("boom"); });
     const good = mock.fn();
     watcher.subscribe(bad);
@@ -168,7 +166,7 @@ describe('SessionStatusWatcher', () => {
     const fetchImpl = makeFetchScript([
       { throw: new Error("network down") },
     ]);
-    const watcher = createSessionStatusWatcher({ sessionName: "dev", fetchImpl });
+    const watcher = createSessionStatusWatcher({ sessionId: "idDev", fetchImpl });
     const events = [];
     watcher.subscribe(e => events.push(e));
     timers.tick(5000);


### PR DESCRIPTION
## Summary

Migrates every client callsite that hits a name-keyed session route onto the stable id-keyed routes introduced in PR2. Unblocks PR3c deleting the `/sessions/:name/{status,output,exec,input}` handlers and PUT/DELETE `/sessions/:name`.

- New `resolveSessionId(name)` + `invalidateSessionIdCache(name)` in `api-client.js` (lightweight in-memory cache that mirrors the CLI resolver from PR3a)
- `session-status-watcher` polls `/sessions/by-id/:id/status`; `setSessionName` removed since the id is stable
- `terminal-tile` resolves sessionId asynchronously at mount then wires the watcher + dashboard back tile
- `dashboard-back-tile` accepts `sessionId` and routes kill/restart through the by-id DELETE
- `app.js` (cluster rollback, kill-current, tab detach/kill, tab rename) and `session-list-component.js` / `shortcut-bar.js` all go through by-id routes — list-rendered paths use `s.id` from the list response directly, rename paths go through `resolveSessionId(oldName)` once

## Rescoped from original plan

The original PR3b plan also included (a) localStorage v3→v4 tile-prop rename `sessionName → sessionId` and (b) `?s=<name>` → `?sid=<id>` URL params. Neither unblocks PR3c (renames already propagate to tile props via `setSessionName` events), so those are deferred as a separate hygiene pass. The only change needed to retire the name-keyed routes is the callsite migration in this PR.

## Out of scope (intentionally)

- `/sessions/cwd/:name` — different route shape, not on PR3c's chopping block
- `/sessions/:name/buffer?lines=50` in dashboard-back-tile — pre-existing bug (no such server route), not in PR3c's scope

## Test plan

- [x] `npm test` (2198 unit tests pass)
- [ ] Manual verification: tab rename, kill session, detach, shortcut-bar kill, session-list rename/detach/delete all work
- [ ] Back face auto-flip still triggers on child-process idle transition