### PR TITLE
feat: autodetect Claude sessions per tile, auto-install hooks on click

### DIFF
--- a/docs/session-meta.md
+++ b/docs/session-meta.md
@@ -159,8 +159,30 @@ hook payloads.
    MC1e PR2) and proceeds only if the payload's claimed pane matches
    a live, server-tracked session. Payloads claiming unknown panes are
    a silent no-op.
-4. **On `SessionStart`:** `session.setMeta("claude", { uuid, startedAt: now })`.
-5. **On `Stop` / `SessionEnd`:** `session.setMeta("claude", null)`.
+4. **On `SessionStart`:** merge `{ uuid, startedAt: now }` into
+   `session.meta.claude`, preserving any `running` / `detectedAt`
+   keys the pane monitor already wrote (see "Two writers" below).
+5. **On `Stop` / `SessionEnd`:** drop only the hook-owned keys
+   (`uuid`, `startedAt`). If pane-monitor-owned keys remain the
+   namespace survives with `{ running, detectedAt }`; otherwise
+   `session.meta.claude` is cleared entirely.
+
+### Two writers share `meta.claude` — ownership contract
+
+Since the autodetect feature landed, two independent write paths touch
+the `claude` namespace, each restricted to its own keys:
+
+- **Hooks** (ingest handler in `app-routes.js`) own `uuid` and
+  `startedAt`. Only `SessionStart` / `SessionEnd` mutate these.
+- **Pane monitor** (`lib/session-child-counter.js` 5s poll) owns
+  `running` and `detectedAt`. It flips `running` based on tmux's
+  `pane_current_command` field and never touches `uuid` / `startedAt`.
+
+Both writers use partial-merge semantics: they spread the current
+value, overlay their own keys, and leave everything else intact. This
+means a missed hook (e.g., user hasn't installed hooks yet) still
+produces a `running: true` badge from the monitor, and a dead monitor
+poll still leaves a usable `uuid` for the feed button to resolve.
 
 ### Read path (frontend)
 

--- a/lib/claude-hooks.js
+++ b/lib/claude-hooks.js
@@ -1,0 +1,155 @@
+/**
+ * Claude Code hook installer.
+ *
+ * Wires katulong's `relay-hook` stdin-forwarder into Claude Code by patching
+ * `~/.claude/settings.local.json`. Non-destructive: preserves any non-katulong
+ * hooks the user has configured. Idempotent: running install twice is a no-op.
+ *
+ * Two callers:
+ *   - `katulong setup claude-hooks` (CLI, lib/cli/commands/setup.js)
+ *   - POST /api/claude-hooks/install  (HTTP, lib/routes/app-routes.js)
+ *
+ * The server route exists so the frontend can auto-install on first click of
+ * the Claude icon when we detect a running Claude session in a pane — users
+ * should not have to drop to the terminal to enable the feature.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const CLAUDE_DIR = join(homedir(), ".claude");
+const SETTINGS_PATH = join(CLAUDE_DIR, "settings.local.json");
+
+export const HOOK_EVENTS = [
+  "PostToolUse", "Stop", "SubagentStart", "SubagentStop",
+  // SessionStart / SessionEnd carry the Claude UUID and let the server
+  // populate `session.meta.claude.uuid` so the tile feed button can open
+  // the right topic without a lookup. See docs/session-meta.md.
+  "SessionStart", "SessionEnd",
+];
+
+const RELAY_COMMAND = "katulong relay-hook";
+const RELAY_HOOK = { type: "command", command: RELAY_COMMAND };
+
+function readSettings() {
+  try {
+    return JSON.parse(readFileSync(SETTINGS_PATH, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function writeSettings(settings) {
+  mkdirSync(CLAUDE_DIR, { recursive: true });
+  writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2) + "\n", { mode: 0o600 });
+}
+
+function eventHasRelay(settings, event) {
+  const groups = settings.hooks?.[event];
+  if (!Array.isArray(groups)) return false;
+  return groups.some((g) => g.hooks?.some((h) => h.command === RELAY_COMMAND));
+}
+
+/**
+ * Inspect the current install state without mutating anything.
+ *
+ * @returns {{
+ *   installed: boolean,        // true only if every HOOK_EVENT is wired
+ *   partiallyInstalled: boolean,
+ *   missingEvents: string[],
+ *   settingsPath: string,
+ * }}
+ */
+export function getClaudeHooksStatus() {
+  const settings = readSettings();
+  const missingEvents = HOOK_EVENTS.filter((e) => !eventHasRelay(settings, e));
+  return {
+    installed: missingEvents.length === 0,
+    partiallyInstalled: missingEvents.length > 0 && missingEvents.length < HOOK_EVENTS.length,
+    missingEvents,
+    settingsPath: SETTINGS_PATH,
+  };
+}
+
+/**
+ * Install the katulong relay hook for any events that don't already have it.
+ * Non-destructive: existing non-katulong hooks are preserved. Any stale
+ * `http` hooks pointing at the old `/api/claude-events` URL are cleaned up
+ * so we don't end up with a double-fire.
+ *
+ * @returns {{
+ *   installed: boolean,       // true after this call (always)
+ *   added: string[],          // event names newly wired
+ *   alreadyInstalled: string[],
+ *   settingsPath: string,
+ * }}
+ */
+export function installClaudeHooks() {
+  const settings = readSettings();
+  if (!settings.hooks) settings.hooks = {};
+
+  const added = [];
+  const alreadyInstalled = [];
+
+  for (const event of HOOK_EVENTS) {
+    const matcher = event === "PostToolUse" ? "*" : "";
+    if (!settings.hooks[event]) settings.hooks[event] = [];
+
+    if (eventHasRelay(settings, event)) {
+      alreadyInstalled.push(event);
+      continue;
+    }
+
+    // Drop any stale http hooks pointing at the old claude-events URL so a
+    // pre-relay-hook install doesn't leave us double-firing.
+    settings.hooks[event] = settings.hooks[event].filter(
+      (g) => !g.hooks?.some((h) => h.url && h.url.includes("/api/claude-events"))
+    );
+
+    settings.hooks[event].push({ matcher, hooks: [RELAY_HOOK] });
+    added.push(event);
+  }
+
+  if (added.length > 0) {
+    writeSettings(settings);
+  }
+
+  return {
+    installed: true,
+    added,
+    alreadyInstalled,
+    settingsPath: SETTINGS_PATH,
+  };
+}
+
+/**
+ * Remove every katulong relay hook from the settings file. Non-katulong
+ * hooks are preserved untouched.
+ *
+ * @returns {{ removed: string[], settingsPath: string }}
+ */
+export function removeClaudeHooks() {
+  const settings = readSettings();
+  if (!settings.hooks) {
+    return { removed: [], settingsPath: SETTINGS_PATH };
+  }
+
+  const removed = [];
+  for (const event of HOOK_EVENTS) {
+    if (!settings.hooks[event]) continue;
+    const before = settings.hooks[event];
+    settings.hooks[event] = before.filter(
+      (g) => !g.hooks?.some((h) => h.command === RELAY_COMMAND)
+    );
+    if (settings.hooks[event].length !== before.length) removed.push(event);
+    if (settings.hooks[event].length === 0) delete settings.hooks[event];
+  }
+  if (Object.keys(settings.hooks).length === 0) delete settings.hooks;
+
+  if (removed.length > 0) {
+    writeSettings(settings);
+  }
+
+  return { removed, settingsPath: SETTINGS_PATH };
+}

--- a/lib/claude-hooks.js
+++ b/lib/claude-hooks.js
@@ -14,12 +14,13 @@
  * should not have to drop to the terminal to enable the feature.
  */
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
 const CLAUDE_DIR = join(homedir(), ".claude");
 const SETTINGS_PATH = join(CLAUDE_DIR, "settings.local.json");
+const SETTINGS_TMP_PATH = SETTINGS_PATH + ".tmp";
 
 export const HOOK_EVENTS = [
   "PostToolUse", "Stop", "SubagentStart", "SubagentStop",
@@ -40,9 +41,13 @@ function readSettings() {
   }
 }
 
+// Atomic write: two browser tabs both clicking "install" (or the CLI racing
+// the HTTP route) could otherwise truncate each other mid-write and leave the
+// user with a half-written JSON file that silently drops their other hooks.
 function writeSettings(settings) {
   mkdirSync(CLAUDE_DIR, { recursive: true });
-  writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2) + "\n", { mode: 0o600 });
+  writeFileSync(SETTINGS_TMP_PATH, JSON.stringify(settings, null, 2) + "\n", { mode: 0o600 });
+  renameSync(SETTINGS_TMP_PATH, SETTINGS_PATH);
 }
 
 function eventHasRelay(settings, event) {

--- a/lib/cli/commands/setup.js
+++ b/lib/cli/commands/setup.js
@@ -4,16 +4,17 @@
  * One-time setup helpers for katulong features.
  */
 
-import { writeFileSync, mkdirSync, existsSync, readFileSync, chmodSync } from "node:fs";
+import { writeFileSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { mkdirSync } from "node:fs";
 import { ensureRunning, api } from "../api-client.js";
+import {
+  HOOK_EVENTS, installClaudeHooks, removeClaudeHooks, getClaudeHooksStatus,
+} from "../../claude-hooks.js";
 
 const KATULONG_DIR = join(homedir(), ".katulong");
 const REMOTE_PATH = join(KATULONG_DIR, "remote.json");
-
-const CLAUDE_DIR = join(homedir(), ".claude");
-const CLAUDE_SETTINGS_PATH = join(CLAUDE_DIR, "settings.local.json");
 
 function usage() {
   console.log(`
@@ -103,45 +104,20 @@ async function selfAccess(args) {
   }
 }
 
-const HOOK_EVENTS = [
-  "PostToolUse", "Stop", "SubagentStart", "SubagentStop",
-  // SessionStart / SessionEnd carry the Claude UUID and let the server
-  // populate `session.meta.claude` so the tile feed button can open the
-  // right topic without a lookup. See docs/session-meta.md.
-  "SessionStart", "SessionEnd",
-];
-const RELAY_HOOK = { type: "command", command: "katulong relay-hook" };
-
 async function claudeHooks(args) {
   const remove = args.includes("--remove");
 
-  // Read existing settings or start fresh
-  let settings = {};
-  try {
-    settings = JSON.parse(readFileSync(CLAUDE_SETTINGS_PATH, "utf8"));
-  } catch {
-    // File doesn't exist or malformed — start with empty object
-  }
-
   if (remove) {
-    if (!settings.hooks) {
-      console.log("No hooks configured — nothing to remove.");
-      return;
+    const { removed, settingsPath } = removeClaudeHooks();
+    if (removed.length === 0) {
+      console.log("No katulong hooks configured — nothing to remove.");
+    } else {
+      console.log(`Katulong hooks removed from ${settingsPath}.`);
     }
-    for (const event of HOOK_EVENTS) {
-      if (!settings.hooks[event]) continue;
-      settings.hooks[event] = settings.hooks[event].filter(
-        (group) => !group.hooks?.some((h) => h.command === "katulong relay-hook")
-      );
-      if (settings.hooks[event].length === 0) delete settings.hooks[event];
-    }
-    if (Object.keys(settings.hooks).length === 0) delete settings.hooks;
-    writeFileSync(CLAUDE_SETTINGS_PATH, JSON.stringify(settings, null, 2) + "\n", { mode: 0o600 });
-    console.log("Katulong hooks removed from Claude Code settings.");
     return;
   }
 
-  // Check that katulong CLI is accessible
+  // Check that katulong CLI is accessible for the hook command to run.
   const { execSync } = await import("node:child_process");
   try {
     execSync("katulong --version", { stdio: "pipe" });
@@ -151,45 +127,21 @@ async function claudeHooks(args) {
     process.exit(1);
   }
 
-  // Add hooks
-  if (!settings.hooks) settings.hooks = {};
-
-  let alreadyConfigured = true;
-  for (const event of HOOK_EVENTS) {
-    const matcher = event === "PostToolUse" ? "*" : "";
-    if (!settings.hooks[event]) settings.hooks[event] = [];
-
-    // Check if relay-hook is already configured for this event
-    const hasRelay = settings.hooks[event].some(
-      (group) => group.hooks?.some((h) => h.command === "katulong relay-hook")
-    );
-    if (hasRelay) continue;
-
-    alreadyConfigured = false;
-
-    // Remove any old hardcoded http hooks pointing to katulong
-    settings.hooks[event] = settings.hooks[event].filter(
-      (group) => !group.hooks?.some((h) => h.url && h.url.includes("/api/claude-events"))
-    );
-
-    settings.hooks[event].push({
-      matcher,
-      hooks: [RELAY_HOOK],
-    });
-  }
-
-  if (alreadyConfigured) {
+  const before = getClaudeHooksStatus();
+  if (before.installed) {
     console.log("Claude Code hooks are already configured for katulong.");
     return;
   }
 
-  mkdirSync(CLAUDE_DIR, { recursive: true });
-  writeFileSync(CLAUDE_SETTINGS_PATH, JSON.stringify(settings, null, 2) + "\n", { mode: 0o600 });
+  const { added, settingsPath } = installClaudeHooks();
 
   console.log("Claude Code hooks configured.");
-  console.log(`  File: ${CLAUDE_SETTINGS_PATH}`);
+  console.log(`  File: ${settingsPath}`);
   console.log("");
   console.log("Events relayed: " + HOOK_EVENTS.join(", "));
+  if (added.length > 0 && added.length < HOOK_EVENTS.length) {
+    console.log(`(Added: ${added.join(", ")})`);
+  }
   console.log("");
   console.log("Claude Code will now relay activity events to katulong.");
   console.log("View them by opening a Feed tile and subscribing to a claude/ topic.");

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -117,7 +117,7 @@ function hasPrivateKey(meta) {
 
 export function createAppRoutes(ctx) {
   const {
-    json, parseJSON, isAuthenticated, sessionManager,
+    json, parseJSON, readBody, isAuthenticated, sessionManager,
     bridge,
     configManager, __dirname, DATA_DIR, APP_VERSION,
     getDraining, shortcutsPath,
@@ -540,17 +540,24 @@ export function createAppRoutes(ctx) {
     // file. Frontend uses this to decide whether to show the Claude icon
     // in install-prompt mode vs. direct-open mode.
     { method: "GET", path: "/api/claude-hooks/status", handler: auth((req, res) => {
-      json(res, 200, getClaudeHooksStatus());
+      // `settingsPath` contains an absolute host path (with the user's
+      // home dir) and is only used server-side — strip it before
+      // crossing the HTTP boundary, matching the publicMeta pattern.
+      const { settingsPath: _sp, ...publicStatus } = getClaudeHooksStatus();
+      json(res, 200, publicStatus);
     })},
 
     // Install the katulong relay hook into ~/.claude/settings.local.json.
     // Idempotent and non-destructive. Exposed over HTTP so the frontend
     // can wire up hooks on first click of the Claude icon without
-    // requiring the user to drop to a terminal.
-    { method: "POST", path: "/api/claude-hooks/install", handler: auth(csrf((req, res) => {
+    // requiring the user to drop to a terminal. No body is expected;
+    // we still drain the request via readBody to enforce a small size
+    // cap consistent with every other mutating route.
+    { method: "POST", path: "/api/claude-hooks/install", handler: auth(csrf(async (req, res) => {
       try {
-        const result = installClaudeHooks();
-        json(res, 200, result);
+        await readBody(req, 256);
+        const { settingsPath: _sp, ...publicResult } = installClaudeHooks();
+        json(res, 200, publicResult);
       } catch (err) {
         log.warn("Failed to install Claude hooks via API", { error: err.message });
         json(res, 500, { error: "Failed to install hooks" });

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -25,6 +25,7 @@ import { captureVisiblePane, tmuxSocketArgs } from "../tmux.js";
 import { bridgeClipboardToContainers, bridgePaneContainer } from "../container-detect.js";
 import { readRawBody } from "../request-util.js";
 import { transformClaudeEvent, readTranscriptEntries, UUID_RE, UUID_SEARCH_RE } from "../claude-event-transform.js";
+import { getClaudeHooksStatus, installClaudeHooks } from "../claude-hooks.js";
 import { createNarrativeProcessor } from "../narrative-processor.js";
 import {
   MAX_UPLOAD_BYTES, detectImage, imageMimeType, setClipboard,
@@ -59,6 +60,7 @@ export function applyClaudeMetaFromHook(payload, sessionManager, logger = null) 
   if (!session) return null;
 
   const event = payload.hook_event_name;
+  const current = (session.meta && session.meta.claude) ? session.meta.claude : null;
   if (event === "SessionStart") {
     // Validate UUID shape before writing — the value becomes a topic name
     // prefix (`claude/<uuid>`) on the client, and we don't want a bogus
@@ -66,7 +68,12 @@ export function applyClaudeMetaFromHook(payload, sessionManager, logger = null) 
     const uuid = typeof payload.session_id === "string" ? payload.session_id : null;
     if (!uuid || !UUID_RE.test(uuid)) return null;
     try {
+      // Merge rather than replace so the detection-owned `running` /
+      // `detectedAt` keys (written by the pane monitor) survive a hook
+      // update. Hooks own `uuid` / `startedAt`; the pane monitor owns
+      // `running` / `detectedAt`. Each writer touches only its own keys.
       session.setMeta("claude", {
+        ...(current || {}),
         uuid,
         startedAt: Date.now(),
       });
@@ -80,7 +87,11 @@ export function applyClaudeMetaFromHook(payload, sessionManager, logger = null) 
   }
   if (event === "SessionEnd" || event === "Stop") {
     try {
-      session.setMeta("claude", null);
+      if (!current) return "cleared";
+      const next = { ...current };
+      delete next.uuid;
+      delete next.startedAt;
+      session.setMeta("claude", Object.keys(next).length > 0 ? next : null);
       return "cleared";
     } catch (err) {
       logger?.warn?.("Failed to clear meta.claude", {
@@ -523,6 +534,27 @@ export function createAppRoutes(ctx) {
       }
 
       json(res, 200, { ok: true });
+    }))},
+
+    // Claude Code hook install status. Cheap — just reads the settings
+    // file. Frontend uses this to decide whether to show the Claude icon
+    // in install-prompt mode vs. direct-open mode.
+    { method: "GET", path: "/api/claude-hooks/status", handler: auth((req, res) => {
+      json(res, 200, getClaudeHooksStatus());
+    })},
+
+    // Install the katulong relay hook into ~/.claude/settings.local.json.
+    // Idempotent and non-destructive. Exposed over HTTP so the frontend
+    // can wire up hooks on first click of the Claude icon without
+    // requiring the user to drop to a terminal.
+    { method: "POST", path: "/api/claude-hooks/install", handler: auth(csrf((req, res) => {
+      try {
+        const result = installClaudeHooks();
+        json(res, 200, result);
+      } catch (err) {
+        log.warn("Failed to install Claude hooks via API", { error: err.message });
+        json(res, 500, { error: "Failed to install hooks" });
+      }
     }))},
 
     // On-demand transcript-slice drill-down. The pub/sub now carries only

--- a/lib/session-child-counter.js
+++ b/lib/session-child-counter.js
@@ -1,17 +1,18 @@
 /**
- * Session child-count monitor.
+ * Session pane monitor.
  *
- * Periodically counts the number of child processes running inside each
- * alive session's tmux pane and relays the result via the transport bridge.
- * Also reaps dead, clientless sessions from the map so they don't linger.
+ * Periodically inspects each alive session's tmux pane for two facts:
+ *   1. The number of child processes running inside the pane's shell.
+ *   2. The foreground command name (for Claude presence auto-detection).
  *
- * Why it lives in its own module
- * - The monitoring loop has nothing to do with session lifecycle or tmux
- *   control-mode I/O — it's a passive observer that polls tmux and pgrep
- *   on a timer. Extracting it keeps session-manager.js focused on session
- *   creation, attachment, and the bridge contract.
- * - Pure function `countTmuxPaneProcesses` is now trivially testable
- *   (accepts a tmuxName, returns a promise of number) with no setup.
+ * Both are relayed to clients via the transport bridge. Also reaps dead,
+ * clientless sessions from the map so they don't linger.
+ *
+ * Claude presence is derived from tmux's own `pane_current_command` field:
+ * tmux tracks the tty-controlling foreground process per pane, so when the
+ * user runs `claude` in the shell the field flips to `claude` without any
+ * pgrep walk or new process spawn. The same `list-panes` call we already
+ * make for the pane pid carries this for free.
  */
 
 import { execFile } from "node:child_process";
@@ -20,29 +21,57 @@ import { tmuxSocketArgs } from "./tmux.js";
 
 const DEFAULT_INTERVAL_MS = 5000;
 
+// Foreground commands that mean "a Claude Code session is running in this
+// pane." Tmux reports `pane_current_command` as the binary basename, so a
+// small set is sufficient — no path prefix matching needed.
+const CLAUDE_COMMAND_NAMES = new Set(["claude", "claude-code"]);
+
 /**
- * Count the number of child processes running inside a tmux pane's shell.
+ * True when a tmux `pane_current_command` value represents a running Claude
+ * Code session. Null / empty / unrelated commands return false.
  *
- * Resolves to 0 on any error (missing pane, pgrep failure) — the count is
- * advisory and must not crash the monitoring loop.
+ * @param {string | null | undefined} cmd
+ * @returns {boolean}
+ */
+export function isClaudeCommand(cmd) {
+  if (typeof cmd !== "string" || cmd.length === 0) return false;
+  return CLAUDE_COMMAND_NAMES.has(cmd);
+}
+
+/**
+ * Inspect a tmux pane for its pid and foreground command name, then count
+ * the shell's direct children via pgrep.
+ *
+ * Resolves to `{ childCount: 0, currentCommand: null }` on any error so the
+ * monitoring loop never crashes on a transient tmux hiccup.
  *
  * @param {string} tmuxName
- * @returns {Promise<number>}
+ * @returns {Promise<{ childCount: number, currentCommand: string | null }>}
  */
-export function countTmuxPaneProcesses(tmuxName) {
+export function inspectTmuxPane(tmuxName) {
   return new Promise((resolve) => {
     execFile(
       "tmux",
-      [...tmuxSocketArgs(), "list-panes", "-t", tmuxName, "-F", "#{pane_pid}"],
+      [
+        ...tmuxSocketArgs(),
+        "list-panes", "-t", tmuxName,
+        "-F", "#{pane_pid} #{pane_current_command}",
+      ],
       { timeout: 5000 },
       (err, stdout) => {
-        if (err || !stdout.trim()) return resolve(0);
-        const panePid = stdout.trim().split("\n")[0];
-        if (!/^\d+$/.test(panePid)) return resolve(0);
+        if (err || !stdout.trim()) return resolve({ childCount: 0, currentCommand: null });
+        // Only the first pane is inspected — katulong-managed sessions
+        // always have exactly one pane. An externally-adopted multi-pane
+        // session still resolves to the first pane's foreground.
+        const firstLine = stdout.trim().split("\n")[0];
+        const spaceIdx = firstLine.indexOf(" ");
+        const panePid = spaceIdx === -1 ? firstLine : firstLine.slice(0, spaceIdx);
+        const currentCommand = spaceIdx === -1 ? null : firstLine.slice(spaceIdx + 1).trim() || null;
+        if (!/^\d+$/.test(panePid)) return resolve({ childCount: 0, currentCommand });
         execFile("pgrep", ["-P", panePid], (err2, stdout2) => {
-          if (err2 || !stdout2.trim()) return resolve(0);
+          if (err2 || !stdout2.trim()) return resolve({ childCount: 0, currentCommand });
           const children = stdout2.trim().split("\n").filter((p) => /^\d+$/.test(p));
-          resolve(children.length);
+          resolve({ childCount: children.length, currentCommand });
         });
       }
     );
@@ -50,9 +79,73 @@ export function countTmuxPaneProcesses(tmuxName) {
 }
 
 /**
+ * Back-compat shim: callers that only want the child count still get a
+ * plain number. Kept so existing tests and external probes keep working.
+ *
+ * @param {string} tmuxName
+ * @returns {Promise<number>}
+ */
+export function countTmuxPaneProcesses(tmuxName) {
+  return inspectTmuxPane(tmuxName).then((r) => r.childCount);
+}
+
+/**
+ * Reconcile `meta.claude.running` on the session against the latest tmux
+ * `pane_current_command` reading. Preserves any hook-written fields
+ * (`uuid`, `startedAt`) that live in the same namespace.
+ *
+ * Returns `true` if the session's meta changed as a result, `false`
+ * otherwise — callers use this to decide whether to broadcast. The
+ * internal `setMeta` path already fires its own `onChange`, so the
+ * monitor loop doesn't need to relay a separate message.
+ *
+ * @param {object} session  - katulong Session
+ * @param {string | null} currentCommand
+ * @returns {boolean}
+ */
+export function reconcileClaudePresence(session, currentCommand) {
+  const nowRunning = isClaudeCommand(currentCommand);
+  const current = (session.meta && session.meta.claude) ? session.meta.claude : null;
+  const wasRunning = !!(current && current.running);
+
+  if (nowRunning === wasRunning) return false;
+
+  if (nowRunning) {
+    const next = { ...(current || {}), running: true, detectedAt: Date.now() };
+    try {
+      session.setMeta("claude", next);
+      return true;
+    } catch (err) {
+      log.warn("Failed to mark claude running on session", {
+        session: session.name, error: err.message,
+      });
+      return false;
+    }
+  }
+
+  // Claude stopped running in the pane. Drop the detection-owned keys
+  // but keep anything the hook ingest wrote (`uuid`, `startedAt`) so a
+  // still-open feed tile can keep resolving to the right topic.
+  if (!current) return false;
+  const next = { ...current };
+  delete next.running;
+  delete next.detectedAt;
+  try {
+    session.setMeta("claude", Object.keys(next).length > 0 ? next : null);
+    return true;
+  } catch (err) {
+    log.warn("Failed to clear claude running on session", {
+      session: session.name, error: err.message,
+    });
+    return false;
+  }
+}
+
+/**
  * Start a periodic monitor that:
  *  1. Reaps dead, clientless sessions from the map.
- *  2. Counts children for alive sessions and relays `child-count-update`.
+ *  2. Inspects alive sessions' panes for child count + foreground command.
+ *  3. Relays `child-count-update` and reconciles `meta.claude.running`.
  *
  * Returns a stop() function that clears the interval.
  *
@@ -67,16 +160,18 @@ export function startChildCountMonitor({ sessions, tracker, bridge, intervalMs =
   const timer = setInterval(async () => {
     for (const [name, session] of [...sessions]) {
       if (!session.alive) {
-        // Reap dead sessions that have no attached clients
         if (!tracker.hasClients(name)) {
           sessions.delete(name);
           log.info("Reaped dead session", { session: name });
         }
         continue;
       }
-      const count = await countTmuxPaneProcesses(session.tmuxName);
-      session.updateChildCount(count);
-      bridge.relay({ type: "child-count-update", session: name, count });
+      const { childCount, currentCommand } = await inspectTmuxPane(session.tmuxName);
+      session.updateChildCount(childCount);
+      bridge.relay({ type: "child-count-update", session: name, count: childCount });
+      // Claude presence flips trigger a session.setMeta call, which itself
+      // fires onChange → session-updated broadcast; nothing to relay here.
+      reconcileClaudePresence(session, currentCommand);
     }
   }, intervalMs);
   if (timer.unref) timer.unref();

--- a/public/app.js
+++ b/public/app.js
@@ -1601,6 +1601,25 @@
           iconStore.removeIcon(s.name);
         }
       }
+
+      // Reflect the active tile's Claude-presence state onto the joystick
+      // feed button. The monitor loop flips `meta.claude.running` based on
+      // tmux's `pane_current_command`, so this subscription picks up both
+      // the periodic poll and the real-time `session-updated` broadcast.
+      const activeName = getActiveSessionName();
+      const active = activeName ? sessions.find((s) => s.name === activeName) : null;
+      joystickManager.setClaudeRunning(!!active?.meta?.claude?.running);
+    });
+
+    // Active tile changes (e.g. user switches sessions) need an immediate
+    // refresh of the joystick presence indicator — waiting for the next
+    // sessionStore push would leave a stale icon for up to 5s.
+    uiStore.subscribe(() => {
+      const { sessions } = sessionStore.getState();
+      if (!sessions) return;
+      const activeName = getActiveSessionName();
+      const active = activeName ? sessions.find((s) => s.name === activeName) : null;
+      joystickManager.setClaudeRunning(!!active?.meta?.claude?.running);
     });
 
     // Subscribe to shortcuts changes to re-render bar
@@ -1737,43 +1756,51 @@
 
     /** Open a feed tile for the Claude session running in the current terminal.
      *
-     * Primary path: read `session.meta.claude.uuid` populated by the server
-     * hook ingest (MC1f). Fallback: scan topics for a sessionName match —
-     * kept so existing Claude sessions whose SessionStart fired before this
-     * wiring still resolve.
+     * Three-way resolution:
+     *   1. `meta.claude.uuid` present (SessionStart hook fired) → open the
+     *      exact `claude/<uuid>` topic.
+     *   2. `meta.claude.running` present but no uuid → Claude is running in
+     *      the pane but the hook hasn't reported yet. If hooks aren't
+     *      installed, POST to install them so the *next* SessionStart wires
+     *      up automatically. Either way, fall through to the picker.
+     *   3. No Claude signal at all → open the generic picker.
      */
     async function openClaudeFeedTile() {
       const sessionName = getActiveSessionName();
 
-      // No active terminal: the Claude lookup has nothing to key off,
-      // so skip the round trip to /api/topics and open the generic picker.
       if (!sessionName) {
         openFeedTile();
         return;
       }
 
-      try {
-        // Primary: read meta.claude.uuid from the already-cached session
-        // list. The `session-updated` WS push keeps this in sync, so we
-        // don't need a dedicated fetch.
-        const { sessions } = sessionStore.getState();
-        const active = (sessions || []).find(s => s.name === sessionName);
-        const uuid = active?.meta?.claude?.uuid;
-        if (uuid) {
-          const topic = `claude/${uuid}`;
-          const tileId = `feed-${Date.now().toString(36)}`;
-          uiStore.addTile(
-            { id: tileId, type: "feed", props: { topic, title: topic, meta: {} } },
-            { focus: true, insertAt: "afterFocus" },
-          );
-          if (isOverlayViewport()) setOverlaySidebar(false);
-          return;
-        }
+      const { sessions } = sessionStore.getState();
+      const active = (sessions || []).find(s => s.name === sessionName);
+      const claudeMeta = active?.meta?.claude || null;
 
-        // Fallback: scan topics for a sessionName match — resolves Claude
-        // sessions whose SessionStart fired before MC1f was deployed.
-        // Remove once all live Claude sessions have been restarted under
-        // the new hook wiring.
+      // Primary: UUID known → open the specific feed directly.
+      if (claudeMeta?.uuid) {
+        const topic = `claude/${claudeMeta.uuid}`;
+        const tileId = `feed-${Date.now().toString(36)}`;
+        uiStore.addTile(
+          { id: tileId, type: "feed", props: { topic, title: topic, meta: {} } },
+          { focus: true, insertAt: "afterFocus" },
+        );
+        if (isOverlayViewport()) setOverlaySidebar(false);
+        return;
+      }
+
+      // Running but no uuid: auto-install hooks on first encounter so the
+      // next Claude session the user starts wires up without any terminal
+      // plumbing. Silent if already installed; one-shot toast otherwise.
+      if (claudeMeta?.running) {
+        await ensureClaudeHooksInstalled();
+      }
+
+      try {
+        // Legacy fallback: scan topics for a sessionName match. Resolves
+        // Claude sessions that started before MC1f was deployed. Remove
+        // once all live Claude sessions have been restarted under the
+        // new hook wiring.
         const topics = await api.get("/api/topics");
         const match = topics
           .filter(t => t.name.startsWith("claude/") && t.meta?.sessionName === sessionName)
@@ -1791,6 +1818,28 @@
         openFeedTile();
       }
       if (isOverlayViewport()) setOverlaySidebar(false);
+    }
+
+    // Ensure `~/.claude/settings.local.json` has the katulong relay hook
+    // wired. Idempotent on the server side — this client only needs to
+    // care about the first install, so we track a per-tab flag to avoid
+    // retoasting on every click after install.
+    let _claudeHooksToasted = false;
+    async function ensureClaudeHooksInstalled() {
+      try {
+        const status = await api.get("/api/claude-hooks/status");
+        if (status?.installed) return;
+        const result = await api.post("/api/claude-hooks/install", {});
+        if (!_claudeHooksToasted && result?.added?.length) {
+          _claudeHooksToasted = true;
+          showToast("Claude hooks installed. Start a new Claude session for a direct-open feed.");
+        }
+      } catch {
+        // Non-fatal: if install fails the user still gets the topic
+        // picker, and surfacing a red error here would be more noise
+        // than signal. The manual `katulong setup claude-hooks` path
+        // remains available as an escape hatch.
+      }
     }
 
     // --- Localhost Browser (tile) ---

--- a/public/app.js
+++ b/public/app.js
@@ -1590,6 +1590,18 @@
 
     const renderBar = (name) => shortcutBarInstance.render(name);
 
+    // Reflect the active tile's Claude-presence state onto the joystick
+    // feed button. The server flips `meta.claude.running` from tmux's
+    // `pane_current_command` poll, so this fires on both the periodic
+    // `session-updated` broadcast and active-tile switches.
+    function syncClaudePresenceIndicator() {
+      const { sessions } = sessionStore.getState();
+      if (!sessions) return;
+      const activeName = getActiveSessionName();
+      const active = activeName ? sessions.find((s) => s.name === activeName) : null;
+      joystickManager.setClaudeRunning(!!active?.meta?.claude?.running);
+    }
+
     // Sync per-session icons from server session data
     sessionStore.subscribe(() => {
       const { sessions } = sessionStore.getState();
@@ -1601,26 +1613,13 @@
           iconStore.removeIcon(s.name);
         }
       }
-
-      // Reflect the active tile's Claude-presence state onto the joystick
-      // feed button. The monitor loop flips `meta.claude.running` based on
-      // tmux's `pane_current_command`, so this subscription picks up both
-      // the periodic poll and the real-time `session-updated` broadcast.
-      const activeName = getActiveSessionName();
-      const active = activeName ? sessions.find((s) => s.name === activeName) : null;
-      joystickManager.setClaudeRunning(!!active?.meta?.claude?.running);
+      syncClaudePresenceIndicator();
     });
 
     // Active tile changes (e.g. user switches sessions) need an immediate
     // refresh of the joystick presence indicator — waiting for the next
     // sessionStore push would leave a stale icon for up to 5s.
-    uiStore.subscribe(() => {
-      const { sessions } = sessionStore.getState();
-      if (!sessions) return;
-      const activeName = getActiveSessionName();
-      const active = activeName ? sessions.find((s) => s.name === activeName) : null;
-      joystickManager.setClaudeRunning(!!active?.meta?.claude?.running);
-    });
+    uiStore.subscribe(syncClaudePresenceIndicator);
 
     // Subscribe to shortcuts changes to re-render bar
     shortcutsStore.subscribe(() => {

--- a/public/index.html
+++ b/public/index.html
@@ -1159,6 +1159,11 @@
       display: flex; align-items: center; justify-content: center;
     }
     .joystick-action-btn:active { opacity: 1; color: var(--text); }
+    /* Claude-presence variant: the feed button lights up when tmux reports
+       `claude` as the pane's foreground command, so the user can see at a
+       glance that clicking opens a feed for the running Claude session. */
+    .joystick-action-btn--claude { opacity: 0.95; color: var(--accent, #e9b44c); }
+    .joystick-action-btn--claude:active { color: var(--accent, #e9b44c); }
     /* Connection dot at the bottom of the stack */
     .joystick-dot {
       width: 0.625rem; height: 0.625rem; border-radius: 50%;
@@ -1484,6 +1489,19 @@
         color: var(--text-dim); font-size: 0.75rem; opacity: 0.4;
         pointer-events: none; z-index: 1;
       }
+    }
+    /* Claude-presence badge — small glint in the top-right of any session
+       card whose tile currently has claude running. Populated from
+       session.meta.claude.running which the pane monitor keeps live. */
+    .session-card-claude-badge {
+      position: absolute;
+      top: 0.25rem; right: 0.25rem;
+      width: 1rem; height: 1rem;
+      display: flex; align-items: center; justify-content: center;
+      color: var(--accent, #e9b44c);
+      font-size: 0.75rem;
+      pointer-events: none;
+      z-index: 2;
     }
     .session-card-long-press {
       transform: scale(1.03);

--- a/public/lib/joystick.js
+++ b/public/lib/joystick.js
@@ -4,6 +4,10 @@
  * Vertical stack of circular buttons floating in the terminal pane:
  * Files, Settings, and a connection indicator dot at the bottom.
  * Visible on touch devices only.
+ *
+ * The feed button adapts to Claude presence. When the active tile's session
+ * has `meta.claude.running` set by the server's pane monitor, the icon and
+ * label swap to signal "this opens a Claude feed for *this* session."
  */
 
 export function createJoystickManager(options = {}) {
@@ -13,15 +17,16 @@ export function createJoystickManager(options = {}) {
   let _onUploadClick = null;
   let _onSettingsClick = null;
   let _onFeedClick = null;
+  let _claudeRunning = false;
   let dotEl = null;
 
   function buildButtons() {
     if (!joystick) return;
     joystick.innerHTML = "";
 
-    function actionBtn(icon, label, handler) {
+    function actionBtn(icon, label, handler, extraClass = "") {
       const btn = document.createElement("button");
-      btn.className = "joystick-action-btn";
+      btn.className = `joystick-action-btn${extraClass ? " " + extraClass : ""}`;
       btn.innerHTML = `<i class="ph ph-${icon}"></i>`;
       btn.setAttribute("aria-label", label);
       btn.addEventListener("pointerdown", (e) => { e.stopPropagation(); e.stopImmediatePropagation(); e.preventDefault(); }, { capture: true });
@@ -36,7 +41,10 @@ export function createJoystickManager(options = {}) {
       joystick.appendChild(actionBtn("folder-open", "Files", _onFilesClick));
     }
     if (_onFeedClick) {
-      joystick.appendChild(actionBtn("rss", "Claude feed", _onFeedClick));
+      const icon = _claudeRunning ? "sparkle" : "rss";
+      const label = _claudeRunning ? "Claude feed" : "Feed";
+      const cls = _claudeRunning ? "joystick-action-btn--claude" : "";
+      joystick.appendChild(actionBtn(icon, label, _onFeedClick, cls));
     }
     if (_onSettingsClick) {
       joystick.appendChild(actionBtn("gear", "Settings", _onSettingsClick));
@@ -62,6 +70,18 @@ export function createJoystickManager(options = {}) {
       buildButtons();
     },
 
-    getState: () => ({ mode: 'idle' })
+    /**
+     * Update Claude-presence state for the active tile. Idempotent: callers
+     * can invoke this on every `session-updated` broadcast without tearing
+     * down the DOM when the state hasn't actually changed.
+     */
+    setClaudeRunning(running) {
+      const next = !!running;
+      if (_claudeRunning === next) return;
+      _claudeRunning = next;
+      buildButtons();
+    },
+
+    getState: () => ({ mode: 'idle', claudeRunning: _claudeRunning }),
   };
 }

--- a/public/lib/session-list-component.js
+++ b/public/lib/session-list-component.js
@@ -285,6 +285,18 @@ export function createSessionListComponent(store, options = {}) {
       handle.innerHTML = '<i class="ph ph-dots-six"></i>';
       card.appendChild(handle);
 
+      // Claude-presence badge — the server's pane monitor flips
+      // meta.claude.running when tmux reports `claude` as the pane's
+      // foreground command, so this lights up on every card whose tile
+      // has Claude actively running.
+      if (s.meta?.claude?.running) {
+        const badge = document.createElement("div");
+        badge.className = "session-card-claude-badge";
+        badge.setAttribute("aria-label", "Claude session running");
+        badge.innerHTML = '<i class="ph ph-sparkle"></i>';
+        card.appendChild(badge);
+      }
+
       // Terminal preview — cached text from xterm buffer
       const preview = document.createElement("div");
       preview.className = "session-card-preview";

--- a/server.js
+++ b/server.js
@@ -257,7 +257,7 @@ const routes = [
     auth, csrf,
   }),
   ...createAppRoutes({
-    json, parseJSON, isAuthenticated, sessionManager,
+    json, parseJSON, readBody, isAuthenticated, sessionManager,
     bridge,
     configManager,
     __dirname, DATA_DIR, APP_VERSION,

--- a/test/app-routes-meta.test.js
+++ b/test/app-routes-meta.test.js
@@ -161,4 +161,40 @@ describe("applyClaudeMetaFromHook", () => {
     assert.equal(applyClaudeMetaFromHook(null, makeManager(null)), null);
     assert.equal(applyClaudeMetaFromHook("nope", makeManager(null)), null);
   });
+
+  it("preserves detection-owned keys on SessionStart merge", () => {
+    // The pane monitor wrote `running` / `detectedAt` before the hook fired.
+    // SessionStart must add `uuid` / `startedAt` without wiping those.
+    const { session } = makeSession();
+    session.meta.claude = { running: true, detectedAt: 100 };
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "SessionStart",
+      session_id: "11111111-2222-3333-4444-555555555555",
+      _tmuxPane: "%3",
+    }, makeManager(session));
+    assert.equal(verdict, "set");
+    assert.equal(session.meta.claude.running, true);
+    assert.equal(session.meta.claude.detectedAt, 100);
+    assert.equal(session.meta.claude.uuid, "11111111-2222-3333-4444-555555555555");
+    assert.equal(typeof session.meta.claude.startedAt, "number");
+  });
+
+  it("preserves detection-owned keys on SessionEnd clear", () => {
+    // SessionEnd only owns `uuid` / `startedAt`. Pane monitor's
+    // `running` / `detectedAt` must survive a hook clear so the card's
+    // glint doesn't vanish while claude is actually still running.
+    const { session } = makeSession();
+    session.meta.claude = {
+      uuid: "11111111-2222-3333-4444-555555555555",
+      startedAt: 1,
+      running: true,
+      detectedAt: 100,
+    };
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "SessionEnd",
+      _tmuxPane: "%3",
+    }, makeManager(session));
+    assert.equal(verdict, "cleared");
+    assert.deepEqual(session.meta.claude, { running: true, detectedAt: 100 });
+  });
 });

--- a/test/claude-hooks.test.js
+++ b/test/claude-hooks.test.js
@@ -1,0 +1,133 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The module reads ~/.claude; override HOME so the tests hit a temp dir
+// instead of the developer's real settings file.
+describe("claude-hooks (via $HOME override)", () => {
+  let tmpHome;
+  let originalHome;
+  let hooks;
+
+  beforeEach(async () => {
+    tmpHome = mkdtempSync(join(tmpdir(), "katulong-claude-hooks-"));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    // Fresh import per test so the captured CLAUDE_DIR picks up the new HOME.
+    const mod = await import(`../lib/claude-hooks.js?t=${Date.now()}`);
+    hooks = mod;
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("reports not-installed on a fresh machine", () => {
+    const status = hooks.getClaudeHooksStatus();
+    assert.equal(status.installed, false);
+    assert.equal(status.partiallyInstalled, false);
+    assert.equal(status.missingEvents.length, hooks.HOOK_EVENTS.length);
+  });
+
+  it("installs every required event on first run", () => {
+    const result = hooks.installClaudeHooks();
+    assert.equal(result.installed, true);
+    assert.deepEqual(result.added.sort(), [...hooks.HOOK_EVENTS].sort());
+    const status = hooks.getClaudeHooksStatus();
+    assert.equal(status.installed, true);
+    assert.equal(status.missingEvents.length, 0);
+  });
+
+  it("is idempotent — running install twice is a no-op", () => {
+    hooks.installClaudeHooks();
+    const second = hooks.installClaudeHooks();
+    assert.equal(second.installed, true);
+    assert.equal(second.added.length, 0);
+    assert.equal(second.alreadyInstalled.length, hooks.HOOK_EVENTS.length);
+  });
+
+  it("tops up a partially installed settings file without clobbering other hooks", () => {
+    // Seed a partial install with an unrelated user hook present.
+    const settings = {
+      hooks: {
+        PostToolUse: [
+          { matcher: "*", hooks: [{ type: "command", command: "katulong relay-hook" }] },
+        ],
+        UserCustom: [
+          { matcher: "*", hooks: [{ type: "command", command: "/some/other/tool" }] },
+        ],
+      },
+    };
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    writeFileSync(join(tmpHome, ".claude", "settings.local.json"), JSON.stringify(settings, null, 2));
+
+    const result = hooks.installClaudeHooks();
+    assert.equal(result.installed, true);
+    // Every event except PostToolUse should be newly added.
+    assert.ok(result.added.length > 0);
+    assert.ok(!result.added.includes("PostToolUse"));
+    assert.ok(result.alreadyInstalled.includes("PostToolUse"));
+
+    // User's unrelated hook must survive.
+    const onDisk = JSON.parse(readFileSync(join(tmpHome, ".claude", "settings.local.json"), "utf8"));
+    assert.ok(onDisk.hooks.UserCustom);
+    assert.equal(onDisk.hooks.UserCustom[0].hooks[0].command, "/some/other/tool");
+  });
+
+  it("removes only katulong relay hooks, leaving user hooks alone", () => {
+    hooks.installClaudeHooks();
+    // Add a user hook alongside the katulong one.
+    const settingsPath = join(tmpHome, ".claude", "settings.local.json");
+    const s = JSON.parse(readFileSync(settingsPath, "utf8"));
+    s.hooks.PostToolUse.push({
+      matcher: "*",
+      hooks: [{ type: "command", command: "/some/user/hook" }],
+    });
+    writeFileSync(settingsPath, JSON.stringify(s, null, 2));
+
+    const result = hooks.removeClaudeHooks();
+    assert.ok(result.removed.length > 0);
+    const onDisk = JSON.parse(readFileSync(settingsPath, "utf8"));
+    // User hook survives; katulong relay is gone.
+    const postToolUse = onDisk.hooks?.PostToolUse || [];
+    const hasRelay = postToolUse.some((g) =>
+      g.hooks?.some((h) => h.command === "katulong relay-hook")
+    );
+    const hasUser = postToolUse.some((g) =>
+      g.hooks?.some((h) => h.command === "/some/user/hook")
+    );
+    assert.equal(hasRelay, false);
+    assert.equal(hasUser, true);
+  });
+
+  it("strips stale http hooks pointing at the old claude-events url", () => {
+    const settings = {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: "*",
+            hooks: [{ type: "http", url: "http://localhost:3000/api/claude-events" }],
+          },
+        ],
+      },
+    };
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    writeFileSync(join(tmpHome, ".claude", "settings.local.json"), JSON.stringify(settings, null, 2));
+
+    hooks.installClaudeHooks();
+    const onDisk = JSON.parse(readFileSync(join(tmpHome, ".claude", "settings.local.json"), "utf8"));
+    const postToolUse = onDisk.hooks.PostToolUse;
+    // Old http hook is gone, new relay-hook is present.
+    const hasOldHttp = postToolUse.some((g) =>
+      g.hooks?.some((h) => h.url && h.url.includes("/api/claude-events"))
+    );
+    const hasRelay = postToolUse.some((g) =>
+      g.hooks?.some((h) => h.command === "katulong relay-hook")
+    );
+    assert.equal(hasOldHttp, false);
+    assert.equal(hasRelay, true);
+  });
+});

--- a/test/session-child-counter-claude.test.js
+++ b/test/session-child-counter-claude.test.js
@@ -1,0 +1,119 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isClaudeCommand, reconcileClaudePresence,
+} from "../lib/session-child-counter.js";
+
+describe("isClaudeCommand", () => {
+  it("matches the claude binary name", () => {
+    assert.equal(isClaudeCommand("claude"), true);
+  });
+
+  it("matches the long-form name", () => {
+    assert.equal(isClaudeCommand("claude-code"), true);
+  });
+
+  it("does not match shells or editors", () => {
+    assert.equal(isClaudeCommand("bash"), false);
+    assert.equal(isClaudeCommand("zsh"), false);
+    assert.equal(isClaudeCommand("vim"), false);
+    assert.equal(isClaudeCommand("node"), false);
+  });
+
+  it("does not match prefix-collision names", () => {
+    // tmux reports the basename, so arbitrary aliases that happen to start
+    // with "claude" must not be treated as claude unless they are exactly
+    // the allowed list.
+    assert.equal(isClaudeCommand("claudemon"), false);
+    assert.equal(isClaudeCommand("claudesh"), false);
+  });
+
+  it("handles null / empty / non-string", () => {
+    assert.equal(isClaudeCommand(null), false);
+    assert.equal(isClaudeCommand(undefined), false);
+    assert.equal(isClaudeCommand(""), false);
+    assert.equal(isClaudeCommand(42), false);
+  });
+});
+
+describe("reconcileClaudePresence", () => {
+  function makeSession(initialMeta = {}) {
+    return {
+      name: "work",
+      meta: initialMeta,
+      setMeta(ns, val) {
+        if (val == null) delete this.meta[ns];
+        else this.meta[ns] = val;
+      },
+    };
+  }
+
+  it("flips running=true on first claude detection", () => {
+    const session = makeSession();
+    const changed = reconcileClaudePresence(session, "claude");
+    assert.equal(changed, true);
+    assert.equal(session.meta.claude.running, true);
+    assert.equal(typeof session.meta.claude.detectedAt, "number");
+  });
+
+  it("is a no-op when already running", () => {
+    const session = makeSession({ claude: { running: true, detectedAt: 1 } });
+    const changed = reconcileClaudePresence(session, "claude");
+    assert.equal(changed, false);
+    assert.equal(session.meta.claude.detectedAt, 1);
+  });
+
+  it("clears running when command changes away from claude", () => {
+    const session = makeSession({ claude: { running: true, detectedAt: 1 } });
+    const changed = reconcileClaudePresence(session, "bash");
+    assert.equal(changed, true);
+    // The whole namespace is dropped since no hook-owned keys remained.
+    assert.equal(session.meta.claude, undefined);
+  });
+
+  it("preserves hook-owned uuid/startedAt when clearing running", () => {
+    const session = makeSession({
+      claude: {
+        running: true, detectedAt: 1,
+        uuid: "11111111-2222-3333-4444-555555555555",
+        startedAt: 12345,
+      },
+    });
+    const changed = reconcileClaudePresence(session, "bash");
+    assert.equal(changed, true);
+    // Presence keys gone, hook keys survive so the feed button can still
+    // resolve the topic for an already-tracked session.
+    assert.deepEqual(session.meta.claude, {
+      uuid: "11111111-2222-3333-4444-555555555555",
+      startedAt: 12345,
+    });
+  });
+
+  it("preserves hook-owned keys when setting running=true", () => {
+    const session = makeSession({
+      claude: {
+        uuid: "11111111-2222-3333-4444-555555555555",
+        startedAt: 12345,
+      },
+    });
+    const changed = reconcileClaudePresence(session, "claude");
+    assert.equal(changed, true);
+    assert.equal(session.meta.claude.uuid, "11111111-2222-3333-4444-555555555555");
+    assert.equal(session.meta.claude.startedAt, 12345);
+    assert.equal(session.meta.claude.running, true);
+  });
+
+  it("treats null / empty current command as not-running", () => {
+    const session = makeSession();
+    assert.equal(reconcileClaudePresence(session, null), false);
+    assert.equal(reconcileClaudePresence(session, ""), false);
+    assert.equal(session.meta.claude, undefined);
+  });
+
+  it("no-ops on clear when meta.claude was already absent", () => {
+    const session = makeSession();
+    const changed = reconcileClaudePresence(session, "bash");
+    assert.equal(changed, false);
+    assert.equal(session.meta.claude, undefined);
+  });
+});


### PR DESCRIPTION
## Summary

- Backend autodetects Claude sessions per terminal tile via tmux's `pane_current_command` (no pgrep, no xterm sniffing) and writes `meta.claude.running` / `detectedAt` on the session
- Sidebar session cards show a sparkle badge when Claude is running in that tile; joystick feed button swaps from generic RSS to a Claude-themed sparkle with label "Claude feed"
- First click of the Claude feed button installs hooks automatically via new `/api/claude-hooks/{status,install}` routes — subsequent clicks just work
- Per-tile UUID tracking: hooks own `uuid` / `startedAt`, pane monitor owns `running` / `detectedAt`; `applyClaudeMetaFromHook` now partial-merges so the two writers don't clobber each other
- Removes the manual `katulong setup claude-hooks` requirement from the UX

## Test plan

- [x] `npm test` (unit + integration) — 2280 tests pass
- [x] New tests: `test/session-child-counter-claude.test.js`, `test/claude-hooks.test.js`, extended `test/app-routes-meta.test.js`
- [ ] Manual: open a tile, run `claude`, verify sparkle badge appears within ~5s; click feed button → hooks install + feed opens; run `claude` in a second tile → independent UUID per tile