### PR TITLE
consolidate brew tap to Dorky-Robot/homebrew-tap

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -84,11 +84,9 @@ Compute the SHA:
 shasum -a 256 "/tmp/katulong-v${NEW_VERSION}.tar.gz"
 ```
 
-## Step 6: Update both formula files
+## Step 6: Update the local formula
 
-### 6a: Local formula (`Formula/katulong.rb`)
-
-Read the file, then update the `url` and `sha256` lines using the Edit tool.
+Read `Formula/katulong.rb`, then update the `url` and `sha256` lines using the Edit tool.
 
 Commit and push:
 
@@ -99,24 +97,20 @@ git commit -m "formula: update to v${NEW_VERSION}"
 git push origin main
 ```
 
-### 6b: Tap formula (`homebrew-katulong/Formula/katulong.rb`)
-
-Read the tap formula file, update `url` and `sha256` with the same values.
-
-Commit and push. **Note**: the tap repo uses `master` as its default branch:
-
-```bash
-cd homebrew-katulong && git pull origin master && git add Formula/katulong.rb && git commit -m "formula: update to v${NEW_VERSION}" && git push origin master
-```
+The GitHub Release workflow syncs the updated formula into the canonical tap
+at https://github.com/Dorky-Robot/homebrew-tap automatically — no manual
+cross-repo push is needed. (The deprecated `Dorky-Robot/homebrew-katulong`
+tap is no longer updated.)
 
 ## Step 7: Brew upgrade
 
 ```bash
 brew update
-brew info katulong --json | jq -r '.[0] | "formula: \(.versions.stable)\ninstalled: \([.installed[].version] | join(","))"'
+brew info dorky-robot/tap/katulong --json | jq -r '.[0] | "formula: \(.versions.stable)\ninstalled: \([.installed[].version] | join(","))"'
 ```
 
-If installed version matches NEW_VERSION, `brew reinstall katulong`. Otherwise `brew upgrade katulong`.
+If installed version matches NEW_VERSION, `brew reinstall dorky-robot/tap/katulong`.
+Otherwise `brew upgrade dorky-robot/tap/katulong`.
 
 ## Step 8: Verify
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           SHA=$(curl -fsSL "$URL" | sha256sum | cut -d' ' -f1)
           echo "SOURCE_SHA=${SHA}" >> "$GITHUB_ENV"
 
-      - name: Update tap repos
+      - name: Update tap repo
         env:
           TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
         run: |
@@ -45,25 +45,24 @@ jobs:
           sed -i "s|url \".*\"|url \"https://github.com/Dorky-Robot/katulong/archive/refs/tags/${TAG}.tar.gz\"|" /tmp/katulong.rb
           sed -i "s|sha256 \".*\"|sha256 \"${SOURCE_SHA}\"|" /tmp/katulong.rb
 
-          # Update both tap repos (homebrew-tap and homebrew-katulong)
-          for REPO in homebrew-tap homebrew-katulong; do
-            BRANCH="main"
-            if [ "$REPO" = "homebrew-katulong" ]; then BRANCH="master"; fi
+          # Single canonical tap for all Dorky-Robot projects:
+          # https://github.com/Dorky-Robot/homebrew-tap
+          # (The old Dorky-Robot/homebrew-katulong repo is deprecated.)
+          echo "Updating Dorky-Robot/homebrew-tap..."
+          git clone --depth 1 -b main \
+            "https://x-access-token:${TAP_TOKEN}@github.com/Dorky-Robot/homebrew-tap.git" \
+            /tmp/homebrew-tap
 
-            echo "Updating dorky-robot/${REPO} (${BRANCH})..."
-            git clone --depth 1 -b "$BRANCH" \
-              "https://x-access-token:${TAP_TOKEN}@github.com/Dorky-Robot/${REPO}.git" \
-              "/tmp/${REPO}" 2>/dev/null || continue
-
-            mkdir -p "/tmp/${REPO}/Formula"
-            cp /tmp/katulong.rb "/tmp/${REPO}/Formula/katulong.rb"
-            cd "/tmp/${REPO}"
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add Formula/katulong.rb
-            git diff --cached --quiet && echo "  No changes" && cd - && continue
+          mkdir -p /tmp/homebrew-tap/Formula
+          cp /tmp/katulong.rb /tmp/homebrew-tap/Formula/katulong.rb
+          cd /tmp/homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/katulong.rb
+          if git diff --cached --quiet; then
+            echo "  No changes"
+          else
             git commit -m "katulong ${VERSION}"
             git push
             echo "  Updated to ${VERSION}"
-            cd -
-          done
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ test-results.txt
 blob-report/
 ssh/
 tls/
-homebrew-katulong/
 site/
 .claude/worktrees/
 .claude/scheduled_tasks.lock

--- a/Formula/README.md
+++ b/Formula/README.md
@@ -7,8 +7,8 @@ This directory contains the Homebrew formula for installing Katulong.
 ### Installation
 
 ```bash
-# Add the tap
-brew tap dorky-robot/katulong
+# Add the canonical Dorky-Robot tap (shared across all their projects)
+brew tap dorky-robot/tap
 
 # Install katulong
 brew install katulong
@@ -78,21 +78,19 @@ brew services stop katulong
    brew services list | grep katulong
    ```
 
-### Setting Up the Tap
+### Publishing to the Tap
 
-For the first release, create the tap repository:
+All Dorky-Robot projects publish into a single shared tap at
+https://github.com/Dorky-Robot/homebrew-tap. The `update-tap` job in
+`.github/workflows/release.yml` runs on every `v*` tag push: it
+patches `url` + `sha256` in this repo's `Formula/katulong.rb`, clones
+the tap, drops the formula into `homebrew-tap/Formula/katulong.rb`,
+and pushes. No manual cross-repo work is needed.
 
-```bash
-# Create a new repository: dorky-robot/homebrew-katulong
-# Copy Formula/katulong.rb to the tap repository
-
-cd ../homebrew-katulong
-mkdir -p Formula
-cp ../katulong/Formula/katulong.rb Formula/
-git add Formula/katulong.rb
-git commit -m "Add katulong formula"
-git push origin main
-```
+The tap push requires a `TAP_GITHUB_TOKEN` Actions secret with write
+access to `Dorky-Robot/homebrew-tap`. If the job fails with
+"Invalid username or token", that secret has expired — rotate it and
+rerun the workflow.
 
 ## Formula Details
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ docker run -d -p 3001:3001 -v katulong-data:/root/.katulong your-image
 ### Homebrew (macOS)
 
 ```bash
-brew install dorky-robot/katulong/katulong
+brew install dorky-robot/tap/katulong
 katulong start
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,8 +7,8 @@ Simple installation with Homebrew or npm.
 === "Homebrew (macOS)"
 
     ```bash
-    # Add the tap
-    brew tap dorky-robot/katulong
+    # Add the canonical Dorky-Robot tap
+    brew tap dorky-robot/tap
 
     # Install
     brew install katulong

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ Access your shell from any device — desktop browser, phone, or tablet — over
 *Katulong* (kah-too-LONG) means "helper" in Tagalog — your always-ready terminal assistant.
 
 ```bash
-brew tap dorky-robot/katulong
+brew tap dorky-robot/tap
 brew install katulong
 katulong start
 ```

--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ install_deps() {
     brew)
       # macOS — prefer the tap for a managed install
       log "Homebrew detected — installing via tap instead"
-      brew install dorky-robot/katulong/katulong
+      brew install dorky-robot/tap/katulong
       katulong --version || die "Homebrew install succeeded but katulong is not in PATH"
       log "Installed! Run: katulong start"
       exit 0

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # Release katulong: bump version, update Formula, tag, and push.
 #
 # The CI release workflow (.github/workflows/release.yml) takes over from
-# the tag push — it creates the GitHub release and updates both tap repos
-# (homebrew-tap, homebrew-katulong) with the correct SHA256.
+# the tag push — it creates the GitHub release and updates the canonical
+# tap repo (Dorky-Robot/homebrew-tap) with the correct SHA256.
 #
 # Usage:
 #   ./scripts/release.sh <patch|minor|major>
@@ -188,8 +188,7 @@ log "Released v${NEW_VERSION}!"
 log ""
 log "CI will now:"
 log "  1. Create GitHub release"
-log "  2. Update homebrew-tap and homebrew-katulong with correct SHA256"
-log "  3. Trigger bottle builds in homebrew-katulong"
+log "  2. Update Dorky-Robot/homebrew-tap with correct SHA256"
 log ""
-log "After bottles are built, users can upgrade with:"
-log "  brew update && brew upgrade katulong"
+log "Once the tap push lands, users can upgrade with:"
+log "  brew update && brew upgrade dorky-robot/tap/katulong"


### PR DESCRIPTION
## Summary

- Drop the dual-tap setup (`homebrew-tap` + deprecated `homebrew-katulong`); publish only to the canonical `Dorky-Robot/homebrew-tap`.
- Strip the per-repo loop in `.github/workflows/release.yml` — one clone, one push.
- User-facing install commands across README, docs, install.sh, and Formula/README now use `dorky-robot/tap/katulong`.
- Slash command `release.md` drops the manual tap push step (6b); the workflow handles it automatically.
- `.gitignore` loses the `homebrew-katulong/` sibling-checkout entry.

## Why now

v0.55.11's tap-update job failed with `Invalid username or token` while trying to push the first repo in the loop. Looking into it surfaced that we didn't actually need the second repo at all — all our projects should be using the single shared tap. Collapsing the setup also means the expired `TAP_GITHUB_TOKEN` just needs to authorize one repo, not two.

## Caveat

This PR does **not** rotate the expired `TAP_GITHUB_TOKEN` secret. The workflow will still fail to push until that's updated in repo Settings → Secrets → Actions. Once rotated, the next release will push cleanly.

## Test plan

- [ ] `npm test` passes (hooks)
- [ ] CI workflow YAML parses (GitHub's syntax checker on the PR)
- [ ] After merge + token rotation, re-run the v0.55.11 release workflow and confirm it pushes to `Dorky-Robot/homebrew-tap`