### PR TITLE
MC1f: session.meta bucket + Claude presence wiring

### DIFF
--- a/lib/cli/commands/relay-hook.js
+++ b/lib/cli/commands/relay-hook.js
@@ -38,12 +38,35 @@ function readApiKey() {
   }
 }
 
+// Stamps `_tmuxPane` onto the payload when the hook is firing from inside a
+// tmux pane. The server uses this as the middle key that ties a Claude
+// session UUID back to the katulong-managed tile running it (see
+// docs/tile-claude-session-link.md). The server re-validates this against
+// its own pane index before trusting it — a bogus value is a no-op, not a
+// privilege escalation.
+//
+// Exported for tests; pass an explicit `pane` to avoid dependence on
+// `process.env.TMUX_PANE` state leaking between cases.
+export function stampTmuxPane(payload, pane = process.env.TMUX_PANE) {
+  if (!pane || !/^%\d+$/.test(pane)) return payload;
+  try {
+    const obj = JSON.parse(payload);
+    if (!obj || typeof obj !== "object" || Array.isArray(obj)) return payload;
+    obj._tmuxPane = pane;
+    return JSON.stringify(obj);
+  } catch {
+    return payload;
+  }
+}
+
 export default async function relayHook(_args) {
   // Read payload from stdin
   const chunks = [];
   for await (const chunk of process.stdin) chunks.push(chunk);
-  const payload = Buffer.concat(chunks).toString();
-  if (!payload.trim()) process.exit(0);
+  const raw = Buffer.concat(chunks).toString();
+  if (!raw.trim()) process.exit(0);
+
+  const payload = stampTmuxPane(raw);
 
   // Try local server first (localhost — auth bypassed automatically)
   const serverInfo = readServerInfo();

--- a/lib/cli/commands/setup.js
+++ b/lib/cli/commands/setup.js
@@ -103,7 +103,13 @@ async function selfAccess(args) {
   }
 }
 
-const HOOK_EVENTS = ["PostToolUse", "Stop", "SubagentStart", "SubagentStop"];
+const HOOK_EVENTS = [
+  "PostToolUse", "Stop", "SubagentStart", "SubagentStop",
+  // SessionStart / SessionEnd carry the Claude UUID and let the server
+  // populate `session.meta.claude` so the tile feed button can open the
+  // right topic without a lookup. See docs/session-meta.md.
+  "SessionStart", "SessionEnd",
+];
 const RELAY_HOOK = { type: "command", command: "katulong relay-hook" };
 
 async function claudeHooks(args) {

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -37,6 +37,56 @@ import {
 // Exported so route tests can audit the filter list directly.
 export const PRIVATE_META_KEYS = new Set(["transcriptPath"]);
 
+/**
+ * Apply a Claude hook payload to `session.meta.claude` via the provided
+ * sessionManager. Exported for unit tests — the live /api/claude-events
+ * handler is the only production caller.
+ *
+ * Returns `"set"` / `"cleared"` / `null` describing what happened. Unknown
+ * panes, malformed panes, and unrelated events all return `null`.
+ *
+ * @param {object} payload - raw hook payload (already JSON-parsed)
+ * @param {{ getSessionByPane: (pane: string) => object | undefined }} sessionManager
+ * @param {{ warn: Function } | null} [logger]
+ * @returns {"set" | "cleared" | null}
+ */
+export function applyClaudeMetaFromHook(payload, sessionManager, logger = null) {
+  if (!payload || typeof payload !== "object") return null;
+  const pane = typeof payload._tmuxPane === "string" ? payload._tmuxPane : null;
+  if (!pane || !/^%\d+$/.test(pane)) return null;
+
+  const session = sessionManager.getSessionByPane(pane);
+  if (!session) return null;
+
+  const event = payload.hook_event_name;
+  if (event === "SessionStart") {
+    try {
+      session.setMeta("claude", {
+        uuid: payload.session_id,
+        startedAt: Date.now(),
+      });
+      return "set";
+    } catch (err) {
+      logger?.warn?.("Failed to set meta.claude on SessionStart", {
+        session: session.name, error: err.message,
+      });
+      return null;
+    }
+  }
+  if (event === "SessionEnd" || event === "Stop") {
+    try {
+      session.setMeta("claude", null);
+      return "cleared";
+    } catch (err) {
+      logger?.warn?.("Failed to clear meta.claude", {
+        session: session.name, error: err.message,
+      });
+      return null;
+    }
+  }
+  return null;
+}
+
 export function publicMeta(meta) {
   if (!meta || typeof meta !== "object") return meta;
   const out = {};
@@ -460,6 +510,12 @@ export function createAppRoutes(ctx) {
       }
       const result = transformClaudeEvent(payload);
       if (!result) return json(res, 400, { error: "Missing session_id or hook_event_name" });
+
+      // Populate `session.meta.claude` from SessionStart / clear on
+      // SessionEnd / Stop. `_tmuxPane` is stamped by `katulong relay-hook`
+      // from TMUX_PANE and re-validated here against our own pane index
+      // — we never trust the payload itself. Unknown panes are a no-op.
+      applyClaudeMetaFromHook(payload, sessionManager, log);
 
       // Thin-event model: raw hook events are NOT published to the topic broker.
       // The narrative processor decides what to publish (narrative / completion /

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -29,13 +29,13 @@ import { createNarrativeProcessor } from "../narrative-processor.js";
 import {
   MAX_UPLOAD_BYTES, detectImage, imageMimeType, setClipboard,
 } from "./upload.js";
+import { PRIVATE_META_KEYS, publicMeta } from "../session-meta-filter.js";
 
-// Server-only meta fields — filtered from any client-facing response.
-// transcriptPath is an absolute host filesystem path: we use it to read
-// the transcript on the `/api/claude-transcript/:id` endpoint, but
-// leaking it to the client is an information disclosure we don't need.
-// Exported so route tests can audit the filter list directly.
-export const PRIVATE_META_KEYS = new Set(["transcriptPath"]);
+// Re-export so existing route tests and callers continue to import these
+// from app-routes.js. Source of truth lives in session-meta-filter.js so
+// the WS relay in session-manager.js can share the filter without a
+// reverse dependency on this module.
+export { PRIVATE_META_KEYS, publicMeta };
 
 /**
  * Apply a Claude hook payload to `session.meta.claude` via the provided
@@ -60,9 +60,14 @@ export function applyClaudeMetaFromHook(payload, sessionManager, logger = null) 
 
   const event = payload.hook_event_name;
   if (event === "SessionStart") {
+    // Validate UUID shape before writing — the value becomes a topic name
+    // prefix (`claude/<uuid>`) on the client, and we don't want a bogus
+    // hook payload polluting meta with a non-UUID string.
+    const uuid = typeof payload.session_id === "string" ? payload.session_id : null;
+    if (!uuid || !UUID_RE.test(uuid)) return null;
     try {
       session.setMeta("claude", {
-        uuid: payload.session_id,
+        uuid,
         startedAt: Date.now(),
       });
       return "set";
@@ -85,15 +90,6 @@ export function applyClaudeMetaFromHook(payload, sessionManager, logger = null) 
     }
   }
   return null;
-}
-
-export function publicMeta(meta) {
-  if (!meta || typeof meta !== "object") return meta;
-  const out = {};
-  for (const [k, v] of Object.entries(meta)) {
-    if (!PRIVATE_META_KEYS.has(k)) out[k] = v;
-  }
-  return out;
 }
 
 // Returns the first private key name found in caller-supplied meta, or null.

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -22,6 +22,7 @@ import { createSessionStore } from "./session-persistence.js";
 import { startChildCountMonitor } from "./session-child-counter.js";
 import { Session } from "./session.js";
 import { sessionId, SESSION_ID_PATTERN } from "./id.js";
+import { publicMeta } from "./session-meta-filter.js";
 import {
   tmuxExec, tmuxNewSession, tmuxHasSession,
   applyTmuxSessionOptions, captureVisiblePane, getCursorPosition, getPaneCwd, checkTmux,
@@ -222,7 +223,15 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
       },
       onChange: (s) => {
         scheduleSave();
-        bridge.relay({ type: "session-updated", session: s.name, data: s.toJSON() });
+        // Strip server-only meta keys before broadcast — same filter used
+        // by the REST surfaces. Keeps a single source of truth for what
+        // is or isn't safe to ship over the wire.
+        const data = s.toJSON();
+        bridge.relay({
+          type: "session-updated",
+          session: s.name,
+          data: { ...data, meta: publicMeta(data.meta) },
+        });
       },
     });
 
@@ -771,8 +780,8 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
           if (entry.meta && typeof entry.meta === "object" && !Array.isArray(entry.meta)) {
             // Drop any persisted `claude` namespace defensively — it should
             // have been stripped on write, but tolerate older files.
-            const { claude: _claude, ...rest } = entry.meta;
-            persistedMeta = rest;
+            const { claude: _claude, ...persistMeta } = entry.meta;
+            persistedMeta = persistMeta;
           }
         }
         if (!tmuxName) continue;

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -64,11 +64,18 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
     serialize: () => {
       const obj = {};
       for (const [name, session] of sessions) {
-        obj[name] = {
+        // Strip the `claude` namespace on persistence — claude UUIDs are
+        // resolved live from hook events on every session start, so
+        // persisting them would just go stale across restarts. User- and
+        // system-reserved namespaces (MC1f.5) round-trip.
+        const { claude: _claude, ...persistMeta } = session.meta || {};
+        const entry = {
           tmuxName: session.tmuxName,
           id: session.id,
           tmuxPane: session.tmuxPane,
         };
+        if (Object.keys(persistMeta).length > 0) entry.meta = persistMeta;
+        obj[name] = entry;
       }
       return obj;
     },
@@ -183,7 +190,7 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
 
   // --- Shared helper: adopt an existing tmux session ---
 
-  async function adoptSession(name, tmuxName, cols = DEFAULT_COLS, rows = DEFAULT_ROWS, { external = false, id = null } = {}) {
+  async function adoptSession(name, tmuxName, cols = DEFAULT_COLS, rows = DEFAULT_ROWS, { external = false, id = null, meta = null } = {}) {
     // Only apply tmux options for externally adopted sessions —
     // new sessions already have them from tmuxNewSession().
     if (external) await applyTmuxSessionOptions(tmuxName);
@@ -199,6 +206,7 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
     const session = new Session(name, tmuxName, {
       id: id != null ? id : sessionId(),
       tmuxPane,
+      meta,
       maxBufferBytes: MAX_BUFFER_BYTES,
       external,
       onData: (sessionName, fromSeq) => {
@@ -211,6 +219,10 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
         // Immediately delete the exited session — same behavior as a local
         // terminal (Terminal.app, iTerm2) closing when the shell exits.
         deleteSession(sessionName);
+      },
+      onChange: (s) => {
+        scheduleSave();
+        bridge.relay({ type: "session-updated", session: s.name, data: s.toJSON() });
       },
     });
 
@@ -707,6 +719,25 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
     },
 
     /**
+     * Look up a session by its tmux pane id (`%N`).
+     *
+     * Used by the Claude hook ingest handler to resolve payloads stamped
+     * with `_tmuxPane` back to a known katulong session. The pane id is
+     * captured once at spawn/adopt time (see `tmuxGetPaneId`) so the lookup
+     * is authoritative — we do not trust the hook payload itself.
+     *
+     * @param {string} pane - tmux pane id (e.g. "%3")
+     * @returns {Session|undefined}
+     */
+    getSessionByPane(pane) {
+      if (!pane || typeof pane !== "string" || !/^%\d+$/.test(pane)) return undefined;
+      for (const session of sessions.values()) {
+        if (session.tmuxPane === pane) return session;
+      }
+      return undefined;
+    },
+
+    /**
      * Restore sessions from sessions.json, re-adopting tmux sessions that still exist.
      *
      * Accepts both persistence formats:
@@ -729,6 +760,7 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
       for (const [friendlyName, entry] of Object.entries(map)) {
         let tmuxName = null;
         let persistedId = null;
+        let persistedMeta = null;
         if (typeof entry === "string") {
           tmuxName = entry;
         } else if (entry && typeof entry === "object" && typeof entry.tmuxName === "string") {
@@ -736,18 +768,24 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
           if (typeof entry.id === "string" && SESSION_ID_PATTERN.test(entry.id)) {
             persistedId = entry.id;
           }
+          if (entry.meta && typeof entry.meta === "object" && !Array.isArray(entry.meta)) {
+            // Drop any persisted `claude` namespace defensively — it should
+            // have been stripped on write, but tolerate older files.
+            const { claude: _claude, ...rest } = entry.meta;
+            persistedMeta = rest;
+          }
         }
         if (!tmuxName) continue;
         if (sessions.has(friendlyName)) continue;
         if (isAlreadyManaged(tmuxName)) continue;
-        candidates.push({ friendlyName, tmuxName, persistedId });
+        candidates.push({ friendlyName, tmuxName, persistedId, persistedMeta });
       }
 
       await Promise.allSettled(
-        candidates.map(async ({ friendlyName, tmuxName, persistedId }) => {
+        candidates.map(async ({ friendlyName, tmuxName, persistedId, persistedMeta }) => {
           const exists = await tmuxHasSession(tmuxName);
           if (!exists) return;
-          const session = await adoptSession(friendlyName, tmuxName, DEFAULT_COLS, DEFAULT_ROWS, { id: persistedId });
+          const session = await adoptSession(friendlyName, tmuxName, DEFAULT_COLS, DEFAULT_ROWS, { id: persistedId, meta: persistedMeta });
           sessions.set(friendlyName, session);
           log.info("Restored session", { session: friendlyName, tmux: tmuxName });
         })

--- a/lib/session-meta-filter.js
+++ b/lib/session-meta-filter.js
@@ -1,0 +1,24 @@
+/**
+ * Shared filter for session.meta before it leaves the server.
+ *
+ * Some meta keys are server-only (e.g., `transcriptPath` — an absolute
+ * host filesystem path used for reading Claude transcripts but never
+ * meant for clients). Any code path that ships meta over the wire —
+ * REST responses, WS pushes — must funnel through `publicMeta` so a
+ * single list of private keys governs every outbound surface.
+ *
+ * Kept in its own module so both `session-manager.js` (WS `session-updated`
+ * push) and `routes/app-routes.js` (REST responses) can share the filter
+ * without one importing from the other.
+ */
+
+export const PRIVATE_META_KEYS = new Set(["transcriptPath"]);
+
+export function publicMeta(meta) {
+  if (!meta || typeof meta !== "object") return meta;
+  const out = {};
+  for (const [k, v] of Object.entries(meta)) {
+    if (!PRIVATE_META_KEYS.has(k)) out[k] = v;
+  }
+  return out;
+}

--- a/lib/session.js
+++ b/lib/session.js
@@ -12,6 +12,11 @@ import {
 // Chunk large input to stay safely under that limit.
 const SEND_KEYS_MAX_BYTES = 4096;
 
+// Size cap for the serialized `meta` bucket on a Session.
+// Claude's namespace is ~100 bytes; user/system are reserved for MC1f.5.
+// An internal contract violation (not an HTTP 413) — throws.
+const MAX_META_BYTES = 4096;
+
 // Resize gate: defer SIGWINCH when output is actively flowing.
 // The client-side terminal-pool.js applies an 80ms upstream debounce;
 // this server-side gate adds a second layer at the tmux control mode
@@ -92,6 +97,8 @@ export class Session {
       external = false,
       onData,
       onExit,
+      onChange,
+      meta,
       // Injectable for tests — lets us attach without spawning real tmux.
       _spawn = spawn,
       // Injectable for tests — lets the kill() regression test verify that
@@ -101,6 +108,8 @@ export class Session {
 
     this.external = external;
     this.icon = null; // per-session icon override (Phosphor icon name)
+    this.meta = (meta && typeof meta === "object" && !Array.isArray(meta)) ? { ...meta } : {};
+    this._onChange = typeof onChange === "function" ? onChange : null;
     this._spawn = _spawn;
     this._tmuxKillSession = _tmuxKillSession;
 
@@ -696,6 +705,37 @@ export class Session {
   }
 
   /**
+   * Replace a single namespace in the meta bucket.
+   *
+   * Full-replace semantics (not RFC 7396 merge): the whole namespace value is
+   * swapped atomically. Passing `null` or `undefined` removes the namespace.
+   * Throws RangeError if the serialized bucket would exceed MAX_META_BYTES —
+   * this is an internal contract, not an HTTP error.
+   *
+   * @param {string} namespace - non-empty string, e.g. "claude"
+   * @param {*} value - JSON-serializable value, or null/undefined to remove
+   */
+  setMeta(namespace, value) {
+    if (typeof namespace !== "string" || namespace.length === 0) {
+      throw new TypeError("setMeta: namespace must be a non-empty string");
+    }
+    const next = { ...this.meta };
+    if (value === null || value === undefined) {
+      delete next[namespace];
+    } else {
+      next[namespace] = value;
+    }
+    const bytes = Buffer.byteLength(JSON.stringify(next), "utf8");
+    if (bytes > MAX_META_BYTES) {
+      throw new RangeError(`setMeta: serialized meta (${bytes}B) exceeds ${MAX_META_BYTES}B cap`);
+    }
+    this.meta = next;
+    if (this._onChange) {
+      this._onChange(this);
+    }
+  }
+
+  /**
    * Serialize to JSON for API responses.
    * @returns {object}
    */
@@ -709,6 +749,7 @@ export class Session {
       hasChildProcesses: this.hasChildProcesses(),
       external: this.external,
       icon: this.icon,
+      meta: this.meta,
     };
   }
 }

--- a/lib/ws-manager.js
+++ b/lib/ws-manager.js
@@ -189,6 +189,12 @@ export function createWebSocketManager({ bridge, sessionManager, pluginWsHandler
         // Tracker already renamed clients before relay, so route via newName
         sendToSession(msg.newName, { type: "session-renamed", name: msg.newName, id: msg.id });
         break;
+      case "session-updated":
+        // Freeform session-state change (e.g., meta bucket write). Payload
+        // is the full toJSON() snapshot so clients can refresh without a
+        // follow-up GET. Scoped to subscribers of this session.
+        sendToSession(msg.session, { type: "session-updated", session: msg.session, data: msg.data });
+        break;
       case "resize-sync":
         sendToSessionExcluding(msg.session, msg.activeClientId, {
           type: "resize-sync", cols: msg.cols, rows: msg.rows,

--- a/public/app.js
+++ b/public/app.js
@@ -1696,24 +1696,41 @@
       if (isOverlayViewport()) setOverlaySidebar(false);
     }
 
-    /** Open a feed tile for the Claude session running in the current terminal. */
+    /** Open a feed tile for the Claude session running in the current terminal.
+     *
+     * Primary path: read `session.meta.claude.uuid` populated by the server
+     * hook ingest (MC1f). Fallback: scan topics for a sessionName match —
+     * kept so existing Claude sessions whose SessionStart fired before this
+     * wiring still resolve.
+     */
     async function openClaudeFeedTile() {
       const sessionName = getActiveSessionName();
       try {
-        const topics = await api.get("/api/topics");
-        // Find the most recent Claude topic matching this terminal session
-        const match = topics
-          .filter(t => t.name.startsWith("claude/") && t.meta?.sessionName === sessionName)
-          .sort((a, b) => (b.messages || 0) - (a.messages || 0))[0];
+        let topic = null;
+        let meta = null;
 
-        if (match) {
+        if (sessionName) {
+          const list = await api.get("/sessions");
+          const active = (list.sessions || []).find(s => s.name === sessionName);
+          const uuid = active?.meta?.claude?.uuid;
+          if (uuid) topic = `claude/${uuid}`;
+        }
+
+        if (!topic) {
+          const topics = await api.get("/api/topics");
+          const match = topics
+            .filter(t => t.name.startsWith("claude/") && t.meta?.sessionName === sessionName)
+            .sort((a, b) => (b.messages || 0) - (a.messages || 0))[0];
+          if (match) { topic = match.name; meta = match.meta || {}; }
+        }
+
+        if (topic) {
           const tileId = `feed-${Date.now().toString(36)}`;
           uiStore.addTile(
-            { id: tileId, type: "feed", props: { topic: match.name, title: match.name, meta: match.meta || {} } },
+            { id: tileId, type: "feed", props: { topic, title: topic, meta: meta || {} } },
             { focus: true, insertAt: "afterFocus" },
           );
         } else {
-          // No Claude topic found — open blank feed picker
           openFeedTile();
         }
       } catch {

--- a/public/app.js
+++ b/public/app.js
@@ -1706,28 +1706,37 @@
     async function openClaudeFeedTile() {
       const sessionName = getActiveSessionName();
       try {
-        let topic = null;
-        let meta = null;
-
+        // Primary: read meta.claude.uuid from the already-cached session
+        // list. The `session-updated` WS push keeps this in sync, so we
+        // don't need a dedicated fetch.
         if (sessionName) {
-          const list = await api.get("/sessions");
-          const active = (list.sessions || []).find(s => s.name === sessionName);
+          const { sessions } = sessionStore.getState();
+          const active = (sessions || []).find(s => s.name === sessionName);
           const uuid = active?.meta?.claude?.uuid;
-          if (uuid) topic = `claude/${uuid}`;
+          if (uuid) {
+            const topic = `claude/${uuid}`;
+            const tileId = `feed-${Date.now().toString(36)}`;
+            uiStore.addTile(
+              { id: tileId, type: "feed", props: { topic, title: topic, meta: {} } },
+              { focus: true, insertAt: "afterFocus" },
+            );
+            if (isOverlayViewport()) setOverlaySidebar(false);
+            return;
+          }
         }
 
-        if (!topic) {
-          const topics = await api.get("/api/topics");
-          const match = topics
-            .filter(t => t.name.startsWith("claude/") && t.meta?.sessionName === sessionName)
-            .sort((a, b) => (b.messages || 0) - (a.messages || 0))[0];
-          if (match) { topic = match.name; meta = match.meta || {}; }
-        }
-
-        if (topic) {
+        // Fallback: scan topics for a sessionName match — resolves Claude
+        // sessions whose SessionStart fired before MC1f was deployed.
+        // Remove once all live Claude sessions have been restarted under
+        // the new hook wiring.
+        const topics = await api.get("/api/topics");
+        const match = topics
+          .filter(t => t.name.startsWith("claude/") && t.meta?.sessionName === sessionName)
+          .sort((a, b) => (b.messages || 0) - (a.messages || 0))[0];
+        if (match) {
           const tileId = `feed-${Date.now().toString(36)}`;
           uiStore.addTile(
-            { id: tileId, type: "feed", props: { topic, title: topic, meta: meta || {} } },
+            { id: tileId, type: "feed", props: { topic: match.name, title: match.name, meta: match.meta || {} } },
             { focus: true, insertAt: "afterFocus" },
           );
         } else {

--- a/public/lib/ws-message-handlers.js
+++ b/public/lib/ws-message-handlers.js
@@ -222,11 +222,13 @@ export const wsMessageHandlers = {
   // Server notifies that a session's stored meta changed (e.g., Claude
   // SessionStart hook populating meta.claude.uuid). Refresh the cached
   // session list so feed-button and other consumers see the new meta
-  // without a manual fetch.
+  // without a manual fetch. Use `msg.session` — the push is targeted via
+  // `sendToSession`, but a subscribed client may be viewing a different
+  // session, so `ctx.currentSessionName` is not the right key here.
   'session-updated'(msg, ctx) {
     return {
       stateUpdates: {},
-      effects: [{ type: 'invalidateSessions', name: ctx.currentSessionName }],
+      effects: [{ type: 'invalidateSessions', name: msg.session }],
     };
   },
 };

--- a/public/lib/ws-message-handlers.js
+++ b/public/lib/ws-message-handlers.js
@@ -218,4 +218,15 @@ export const wsMessageHandlers = {
       effects: [{ type: 'tabIconChanged', session: msg.session, icon: msg.icon }],
     };
   },
+
+  // Server notifies that a session's stored meta changed (e.g., Claude
+  // SessionStart hook populating meta.claude.uuid). Refresh the cached
+  // session list so feed-button and other consumers see the new meta
+  // without a manual fetch.
+  'session-updated'(msg, ctx) {
+    return {
+      stateUpdates: {},
+      effects: [{ type: 'invalidateSessions', name: ctx.currentSessionName }],
+    };
+  },
 };

--- a/test/app-routes-meta.test.js
+++ b/test/app-routes-meta.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { publicMeta, PRIVATE_META_KEYS } from "../lib/routes/app-routes.js";
+import { publicMeta, PRIVATE_META_KEYS, applyClaudeMetaFromHook } from "../lib/routes/app-routes.js";
 
 describe("publicMeta", () => {
   it("strips known private keys", () => {
@@ -30,5 +30,135 @@ describe("publicMeta", () => {
     // server-only field should update both the set and the broadcast
     // paths (see ensureTopicMeta / /api/topics / POST meta).
     assert.ok(PRIVATE_META_KEYS.has("transcriptPath"));
+  });
+});
+
+describe("applyClaudeMetaFromHook", () => {
+  function makeSession() {
+    const calls = [];
+    const session = {
+      name: "work",
+      tmuxPane: "%3",
+      tmuxName: "kat_work",
+      meta: {},
+      setMeta(ns, val) {
+        calls.push([ns, val]);
+        if (val == null) delete this.meta[ns];
+        else this.meta[ns] = val;
+      },
+    };
+    return { session, calls };
+  }
+  function makeManager(session) {
+    return {
+      getSessionByPane(pane) {
+        return session && session.tmuxPane === pane ? session : undefined;
+      },
+    };
+  }
+
+  it("writes meta.claude on SessionStart when pane resolves", () => {
+    const { session, calls } = makeSession();
+    const mgr = makeManager(session);
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "SessionStart",
+      session_id: "11111111-2222-3333-4444-555555555555",
+      _tmuxPane: "%3",
+    }, mgr);
+    assert.equal(verdict, "set");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][0], "claude");
+    assert.equal(calls[0][1].uuid, "11111111-2222-3333-4444-555555555555");
+    assert.equal(typeof calls[0][1].startedAt, "number");
+    assert.equal(session.meta.claude.uuid, "11111111-2222-3333-4444-555555555555");
+  });
+
+  it("clears meta.claude on SessionEnd", () => {
+    const { session, calls } = makeSession();
+    session.meta.claude = { uuid: "old", startedAt: 1 };
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "SessionEnd",
+      session_id: "11111111-2222-3333-4444-555555555555",
+      _tmuxPane: "%3",
+    }, makeManager(session));
+    assert.equal(verdict, "cleared");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][1], null);
+    assert.equal(session.meta.claude, undefined);
+  });
+
+  it("clears meta.claude on Stop", () => {
+    const { session } = makeSession();
+    session.meta.claude = { uuid: "old", startedAt: 1 };
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "Stop",
+      session_id: "11111111-2222-3333-4444-555555555555",
+      _tmuxPane: "%3",
+    }, makeManager(session));
+    assert.equal(verdict, "cleared");
+    assert.equal(session.meta.claude, undefined);
+  });
+
+  it("no-ops for unknown pane", () => {
+    const { session, calls } = makeSession();
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "SessionStart",
+      session_id: "11111111-2222-3333-4444-555555555555",
+      _tmuxPane: "%99",
+    }, makeManager(session));
+    assert.equal(verdict, null);
+    assert.equal(calls.length, 0);
+  });
+
+  it("no-ops for missing _tmuxPane", () => {
+    const { session, calls } = makeSession();
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "SessionStart",
+      session_id: "11111111-2222-3333-4444-555555555555",
+    }, makeManager(session));
+    assert.equal(verdict, null);
+    assert.equal(calls.length, 0);
+  });
+
+  it("no-ops for malformed _tmuxPane (not %N)", () => {
+    const { session, calls } = makeSession();
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "SessionStart",
+      session_id: "11111111-2222-3333-4444-555555555555",
+      _tmuxPane: "3",
+    }, makeManager(session));
+    assert.equal(verdict, null);
+    assert.equal(calls.length, 0);
+  });
+
+  it("no-ops for unhandled events (PostToolUse, SubagentStart, etc.)", () => {
+    const { session, calls } = makeSession();
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "PostToolUse",
+      session_id: "11111111-2222-3333-4444-555555555555",
+      _tmuxPane: "%3",
+    }, makeManager(session));
+    assert.equal(verdict, null);
+    assert.equal(calls.length, 0);
+  });
+
+  it("returns null and logs when setMeta throws", () => {
+    const logs = [];
+    const session = {
+      name: "work", tmuxPane: "%3", tmuxName: "kat_work", meta: {},
+      setMeta: () => { throw new RangeError("too big"); },
+    };
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "SessionStart",
+      session_id: "11111111-2222-3333-4444-555555555555",
+      _tmuxPane: "%3",
+    }, makeManager(session), { warn: (msg, meta) => logs.push([msg, meta]) });
+    assert.equal(verdict, null);
+    assert.equal(logs.length, 1);
+  });
+
+  it("returns null on non-object payload", () => {
+    assert.equal(applyClaudeMetaFromHook(null, makeManager(null)), null);
+    assert.equal(applyClaudeMetaFromHook("nope", makeManager(null)), null);
   });
 });

--- a/test/helpers/session-manager-fixture.js
+++ b/test/helpers/session-manager-fixture.js
@@ -77,6 +77,17 @@ export class BaseMockSession {
     this._options = options;
     this._childCount = 0;
     this.outputBuffer = { totalBytes: 0, sliceFrom: () => "" };
+    this.meta = (options.meta && typeof options.meta === "object" && !Array.isArray(options.meta))
+      ? { ...options.meta } : {};
+    this._onChange = typeof options.onChange === "function" ? options.onChange : null;
+  }
+
+  setMeta(ns, value) {
+    const next = { ...this.meta };
+    if (value === null || value === undefined) delete next[ns];
+    else next[ns] = value;
+    this.meta = next;
+    if (this._onChange) this._onChange(this);
   }
 
   get alive() { return this.state === BaseMockSession.STATE_ATTACHED; }
@@ -123,6 +134,7 @@ export class BaseMockSession {
       tmuxPane: this.tmuxPane,
       alive: this.alive,
       external: this.external,
+      meta: this.meta,
     };
   }
 }

--- a/test/relay-hook.test.js
+++ b/test/relay-hook.test.js
@@ -1,0 +1,48 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { stampTmuxPane } from "../lib/cli/commands/relay-hook.js";
+
+describe("stampTmuxPane", () => {
+  it("adds _tmuxPane to a valid JSON object payload", () => {
+    const input = JSON.stringify({ hook_event_name: "SessionStart", session_id: "abc" });
+    const out = stampTmuxPane(input, "%3");
+    const parsed = JSON.parse(out);
+    assert.equal(parsed._tmuxPane, "%3");
+    assert.equal(parsed.hook_event_name, "SessionStart");
+  });
+
+  it("returns the payload unchanged when TMUX_PANE is absent", () => {
+    // Pass `null` explicitly: `undefined` triggers the default-parameter
+    // fallback to `process.env.TMUX_PANE`, which is set when the test
+    // suite runs inside tmux.
+    const input = JSON.stringify({ hook_event_name: "SessionStart" });
+    assert.equal(stampTmuxPane(input, null), input);
+    assert.equal(stampTmuxPane(input, ""), input);
+  });
+
+  it("returns the payload unchanged when TMUX_PANE is malformed", () => {
+    const input = JSON.stringify({ hook_event_name: "SessionStart" });
+    assert.equal(stampTmuxPane(input, "3"), input);
+    assert.equal(stampTmuxPane(input, "%"), input);
+    assert.equal(stampTmuxPane(input, "pane-abc"), input);
+  });
+
+  it("returns the payload unchanged when input is not valid JSON", () => {
+    const input = "not valid json";
+    assert.equal(stampTmuxPane(input, "%3"), input);
+  });
+
+  it("returns the payload unchanged when input is a JSON array", () => {
+    const input = JSON.stringify([1, 2, 3]);
+    assert.equal(stampTmuxPane(input, "%3"), input);
+  });
+
+  it("overwrites an existing _tmuxPane field (server re-validates anyway)", () => {
+    // A client that tries to spoof _tmuxPane is not a concern — the server's
+    // pane index is authoritative. But stamping should still overwrite so
+    // the observed behavior is "pane from env wins".
+    const input = JSON.stringify({ _tmuxPane: "%99", hook_event_name: "SessionStart" });
+    const out = stampTmuxPane(input, "%3");
+    assert.equal(JSON.parse(out)._tmuxPane, "%3");
+  });
+});

--- a/test/session-manager.test.js
+++ b/test/session-manager.test.js
@@ -233,6 +233,33 @@ describe("session manager", () => {
     });
   });
 
+  describe("getSessionByPane", () => {
+    it("returns the session whose tmuxPane matches", async () => {
+      // The tmux mock in this test file returns "%1" for tmuxGetPaneId
+      // (see the module mock at the top). So every adopted session ends
+      // up with tmuxPane === "%1" — enough to verify lookup semantics.
+      const { mgr } = makeManager();
+      await mgr.createSession("paneful");
+      const session = mgr.getSessionByPane("%1");
+      assert.ok(session);
+      assert.strictEqual(session.name, "paneful");
+    });
+
+    it("returns undefined for unknown pane", async () => {
+      const { mgr } = makeManager();
+      await mgr.createSession("alpha");
+      assert.strictEqual(mgr.getSessionByPane("%999"), undefined);
+    });
+
+    it("returns undefined for malformed pane (not %N)", () => {
+      const { mgr } = makeManager();
+      assert.strictEqual(mgr.getSessionByPane("3"), undefined);
+      assert.strictEqual(mgr.getSessionByPane("%"), undefined);
+      assert.strictEqual(mgr.getSessionByPane(null), undefined);
+      assert.strictEqual(mgr.getSessionByPane(""), undefined);
+    });
+  });
+
   describe("client attach/detach", () => {
     it("attaches a client to a session and returns visible pane snapshot", async () => {
       const { mgr } = makeManager();

--- a/test/session-persistence.test.js
+++ b/test/session-persistence.test.js
@@ -292,7 +292,7 @@ describe("Session persistence", () => {
     await mgr.createSession("with-meta", 80, 24);
     const session = mgr.getSession("with-meta");
     session.setMeta("user", { note: "hi" });
-    session.setMeta("claude", { sessionUuid: "uuid-live-only" });
+    session.setMeta("claude", { uuid: "uuid-live-only" });
 
     // Wait for debounced save
     await new Promise((r) => setTimeout(r, 200));
@@ -315,7 +315,7 @@ describe("Session persistence", () => {
           tmuxPane: "%1",
           meta: {
             user: { note: "keeps" },
-            claude: { sessionUuid: "should-be-dropped" },
+            claude: { uuid: "should-be-dropped" },
           },
         },
       }),

--- a/test/session-persistence.test.js
+++ b/test/session-persistence.test.js
@@ -24,12 +24,16 @@ class MockSession {
     this.name = name;
     this.tmuxName = tmuxName;
     this.id = options.id || null;
+    this.tmuxPane = options.tmuxPane || null;
     this._alive = true;
     this._cols = 0;
     this._rows = 0;
     this._resizeCalls = [];
     this.outputBuffer = { totalBytes: 0 };
     this.external = options.external || false;
+    this.meta = (options.meta && typeof options.meta === "object" && !Array.isArray(options.meta))
+      ? { ...options.meta } : {};
+    this._onChange = options.onChange || null;
   }
   get alive() { return this._alive; }
   attachControlMode(/* cols, rows */) { /* Real Session does NOT set _cols here */ }
@@ -40,7 +44,16 @@ class MockSession {
   detach() { this._alive = false; }
   kill() { this._alive = false; tmuxSessions.delete(this.tmuxName); }
   serializeScreen() { return ""; }
-  toJSON() { return { id: this.id, name: this.name, alive: this.alive }; }
+  setMeta(ns, value) {
+    const next = { ...this.meta };
+    if (value === null || value === undefined) delete next[ns];
+    else next[ns] = value;
+    this.meta = next;
+    if (this._onChange) this._onChange(this);
+  }
+  toJSON() {
+    return { id: this.id, name: this.name, alive: this.alive, meta: this.meta };
+  }
 }
 
 mock.module(sessionModuleUrl, {
@@ -267,6 +280,71 @@ describe("Session persistence", () => {
       "Narrow session should NOT be forcibly resized");
     assert.strictEqual(wide._resizeCalls.length, 0,
       "Wide session should NOT be forcibly resized");
+
+    mgr.shutdown();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("persists user/system meta but strips the claude namespace", async () => {
+    const mgr = createSessionManager({
+      bridge: makeBridge(), shell: "/bin/sh", home: "/tmp", dataDir,
+    });
+    await mgr.createSession("with-meta", 80, 24);
+    const session = mgr.getSession("with-meta");
+    session.setMeta("user", { note: "hi" });
+    session.setMeta("claude", { sessionUuid: "uuid-live-only" });
+
+    // Wait for debounced save
+    await new Promise((r) => setTimeout(r, 200));
+
+    const saved = JSON.parse(readFileSync(join(dataDir, "sessions.json"), "utf-8"));
+    assert.deepStrictEqual(saved["with-meta"].meta, { user: { note: "hi" } });
+    assert.strictEqual(saved["with-meta"].meta.claude, undefined);
+
+    mgr.shutdown();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("round-trips persisted meta through restore (minus claude)", async () => {
+    writeFileSync(
+      join(dataDir, "sessions.json"),
+      JSON.stringify({
+        "alpha": {
+          tmuxName: "kat_alpha",
+          id: "aaaaaaaaaaaaaaaaaaaaa",
+          tmuxPane: "%1",
+          meta: {
+            user: { note: "keeps" },
+            claude: { sessionUuid: "should-be-dropped" },
+          },
+        },
+      }),
+    );
+    tmuxSessions.set("kat_alpha", true);
+
+    const mgr = createSessionManager({
+      bridge: makeBridge(), shell: "/bin/sh", home: "/tmp", dataDir,
+    });
+    await mgr.restoreSessions();
+
+    const alpha = mgr.getSession("alpha");
+    assert.ok(alpha, "alpha should be restored");
+    assert.deepStrictEqual(alpha.meta, { user: { note: "keeps" } });
+
+    mgr.shutdown();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("omits the meta field from sessions.json when the bucket is empty", async () => {
+    const mgr = createSessionManager({
+      bridge: makeBridge(), shell: "/bin/sh", home: "/tmp", dataDir,
+    });
+    await mgr.createSession("empty-meta", 80, 24);
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    const saved = JSON.parse(readFileSync(join(dataDir, "sessions.json"), "utf-8"));
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(saved["empty-meta"], "meta"), false);
 
     mgr.shutdown();
     rmSync(dataDir, { recursive: true, force: true });

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -1541,13 +1541,13 @@ describe("Session.meta", () => {
 
   it("accepts an initial meta object on construction", () => {
     const session = new Session("test", "test", {
-      meta: { claude: { sessionUuid: "abc", startedAt: 1 } },
+      meta: { claude: { uuid: "abc", startedAt: 1 } },
     });
-    assert.deepStrictEqual(session.meta, { claude: { sessionUuid: "abc", startedAt: 1 } });
+    assert.deepStrictEqual(session.meta, { claude: { uuid: "abc", startedAt: 1 } });
   });
 
   it("shallow-copies the initial meta so the caller's object is not retained", () => {
-    const initial = { claude: { sessionUuid: "abc" } };
+    const initial = { claude: { uuid: "abc" } };
     const session = new Session("test", "test", { meta: initial });
     assert.notStrictEqual(session.meta, initial);
   });
@@ -1563,30 +1563,30 @@ describe("Session.meta", () => {
 
   it("toJSON includes the meta bucket", () => {
     const session = new Session("test", "test", {
-      meta: { claude: { sessionUuid: "abc" } },
+      meta: { claude: { uuid: "abc" } },
     });
     const json = session.toJSON();
-    assert.deepStrictEqual(json.meta, { claude: { sessionUuid: "abc" } });
+    assert.deepStrictEqual(json.meta, { claude: { uuid: "abc" } });
   });
 
   describe("setMeta", () => {
     it("replaces a namespace with the given value", () => {
       const session = new Session("test", "test");
-      session.setMeta("claude", { sessionUuid: "abc" });
-      assert.deepStrictEqual(session.meta, { claude: { sessionUuid: "abc" } });
+      session.setMeta("claude", { uuid: "abc" });
+      assert.deepStrictEqual(session.meta, { claude: { uuid: "abc" } });
     });
 
     it("fully replaces an existing namespace (not a deep merge)", () => {
       const session = new Session("test", "test", {
-        meta: { claude: { sessionUuid: "abc", startedAt: 1 } },
+        meta: { claude: { uuid: "abc", startedAt: 1 } },
       });
-      session.setMeta("claude", { sessionUuid: "def" });
-      assert.deepStrictEqual(session.meta, { claude: { sessionUuid: "def" } });
+      session.setMeta("claude", { uuid: "def" });
+      assert.deepStrictEqual(session.meta, { claude: { uuid: "def" } });
     });
 
     it("removes a namespace when value is null", () => {
       const session = new Session("test", "test", {
-        meta: { claude: { sessionUuid: "abc" }, user: { foo: 1 } },
+        meta: { claude: { uuid: "abc" }, user: { foo: 1 } },
       });
       session.setMeta("claude", null);
       assert.deepStrictEqual(session.meta, { user: { foo: 1 } });
@@ -1594,7 +1594,7 @@ describe("Session.meta", () => {
 
     it("removes a namespace when value is undefined", () => {
       const session = new Session("test", "test", {
-        meta: { claude: { sessionUuid: "abc" } },
+        meta: { claude: { uuid: "abc" } },
       });
       session.setMeta("claude", undefined);
       assert.deepStrictEqual(session.meta, {});
@@ -1604,11 +1604,11 @@ describe("Session.meta", () => {
       const session = new Session("test", "test", {
         meta: { user: { note: "hi" }, system: { v: 1 } },
       });
-      session.setMeta("claude", { sessionUuid: "abc" });
+      session.setMeta("claude", { uuid: "abc" });
       assert.deepStrictEqual(session.meta, {
         user: { note: "hi" },
         system: { v: 1 },
-        claude: { sessionUuid: "abc" },
+        claude: { uuid: "abc" },
       });
     });
 
@@ -1632,7 +1632,7 @@ describe("Session.meta", () => {
       const session = new Session("test", "test", {
         onChange: (s) => calls.push(s),
       });
-      session.setMeta("claude", { sessionUuid: "abc" });
+      session.setMeta("claude", { uuid: "abc" });
       assert.strictEqual(calls.length, 1);
       assert.strictEqual(calls[0], session);
     });

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -1530,3 +1530,124 @@ describe("seedScreen", () => {
     assert.strictEqual(x, 4, "cursor col should be 4 (0-based) for col:5");
   });
 });
+
+// --- meta bucket tests (MC1f) ---
+
+describe("Session.meta", () => {
+  it("initializes meta to {} when no option provided", () => {
+    const session = new Session("test", "test");
+    assert.deepStrictEqual(session.meta, {});
+  });
+
+  it("accepts an initial meta object on construction", () => {
+    const session = new Session("test", "test", {
+      meta: { claude: { sessionUuid: "abc", startedAt: 1 } },
+    });
+    assert.deepStrictEqual(session.meta, { claude: { sessionUuid: "abc", startedAt: 1 } });
+  });
+
+  it("shallow-copies the initial meta so the caller's object is not retained", () => {
+    const initial = { claude: { sessionUuid: "abc" } };
+    const session = new Session("test", "test", { meta: initial });
+    assert.notStrictEqual(session.meta, initial);
+  });
+
+  it("ignores non-object meta (string, array, null)", () => {
+    const s1 = new Session("a", "a", { meta: "not-object" });
+    const s2 = new Session("b", "b", { meta: ["not", "object"] });
+    const s3 = new Session("c", "c", { meta: null });
+    assert.deepStrictEqual(s1.meta, {});
+    assert.deepStrictEqual(s2.meta, {});
+    assert.deepStrictEqual(s3.meta, {});
+  });
+
+  it("toJSON includes the meta bucket", () => {
+    const session = new Session("test", "test", {
+      meta: { claude: { sessionUuid: "abc" } },
+    });
+    const json = session.toJSON();
+    assert.deepStrictEqual(json.meta, { claude: { sessionUuid: "abc" } });
+  });
+
+  describe("setMeta", () => {
+    it("replaces a namespace with the given value", () => {
+      const session = new Session("test", "test");
+      session.setMeta("claude", { sessionUuid: "abc" });
+      assert.deepStrictEqual(session.meta, { claude: { sessionUuid: "abc" } });
+    });
+
+    it("fully replaces an existing namespace (not a deep merge)", () => {
+      const session = new Session("test", "test", {
+        meta: { claude: { sessionUuid: "abc", startedAt: 1 } },
+      });
+      session.setMeta("claude", { sessionUuid: "def" });
+      assert.deepStrictEqual(session.meta, { claude: { sessionUuid: "def" } });
+    });
+
+    it("removes a namespace when value is null", () => {
+      const session = new Session("test", "test", {
+        meta: { claude: { sessionUuid: "abc" }, user: { foo: 1 } },
+      });
+      session.setMeta("claude", null);
+      assert.deepStrictEqual(session.meta, { user: { foo: 1 } });
+    });
+
+    it("removes a namespace when value is undefined", () => {
+      const session = new Session("test", "test", {
+        meta: { claude: { sessionUuid: "abc" } },
+      });
+      session.setMeta("claude", undefined);
+      assert.deepStrictEqual(session.meta, {});
+    });
+
+    it("leaves other namespaces untouched", () => {
+      const session = new Session("test", "test", {
+        meta: { user: { note: "hi" }, system: { v: 1 } },
+      });
+      session.setMeta("claude", { sessionUuid: "abc" });
+      assert.deepStrictEqual(session.meta, {
+        user: { note: "hi" },
+        system: { v: 1 },
+        claude: { sessionUuid: "abc" },
+      });
+    });
+
+    it("throws TypeError on empty or non-string namespace", () => {
+      const session = new Session("test", "test");
+      assert.throws(() => session.setMeta("", { x: 1 }), TypeError);
+      assert.throws(() => session.setMeta(null, { x: 1 }), TypeError);
+      assert.throws(() => session.setMeta(42, { x: 1 }), TypeError);
+    });
+
+    it("throws RangeError when serialized meta exceeds the cap", () => {
+      const session = new Session("test", "test");
+      const big = "x".repeat(5000);
+      assert.throws(() => session.setMeta("huge", { value: big }), RangeError);
+      // meta must remain unchanged when setMeta rejects
+      assert.deepStrictEqual(session.meta, {});
+    });
+
+    it("fires onChange exactly once with the session as argument", () => {
+      const calls = [];
+      const session = new Session("test", "test", {
+        onChange: (s) => calls.push(s),
+      });
+      session.setMeta("claude", { sessionUuid: "abc" });
+      assert.strictEqual(calls.length, 1);
+      assert.strictEqual(calls[0], session);
+    });
+
+    it("does not fire onChange when the setMeta call throws", () => {
+      const calls = [];
+      const session = new Session("test", "test", {
+        onChange: (s) => calls.push(s),
+      });
+      assert.throws(() => session.setMeta("", { x: 1 }), TypeError);
+      assert.throws(
+        () => session.setMeta("huge", { value: "x".repeat(5000) }),
+        RangeError,
+      );
+      assert.strictEqual(calls.length, 0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **PR1 plumbing**: adds a namespaced `meta` bucket to `Session` with `setMeta(namespace, value)` (full-replace, 4 KB cap), persistence that strips the `claude` namespace, and a `session-updated` relay that broadcasts `toJSON()` on change.
- **PR2 Claude presence**: `katulong relay-hook` stamps `_tmuxPane` from `TMUX_PANE`; `katulong setup claude-hooks` subscribes `SessionStart` / `SessionEnd`; `/api/claude-events` ingest validates the claimed pane against the server's own pane index before writing `session.meta.claude`.
- Feed button reads `session.meta.claude.uuid` to jump straight to the right `claude/<uuid>` topic (falls back to the existing topic-name scan).

Combined into one PR because PR1's write-path broadcast and PR2's consumer land together — splitting them ships dead code on both sides.

## Design notes

- **Middle-key is the tmux pane id**, captured server-side at spawn (MC1e PR2). The payload's `_tmuxPane` is treated as a hint only; the server re-validates via `getSessionByPane()`. Unknown panes are a silent no-op.
- **`meta.claude` is not persisted.** On server restart the entry is absent until the next hook event — an acceptable staleness tradeoff vs. the worse failure of reporting Claude as present when it died mid-restart. Documented in `docs/session-meta.md`.
- **No public write API** in MC1f. `setMeta` is server-internal; the only caller is the hook ingest handler.

## Test plan

- [x] \`npm run test:unit\` passes (2233 tests, +21 new)
- [ ] Manual: start a Claude session inside a katulong terminal, click the feed button, verify it opens \`claude/<uuid>\` directly instead of the picker
- [ ] Manual: kill Claude (Ctrl-C), verify \`meta.claude\` clears on next \`/sessions\` read