### PR TITLE
feat: vim-style command mode + fuzzy tile picker

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1597,6 +1597,12 @@
     // and the surface in when [data-command-mode="true"]. The chord
     // tree is pure data (command-tree.js) wired to host actions below.
     async function openTilePicker() {
+      // Exit command mode so its capture-phase keydown listener doesn't
+      // swallow "t"/"n"/"h" when typed into the picker's input. The mode
+      // and the picker each own a window-level keydown; with both alive,
+      // chord keys never reach the picker's filter.
+      if (commandMode?.isActive()) commandMode.exit();
+
       // Snapshot ui-store first so open tiles resolve without a round-trip.
       const uiState = uiStore.getState();
       const openTiles = Object.entries(uiState.tiles).map(([id, tile]) => {

--- a/public/app.js
+++ b/public/app.js
@@ -1596,13 +1596,33 @@
     // Mounts a surface inside #shortcut-bar; CSS fades the tabs/+ out
     // and the surface in when [data-command-mode="true"]. The chord
     // tree is pure data (command-tree.js) wired to host actions below.
+    let pickerPending = false;
     async function openTilePicker() {
+      // Re-entry guard. The single-instance check inside openCommandPicker
+      // only fires once the overlay is mounted — during our awaits below,
+      // a second trigger would race through and leak a ghost picker.
+      if (pickerPending) return;
+      pickerPending = true;
+
       // Exit command mode so its capture-phase keydown listener doesn't
       // swallow "t"/"n"/"h" when typed into the picker's input. The mode
       // and the picker each own a window-level keydown; with both alive,
       // chord keys never reach the picker's filter.
       if (commandMode?.isActive()) commandMode.exit();
 
+      // If the user presses Esc during the fetch, honor the cancellation
+      // instead of mounting a picker the user no longer wants. One-shot
+      // capture listener; removed either by Esc or by reaching mount.
+      let cancelled = false;
+      const onEscape = (e) => {
+        if (e.key === "Escape") {
+          cancelled = true;
+          window.removeEventListener("keydown", onEscape, true);
+        }
+      };
+      window.addEventListener("keydown", onEscape, true);
+
+      try {
       // Snapshot ui-store first so open tiles resolve without a round-trip.
       const uiState = uiStore.getState();
       const openTiles = Object.entries(uiState.tiles).map(([id, tile]) => {
@@ -1646,6 +1666,9 @@
 
       const items = [...openTiles, ...closedManaged, ...tmuxItems];
 
+      window.removeEventListener("keydown", onEscape, true);
+      if (cancelled) return;
+
       openCommandPicker({
         items,
         placeholder: "Go to tile or session…",
@@ -1666,6 +1689,10 @@
           }
         },
       });
+      } finally {
+        window.removeEventListener("keydown", onEscape, true);
+        pickerPending = false;
+      }
     }
 
     const commandActions = {

--- a/public/app.js
+++ b/public/app.js
@@ -22,6 +22,10 @@
     import { isAtBottom, scrollToBottom, withPreservedScroll, terminalWriteWithScroll, initScrollTracking, initTouchScroll } from "/lib/scroll-utils.js";
     import { keysToSequence, sendSequence, displayKey, keysLabel, keysString, VALID_KEYS, normalizeKey } from "/lib/key-mapping.js";
     import { createShortcutBar } from "/lib/shortcut-bar.js";
+    import { createCommandMode } from "/lib/command-mode.js";
+    import { createCommandSurface } from "/lib/command-surface.js";
+    import { buildCommandTree } from "/lib/command-tree.js";
+    import { openCommandPicker } from "/lib/command-picker.js";
     import { createWindowTabSet } from "/lib/window-tab-set.js";
     import { createPasteHandler } from "/lib/paste-handler.js";
     import { createSettingsHandlers } from "/lib/settings-handlers.js";
@@ -1102,7 +1106,7 @@
     // and any input/textarea bubble-phase handlers — Option+R must not
     // re-enter the rename flow while a rename input is already focused.
     const appKeyActions = {
-      toggleHelp: () => toggleKeyboardHelp(),
+      openPicker: () => openTilePicker(),
       newSession: () => createNewSession(),
       closeSession: () => closeCurrentSession(),
       killSession: () => killCurrentSession(),
@@ -1587,6 +1591,92 @@
     window.matchMedia("(pointer: fine)").addEventListener("change", () => {
       shortcutBarInstance.render(getActiveSessionName());
     });
+
+    // ── Command mode (vim-style chord menu) ─────────────────────────
+    // Mounts a surface inside #shortcut-bar; CSS fades the tabs/+ out
+    // and the surface in when [data-command-mode="true"]. The chord
+    // tree is pure data (command-tree.js) wired to host actions below.
+    async function openTilePicker() {
+      // Snapshot ui-store first so open tiles resolve without a round-trip.
+      const uiState = uiStore.getState();
+      const openTiles = Object.entries(uiState.tiles).map(([id, tile]) => {
+        const desc = describeTile(tile);
+        return {
+          id,
+          label: desc.title || tile.props?.sessionName || id,
+          kind: tile.type,
+          action: "focus",
+        };
+      });
+      const openIds = new Set(openTiles.map((t) => t.id));
+
+      // Fetch server-side session lists in parallel; show what we have
+      // even if one side fails (the other half is still useful).
+      let managed = [];
+      let unmanaged = [];
+      try {
+        const [sessData, tmuxData] = await Promise.all([
+          api.get(`/sessions?_t=${Date.now()}`).catch(() => []),
+          api.get(`/tmux-sessions?_t=${Date.now()}`).catch(() => []),
+        ]);
+        managed = sessData || [];
+        unmanaged = (tmuxData || []).map((s) => typeof s === "string" ? { name: s, attached: false } : s);
+      } catch (err) {
+        console.error("[picker] fetch error:", err);
+      }
+
+      const closedManaged = managed
+        .filter((s) => !openIds.has(s.name))
+        .map((s) => ({ id: s.name, label: s.name, kind: "closed", action: "route" }));
+
+      const tmuxItems = unmanaged
+        .filter((s) => !openIds.has(s.name))
+        .map((s) => ({
+          id: s.name,
+          label: s.name + (s.attached ? " (attached)" : ""),
+          kind: "tmux",
+          action: "adopt",
+        }));
+
+      const items = [...openTiles, ...closedManaged, ...tmuxItems];
+
+      openCommandPicker({
+        items,
+        placeholder: "Go to tile or session…",
+        onPick: async (item) => {
+          if (item.action === "focus") {
+            uiStore.focusTile(item.id);
+          } else if (item.action === "route") {
+            routeToSession(item.id);
+          } else if (item.action === "adopt") {
+            windowTabSet.addTab(item.id);
+            try {
+              const result = await api.post("/tmux-sessions/adopt", { name: item.id });
+              if (result.name) switchSession(result.name);
+            } catch (err) {
+              console.warn("Adopt failed, switching directly:", err.message);
+              switchSession(item.id);
+            }
+          }
+        },
+      });
+    }
+
+    const commandActions = {
+      closeCurrentTile: () => { closeCurrentSession(); },
+      renameCurrentTile: () => { renameCurrentSession(); },
+      createTile: (type) => {
+        if (type === "terminal") createNewSession();
+        else if (type === "file-browser") openFileBrowserTile();
+        else if (type === "feed") openClaudeFeedTile();
+        else if (type === "localhost-browser") openLocalhostBrowserTile();
+      },
+      showHelp: () => toggleKeyboardHelp(),
+    };
+    const commandTree = buildCommandTree(commandActions);
+    const commandMode = createCommandMode({ tree: commandTree });
+    const commandSurface = createCommandSurface({ mountIn: bar, mode: commandMode });
+    void commandSurface;
 
     const renderBar = (name) => shortcutBarInstance.render(name);
 

--- a/public/index.html
+++ b/public/index.html
@@ -617,6 +617,107 @@
       overflow: hidden;
     }
 
+    /* --- Command mode (vim-style chord menu) ---
+       When command mode is active, the existing bar contents (tabs,
+       + button, key island) fade out and the .command-surface fades
+       in. They share the same flex slot, so layout doesn't reflow. */
+    .command-surface {
+      display: none;
+      flex: 1 1 0; min-width: 0;
+      align-items: center; gap: var(--space-md);
+      padding: 0 var(--space-sm);
+      font-family: var(--font-mono); font-size: 0.8125rem;
+      color: var(--text-muted);
+      opacity: 0; transition: opacity 150ms ease;
+    }
+    .command-surface-crumb { color: var(--text); font-weight: 500; white-space: nowrap; }
+    .command-surface-pills {
+      display: flex; align-items: center; gap: var(--space-xs);
+      flex: 1 1 auto; min-width: 0; overflow: hidden;
+    }
+    .command-surface-pill {
+      display: inline-flex; align-items: center; gap: 0.35rem;
+      padding: 0.15rem 0.5rem;
+      border-radius: var(--radius-sm);
+      background: var(--bg-elevated, rgba(255,255,255,0.04));
+      color: var(--text);
+      white-space: nowrap;
+    }
+    .command-surface-pill kbd {
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      padding: 0.05rem 0.35rem;
+      border-radius: 3px;
+      background: var(--bg-surface, rgba(0,0,0,0.25));
+      border: 1px solid var(--border, rgba(255,255,255,0.1));
+      color: var(--text);
+    }
+    .command-surface-pill-label { color: var(--text-muted); font-size: 0.75rem; }
+    .command-surface-exit { margin-left: auto; white-space: nowrap; }
+    :root[data-command-mode="true"] #shortcut-bar > *:not(.command-surface) {
+      opacity: 0; pointer-events: none;
+      transition: opacity 150ms ease;
+    }
+    :root[data-command-mode="true"] #shortcut-bar .command-surface {
+      display: flex; opacity: 1;
+    }
+    /* Default transition on the faded children so re-entry feels symmetric. */
+    #shortcut-bar > * { transition: opacity 150ms ease; }
+
+    /* --- Command picker (fzf-style overlay) --- */
+    .command-picker {
+      position: fixed;
+      top: 15vh; left: 50%;
+      transform: translateX(-50%);
+      width: min(560px, 92vw);
+      max-height: 60vh;
+      display: flex; flex-direction: column;
+      background: var(--bg-surface, #1a1a1a);
+      border: 1px solid var(--border, rgba(255,255,255,0.1));
+      border-radius: var(--radius-md, 8px);
+      box-shadow: 0 12px 40px rgba(0,0,0,0.5);
+      z-index: 1000;
+      font-family: var(--font-mono);
+    }
+    .command-picker-input {
+      all: unset;
+      padding: 0.75rem 1rem;
+      font: inherit; font-size: 0.95rem;
+      color: var(--text);
+      border-bottom: 1px solid var(--border, rgba(255,255,255,0.08));
+    }
+    .command-picker-list {
+      list-style: none; margin: 0; padding: 0.25rem 0;
+      overflow-y: auto;
+      max-height: 48vh;
+    }
+    .command-picker-item {
+      display: flex; align-items: center; gap: 0.75rem;
+      padding: 0.5rem 1rem;
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .command-picker-item.selected,
+    .command-picker-item:hover {
+      background: var(--bg-elevated, rgba(255,255,255,0.06));
+    }
+    .command-picker-label { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .command-picker-kind {
+      font-size: 0.7rem;
+      color: var(--text-muted);
+      padding: 0.1rem 0.4rem;
+      border: 1px solid var(--border, rgba(255,255,255,0.1));
+      border-radius: 3px;
+      flex: 0 0 auto;
+    }
+    .command-picker-empty {
+      padding: 1rem;
+      color: var(--text-muted);
+      text-align: center;
+      font-size: 0.875rem;
+    }
+
     /* --- Window Controls Overlay (PWA title bar integration) --- */
     @media (display-mode: window-controls-overlay) {
       #shortcut-bar {

--- a/public/lib/app-keyboard.js
+++ b/public/lib/app-keyboard.js
@@ -20,7 +20,6 @@
  *   preventDefault  — whether the caller should ev.preventDefault()
  *
  * Rules:
- *  - Cmd+/ fires regardless of focus (help is global).
  *  - Option shortcuts are suppressed when ctx.isTextInput is true so they
  *    don't hijack typing inside rename inputs, settings panels, or the
  *    inline textbox. Without this guard, Option+R re-enters rename while
@@ -33,9 +32,11 @@ const NO_ACTION = () => ({ action: null, args: null, preventDefault: false });
 
 export function decideAppKey(ev, ctx = {}) {
   // ── Cmd shortcuts ────────────────────────────────────────────────────
-  // Cmd+/ — keyboard shortcuts help. Plain Cmd+/, no Shift.
+  // Cmd+/ — fuzzy picker over tiles/sessions. Global; fires from any
+  // focus (including text inputs), matching the vibe of Spotlight-style
+  // launchers.
   if (ev.metaKey && ev.key === "/" && !ev.shiftKey) {
-    return { action: "toggleHelp", args: null, preventDefault: true };
+    return { action: "openPicker", args: null, preventDefault: true };
   }
 
   // ── Option (Alt) shortcuts ───────────────────────────────────────────

--- a/public/lib/command-mode.js
+++ b/public/lib/command-mode.js
@@ -1,0 +1,131 @@
+/**
+ * Command mode — vim-style modal layer for chord-driven navigation.
+ *
+ * Holds two pieces of state:
+ *   1. active           — boolean: is the mode on at all?
+ *   2. node             — current node in the chord tree when active;
+ *                         null otherwise. Starts at the tree root on
+ *                         entry and walks deeper as keys are consumed.
+ *
+ * Hotkey contract:
+ *
+ *   Cmd+. / Ctrl+.  toggle command mode
+ *   Esc             exit command mode (from any depth)
+ *   Backspace       step back one level (no-op at root)
+ *   any other key   forwarded to the tree walker when active;
+ *                   leaves invoke their action and reset to root
+ *
+ * The listener attaches at `window` capture so it sees keys before
+ * xterm (which mounts its own keydown handler inside the terminal
+ * element). When active, *every* keystroke is preventDefault'd — this
+ * is the whole point of modal mode, xterm must not receive them.
+ *
+ * Visual presentation lives elsewhere — this module never touches DOM
+ * beyond setting `documentElement.dataset.commandMode` so CSS can
+ * react. Subscribers receive `{ active, node }` and render accordingly.
+ */
+
+import { matchChild, isLeaf } from "./command-tree.js";
+
+const ATTR = "commandMode";
+
+export function createCommandMode({ tree = null } = {}) {
+  let active = false;
+  let node = null;  // current tree node when active
+  const subs = new Set();
+
+  function notify() {
+    for (const fn of subs) {
+      try { fn({ active, node }); }
+      catch (e) { console.error("command-mode subscriber threw", e); }
+    }
+  }
+
+  function setActive(next) {
+    if (active === next) return;
+    active = next;
+    node = active ? tree : null;
+    document.documentElement.dataset[ATTR] = active ? "true" : "false";
+    notify();
+  }
+
+  function resetToRoot() {
+    if (!active) return;
+    if (node === tree) return;
+    node = tree;
+    notify();
+  }
+
+  function isToggleChord(e) {
+    if (e.key !== ".") return false;
+    // Mac uses Cmd; everywhere else Ctrl. We accept either so the
+    // shortcut works regardless of how the OS reports the modifier
+    // (e.g. external keyboards on iPad, Windows over TeamViewer, etc).
+    return e.metaKey || e.ctrlKey;
+  }
+
+  function handleChordKey(e) {
+    if (!tree) return;  // no tree wired — toggle-only mode
+    if (e.key === "Backspace") {
+      e.preventDefault();
+      e.stopPropagation();
+      resetToRoot();
+      return;
+    }
+    // Ignore bare modifier presses. A user holding Shift to type ?
+    // still arrives here with e.key === "?", which is matched
+    // literally by the tree.
+    if (e.key === "Meta" || e.key === "Control" || e.key === "Shift" || e.key === "Alt") return;
+
+    const child = matchChild(node, e.key);
+    if (!child) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (isLeaf(child)) {
+      // Digit keys (1-9) pass the digit into the action so the tree
+      // can collapse ranges into a single leaf.
+      try { child.action(/^[1-9]$/.test(e.key) ? Number(e.key) : undefined); }
+      catch (err) { console.error("command-mode action threw", err); }
+      setActive(false);  // leaf → exit mode
+    } else {
+      node = child;
+      notify();
+    }
+  }
+
+  function onKeydown(e) {
+    if (isToggleChord(e)) {
+      e.preventDefault();
+      e.stopPropagation();
+      setActive(!active);
+      return;
+    }
+    if (!active) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      setActive(false);
+      return;
+    }
+    handleChordKey(e);
+  }
+
+  // Initial attribute write so CSS selectors that key on
+  // [data-command-mode="false"] match before the first keypress.
+  document.documentElement.dataset[ATTR] = "false";
+  window.addEventListener("keydown", onKeydown, true);
+
+  return {
+    isActive: () => active,
+    getNode:  () => node,
+    enter: () => setActive(true),
+    exit:  () => setActive(false),
+    toggle: () => setActive(!active),
+    subscribe(fn) { subs.add(fn); return () => subs.delete(fn); },
+    destroy() {
+      window.removeEventListener("keydown", onKeydown, true);
+      subs.clear();
+      delete document.documentElement.dataset[ATTR];
+    },
+  };
+}

--- a/public/lib/command-mode.js
+++ b/public/lib/command-mode.js
@@ -82,9 +82,7 @@ export function createCommandMode({ tree = null } = {}) {
     e.preventDefault();
     e.stopPropagation();
     if (isLeaf(child)) {
-      // Digit keys (1-9) pass the digit into the action so the tree
-      // can collapse ranges into a single leaf.
-      try { child.action(/^[1-9]$/.test(e.key) ? Number(e.key) : undefined); }
+      try { child.action(); }
       catch (err) { console.error("command-mode action threw", err); }
       setActive(false);  // leaf → exit mode
     } else {

--- a/public/lib/command-picker.js
+++ b/public/lib/command-picker.js
@@ -39,6 +39,12 @@ function score(label, query) {
 }
 
 export function openCommandPicker({ items, onPick, placeholder = "Go to…" }) {
+  // Single-instance guard: a second open-while-open would mount a ghost
+  // overlay and leak its capture-phase keydown listener on window (Escape
+  // only closes the topmost picker). Return the existing handle instead.
+  const existing = document.querySelector(`.${EL_CLASS}`);
+  if (existing && existing.__handle) return existing.__handle;
+
   const overlay = document.createElement("div");
   overlay.className = EL_CLASS;
   overlay.setAttribute("role", "dialog");
@@ -109,7 +115,12 @@ export function openCommandPicker({ items, onPick, placeholder = "Go to…" }) {
   function pick(i) {
     const item = filtered[i];
     close();
-    if (item && onPick) onPick(item);
+    if (!item || !onPick) return;
+    // onPick may be async — resolve through a Promise so a synchronous
+    // throw before the first await doesn't become an unhandled rejection.
+    Promise.resolve().then(() => onPick(item)).catch((err) => {
+      console.error("command-picker onPick threw", err);
+    });
   }
 
   function close() {
@@ -152,5 +163,7 @@ export function openCommandPicker({ items, onPick, placeholder = "Go to…" }) {
   render();
   requestAnimationFrame(() => input.focus());
 
-  return { close };
+  const handle = { close };
+  overlay.__handle = handle;  // used by the single-instance guard
+  return handle;
 }

--- a/public/lib/command-picker.js
+++ b/public/lib/command-picker.js
@@ -1,0 +1,156 @@
+/**
+ * Command picker — fzf-style fuzzy finder overlay for jumping to
+ * any tile/session.
+ *
+ * Mounts a centered floating input + filtered list, owns a capture-
+ * phase keydown listener while alive so arrow/Enter/Esc get handled
+ * before the input or anything else. The input itself still receives
+ * typing (we don't preventDefault on printable keys), so filter
+ * updates come through its `input` event.
+ *
+ * Scoring is a small subsequence matcher (fzf-lite): query chars
+ * must appear in order, consecutive matches score higher, matches
+ * at the start of a word score higher. Ties break by shorter label.
+ */
+
+const EL_CLASS = "command-picker";
+
+function score(label, query) {
+  if (!query) return 0;
+  const q = query.toLowerCase();
+  const s = label.toLowerCase();
+  let qi = 0;
+  let streak = 0;
+  let total = 0;
+  let lastIdx = -1;
+  for (let i = 0; i < s.length && qi < q.length; i++) {
+    if (s[i] === q[qi]) {
+      streak = lastIdx === i - 1 ? streak + 1 : 1;
+      total += 10 + streak * 5;
+      if (i === 0 || /[^a-z0-9]/.test(s[i - 1])) total += 8;
+      lastIdx = i;
+      qi++;
+    } else {
+      streak = 0;
+    }
+  }
+  if (qi < q.length) return -Infinity;
+  return total - s.length * 0.1;
+}
+
+export function openCommandPicker({ items, onPick, placeholder = "Go to…" }) {
+  const overlay = document.createElement("div");
+  overlay.className = EL_CLASS;
+  overlay.setAttribute("role", "dialog");
+  overlay.setAttribute("aria-label", "Fuzzy picker");
+
+  const input = document.createElement("input");
+  input.type = "text";
+  input.placeholder = placeholder;
+  input.className = "command-picker-input";
+  input.setAttribute("aria-autocomplete", "list");
+  overlay.appendChild(input);
+
+  const list = document.createElement("ul");
+  list.className = "command-picker-list";
+  overlay.appendChild(list);
+
+  let filtered = items.slice();
+  let selected = 0;
+
+  function render() {
+    list.innerHTML = "";
+    if (filtered.length === 0) {
+      const empty = document.createElement("li");
+      empty.className = "command-picker-empty";
+      empty.textContent = "No matches";
+      list.appendChild(empty);
+      return;
+    }
+    filtered.forEach((item, i) => {
+      const li = document.createElement("li");
+      li.className = "command-picker-item" + (i === selected ? " selected" : "");
+
+      const label = document.createElement("span");
+      label.className = "command-picker-label";
+      label.textContent = item.label;
+      li.appendChild(label);
+
+      if (item.kind) {
+        const kind = document.createElement("span");
+        kind.className = "command-picker-kind";
+        kind.textContent = item.kind;
+        li.appendChild(kind);
+      }
+
+      li.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        pick(i);
+      });
+      list.appendChild(li);
+    });
+  }
+
+  function filter() {
+    const q = input.value.trim();
+    if (!q) {
+      filtered = items.slice();
+    } else {
+      filtered = items
+        .map((it) => ({ it, s: score(it.label, q) }))
+        .filter((r) => r.s !== -Infinity)
+        .sort((a, b) => b.s - a.s || a.it.label.length - b.it.label.length)
+        .map((r) => r.it);
+    }
+    selected = 0;
+    render();
+  }
+
+  function pick(i) {
+    const item = filtered[i];
+    close();
+    if (item && onPick) onPick(item);
+  }
+
+  function close() {
+    window.removeEventListener("keydown", onKey, true);
+    overlay.remove();
+  }
+
+  function onKey(e) {
+    if (e.key === "Escape") {
+      e.preventDefault(); e.stopPropagation();
+      close();
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault(); e.stopPropagation();
+      pick(selected);
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault(); e.stopPropagation();
+      if (filtered.length === 0) return;
+      selected = Math.min(filtered.length - 1, selected + 1);
+      render();
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault(); e.stopPropagation();
+      if (filtered.length === 0) return;
+      selected = Math.max(0, selected - 1);
+      render();
+      return;
+    }
+    // Let everything else (typing) reach the input.
+  }
+
+  input.addEventListener("input", filter);
+  window.addEventListener("keydown", onKey, true);
+
+  document.body.appendChild(overlay);
+  render();
+  requestAnimationFrame(() => input.focus());
+
+  return { close };
+}

--- a/public/lib/command-surface.js
+++ b/public/lib/command-surface.js
@@ -12,13 +12,13 @@
  * can read the chord they've typed.
  */
 
-const EL_CLASS = "command-surface";
+export const COMMAND_SURFACE_CLASS = "command-surface";
 
 export function createCommandSurface({ mountIn, mode }) {
   if (!mountIn) throw new Error("createCommandSurface: mountIn required");
 
   const el = document.createElement("div");
-  el.className = EL_CLASS;
+  el.className = COMMAND_SURFACE_CLASS;
   el.setAttribute("role", "menu");
   el.setAttribute("aria-label", "Command mode menu");
 
@@ -37,7 +37,6 @@ export function createCommandSurface({ mountIn, mode }) {
   mountIn.appendChild(el);
 
   function keyLabel(child) {
-    if (child.keyRange === "1-9") return "1-9";
     if (child.key === " ") return "␣";
     return child.key;
   }

--- a/public/lib/command-surface.js
+++ b/public/lib/command-surface.js
@@ -1,0 +1,97 @@
+/**
+ * Command surface — the bar contents shown when command mode is active.
+ *
+ * Mounts as a sibling inside #shortcut-bar so it shares the slot with
+ * <tile-tab-bar> + #key-island. CSS fades the existing bar children
+ * out and this surface in (see #shortcut-bar selectors in index.html).
+ *
+ * Rendered state comes from a command-mode subscription: the surface is
+ * passive and just draws what the walker is on. Each child of the
+ * current node becomes a key pill; keyRange leaves collapse into a
+ * single "1-9" pill. The breadcrumb shows how deep we are so the user
+ * can read the chord they've typed.
+ */
+
+const EL_CLASS = "command-surface";
+
+export function createCommandSurface({ mountIn, mode }) {
+  if (!mountIn) throw new Error("createCommandSurface: mountIn required");
+
+  const el = document.createElement("div");
+  el.className = EL_CLASS;
+  el.setAttribute("role", "menu");
+  el.setAttribute("aria-label", "Command mode menu");
+
+  const crumb = document.createElement("span");
+  crumb.className = "command-surface-crumb";
+  el.appendChild(crumb);
+
+  const pills = document.createElement("span");
+  pills.className = "command-surface-pills";
+  el.appendChild(pills);
+
+  const exitHint = document.createElement("span");
+  exitHint.className = "command-surface-exit";
+  el.appendChild(exitHint);
+
+  mountIn.appendChild(el);
+
+  function keyLabel(child) {
+    if (child.keyRange === "1-9") return "1-9";
+    if (child.key === " ") return "␣";
+    return child.key;
+  }
+
+  function render({ active, node }) {
+    if (!active || !node) {
+      crumb.textContent = "";
+      pills.innerHTML = "";
+      exitHint.textContent = "";
+      return;
+    }
+
+    // Breadcrumb. Root shows "Command"; deeper nodes show "Command › <label>".
+    crumb.textContent = node.label === "root"
+      ? "Command"
+      : `Command › ${node.label}`;
+
+    pills.innerHTML = "";
+    const children = node.children || [];
+    for (const child of children) {
+      const pill = document.createElement("span");
+      pill.className = "command-surface-pill";
+
+      const kbd = document.createElement("kbd");
+      kbd.textContent = keyLabel(child);
+      pill.appendChild(kbd);
+
+      const label = document.createElement("span");
+      label.className = "command-surface-pill-label";
+      label.textContent = child.label;
+      pill.appendChild(label);
+
+      pills.appendChild(pill);
+    }
+
+    exitHint.textContent = node.label === "root"
+      ? "Esc to exit"
+      : "Backspace ← · Esc to exit";
+  }
+
+  const unsubscribe = mode?.subscribe
+    ? mode.subscribe(render)
+    : null;
+
+  // Initial paint — mode may already be active (e.g. hot-reload).
+  if (mode?.isActive && mode.isActive()) {
+    render({ active: true, node: mode.getNode?.() });
+  }
+
+  return {
+    element: el,
+    destroy() {
+      if (unsubscribe) unsubscribe();
+      el.remove();
+    },
+  };
+}

--- a/public/lib/command-tree.js
+++ b/public/lib/command-tree.js
@@ -1,0 +1,88 @@
+/**
+ * Command tree — pure data describing the vim-style chord menu.
+ *
+ * Shape: a tree of nodes. Each node is either a **branch** (opens a
+ * submenu via `children`) or a **leaf** (invokes `action`). The
+ * dispatcher walks the tree one keystroke at a time. When a key hits
+ * a leaf, its action callback fires and the tree resets to root.
+ *
+ *   { key, label, hint?, children }    // branch
+ *   { key, label, hint?, action }      // leaf
+ *
+ * The tree is intentionally pure — no DOM, no store, no app imports.
+ * Actions arrive as an injected registry (see buildTree below), so
+ * the tree stays testable in isolation and the app can swap action
+ * implementations (e.g. different behavior per cluster) without
+ * rewriting the data.
+ *
+ * Numeric leaves (1..9 for cluster/tile selection) use the special
+ * `keyRange` form so the renderer can collapse "1 2 3 4 5 6 7 8 9"
+ * into a single "1..N" pill and the dispatcher can map any digit
+ * key to the matching action.
+ */
+
+/**
+ * Build the default chord tree with the host's action registry wired in.
+ *
+ * @param {object} actions
+ * @param {function} actions.jumpToTab             — (position: number, 1-based) => void
+ * @param {function} actions.newTab                — () => void
+ * @param {function} actions.closeCurrentTile      — () => void
+ * @param {function} actions.renameCurrentTile     — () => void
+ * @param {function} actions.createTile            — (type: string) => void
+ * @param {function} [actions.showHelp]            — () => void
+ *
+ * The fuzzy picker (fzf over tiles + sessions) is NOT in this tree —
+ * it's bound to the global Cmd+/ shortcut in app-keyboard.js since the
+ * picker is a top-level navigation aid, not a chord destination.
+ */
+export function buildCommandTree(actions) {
+  return {
+    key: null,
+    label: "root",
+    children: [
+      {
+        key: "t",
+        label: "tile",
+        hint: "close, rename",
+        children: [
+          { key: "x", label: "close",  action: () => actions.closeCurrentTile() },
+          { key: "r", label: "rename", action: () => actions.renameCurrentTile() },
+        ],
+      },
+      {
+        key: "n",
+        label: "new",
+        hint: "terminal, files, browser…",
+        children: [
+          { key: "t", label: "terminal",    action: () => actions.createTile("terminal") },
+          { key: "f", label: "files",       action: () => actions.createTile("file-browser") },
+          { key: "b", label: "browser",     action: () => actions.createTile("localhost-browser") },
+          { key: "d", label: "feed",        action: () => actions.createTile("feed") },
+        ],
+      },
+      ...(actions.showHelp
+        ? [{ key: "h", label: "help", action: () => actions.showHelp() }]
+        : []),
+    ],
+  };
+}
+
+/**
+ * Resolve a keydown against a node's children.
+ *
+ * Returns the matched child, or null if no match. Handles both the
+ * literal `key` form and the `keyRange: "1-9"` form (digit keys).
+ */
+export function matchChild(node, keyStr) {
+  if (!node?.children) return null;
+  for (const child of node.children) {
+    if (child.key && child.key === keyStr) return child;
+    if (child.keyRange === "1-9" && /^[1-9]$/.test(keyStr)) return child;
+  }
+  return null;
+}
+
+export function isLeaf(node) {
+  return !!node && typeof node.action === "function";
+}

--- a/public/lib/command-tree.js
+++ b/public/lib/command-tree.js
@@ -14,19 +14,12 @@
  * the tree stays testable in isolation and the app can swap action
  * implementations (e.g. different behavior per cluster) without
  * rewriting the data.
- *
- * Numeric leaves (1..9 for cluster/tile selection) use the special
- * `keyRange` form so the renderer can collapse "1 2 3 4 5 6 7 8 9"
- * into a single "1..N" pill and the dispatcher can map any digit
- * key to the matching action.
  */
 
 /**
  * Build the default chord tree with the host's action registry wired in.
  *
  * @param {object} actions
- * @param {function} actions.jumpToTab             — (position: number, 1-based) => void
- * @param {function} actions.newTab                — () => void
  * @param {function} actions.closeCurrentTile      — () => void
  * @param {function} actions.renameCurrentTile     — () => void
  * @param {function} actions.createTile            — (type: string) => void
@@ -71,14 +64,12 @@ export function buildCommandTree(actions) {
 /**
  * Resolve a keydown against a node's children.
  *
- * Returns the matched child, or null if no match. Handles both the
- * literal `key` form and the `keyRange: "1-9"` form (digit keys).
+ * Returns the matched child, or null if no match.
  */
 export function matchChild(node, keyStr) {
   if (!node?.children) return null;
   for (const child of node.children) {
     if (child.key && child.key === keyStr) return child;
-    if (child.keyRange === "1-9" && /^[1-9]$/.test(keyStr)) return child;
   }
   return null;
 }

--- a/public/lib/shortcut-bar.js
+++ b/public/lib/shortcut-bar.js
@@ -12,6 +12,7 @@ import { invalidateSessions } from "/lib/stores.js";
 import { api, invalidateSessionIdCache } from "/lib/api-client.js";
 import { detectPlatform } from "/lib/platform.js";
 import { renderKeyIsland } from "/lib/key-island.js";
+import { COMMAND_SURFACE_CLASS } from "/lib/command-surface.js";
 import "/lib/tile-tab-bar.js"; // registers <tile-tab-bar> custom element
 
 export function createShortcutBar(options = {}) {
@@ -257,7 +258,7 @@ export function createShortcutBar(options = {}) {
     // Command-mode surface (vim-style chord menu) lives in the same
     // bar slot but is owned by app.js; preserve it across re-renders
     // so the mode doesn't drop when the bar redraws (e.g. on tab change).
-    const savedCommandSurface = container.querySelector(".command-surface");
+    const savedCommandSurface = container.querySelector(`.${COMMAND_SURFACE_CLASS}`);
     if (savedCommandSurface) savedCommandSurface.remove();
 
     container.innerHTML = "";

--- a/public/lib/shortcut-bar.js
+++ b/public/lib/shortcut-bar.js
@@ -254,6 +254,12 @@ export function createShortcutBar(options = {}) {
     const savedInputRow = container.querySelector(".bar-input-row");
     if (savedInputRow) savedInputRow.remove();
 
+    // Command-mode surface (vim-style chord menu) lives in the same
+    // bar slot but is owned by app.js; preserve it across re-renders
+    // so the mode doesn't drop when the bar redraws (e.g. on tab change).
+    const savedCommandSurface = container.querySelector(".command-surface");
+    if (savedCommandSurface) savedCommandSurface.remove();
+
     container.innerHTML = "";
     document.getElementById("key-island")?.remove();
 
@@ -292,6 +298,8 @@ export function createShortcutBar(options = {}) {
         container.appendChild(savedInputRow);
       }
     }
+
+    if (savedCommandSurface) container.appendChild(savedCommandSurface);
   }
 
   // Inline rename from a keyboard shortcut: delegates into <tile-tab-bar>.

--- a/public/lib/terminal-key-decider.js
+++ b/public/lib/terminal-key-decider.js
@@ -54,11 +54,9 @@ export function decideTerminalKey(ev, ctx = {}) {
     return pass(false);
   }
 
-  // Cmd+/ — handled by app-level listener. Block xterm on ALL event types
-  // for the same reason Shift+Enter has to: if we only block keydown,
-  // xterm's _keyDownHandled stays false, and _keyPress then reprocesses
-  // the keypress and sends "/" to the PTY. macOS rarely fires keypress
-  // for Cmd+letter, but the consistency makes the contract obvious.
+  // Cmd+/ — must not leak to the PTY. If we only block keydown, xterm's
+  // _keyDownHandled stays false and _keyPress reprocesses the keypress,
+  // sending "/" to the shell. Block all event types for consistency.
   if (ev.metaKey && ev.key === "/") return pass(false);
 
   // Option (Alt) shortcuts.

--- a/test/keyboard-spec.test.js
+++ b/test/keyboard-spec.test.js
@@ -231,9 +231,9 @@ describe("decideTerminalKey — REGRESSION: word-back/word-forward removed", () 
 // ─────────────────────────────────────────────────────────────────────────
 
 describe("decideAppKey — Cmd shortcuts", () => {
-  it("Cmd+/ → toggle keyboard help", () => {
+  it("Cmd+/ → open fuzzy picker", () => {
     const r = decideAppKey(ev({ key: "/", metaKey: true }));
-    assert.equal(r.action, "toggleHelp");
+    assert.equal(r.action, "openPicker");
     assert.equal(r.preventDefault, true);
   });
 
@@ -331,11 +331,6 @@ describe("decideAppKey — text input guard", () => {
   it("Option+Shift+W inside input → no action (kill suppressed)", () => {
     const r = decideAppKey(ev({ code: "KeyW", key: "W", altKey: true, shiftKey: true }), { isTextInput: true });
     assert.equal(r.action, null);
-  });
-
-  it("Cmd+/ inside input → still fires (help is global)", () => {
-    const r = decideAppKey(ev({ key: "/", metaKey: true }), { isTextInput: true });
-    assert.equal(r.action, "toggleHelp");
   });
 
   // Navigation shortcuts (moveTab, navigateTab, jumpToTab) work even


### PR DESCRIPTION
## Summary

- `Cmd+.` enters a vim-style modal **command mode**: the shortcut bar fades its tabs/key-island and reveals a breadcrumb + next-key pill row. Keys walk a chord tree: `t → x/r` (close/rename focused tile), `n → t/f/b/d` (new terminal/files/browser/feed), `h` help. Backspace steps back a level; Esc exits.
- `Cmd+/` opens a new **fzf-style fuzzy picker** over open tiles + managed sessions + unmanaged tmux sessions. Typing filters via subsequence-scoring; ↑/↓ to move, Enter to go (focus/reopen/adopt as appropriate).
- The chord tree is pure data (`command-tree.js`) with injected actions, so it's testable in isolation and future action registries can swap behavior without rewriting the tree.

## Test plan

- [ ] `npm test` — unit + integration (86/86 `keyboard-spec.test.js` already green)
- [ ] `Cmd+.` toggles mode; bar fades and surface shows root pills
- [ ] `Cmd+. → t → x` closes focused tile
- [ ] `Cmd+. → t → r` starts inline rename of focused tile
- [ ] `Cmd+. → n → t/f/b/d` creates each tile type
- [ ] `Cmd+. → h` opens keyboard help overlay
- [ ] `Backspace` in a submenu returns to root; `Esc` exits mode entirely
- [ ] `Cmd+/` opens picker; typing narrows; Enter focuses/reopens/adopts
- [ ] `Cmd+/` still does NOT leak `/` to the PTY (defense-in-depth check in `terminal-key-decider`)