### PR TITLE
feat: wire sidebar RSS button to Claude feed tile

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1705,24 +1705,30 @@
      */
     async function openClaudeFeedTile() {
       const sessionName = getActiveSessionName();
+
+      // No active terminal: the Claude lookup has nothing to key off,
+      // so skip the round trip to /api/topics and open the generic picker.
+      if (!sessionName) {
+        openFeedTile();
+        return;
+      }
+
       try {
         // Primary: read meta.claude.uuid from the already-cached session
         // list. The `session-updated` WS push keeps this in sync, so we
         // don't need a dedicated fetch.
-        if (sessionName) {
-          const { sessions } = sessionStore.getState();
-          const active = (sessions || []).find(s => s.name === sessionName);
-          const uuid = active?.meta?.claude?.uuid;
-          if (uuid) {
-            const topic = `claude/${uuid}`;
-            const tileId = `feed-${Date.now().toString(36)}`;
-            uiStore.addTile(
-              { id: tileId, type: "feed", props: { topic, title: topic, meta: {} } },
-              { focus: true, insertAt: "afterFocus" },
-            );
-            if (isOverlayViewport()) setOverlaySidebar(false);
-            return;
-          }
+        const { sessions } = sessionStore.getState();
+        const active = (sessions || []).find(s => s.name === sessionName);
+        const uuid = active?.meta?.claude?.uuid;
+        if (uuid) {
+          const topic = `claude/${uuid}`;
+          const tileId = `feed-${Date.now().toString(36)}`;
+          uiStore.addTile(
+            { id: tileId, type: "feed", props: { topic, title: topic, meta: {} } },
+            { focus: true, insertAt: "afterFocus" },
+          );
+          if (isOverlayViewport()) setOverlaySidebar(false);
+          return;
         }
 
         // Fallback: scan topics for a sessionName match — resolves Claude

--- a/public/app.js
+++ b/public/app.js
@@ -1373,7 +1373,7 @@
         } else if (type === "file-browser") {
           openFileBrowserTile();
         } else if (type === "feed") {
-          openFeedTile();
+          openClaudeFeedTile();
         } else if (type === "localhost-browser") {
           openLocalhostBrowserTile();
         }

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -14,12 +14,18 @@ set -euo pipefail
 #   ./scripts/dev-server.sh            # port 3001
 #   PORT=3002 ./scripts/dev-server.sh  # override port
 
-PORT="${PORT:-3001}"
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-cd "$REPO_ROOT"
-
 log() { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m==>\033[0m %s\n' "$*"; }
+err() { printf '\033[1;31m==>\033[0m %s\n' "$*" >&2; }
+
+PORT="${PORT:-3001}"
+if ! [[ "$PORT" =~ ^[0-9]+$ ]]; then
+  err "PORT must be numeric (got: $PORT)"
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
 
 # 1. Unload the LaunchAgent so brew's katulong stops auto-respawning.
 PLIST="$HOME/Library/LaunchAgents/com.dorkyrobot.katulong.plist"
@@ -44,7 +50,7 @@ if [ -n "$occupant" ]; then
 fi
 
 if lsof -ti:"$PORT" >/dev/null 2>&1; then
-  echo "ERROR: port $PORT is still in use" >&2
+  err "port $PORT is still in use"
   lsof -nP -iTCP:"$PORT" >&2 || true
   exit 1
 fi

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the local git checkout as the katulong server on port 3001, against
+# the real ~/.katulong data dir, so you can iterate against live sessions
+# and pub/sub topics without touching a staging directory.
+#
+# The Homebrew-installed katulong + its LaunchAgent are unloaded for the
+# duration of the dev run. After the dev server exits, run
+# `katulong service install` (or `launchctl bootstrap`) to restore the
+# brew-managed instance.
+#
+# Usage:
+#   ./scripts/dev-server.sh            # port 3001
+#   PORT=3002 ./scripts/dev-server.sh  # override port
+
+PORT="${PORT:-3001}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+log() { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m==>\033[0m %s\n' "$*"; }
+
+# 1. Unload the LaunchAgent so brew's katulong stops auto-respawning.
+PLIST="$HOME/Library/LaunchAgents/com.dorkyrobot.katulong.plist"
+if [ -f "$PLIST" ]; then
+  log "Unloading LaunchAgent (will be restorable via 'katulong service install')"
+  launchctl bootout "gui/$UID/com.dorkyrobot.katulong" 2>/dev/null || true
+fi
+
+# 2. Free the port. Any lingering brew-katulong or prior dev instance gets
+#    SIGTERM; a second pass sends SIGKILL to anything stubborn.
+occupant=$(lsof -ti:"$PORT" 2>/dev/null || true)
+if [ -n "$occupant" ]; then
+  log "Freeing port $PORT (pids: $occupant)"
+  kill $occupant 2>/dev/null || true
+  sleep 1
+  occupant=$(lsof -ti:"$PORT" 2>/dev/null || true)
+  if [ -n "$occupant" ]; then
+    warn "Still bound, sending SIGKILL to $occupant"
+    kill -9 $occupant 2>/dev/null || true
+    sleep 1
+  fi
+fi
+
+if lsof -ti:"$PORT" >/dev/null 2>&1; then
+  echo "ERROR: port $PORT is still in use" >&2
+  lsof -nP -iTCP:"$PORT" >&2 || true
+  exit 1
+fi
+
+# 3. Surface the version so you can tell this is the local build at a glance.
+VERSION=$(node -p "require('./package.json').version")
+log "katulong dev @ v$VERSION  →  http://localhost:$PORT"
+log "data dir: ${KATULONG_DATA_DIR:-$HOME/.katulong}  (real data, not staging)"
+log "Ctrl-C stops the server. Run 'katulong service install' to bring brew back."
+
+# 4. Exec so signals go straight to node and there's no bash wrapper in the
+#    process tree hiding the real server.
+exec env PORT="$PORT" node server.js

--- a/scripts/restart-dev.sh
+++ b/scripts/restart-dev.sh
@@ -18,8 +18,13 @@ set -euo pipefail
 #   ./scripts/restart-dev.sh            # port 3001
 #   PORT=3002 ./scripts/restart-dev.sh  # override port
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PORT="${PORT:-3001}"
+if ! [[ "$PORT" =~ ^[0-9]+$ ]]; then
+  printf '\033[1;31m==>\033[0m PORT must be numeric (got: %s)\n' "$PORT" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 LOG="$HOME/.katulong/dev-server.log"
 mkdir -p "$(dirname "$LOG")"
 
@@ -36,9 +41,12 @@ if [ "${KATULONG_RESTART_DETACHED:-}" != "1" ]; then
     "$WORKER_PID" "$LOG"
 
   for _ in $(seq 1 30); do
-    if curl -sf "http://localhost:$PORT/health" >/dev/null 2>&1; then
-      version=$(curl -s "http://localhost:$PORT/health" \
-        | sed -n 's/.*"version":"\([^"]*\)".*/\1/p')
+    # Single fetch: reuse the body for both liveness and version extraction
+    # so we don't print `v` with an empty version if the server flaps between
+    # the liveness probe and the follow-up read.
+    body=$(curl -sf "http://localhost:$PORT/health" 2>/dev/null || true)
+    if [ -n "$body" ]; then
+      version=$(printf '%s' "$body" | sed -n 's/.*"version":"\([^"]*\)".*/\1/p')
       printf '\033[1;32m==>\033[0m dev server up on :%s (v%s)\n' \
         "$PORT" "$version"
       exit 0

--- a/scripts/restart-dev.sh
+++ b/scripts/restart-dev.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Restart the dev server (scripts/dev-server.sh) in a fully detached
+# background process. Safe to invoke from inside a katulong terminal you're
+# actively using: if your shell/SSH dies mid-restart, the detached worker
+# keeps going and brings the server back on its own.
+#
+# How the detach works:
+#   - We re-exec ourselves with KATULONG_RESTART_DETACHED=1 via `nohup` and
+#     `disown`, redirecting stdin/stdout/stderr to a log file. The child
+#     process no longer has a controlling terminal, so SIGHUP from the
+#     parent closing does nothing. The parent wrapper then polls /health
+#     for a few seconds to give the caller quick feedback, but even if the
+#     wrapper is killed (connection drop), the worker finishes the restart.
+#
+# Usage:
+#   ./scripts/restart-dev.sh            # port 3001
+#   PORT=3002 ./scripts/restart-dev.sh  # override port
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PORT="${PORT:-3001}"
+LOG="$HOME/.katulong/dev-server.log"
+mkdir -p "$(dirname "$LOG")"
+
+if [ "${KATULONG_RESTART_DETACHED:-}" != "1" ]; then
+  # Parent: detach a worker copy of this same script, then wait briefly for
+  # /health to come back so the user sees confirmation.
+  : > "$LOG"
+  KATULONG_RESTART_DETACHED=1 PORT="$PORT" \
+    nohup "$0" </dev/null >>"$LOG" 2>&1 &
+  WORKER_PID=$!
+  disown "$WORKER_PID" 2>/dev/null || true
+
+  printf '\033[1;32m==>\033[0m restart-dev detached (pid %s); tailing %s\n' \
+    "$WORKER_PID" "$LOG"
+
+  for _ in $(seq 1 30); do
+    if curl -sf "http://localhost:$PORT/health" >/dev/null 2>&1; then
+      version=$(curl -s "http://localhost:$PORT/health" \
+        | sed -n 's/.*"version":"\([^"]*\)".*/\1/p')
+      printf '\033[1;32m==>\033[0m dev server up on :%s (v%s)\n' \
+        "$PORT" "$version"
+      exit 0
+    fi
+    sleep 0.5
+  done
+
+  printf '\033[1;33m==>\033[0m server not responding on :%s after 15s\n' "$PORT" >&2
+  printf '    worker still running in background — check %s\n' "$LOG" >&2
+  exit 1
+fi
+
+# --- Detached worker ---
+# dev-server.sh already handles LaunchAgent bootout and freeing the port,
+# then execs node. We just hand off to it in this detached session.
+cd "$REPO_ROOT"
+echo "[$(date)] restart-dev: handing off to dev-server.sh on port $PORT"
+exec env PORT="$PORT" "$REPO_ROOT/scripts/dev-server.sh"


### PR DESCRIPTION
## Summary

- `public/app.js`: Sidebar RSS button now calls `openClaudeFeedTile()` instead of `openFeedTile()`. Closes the MC1e + MC1f chain so the button opens the Claude session's topic directly.
- `scripts/dev-server.sh`: Runs the worktree's code on :3001 against real `~/.katulong` data, unloading brew's LaunchAgent for the duration.
- `scripts/restart-dev.sh`: Detached restart wrapper so restarting the dev server from inside a katulong session doesn't lock you out when SSH dies mid-restart.

## Test plan

- [ ] `npm test` passes
- [ ] Click sidebar RSS button while Claude is running in the active tile → opens that session's `claude/<uuid>` topic
- [ ] Click sidebar RSS button when no Claude session is active → falls back to topic picker