### PR TITLE
fix: strip TMUX/TMUX_PANE from spawned pane env

### DIFF
--- a/lib/env-filter.js
+++ b/lib/env-filter.js
@@ -12,6 +12,17 @@ export const SENSITIVE_ENV_VARS = new Set([
   // the server is running with drift logging on (information disclosure).
   "KATULONG_DRIFT_LOG",
   "KATULONG_DRIFT_DEBUG",
+  // tmux server state — TMUX and TMUX_PANE are set by tmux itself when it
+  // spawns the pane's shell. If katulong runs inside an outer tmux (common
+  // with SSH + tmux, or `katulong-stage` launched from a tmux window), the
+  // outer values arrive via process.env and our wrapper's `export` line
+  // clobbers the inner tmux's values. That breaks MC1f pane-to-session
+  // matching — hook payloads stamp the outer pane id and
+  // `applyClaudeMetaFromHook` no-ops because it can't find the session.
+  // See docs/session-meta.md.
+  "TMUX",
+  "TMUX_PANE",
+  "TMUX_TMPDIR",
 ]);
 
 /**

--- a/test/env-filter.test.js
+++ b/test/env-filter.test.js
@@ -19,9 +19,10 @@ describe("SENSITIVE_ENV_VARS", () => {
 });
 
 describe("getSafeEnv", () => {
-  // Stash and restore any pre-existing values
+  // Stash and restore any pre-existing values. Derived from the Set itself
+  // so adding a new filtered var never requires a parallel edit here.
   let saved = {};
-  const TEST_VARS = ["SETUP_TOKEN", "CLAUDECODE", "TMUX", "TMUX_PANE", "TMUX_TMPDIR"];
+  const TEST_VARS = [...SENSITIVE_ENV_VARS];
 
   beforeEach(() => {
     saved = {};
@@ -88,14 +89,21 @@ describe("getSafeEnv", () => {
     assert.ok(!("CLAUDECODE" in env));
   });
 
-  it("filters TMUX, TMUX_PANE, TMUX_TMPDIR so outer-tmux state does not leak into spawned panes", () => {
+  // Without this filter, outer-tmux values leak into the /bin/sh wrapper
+  // that tmuxNewSession emits and clobber the inner tmux's own
+  // TMUX_PANE assignment — breaking MC1f pane-to-session matching.
+  it("filters TMUX from the returned environment", () => {
     process.env.TMUX = "/private/tmp/tmux-501/default,11509,1";
-    process.env.TMUX_PANE = "%1";
-    process.env.TMUX_TMPDIR = "/private/tmp";
+    assert.ok(!("TMUX" in getSafeEnv()));
+  });
 
-    const env = getSafeEnv();
-    assert.ok(!("TMUX" in env), "TMUX must not leak (outer tmux server address)");
-    assert.ok(!("TMUX_PANE" in env), "TMUX_PANE must not leak (breaks pane-to-session matching)");
-    assert.ok(!("TMUX_TMPDIR" in env), "TMUX_TMPDIR must not leak");
+  it("filters TMUX_PANE from the returned environment", () => {
+    process.env.TMUX_PANE = "%1";
+    assert.ok(!("TMUX_PANE" in getSafeEnv()));
+  });
+
+  it("filters TMUX_TMPDIR from the returned environment", () => {
+    process.env.TMUX_TMPDIR = "/private/tmp";
+    assert.ok(!("TMUX_TMPDIR" in getSafeEnv()));
   });
 });

--- a/test/env-filter.test.js
+++ b/test/env-filter.test.js
@@ -10,12 +10,18 @@ describe("SENSITIVE_ENV_VARS", () => {
   it("contains CLAUDECODE", () => {
     assert.ok(SENSITIVE_ENV_VARS.has("CLAUDECODE"));
   });
+
+  it("contains TMUX, TMUX_PANE, TMUX_TMPDIR", () => {
+    assert.ok(SENSITIVE_ENV_VARS.has("TMUX"));
+    assert.ok(SENSITIVE_ENV_VARS.has("TMUX_PANE"));
+    assert.ok(SENSITIVE_ENV_VARS.has("TMUX_TMPDIR"));
+  });
 });
 
 describe("getSafeEnv", () => {
   // Stash and restore any pre-existing values
   let saved = {};
-  const TEST_VARS = ["SETUP_TOKEN", "CLAUDECODE"];
+  const TEST_VARS = ["SETUP_TOKEN", "CLAUDECODE", "TMUX", "TMUX_PANE", "TMUX_TMPDIR"];
 
   beforeEach(() => {
     saved = {};
@@ -80,5 +86,16 @@ describe("getSafeEnv", () => {
     const env = getSafeEnv();
     assert.ok(!("SETUP_TOKEN" in env));
     assert.ok(!("CLAUDECODE" in env));
+  });
+
+  it("filters TMUX, TMUX_PANE, TMUX_TMPDIR so outer-tmux state does not leak into spawned panes", () => {
+    process.env.TMUX = "/private/tmp/tmux-501/default,11509,1";
+    process.env.TMUX_PANE = "%1";
+    process.env.TMUX_TMPDIR = "/private/tmp";
+
+    const env = getSafeEnv();
+    assert.ok(!("TMUX" in env), "TMUX must not leak (outer tmux server address)");
+    assert.ok(!("TMUX_PANE" in env), "TMUX_PANE must not leak (breaks pane-to-session matching)");
+    assert.ok(!("TMUX_TMPDIR" in env), "TMUX_TMPDIR must not leak");
   });
 });


### PR DESCRIPTION
## Summary

- Add `TMUX`, `TMUX_PANE`, `TMUX_TMPDIR` to `SENSITIVE_ENV_VARS` so they're stripped from `getSafeEnv()`.
- Fixes MC1f pane-to-session matching: when katulong runs inside an outer tmux (SSH + tmux, or `katulong-stage` launched from a tmux window), the outer tmux's env vars leaked through our wrapper's `export` line and clobbered the inner tmux's assignments. The shell then saw `\$TMUX_PANE` from the outer pane while the server captured the inner pane.
- Downstream effect: hook payloads stamped `_tmuxPane=%1` but the server indexed `%0`, so `applyClaudeMetaFromHook` always no-opped — `session.meta.claude` was never set, and the Claude-aware sidebar button always fell back to the topic picker.

## Test plan

- [x] `npm run test:unit` (2285 tests pass, 3 pre-existing skips)
- [x] New test asserts `TMUX` / `TMUX_PANE` / `TMUX_TMPDIR` are filtered
- [ ] Manual: restart staging from inside a tmux window, launch claude in a browser terminal, confirm `session.meta.claude.uuid` populates on SessionStart