### PR TITLE
MC3 follow-ups: flip pinch direction; preserve tiles across cluster switch

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -540,15 +540,20 @@
     // two-finger scroll doesn't flip levels, loose enough that a
     // deliberate pinch always lands. The gesture emits on phase=end so
     // mid-gesture wobble never commits.
-    const PINCH_OUT_COMMIT = 1.15;  // L1 → L2 (zoom out to overview)
-    const PINCH_IN_COMMIT  = 0.85;  // L2 → L1 (zoom into active cluster)
+    //
+    // Direction follows the standard "zoom out to see more" convention:
+    // pinch IN (fingers together, scale < 1) zooms out from L1's focused
+    // cluster to the L2 overview; pinch OUT (fingers apart, scale > 1)
+    // zooms back into the active cluster.
+    const PINCH_IN_COMMIT  = 0.85;  // L1 → L2 (zoom out to overview)
+    const PINCH_OUT_COMMIT = 1.15;  // L2 → L1 (zoom into active cluster)
     const pinch = createPinchGesture({
       target: document.getElementById("main-stage"),
       onPinch: ({ scale, phase }) => {
         if (phase !== "end") return;
         const level = uiStore.getState().level;
-        if (level === 1 && scale >= PINCH_OUT_COMMIT) uiStore.setLevel(2);
-        else if (level === 2 && scale <= PINCH_IN_COMMIT) uiStore.setLevel(1);
+        if (level === 1 && scale <= PINCH_IN_COMMIT) uiStore.setLevel(2);
+        else if (level === 2 && scale >= PINCH_OUT_COMMIT) uiStore.setLevel(1);
       },
     });
     pinch.attach();

--- a/public/lib/card-carousel.js
+++ b/public/lib/card-carousel.js
@@ -568,8 +568,9 @@ export function createCardCarousel({
     fitAll();
   }
 
-  function deactivate() {
+  function deactivate(opts = {}) {
     if (!active) return;
+    const silent = opts.silent === true;
 
     // Unmount all tiles, destroy chrome, detach resize handles
     for (const [, entry] of cardEls) {
@@ -592,7 +593,7 @@ export function createCardCarousel({
     focusedId = null;
 
     save();
-    if (onAllCardsDismissed) onAllCardsDismissed();
+    if (!silent && onAllCardsDismissed) onAllCardsDismissed();
   }
 
   // ── Card management ────────────────────────────────────────────────
@@ -637,11 +638,23 @@ export function createCardCarousel({
     save();
   }
 
-  function removeCard(tileId) {
+  /**
+   * Remove a card from the carousel.
+   *
+   * @param {string} tileId
+   * @param {object} [opts]
+   * @param {boolean} [opts.silent] When true, suppress onCardDismissed and
+   *   onAllCardsDismissed callbacks. Used by tile-host when a tile leaves
+   *   the visible cluster but still exists in store (cluster switch). The
+   *   default false matches the user-initiated dismiss path: callbacks
+   *   fire so the host can dispatch removeTile / reset.
+   */
+  function removeCard(tileId, opts = {}) {
     if (!active) return;
     const idx = cards.indexOf(tileId);
     if (idx === -1) return;
 
+    const silent = opts.silent === true;
     const entry = cardEls.get(tileId);
 
     const doRemove = () => {
@@ -662,7 +675,7 @@ export function createCardCarousel({
       cardEls.delete(tileId);
       cards.splice(currentIdx, 1);
 
-      if (onCardDismissed) onCardDismissed(tileId);
+      if (!silent && onCardDismissed) onCardDismissed(tileId);
 
       // Shift focus
       if (focusedId === tileId) {
@@ -674,7 +687,7 @@ export function createCardCarousel({
           positionCards(true);
         } else {
           focusedId = null;
-          deactivate();
+          deactivate({ silent });
           return;
         }
       } else {

--- a/public/lib/tile-host.js
+++ b/public/lib/tile-host.js
@@ -79,17 +79,29 @@ export function createTileHost({ store, carousel, getRenderer, getClusterIdx, on
     const prevIds = new Set(Object.keys(prev.tiles));
     const nextIds = new Set(Object.keys(view.tiles));
 
-    // Removed tiles
+    // Removed tiles. Two flavors:
+    //   (a) Tile gone from store entirely (REMOVE_TILE, REMOVE_CLUSTER) —
+    //       fire onTileRemoved so the host can do WS unsubscribe / tab-set
+    //       cleanup, and let carousel.removeCard fire its callbacks (which
+    //       the user-swipe path relies on to drive removeTile back to the
+    //       store; for store-driven removals this is an idempotent no-op
+    //       since the tile is already gone).
+    //   (b) Tile still in state.tiles but no longer in this host's cluster
+    //       view (SWITCH_CLUSTER). The tile is alive — only its DOM mount
+    //       needs teardown. Use silent removal so onCardDismissed and
+    //       onAllCardsDismissed don't fire and dispatch removeTile/reset
+    //       back into the store, which would wipe the inactive cluster.
     for (const id of prevIds) {
       if (!nextIds.has(id)) {
         const handle = handles.get(id);
         if (handle) {
-          // Notify host before teardown so it can do cleanup (WS
-          // unsubscribe, tab-set removal) while the handle is still live.
-          if (onTileRemoved) onTileRemoved(id, handle);
-          // Let carousel handle DOM teardown (wrapper removal, chrome
-          // destroy, resize handles). We just need to tell it.
-          carousel.removeCard(id);
+          const stillInStore = !!state.tiles[id];
+          if (stillInStore) {
+            carousel.removeCard(id, { silent: true });
+          } else {
+            if (onTileRemoved) onTileRemoved(id, handle);
+            carousel.removeCard(id);
+          }
           handles.delete(id);
         }
       }

--- a/test/tile-host.test.js
+++ b/test/tile-host.test.js
@@ -209,8 +209,8 @@ function createMockCarousel() {
       tile.mount({}, {});
     },
 
-    removeCard(id) {
-      log.push({ op: "removeCard", id });
+    removeCard(id, opts = {}) {
+      log.push({ op: "removeCard", id, silent: opts.silent === true });
       cards = cards.filter(c => c !== id);
       if (focusedId === id) focusedId = cards[0] || null;
     },
@@ -550,6 +550,87 @@ describe("tile-host", () => {
       assert.strictEqual(removed.length, 2, "onTileRemoved fires for each tile");
       const ids = removed.map(r => r.id).sort();
       assert.deepStrictEqual(ids, ["s1", "s2"]);
+    });
+  });
+
+  // ── Cluster switch (regression: don't dispatch removeTile/reset) ──
+  // When the active cluster changes, tile-host's view changes — tiles
+  // from the old cluster vanish from view but remain in state.tiles
+  // (they live in another cluster). Tearing them down through the
+  // carousel's user-dismiss path would fire onCardDismissed → host
+  // dispatches removeTile, and onAllCardsDismissed → host resets the
+  // store to EMPTY_STATE. Both are wrong: the tile and cluster are
+  // still live, just not visible.
+  describe("cluster switch", () => {
+    it("does not call onTileRemoved when tile remains in another cluster", () => {
+      const removed = [];
+      // Cluster 0 has a terminal; cluster 1 is empty. Active = 0.
+      store.setState({
+        clusters: [[[{ id: "s1", type: "terminal", props: { sessionName: "s1" } }]], []],
+        activeClusterIdx: 0,
+        focusedTileIdByCluster: ["s1", null],
+      });
+
+      createHost({
+        onTileRemoved: (id, handle) => removed.push({ id, sessions: handle.getSessions?.() }),
+      });
+      host.init();
+
+      // Switch active cluster to the empty one. The terminal is still
+      // in state.clusters[0] — only the carousel view changes.
+      store.setState({
+        clusters: [[[{ id: "s1", type: "terminal", props: { sessionName: "s1" } }]], []],
+        activeClusterIdx: 1,
+        focusedTileIdByCluster: ["s1", null],
+      });
+
+      assert.strictEqual(removed.length, 0, "onTileRemoved must not fire — tile is still in store");
+    });
+
+    it("uses silent removeCard so the carousel does not call back into the store", () => {
+      store.setState({
+        clusters: [[[{ id: "s1", type: "terminal", props: { sessionName: "s1" } }]], []],
+        activeClusterIdx: 0,
+        focusedTileIdByCluster: ["s1", null],
+      });
+
+      createHost();
+      host.init();
+
+      store.setState({
+        clusters: [[[{ id: "s1", type: "terminal", props: { sessionName: "s1" } }]], []],
+        activeClusterIdx: 1,
+        focusedTileIdByCluster: ["s1", null],
+      });
+
+      const remove = carousel.log.find(l => l.op === "removeCard" && l.id === "s1");
+      assert.ok(remove, "carousel.removeCard must be called for the off-screen tile");
+      assert.strictEqual(remove.silent, true, "removal must be silent (no onCardDismissed/onAllCardsDismissed)");
+    });
+
+    it("still uses non-silent removeCard when tile is genuinely deleted", () => {
+      const removed = [];
+      store.setState({
+        tiles: {
+          s1: { type: "terminal", props: { sessionName: "s1" } },
+          s2: { type: "terminal", props: { sessionName: "s2" } },
+        },
+        order: ["s1", "s2"],
+        focusedId: "s1",
+      });
+
+      createHost({
+        onTileRemoved: (id, handle) => removed.push({ id, sessions: handle.getSessions?.() }),
+      });
+      host.init();
+
+      store.removeTile("s2");
+
+      const remove = carousel.log.find(l => l.op === "removeCard" && l.id === "s2");
+      assert.ok(remove);
+      assert.strictEqual(remove.silent, false, "true removals stay non-silent so the host can fire WS cleanup");
+      assert.strictEqual(removed.length, 1);
+      assert.strictEqual(removed[0].id, "s2");
     });
   });
 });


### PR DESCRIPTION
## Summary

Two follow-up fixes to the MC3 Level-2 cluster strips PR (#603):

- **Pinch direction flipped** (`6e138f3`) — pinch-in (fingers together, scale < 1) now zooms *out* to the L2 overview; pinch-out zooms *into* the active cluster. Matches the standard "zoom out to see more" convention.
- **Cluster switch no longer wipes tiles** (`02ef73e`) — switching the active cluster from cluster-strips (or any switchCluster dispatch) was treated by tile-host as "tiles removed", which fired `onCardDismissed` → `uiStore.removeTile` and `onAllCardsDismissed` → `uiStore.reset(EMPTY_STATE)`. The result: tapping a strip in L2 could wipe every cluster down to one empty cluster, which then persisted to localStorage on the next save.
  - `card-carousel.removeCard / deactivate` accept `{ silent: true }` to suppress dismiss callbacks.
  - `tile-host` uses the silent path when a tile leaves the visible cluster but is still present in `state.tiles` (it lives in another cluster). Genuine removals (`REMOVE_TILE`, `REMOVE_CLUSTER`) keep the non-silent path so user-swipe and WS-cleanup flows are unchanged.
  - Three regression tests in `tile-host.test.js` cover the three cases.

## Test plan

- [x] `npm test` — 2263 pass / 0 fail
- [ ] Manual: load app, pinch-in → L2 overview shows. Add 2 clusters via "+". Pinch-out → return to focused cluster.
- [ ] Manual: at L2, tap a different cluster strip → that cluster becomes active at L1; the previously-active cluster's tiles are still in localStorage (`JSON.parse(localStorage.getItem("katulong-ui-v1"))` shows all clusters).
- [ ] Manual: refresh — all clusters and the focused tile restore correctly.