### PR TITLE
Contextual joystick slot — hide feed button when no tile context

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -762,7 +762,7 @@
 
     // Wire Files + Upload + Settings into the joystick floating buttons.
     // The contextual slot (feed/topic icon) is driven separately via
-    // `joystickManager.setContext()` in syncContextualFeedIcon below.
+    // `joystickManager.setContext()` in syncJoystickContext below.
     joystickManager.setActions({
       onFilesClick: () => openFileBrowserTile(),
       onUploadClick: () => triggerImageUpload(),
@@ -786,14 +786,7 @@
 
     function detectTileContext(session) {
       if (!session) return null;
-      const match = TILE_CONTEXTS.find((c) => c.test(session));
-      if (!match) return null;
-      return {
-        icon: match.icon,
-        label: match.label,
-        className: match.className,
-        action: match.action,
-      };
+      return TILE_CONTEXTS.find((c) => c.test(session)) || null;
     }
 
     // Joystick (floating action buttons) is always visible — same
@@ -1621,10 +1614,11 @@
     // Reflect the active tile's detected context onto the joystick's
     // contextual slot. The server flips `meta.claude.running` from tmux's
     // `pane_current_command` poll and `meta.claude.uuid` from the
-    // SessionStart hook, so this fires on both the periodic
-    // `session-updated` broadcast and active-tile switches. When no
+    // SessionStart hook. Wired below to both sessionStore (server pushes
+    // every ~5s) and uiStore (active-tile switches), so the icon never
+    // lags by more than one broadcast interval or one tap. When no
     // context matches, the button is hidden entirely.
-    function syncContextualFeedIcon() {
+    function syncJoystickContext() {
       const { sessions } = sessionStore.getState();
       if (!sessions) return;
       const activeName = getActiveSessionName();
@@ -1643,13 +1637,13 @@
           iconStore.removeIcon(s.name);
         }
       }
-      syncContextualFeedIcon();
+      syncJoystickContext();
     });
 
     // Active tile changes (e.g. user switches sessions) need an immediate
     // refresh of the joystick presence indicator — waiting for the next
     // sessionStore push would leave a stale icon for up to 5s.
-    uiStore.subscribe(syncContextualFeedIcon);
+    uiStore.subscribe(syncJoystickContext);
 
     // Subscribe to shortcuts changes to re-render bar
     shortcutsStore.subscribe(() => {

--- a/public/app.js
+++ b/public/app.js
@@ -760,13 +760,41 @@
     });
     joystickManager.init();
 
-    // Wire Files + Upload + Settings + Feed into the joystick floating buttons
+    // Wire Files + Upload + Settings into the joystick floating buttons.
+    // The contextual slot (feed/topic icon) is driven separately via
+    // `joystickManager.setContext()` in syncContextualFeedIcon below.
     joystickManager.setActions({
       onFilesClick: () => openFileBrowserTile(),
       onUploadClick: () => triggerImageUpload(),
       onSettingsClick: () => modals.open('settings'),
-      onFeedClick: () => openClaudeFeedTile(),
     });
+
+    // Context detection for the joystick's contextual slot. Each entry maps
+    // a tile signal to a button config. First match wins; no match hides
+    // the button. Adding a new context (e.g. `meta.node`, `meta.git`) is a
+    // single entry — no joystick or subscriber changes required.
+    const TILE_CONTEXTS = [
+      {
+        id: "claude",
+        test: (s) => !!(s?.meta?.claude?.uuid || s?.meta?.claude?.running),
+        icon: "sparkle",
+        label: "Claude feed",
+        className: "joystick-action-btn--claude",
+        action: () => openClaudeFeedTile(),
+      },
+    ];
+
+    function detectTileContext(session) {
+      if (!session) return null;
+      const match = TILE_CONTEXTS.find((c) => c.test(session));
+      if (!match) return null;
+      return {
+        icon: match.icon,
+        label: match.label,
+        className: match.className,
+        action: match.action,
+      };
+    }
 
     // Joystick (floating action buttons) is always visible — same
     // experience on iPad and desktop.
@@ -1590,16 +1618,18 @@
 
     const renderBar = (name) => shortcutBarInstance.render(name);
 
-    // Reflect the active tile's Claude-presence state onto the joystick
-    // feed button. The server flips `meta.claude.running` from tmux's
-    // `pane_current_command` poll, so this fires on both the periodic
-    // `session-updated` broadcast and active-tile switches.
-    function syncClaudePresenceIndicator() {
+    // Reflect the active tile's detected context onto the joystick's
+    // contextual slot. The server flips `meta.claude.running` from tmux's
+    // `pane_current_command` poll and `meta.claude.uuid` from the
+    // SessionStart hook, so this fires on both the periodic
+    // `session-updated` broadcast and active-tile switches. When no
+    // context matches, the button is hidden entirely.
+    function syncContextualFeedIcon() {
       const { sessions } = sessionStore.getState();
       if (!sessions) return;
       const activeName = getActiveSessionName();
       const active = activeName ? sessions.find((s) => s.name === activeName) : null;
-      joystickManager.setClaudeRunning(!!active?.meta?.claude?.running);
+      joystickManager.setContext(detectTileContext(active));
     }
 
     // Sync per-session icons from server session data
@@ -1613,13 +1643,13 @@
           iconStore.removeIcon(s.name);
         }
       }
-      syncClaudePresenceIndicator();
+      syncContextualFeedIcon();
     });
 
     // Active tile changes (e.g. user switches sessions) need an immediate
     // refresh of the joystick presence indicator — waiting for the next
     // sessionStore push would leave a stale icon for up to 5s.
-    uiStore.subscribe(syncClaudePresenceIndicator);
+    uiStore.subscribe(syncContextualFeedIcon);
 
     // Subscribe to shortcuts changes to re-render bar
     shortcutsStore.subscribe(() => {

--- a/public/lib/joystick.js
+++ b/public/lib/joystick.js
@@ -3,11 +3,13 @@
  *
  * Vertical stack of circular buttons floating in the terminal pane:
  * Files, Settings, and a connection indicator dot at the bottom.
- * Visible on touch devices only.
  *
- * The feed button adapts to Claude presence. When the active tile's session
- * has `meta.claude.running` set by the server's pane monitor, the icon and
- * label swap to signal "this opens a Claude feed for *this* session."
+ * The feed slot is contextual: it only renders when the active tile has a
+ * detected context (e.g. `meta.claude` set by the server's pane monitor or
+ * the SessionStart hook). When no context is active, the slot is hidden
+ * entirely — the button is not greyed out, it simply does not exist.
+ * Callers drive this via `setContext({ icon, label, className, action })`
+ * or `setContext(null)` to hide.
  */
 
 export function createJoystickManager(options = {}) {
@@ -16,8 +18,7 @@ export function createJoystickManager(options = {}) {
   let _onFilesClick = null;
   let _onUploadClick = null;
   let _onSettingsClick = null;
-  let _onFeedClick = null;
-  let _claudeRunning = false;
+  let _context = null;
   let dotEl = null;
 
   function buildButtons() {
@@ -40,11 +41,8 @@ export function createJoystickManager(options = {}) {
     if (_onFilesClick) {
       joystick.appendChild(actionBtn("folder-open", "Files", _onFilesClick));
     }
-    if (_onFeedClick) {
-      const icon = _claudeRunning ? "sparkle" : "rss";
-      const label = _claudeRunning ? "Claude feed" : "Feed";
-      const cls = _claudeRunning ? "joystick-action-btn--claude" : "";
-      joystick.appendChild(actionBtn(icon, label, _onFeedClick, cls));
+    if (_context) {
+      joystick.appendChild(actionBtn(_context.icon, _context.label, _context.action, _context.className || ""));
     }
     if (_onSettingsClick) {
       joystick.appendChild(actionBtn("gear", "Settings", _onSettingsClick));
@@ -57,31 +55,45 @@ export function createJoystickManager(options = {}) {
     joystick.appendChild(dotEl);
   }
 
+  function contextEquals(a, b) {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    return a.icon === b.icon && a.label === b.label && (a.className || "") === (b.className || "");
+  }
+
   return {
     init() {
       // No gesture handling needed — just buttons
     },
 
-    setActions({ onFilesClick, onUploadClick, onSettingsClick, onFeedClick }) {
+    setActions({ onFilesClick, onUploadClick, onSettingsClick }) {
       _onFilesClick = onFilesClick;
       _onUploadClick = onUploadClick;
       _onSettingsClick = onSettingsClick;
-      _onFeedClick = onFeedClick;
       buildButtons();
     },
 
     /**
-     * Update Claude-presence state for the active tile. Idempotent: callers
-     * can invoke this on every `session-updated` broadcast without tearing
-     * down the DOM when the state hasn't actually changed.
+     * Set the contextual slot for the active tile. Pass `null` to hide.
+     * Idempotent: repeated calls with the same visual state skip the DOM
+     * rebuild, so callers can invoke this on every `session-updated`
+     * broadcast without churn.
+     *
+     * Context shape:
+     *   { icon: "sparkle", label: "Claude feed",
+     *     className: "joystick-action-btn--claude", action: () => ... }
      */
-    setClaudeRunning(running) {
-      const next = !!running;
-      if (_claudeRunning === next) return;
-      _claudeRunning = next;
+    setContext(context) {
+      if (contextEquals(_context, context)) {
+        // Action reference may have changed even if visuals match; update it
+        // in place so clicks always invoke the latest closure.
+        if (_context && context) _context.action = context.action;
+        return;
+      }
+      _context = context;
       buildButtons();
     },
 
-    getState: () => ({ mode: 'idle', claudeRunning: _claudeRunning }),
+    getState: () => ({ mode: 'idle', context: _context }),
   };
 }

--- a/public/lib/joystick.js
+++ b/public/lib/joystick.js
@@ -55,6 +55,11 @@ export function createJoystickManager(options = {}) {
     joystick.appendChild(dotEl);
   }
 
+  // Equality for the "should we skip the DOM rebuild?" check. `action` is
+  // intentionally excluded — a fresh closure with identical visuals is
+  // handled by the in-place action patch in `setContext`. If the context
+  // shape grows new visual fields (e.g. `badge`, `count`), add them here
+  // or they will silently fail to trigger rebuilds.
   function contextEquals(a, b) {
     if (a === b) return true;
     if (!a || !b) return false;


### PR DESCRIPTION
## Summary

- Replace the always-visible feed button with a contextual slot that only renders when the active tile has a detected context (e.g. `meta.claude.uuid` or `meta.claude.running`).
- Introduce a `TILE_CONTEXTS` table in `public/app.js` — adding a new context (node, git, etc.) is now a single entry, no joystick or subscriber changes required.
- Generalize the joystick API: `setContext({ icon, label, className, action } | null)` replaces the Claude-specific `setClaudeRunning(bool)` flag. The action lives on the context so each context is self-contained.

## Test plan

- [x] `npm run test:unit` — 2284 passing
- [ ] Manual: open staged instance, confirm the joystick feed button is hidden for a plain shell, appears as a sparkle when Claude starts, and opens the right feed.
- [ ] Manual: confirm clicking switches behavior between `meta.claude.uuid` (direct open) and `meta.claude.running` (scan/picker fallback).