### PR TITLE
Claude feed tile: blank stream + robust uuid adoption

### DIFF
--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -63,12 +63,14 @@ export function applyClaudeMetaFromHook(payload, sessionManager, logger = null) 
   const current = (session.meta && session.meta.claude) ? session.meta.claude : null;
   // SessionStart always adopts the uuid — that's the explicit new-session
   // signal. Other hook events (UserPromptSubmit, PreToolUse, PostToolUse,
-  // …) only adopt when we don't already have one. This covers the case
-  // where hooks were installed after Claude already started: SessionStart
-  // is already in the past and lost, but the next tool-use event lets the
-  // server learn the uuid retroactively so the awaiting-Claude feed tile
-  // can resolve its topic. Events for a different uuid are ignored — only
-  // an explicit SessionStart may replace a known uuid.
+  // …) only adopt when we don't already have one, covering the case where
+  // hooks were installed after Claude already started and SessionStart is
+  // already in the past. Only SessionStart may replace a known uuid.
+  //
+  // Policy mirror: client-side `isNewerSession` in
+  // public/lib/tile-renderers/feed.js reads the resulting meta.claude and
+  // treats any newer uuid OR advanced startedAt as a swap signal — keep
+  // the two in sync.
   if (event === "SessionStart" || (event && current?.uuid == null && event !== "SessionEnd" && event !== "Stop")) {
     // Validate UUID shape before writing — the value becomes a topic name
     // prefix (`claude/<uuid>`) on the client, and we don't want a bogus

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -61,7 +61,15 @@ export function applyClaudeMetaFromHook(payload, sessionManager, logger = null) 
 
   const event = payload.hook_event_name;
   const current = (session.meta && session.meta.claude) ? session.meta.claude : null;
-  if (event === "SessionStart") {
+  // SessionStart always adopts the uuid — that's the explicit new-session
+  // signal. Other hook events (UserPromptSubmit, PreToolUse, PostToolUse,
+  // …) only adopt when we don't already have one. This covers the case
+  // where hooks were installed after Claude already started: SessionStart
+  // is already in the past and lost, but the next tool-use event lets the
+  // server learn the uuid retroactively so the awaiting-Claude feed tile
+  // can resolve its topic. Events for a different uuid are ignored — only
+  // an explicit SessionStart may replace a known uuid.
+  if (event === "SessionStart" || (event && current?.uuid == null && event !== "SessionEnd" && event !== "Stop")) {
     // Validate UUID shape before writing — the value becomes a topic name
     // prefix (`claude/<uuid>`) on the client, and we don't want a bogus
     // hook payload polluting meta with a non-UUID string.
@@ -79,8 +87,8 @@ export function applyClaudeMetaFromHook(payload, sessionManager, logger = null) 
       });
       return "set";
     } catch (err) {
-      logger?.warn?.("Failed to set meta.claude on SessionStart", {
-        session: session.name, error: err.message,
+      logger?.warn?.("Failed to set meta.claude from hook", {
+        session: session.name, event, error: err.message,
       });
       return null;
     }

--- a/lib/session-child-counter.js
+++ b/lib/session-child-counter.js
@@ -22,9 +22,25 @@ import { tmuxSocketArgs } from "./tmux.js";
 const DEFAULT_INTERVAL_MS = 5000;
 
 // Foreground commands that mean "a Claude Code session is running in this
-// pane." Tmux reports `pane_current_command` as the binary basename, so a
-// small set is sufficient — no path prefix matching needed.
+// pane." Matching falls into two cases:
+//
+//   1. The binary basename (`claude`, `claude-code`) — what you'd expect,
+//      but only hits on systems where Claude Code hasn't called
+//      `process.title` yet (brief startup window) or on distros that
+//      expose the exec name via tmux.
+//   2. A SemVer string (e.g. `2.1.109`, `2.2.0-beta.1`) — Claude Code sets
+//      `process.title = <version>` at startup. On macOS (and BSDs), tmux's
+//      `pane_current_command` reads `kinfo_proc.p_comm` / ucomm, which
+//      reflects the *current* title, not the original exec name. So for a
+//      live Claude Code session on macOS, the thing you see in tmux is
+//      literally the version number — `claude` never appears.
+//
+// The SemVer matcher is strict enough that real-world command names
+// don't collide: no well-known CLI sets its process title to a dotted
+// three-component numeric string. Two-component versions, pids, and IP
+// fragments are all rejected.
 const CLAUDE_COMMAND_NAMES = new Set(["claude", "claude-code"]);
+const SEMVER_TITLE_RE = /^\d+\.\d+\.\d+(?:[-+][\w.]+)?$/;
 
 /**
  * True when a tmux `pane_current_command` value represents a running Claude
@@ -35,7 +51,8 @@ const CLAUDE_COMMAND_NAMES = new Set(["claude", "claude-code"]);
  */
 export function isClaudeCommand(cmd) {
   if (typeof cmd !== "string" || cmd.length === 0) return false;
-  return CLAUDE_COMMAND_NAMES.has(cmd);
+  if (CLAUDE_COMMAND_NAMES.has(cmd)) return true;
+  return SEMVER_TITLE_RE.test(cmd);
 }
 
 /**

--- a/public/app.js
+++ b/public/app.js
@@ -357,6 +357,9 @@
       terminalPool,
       createTerminalTile: (opts) => terminalTileFactory(opts),
       uiStore,
+      // Lazy getter — `sessionStore` is initialized further down in this
+      // module. The feed tile only calls this at mount time, long after.
+      getSessionStore: () => sessionStore,
     });
 
     /** Derive renderer capabilities for a tile descriptor.
@@ -1902,16 +1905,18 @@
 
     /** Open a feed tile for the Claude session running in the current terminal.
      *
-     * Three-way resolution:
-     *   1. `meta.claude.uuid` present (SessionStart hook fired) → open the
-     *      exact `claude/<uuid>` topic.
-     *   2. `meta.claude.running` present but no uuid → Claude is running in
-     *      the pane but the hook hasn't reported yet. If hooks aren't
-     *      installed, POST to install them so the *next* SessionStart wires
-     *      up automatically. Either way, fall through to the picker.
-     *   3. No Claude signal at all → open the generic picker.
+     * Resolution order:
+     *   1. `meta.claude.uuid` present → open the exact `claude/<uuid>` topic.
+     *      SessionStart overwrites uuid when a new Claude starts, so we trust
+     *      whatever uuid is currently in meta.
+     *   2. `meta.claude.running` is true but no uuid → open a blank stream
+     *      tile that subscribes to sessionStore and swaps to the real topic
+     *      when the hook lands a uuid. Covers the case where hooks were
+     *      installed after Claude started (SessionStart already fired into
+     *      the void; the server now adopts the uuid on the next hook event).
+     *   3. No Claude signal at all → generic picker.
      */
-    async function openClaudeFeedTile() {
+    function openClaudeFeedTile() {
       const sessionName = getActiveSessionName();
 
       if (!sessionName) {
@@ -1923,46 +1928,42 @@
       const active = (sessions || []).find(s => s.name === sessionName);
       const claudeMeta = active?.meta?.claude || null;
 
-      // Primary: UUID known → open the specific feed directly.
       if (claudeMeta?.uuid) {
         const topic = `claude/${claudeMeta.uuid}`;
         const tileId = `feed-${Date.now().toString(36)}`;
         uiStore.addTile(
-          { id: tileId, type: "feed", props: { topic, title: topic, meta: {} } },
+          { id: tileId, type: "feed", props: { topic, title: topic, meta: { type: "progress" } } },
           { focus: true, insertAt: "afterFocus" },
         );
         if (isOverlayViewport()) setOverlaySidebar(false);
         return;
       }
 
-      // Running but no uuid: auto-install hooks on first encounter so the
-      // next Claude session the user starts wires up without any terminal
-      // plumbing. Silent if already installed; one-shot toast otherwise.
       if (claudeMeta?.running) {
-        await ensureClaudeHooksInstalled();
+        // Fire-and-forget: install hooks if missing so the next hook event
+        // wires up automatically.
+        ensureClaudeHooksInstalled();
+
+        const tileId = `feed-${Date.now().toString(36)}`;
+        uiStore.addTile(
+          {
+            id: tileId,
+            type: "feed",
+            props: {
+              topic: null,
+              title: "Claude",
+              meta: {},
+              awaitingClaudeForSession: sessionName,
+              awaitingBaseline: { uuid: null, startedAt: 0 },
+            },
+          },
+          { focus: true, insertAt: "afterFocus" },
+        );
+        if (isOverlayViewport()) setOverlaySidebar(false);
+        return;
       }
 
-      try {
-        // Legacy fallback: scan topics for a sessionName match. Resolves
-        // Claude sessions that started before MC1f was deployed. Remove
-        // once all live Claude sessions have been restarted under the
-        // new hook wiring.
-        const topics = await api.get("/api/topics");
-        const match = topics
-          .filter(t => t.name.startsWith("claude/") && t.meta?.sessionName === sessionName)
-          .sort((a, b) => (b.messages || 0) - (a.messages || 0))[0];
-        if (match) {
-          const tileId = `feed-${Date.now().toString(36)}`;
-          uiStore.addTile(
-            { id: tileId, type: "feed", props: { topic: match.name, title: match.name, meta: match.meta || {} } },
-            { focus: true, insertAt: "afterFocus" },
-          );
-        } else {
-          openFeedTile();
-        }
-      } catch {
-        openFeedTile();
-      }
+      openFeedTile();
       if (isOverlayViewport()) setOverlaySidebar(false);
     }
 

--- a/public/app.js
+++ b/public/app.js
@@ -1953,8 +1953,10 @@
               topic: null,
               title: "Claude",
               meta: {},
-              awaitingClaudeForSession: sessionName,
-              awaitingBaseline: { uuid: null, startedAt: 0 },
+              awaitingClaude: {
+                session: sessionName,
+                baseline: { uuid: null, startedAt: 0 },
+              },
             },
           },
           { focus: true, insertAt: "afterFocus" },
@@ -2196,6 +2198,18 @@
         windowTabSet.addTab(e.session);
         switchSession(e.session);
       },
+      /**
+       * Broadcast that a pub/sub topic was created on the server.
+       *
+       * Consumed by feed tiles — the picker uses it to add live rows,
+       * and awaiting-Claude tiles use it as a second signal path for
+       * swapping to a fresh `claude/<uuid>` stream when the session
+       * store's `meta.claude.uuid` never surfaces (e.g. hooks weren't
+       * installed before Claude started). Any new listener should
+       * verify the topic shape before acting — detail is not validated.
+       *
+       * @param {{ topic: string, meta?: object }} e
+       */
       dispatchTopicNew: (e) => {
         window.dispatchEvent(new CustomEvent('katulong:topic-new', {
           detail: { topic: e.topic, meta: e.meta },

--- a/public/index.html
+++ b/public/index.html
@@ -2434,16 +2434,6 @@
     /* Narrative block — blog-like prose from the Ollama model */
     .feed-status-narrative { flex-direction: column; gap: var(--space-xs); }
     .feed-tile-narrative { line-height: 1.55; color: var(--text); overflow-wrap: break-word; }
-    .feed-tile-files { display: flex; flex-wrap: wrap; gap: 4px; padding-top: 2px; }
-    .feed-tile-file-pill {
-      display: inline-flex; align-items: center; gap: 2px;
-      padding: 2px 8px; border-radius: 999px;
-      background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.1);
-      color: var(--accent, #58a6ff); font-size: var(--text-xs);
-      font-family: var(--font-mono); cursor: pointer;
-      white-space: nowrap;
-    }
-    .feed-tile-file-pill:hover { background: rgba(255,255,255,0.12); }
     /* Summary — session objective */
     .feed-status-summary { border-left: 2px solid var(--accent, #58a6ff); padding-left: var(--space-sm); }
     .feed-tile-summary { font-weight: 600; color: var(--text); font-size: var(--text-sm); }

--- a/public/index.html
+++ b/public/index.html
@@ -1252,20 +1252,43 @@
       flex-direction: column; gap: 0.5rem;
       align-items: center;
     }
+    /* Glass "island" — one unified frosted pill wraps every action button.
+       Per-button chips were noisy; a single blurred surface reads as one UI
+       element and leaves icons flat inside. */
+    .joystick-island {
+      display: flex; flex-direction: column;
+      align-items: center; gap: 0.375rem;
+      padding: 0.5rem 0.375rem;
+      background: transparent;
+      border: 1px solid rgba(255,255,255,0.05);
+      border-radius: 999px;
+      backdrop-filter: blur(4px) saturate(1.2);
+      -webkit-backdrop-filter: blur(4px) saturate(1.2);
+      box-shadow:
+        inset 0 1px 0 rgba(255,255,255,0.04),
+        0 2px 8px rgba(0,0,0,0.12);
+    }
     .joystick-action-btn {
       background: none; border: none;
-      color: var(--text-dim); font-size: 1.375rem;
-      cursor: pointer; opacity: 0.5;
-      padding: 0.25rem;
+      color: var(--text); font-size: 1.25rem;
+      cursor: pointer;
+      width: 2rem; height: 2rem;
+      border-radius: 999px;
       display: flex; align-items: center; justify-content: center;
     }
-    .joystick-action-btn:active { opacity: 1; color: var(--text); }
-    /* Claude-presence variant: the feed button lights up when tmux reports
-       `claude` as the pane's foreground command, so the user can see at a
-       glance that clicking opens a feed for the running Claude session. */
-    .joystick-action-btn--claude { opacity: 0.95; color: var(--accent, #e9b44c); }
+    .joystick-action-btn:active {
+      background: rgba(255,255,255,0.12);
+      color: var(--text);
+    }
+    /* Claude-presence variant: same lightness as siblings so the sparkle
+       doesn't look faded in the island; accent tint only on active tap. */
+    .joystick-action-btn--claude { color: var(--text); }
     .joystick-action-btn--claude:active { color: var(--accent, #e9b44c); }
-    /* Connection dot at the bottom of the stack */
+    /* Connection dot spacing inside the island */
+    .joystick-island .joystick-dot {
+      margin-top: 0.375rem;
+      margin-bottom: 0.25rem;
+    }
     .joystick-dot {
       width: 0.625rem; height: 0.625rem; border-radius: 50%;
       background: var(--text-dim); cursor: pointer; position: relative;
@@ -2393,6 +2416,40 @@
     .feed-log-item { gap: var(--space-sm); border-bottom: 1px solid var(--border-subtle, rgba(255,255,255,0.04)); }
     .feed-tile-time { flex-shrink: 0; color: var(--text-muted); font-family: var(--font-mono); font-size: var(--text-xs); }
     .feed-tile-text { font-family: var(--font-mono); word-break: break-all; min-width: 0; }
+
+    /* Collapsible step groups — non-narrative events fold into <details> */
+    .feed-tile-details-group { margin: var(--space-xs) 0; }
+    .feed-tile-details-summary {
+      cursor: pointer; color: var(--text-secondary); font-size: var(--text-xs);
+      padding: 4px 0; user-select: none; list-style: none;
+    }
+    .feed-tile-details-summary::before {
+      content: "\25B8"; display: inline-block; width: 1.2em; transition: transform 0.15s;
+    }
+    .feed-tile-details-group[open] > .feed-tile-details-summary::before { transform: rotate(90deg); }
+    .feed-tile-details-summary::-webkit-details-marker { display: none; }
+    .feed-tile-details-body { padding-left: 1.2em; }
+    .feed-tile-details-body .feed-tile-item { opacity: 0.7; font-size: var(--text-xs); }
+
+    /* Narrative block — blog-like prose from the Ollama model */
+    .feed-status-narrative { flex-direction: column; gap: var(--space-xs); }
+    .feed-tile-narrative { line-height: 1.55; color: var(--text); overflow-wrap: break-word; }
+    .feed-tile-files { display: flex; flex-wrap: wrap; gap: 4px; padding-top: 2px; }
+    .feed-tile-file-pill {
+      display: inline-flex; align-items: center; gap: 2px;
+      padding: 2px 8px; border-radius: 999px;
+      background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.1);
+      color: var(--accent, #58a6ff); font-size: var(--text-xs);
+      font-family: var(--font-mono); cursor: pointer;
+      white-space: nowrap;
+    }
+    .feed-tile-file-pill:hover { background: rgba(255,255,255,0.12); }
+    /* Summary — session objective */
+    .feed-status-summary { border-left: 2px solid var(--accent, #58a6ff); padding-left: var(--space-sm); }
+    .feed-tile-summary { font-weight: 600; color: var(--text); font-size: var(--text-sm); }
+    /* Attention — Claude waiting for input */
+    .feed-status-attention { background: rgba(233,180,76,0.08); border-radius: var(--radius-sm, 4px); padding: var(--space-xs) var(--space-sm); }
+    .feed-tile-attention { color: var(--accent, #e9b44c); font-weight: 500; }
 
     /* --- Feed Tile: inline topic picker --- */
     .feed-tile-picker { display: flex; flex-direction: column; height: 100%; padding: var(--space-md); gap: var(--space-sm); color: var(--text); }

--- a/public/lib/joystick.js
+++ b/public/lib/joystick.js
@@ -35,24 +35,31 @@ export function createJoystickManager(options = {}) {
       return btn;
     }
 
+    // Glass "island" wraps the action buttons and the connection dot as a
+    // single unified surface.
+    const island = document.createElement("div");
+    island.className = "joystick-island";
+
     if (_onUploadClick) {
-      joystick.appendChild(actionBtn("image", "Upload image", _onUploadClick));
+      island.appendChild(actionBtn("image", "Upload image", _onUploadClick));
     }
     if (_onFilesClick) {
-      joystick.appendChild(actionBtn("folder-open", "Files", _onFilesClick));
+      island.appendChild(actionBtn("folder-open", "Files", _onFilesClick));
     }
     if (_context) {
-      joystick.appendChild(actionBtn(_context.icon, _context.label, _context.action, _context.className || ""));
+      island.appendChild(actionBtn(_context.icon, _context.label, _context.action, _context.className || ""));
     }
     if (_onSettingsClick) {
-      joystick.appendChild(actionBtn("gear", "Settings", _onSettingsClick));
+      island.appendChild(actionBtn("gear", "Settings", _onSettingsClick));
     }
 
     // Connection dot — ID lets the connection subscriber in app.js target it
     dotEl = document.createElement("div");
     dotEl.className = "joystick-dot";
     dotEl.id = "joystick-connection-dot";
-    joystick.appendChild(dotEl);
+    island.appendChild(dotEl);
+
+    joystick.appendChild(island);
   }
 
   // Equality for the "should we skip the DOM rebuild?" check. `action` is

--- a/public/lib/tile-host.js
+++ b/public/lib/tile-host.js
@@ -25,6 +25,7 @@ import { selectClusterView } from "./selectors.js";
 // a user-dragged width saved in localStorage always wins.
 const DEFAULT_CARD_WIDTHS = {
   "file-browser": 420,
+  "feed": 480,
 };
 
 function defaultCardWidthForType(type) {

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -1,10 +1,16 @@
 /**
  * Feed Tile Renderer
  *
- * General-purpose event streamer that subscribes to a pub/sub topic via
- * SSE and renders events according to topic metadata. The tile is a
- * subscriber — it decides how to display raw domain events. Another
- * subscriber (an orchestrator) could use the same events for choreography.
+ * Event streamer that subscribes to a pub/sub topic via SSE and renders
+ * events according to topic metadata. The tile is a subscriber — it
+ * decides how to display raw domain events. Another subscriber (an
+ * orchestrator) could use the same events for choreography.
+ *
+ * Dual role:
+ *   - Generic mode — pick any topic and stream it.
+ *   - Claude-aware mode — when `props.awaitingClaude` is set, render a
+ *     blank stream and auto-swap to the live `claude/<uuid>` topic the
+ *     moment a fresh uuid surfaces (via sessionStore or topic-new event).
  *
  * Lifecycle:
  *   1. Opens blank with an inline topic picker (fetched from /api/topics)
@@ -14,7 +20,9 @@
  *      - "progress" — checklist with keyed step updates + status bullets
  *      - default    — chronological event log with timestamps
  *
- * Single-file renderer: no factory, no init deps.
+ * Single-file renderer. `init({ getSessionStore })` is optional — when
+ * omitted the awaiting-Claude view falls back to the topic-new broadcast
+ * path alone.
  */
 
 // ── Rendering strategies ────────────────────────────────────────────
@@ -101,13 +109,13 @@ function renderLogItem(row, msg, ts) {
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-let _getSessionStore = () => null;
+let _sessionStoreGetter = () => null;
 
 export const feedRenderer = {
   type: "feed",
 
   init({ getSessionStore } = {}) {
-    if (typeof getSessionStore === "function") _getSessionStore = getSessionStore;
+    if (typeof getSessionStore === "function") _sessionStoreGetter = getSessionStore;
   },
 
   describe(props) {
@@ -115,7 +123,7 @@ export const feedRenderer = {
     // would restore a blank waiter whose baseline is epoch-zero, which
     // would then swap to any lingering claude/<uuid> uuid. Drop them on
     // reload and let the user re-invoke the sparkle.
-    const persistable = !props.awaitingClaudeForSession;
+    const persistable = !props.awaitingClaude;
     return {
       title: props.title || props.topic || "Feed",
       icon: "rss",
@@ -145,16 +153,45 @@ export const feedRenderer = {
     root.className = "feed-tile-root";
     el.appendChild(root);
 
+    // Shared header for awaiting + streaming views — keeps the DOM
+    // identical across the transition so the swap has no visual reshuffle.
+    function buildStreamHeader(titleText) {
+      const header = document.createElement("div");
+      header.className = "feed-tile-header";
+
+      const backBtn = document.createElement("button");
+      backBtn.className = "feed-tile-back-btn";
+      backBtn.innerHTML = '<i class="ph ph-arrow-left"></i>';
+      backBtn.title = "Back to topics";
+      backBtn.addEventListener("click", () => { if (mounted) showTopicPicker(); });
+      header.appendChild(backBtn);
+
+      const headerTitle = document.createElement("span");
+      headerTitle.className = "feed-tile-header-title";
+      headerTitle.textContent = titleText;
+      header.appendChild(headerTitle);
+
+      const closeBtn = document.createElement("button");
+      closeBtn.className = "feed-tile-close-btn";
+      closeBtn.innerHTML = '<i class="ph ph-x"></i>';
+      closeBtn.title = "Close";
+      closeBtn.addEventListener("click", () => ctx?.requestClose?.());
+      header.appendChild(closeBtn);
+
+      return header;
+    }
+
     // Route on mount:
     //   - `topic` present → stream it (normal restore path).
-    //   - `awaitingClaudeForSession` → blank stream view that subscribes to
-    //     the session store and auto-swaps when the new Claude uuid lands.
+    //   - `awaitingClaude: { session, baseline }` → blank stream view that
+    //     subscribes to the session store and auto-swaps when the Claude
+    //     uuid for `session` advances past `baseline`.
     //   - otherwise → topic picker.
     try {
       if (props.topic) {
         startStreaming(props.topic, props.meta || {});
-      } else if (props.awaitingClaudeForSession) {
-        startAwaitingClaude(props.awaitingClaudeForSession, props.awaitingBaseline || null);
+      } else if (props.awaitingClaude?.session) {
+        startAwaitingClaude(props.awaitingClaude.session, props.awaitingClaude.baseline || null);
       } else {
         showTopicPicker();
       }
@@ -357,29 +394,7 @@ export const feedRenderer = {
       drainViewCleanups();
       root.innerHTML = "";
 
-      const header = document.createElement("div");
-      header.className = "feed-tile-header";
-
-      const backBtn = document.createElement("button");
-      backBtn.className = "feed-tile-back-btn";
-      backBtn.innerHTML = '<i class="ph ph-arrow-left"></i>';
-      backBtn.title = "Back to topics";
-      backBtn.addEventListener("click", () => { if (mounted) showTopicPicker(); });
-      header.appendChild(backBtn);
-
-      const headerTitle = document.createElement("span");
-      headerTitle.className = "feed-tile-header-title";
-      headerTitle.textContent = "Claude";
-      header.appendChild(headerTitle);
-
-      const closeBtn = document.createElement("button");
-      closeBtn.className = "feed-tile-close-btn";
-      closeBtn.innerHTML = '<i class="ph ph-x"></i>';
-      closeBtn.title = "Close";
-      closeBtn.addEventListener("click", () => ctx?.requestClose?.());
-      header.appendChild(closeBtn);
-
-      root.appendChild(header);
+      root.appendChild(buildStreamHeader("Claude"));
 
       const list = document.createElement("div");
       list.className = "feed-tile-list";
@@ -389,7 +404,11 @@ export const feedRenderer = {
       const seenUuid = baseline?.uuid || null;
       const seenStartedAt = baseline?.startedAt || 0;
 
-      function isFreshUuid(m) {
+      // Policy mirror: see `applyClaudeMetaFromHook` in
+      // lib/routes/app-routes.js — SessionStart bumps `startedAt`, so a
+      // newer uuid OR a later `startedAt` signals a new Claude session
+      // worth swapping to.
+      function isNewerSession(m) {
         if (!m?.uuid) return false;
         if (m.uuid !== seenUuid) return true;
         return (m.startedAt || 0) > seenStartedAt;
@@ -407,7 +426,7 @@ export const feedRenderer = {
             id,
             patch: {
               topic, title: topic, meta,
-              awaitingClaudeForSession: null, awaitingBaseline: null,
+              awaitingClaude: null,
             },
           });
         }
@@ -433,7 +452,7 @@ export const feedRenderer = {
       window.addEventListener("katulong:topic-new", onTopicNew);
       viewCleanups.push(() => window.removeEventListener("katulong:topic-new", onTopicNew));
 
-      const store = _getSessionStore();
+      const store = _sessionStoreGetter();
       if (!store) return; // No store wired — topic-new listener still active.
 
       function readClaudeMeta() {
@@ -445,12 +464,12 @@ export const feedRenderer = {
       // Check once synchronously in case the uuid landed between the
       // click and mount.
       const immediate = readClaudeMeta();
-      if (isFreshUuid(immediate)) { swapToTopic(immediate.uuid); return; }
+      if (isNewerSession(immediate)) { swapToTopic(immediate.uuid); return; }
 
       const unsubscribe = store.subscribe(() => {
         if (!mounted || swapped) return;
         const m = readClaudeMeta();
-        if (isFreshUuid(m)) swapToTopic(m.uuid);
+        if (isNewerSession(m)) swapToTopic(m.uuid);
       });
       viewCleanups.push(unsubscribe);
     }

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -52,10 +52,10 @@ function renderProgressItem(row, msg) {
 
   // Summary — session objective line from the model.
   if (status === "summary") {
-    const obj = document.createElement("div");
-    obj.className = "feed-tile-summary";
-    obj.textContent = msg.step || "";
-    row.appendChild(obj);
+    const summaryEl = document.createElement("div");
+    summaryEl.className = "feed-tile-summary";
+    summaryEl.textContent = msg.step || "";
+    row.appendChild(summaryEl);
     return;
   }
 
@@ -115,7 +115,9 @@ export const feedRenderer = {
   type: "feed",
 
   init({ getSessionStore } = {}) {
-    if (typeof getSessionStore === "function") _sessionStoreGetter = getSessionStore;
+    _sessionStoreGetter = typeof getSessionStore === "function"
+      ? getSessionStore
+      : () => null;
   },
 
   describe(props) {
@@ -481,41 +483,16 @@ export const feedRenderer = {
       root.innerHTML = "";
       const topicMeta = meta || {};
 
-      // Header
-      const header = document.createElement("div");
-      header.className = "feed-tile-header";
+      root.appendChild(buildStreamHeader(topic));
 
-      const backBtn = document.createElement("button");
-      backBtn.className = "feed-tile-back-btn";
-      backBtn.innerHTML = '<i class="ph ph-arrow-left"></i>';
-      backBtn.title = "Back to topics";
-      backBtn.addEventListener("click", () => { if (mounted) showTopicPicker(); });
-      header.appendChild(backBtn);
-
-      const headerTitle = document.createElement("span");
-      headerTitle.className = "feed-tile-header-title";
-      headerTitle.textContent = topic;
-      header.appendChild(headerTitle);
-
-      const closeBtn = document.createElement("button");
-      closeBtn.className = "feed-tile-close-btn";
-      closeBtn.innerHTML = '<i class="ph ph-x"></i>';
-      closeBtn.title = "Close";
-      closeBtn.addEventListener("click", () => ctx?.requestClose?.());
-      header.appendChild(closeBtn);
-
-      root.appendChild(header);
-
-      // Event list
       const list = document.createElement("div");
       list.className = "feed-tile-list";
       list.tabIndex = 0;
       root.appendChild(list);
 
-      // State
       const items = new Map();
       let autoKey = 0;
-      const isProgress = topicMeta.type === "progress" || topic.startsWith("claude/");
+      const isProgress = topicMeta.type === "progress";
 
       // Narrative-first rendering: narrative/summary/attention events are
       // always visible. Tool-use progress events (active, done, pending,
@@ -531,13 +508,14 @@ export const feedRenderer = {
         currentDetails.className = "feed-tile-details-group";
         const summary = document.createElement("summary");
         summary.className = "feed-tile-details-summary";
-        summary.textContent = "1 step";
         currentDetails.appendChild(summary);
         const body = document.createElement("div");
         body.className = "feed-tile-details-body";
         currentDetails.appendChild(body);
         list.appendChild(currentDetails);
         detailCount = 0;
+        // Caller increments detailCount + calls updateDetailsSummary for
+        // the first item, which sets the visible label.
         return body;
       }
 

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -34,32 +34,11 @@ function renderProgressItem(row, msg) {
   }
 
   // Narrative — blog-like markdown update from the Ollama model.
-  // Renders the prose with clickable file pills when present.
   if (status === "narrative") {
     const prose = document.createElement("div");
     prose.className = "feed-tile-narrative";
     prose.textContent = msg.step || "";
     row.appendChild(prose);
-
-    if (Array.isArray(msg.files) && msg.files.length > 0) {
-      const fileBar = document.createElement("div");
-      fileBar.className = "feed-tile-files";
-      for (const f of msg.files) {
-        const pill = document.createElement("button");
-        pill.className = "feed-tile-file-pill";
-        const basename = f.path.split("/").pop();
-        pill.textContent = f.line ? `${basename}:${f.line}` : basename;
-        pill.title = f.path;
-        pill.addEventListener("click", (e) => {
-          e.stopPropagation();
-          window.dispatchEvent(new CustomEvent("katulong:open-file", {
-            detail: { path: f.path, line: f.line },
-          }));
-        });
-        fileBar.appendChild(pill);
-      }
-      row.appendChild(fileBar);
-    }
     return;
   }
 
@@ -120,6 +99,8 @@ function renderLogItem(row, msg, ts) {
 
 // ── Renderer ────────────────────────────────────────────────────────
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 let _getSessionStore = () => null;
 
 export const feedRenderer = {
@@ -130,10 +111,15 @@ export const feedRenderer = {
   },
 
   describe(props) {
+    // Awaiting-Claude tiles are transient — a reload without a live click
+    // would restore a blank waiter whose baseline is epoch-zero, which
+    // would then swap to any lingering claude/<uuid> uuid. Drop them on
+    // reload and let the user re-invoke the sparkle.
+    const persistable = !props.awaitingClaudeForSession;
     return {
       title: props.title || props.topic || "Feed",
       icon: "rss",
-      persistable: true,
+      persistable,
       session: null,
       updatesUrl: false,
       renameable: false,
@@ -144,7 +130,16 @@ export const feedRenderer = {
   mount(el, { id, props, dispatch, ctx }) {
     let mounted = true;
     let es = null;
-    const cleanups = [];
+    // View-local cleanups: drained whenever we transition between views
+    // (picker → awaiting → streaming) so stale window listeners don't
+    // accumulate. Each view function calls drainViewCleanups() before
+    // registering its own listeners.
+    let viewCleanups = [];
+    function drainViewCleanups() {
+      const fns = viewCleanups;
+      viewCleanups = [];
+      for (const fn of fns) { try { fn(); } catch { /* ignore */ } }
+    }
 
     const root = document.createElement("div");
     root.className = "feed-tile-root";
@@ -170,6 +165,7 @@ export const feedRenderer = {
     // ── Topic picker (inline) ───────────────────────────────────
     function showTopicPicker() {
       if (es) { es.close(); es = null; }
+      drainViewCleanups();
       root.innerHTML = "";
 
       // Restore checked state from persisted props
@@ -319,7 +315,7 @@ export const feedRenderer = {
         createTopicItem({ name: e.detail.topic, meta: e.detail.meta, messages: 0 });
       }
       window.addEventListener("katulong:topic-new", onTopicNew);
-      cleanups.push(() => window.removeEventListener("katulong:topic-new", onTopicNew));
+      viewCleanups.push(() => window.removeEventListener("katulong:topic-new", onTopicNew));
 
       // Fetch existing topics
       fetch("/api/topics", { credentials: "same-origin", redirect: "error" })
@@ -358,6 +354,7 @@ export const feedRenderer = {
     // then swaps to the real streaming view with no UI reshuffle.
     function startAwaitingClaude(sessionName, baseline) {
       if (es) { es.close(); es = null; }
+      drainViewCleanups();
       root.innerHTML = "";
 
       const header = document.createElement("div");
@@ -427,11 +424,14 @@ export const feedRenderer = {
         const topic = e?.detail?.topic || "";
         if (!topic.startsWith("claude/")) return;
         const uuid = topic.slice("claude/".length);
-        if (!uuid || uuid === seenUuid) return;
+        // Defense-in-depth: the server already gates /sub/ topics via an
+        // allowlist regex, but matching here too keeps client-side pivots
+        // safe regardless of who dispatched the CustomEvent.
+        if (!UUID_RE.test(uuid) || uuid === seenUuid) return;
         swapToTopic(uuid);
       }
       window.addEventListener("katulong:topic-new", onTopicNew);
-      cleanups.push(() => window.removeEventListener("katulong:topic-new", onTopicNew));
+      viewCleanups.push(() => window.removeEventListener("katulong:topic-new", onTopicNew));
 
       const store = _getSessionStore();
       if (!store) return; // No store wired — topic-new listener still active.
@@ -452,12 +452,13 @@ export const feedRenderer = {
         const m = readClaudeMeta();
         if (isFreshUuid(m)) swapToTopic(m.uuid);
       });
-      cleanups.push(unsubscribe);
+      viewCleanups.push(unsubscribe);
     }
 
     // ── Streaming view ──────────────────────────────────────────
     function startStreaming(topic, meta) {
       if (es) { es.close(); es = null; }
+      drainViewCleanups();
       root.innerHTML = "";
       const topicMeta = meta || {};
 
@@ -587,7 +588,7 @@ export const feedRenderer = {
       unmount() {
         mounted = false;
         if (es) es.close();
-        for (const fn of cleanups) fn();
+        drainViewCleanups();
         el.innerHTML = "";
       },
       focus() {

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -33,6 +33,54 @@ function renderProgressItem(row, msg) {
     return;
   }
 
+  // Narrative — blog-like markdown update from the Ollama model.
+  // Renders the prose with clickable file pills when present.
+  if (status === "narrative") {
+    const prose = document.createElement("div");
+    prose.className = "feed-tile-narrative";
+    prose.textContent = msg.step || "";
+    row.appendChild(prose);
+
+    if (Array.isArray(msg.files) && msg.files.length > 0) {
+      const fileBar = document.createElement("div");
+      fileBar.className = "feed-tile-files";
+      for (const f of msg.files) {
+        const pill = document.createElement("button");
+        pill.className = "feed-tile-file-pill";
+        const basename = f.path.split("/").pop();
+        pill.textContent = f.line ? `${basename}:${f.line}` : basename;
+        pill.title = f.path;
+        pill.addEventListener("click", (e) => {
+          e.stopPropagation();
+          window.dispatchEvent(new CustomEvent("katulong:open-file", {
+            detail: { path: f.path, line: f.line },
+          }));
+        });
+        fileBar.appendChild(pill);
+      }
+      row.appendChild(fileBar);
+    }
+    return;
+  }
+
+  // Summary — session objective line from the model.
+  if (status === "summary") {
+    const obj = document.createElement("div");
+    obj.className = "feed-tile-summary";
+    obj.textContent = msg.step || "";
+    row.appendChild(obj);
+    return;
+  }
+
+  // Attention — Claude is waiting for user input.
+  if (status === "attention") {
+    const attn = document.createElement("div");
+    attn.className = "feed-tile-attention";
+    attn.textContent = msg.step || "Waiting for input\u2026";
+    row.appendChild(attn);
+    return;
+  }
+
   const bullet = document.createElement("span");
   bullet.className = "feed-tile-bullet";
   bullet.textContent = status === "done" ? "\u25CF"
@@ -72,10 +120,14 @@ function renderLogItem(row, msg, ts) {
 
 // ── Renderer ────────────────────────────────────────────────────────
 
+let _getSessionStore = () => null;
+
 export const feedRenderer = {
   type: "feed",
 
-  init(_deps) {},
+  init({ getSessionStore } = {}) {
+    if (typeof getSessionStore === "function") _getSessionStore = getSessionStore;
+  },
 
   describe(props) {
     return {
@@ -98,11 +150,16 @@ export const feedRenderer = {
     root.className = "feed-tile-root";
     el.appendChild(root);
 
-    // If we already have a topic (e.g. restored from persistence), go
-    // straight to streaming. Otherwise show the inline topic picker.
+    // Route on mount:
+    //   - `topic` present → stream it (normal restore path).
+    //   - `awaitingClaudeForSession` → blank stream view that subscribes to
+    //     the session store and auto-swaps when the new Claude uuid lands.
+    //   - otherwise → topic picker.
     try {
       if (props.topic) {
         startStreaming(props.topic, props.meta || {});
+      } else if (props.awaitingClaudeForSession) {
+        startAwaitingClaude(props.awaitingClaudeForSession, props.awaitingBaseline || null);
       } else {
         showTopicPicker();
       }
@@ -293,6 +350,111 @@ export const feedRenderer = {
         });
     }
 
+    // ── Awaiting Claude view ────────────────────────────────────
+    // Shown when the user clicks the Claude sparkle before the
+    // SessionStart hook has reported a fresh uuid. Renders a blank
+    // stream (header + empty list) and waits for the sessionStore
+    // to surface a uuid that is newer than the click-time baseline,
+    // then swaps to the real streaming view with no UI reshuffle.
+    function startAwaitingClaude(sessionName, baseline) {
+      if (es) { es.close(); es = null; }
+      root.innerHTML = "";
+
+      const header = document.createElement("div");
+      header.className = "feed-tile-header";
+
+      const backBtn = document.createElement("button");
+      backBtn.className = "feed-tile-back-btn";
+      backBtn.innerHTML = '<i class="ph ph-arrow-left"></i>';
+      backBtn.title = "Back to topics";
+      backBtn.addEventListener("click", () => { if (mounted) showTopicPicker(); });
+      header.appendChild(backBtn);
+
+      const headerTitle = document.createElement("span");
+      headerTitle.className = "feed-tile-header-title";
+      headerTitle.textContent = "Claude";
+      header.appendChild(headerTitle);
+
+      const closeBtn = document.createElement("button");
+      closeBtn.className = "feed-tile-close-btn";
+      closeBtn.innerHTML = '<i class="ph ph-x"></i>';
+      closeBtn.title = "Close";
+      closeBtn.addEventListener("click", () => ctx?.requestClose?.());
+      header.appendChild(closeBtn);
+
+      root.appendChild(header);
+
+      const list = document.createElement("div");
+      list.className = "feed-tile-list";
+      list.tabIndex = 0;
+      root.appendChild(list);
+
+      const seenUuid = baseline?.uuid || null;
+      const seenStartedAt = baseline?.startedAt || 0;
+
+      function isFreshUuid(m) {
+        if (!m?.uuid) return false;
+        if (m.uuid !== seenUuid) return true;
+        return (m.startedAt || 0) > seenStartedAt;
+      }
+
+      let swapped = false;
+      function swapToTopic(uuid) {
+        if (swapped) return;
+        swapped = true;
+        const topic = `claude/${uuid}`;
+        const meta = { type: "progress" };
+        if (dispatch) {
+          dispatch({
+            type: "ui/UPDATE_PROPS",
+            id,
+            patch: {
+              topic, title: topic, meta,
+              awaitingClaudeForSession: null, awaitingBaseline: null,
+            },
+          });
+        }
+        startStreaming(topic, meta);
+      }
+
+      // Topic-new listener: broadcast path. The pub/sub bridge publishes
+      // a `katulong:topic-new` CustomEvent whenever a topic is created on
+      // the server — this fires even when session.meta.claude.uuid never
+      // surfaces (e.g. hooks were installed late, or the session store
+      // isn't the authoritative source). Matches any fresh `claude/<uuid>`.
+      function onTopicNew(e) {
+        if (!mounted || swapped) return;
+        const topic = e?.detail?.topic || "";
+        if (!topic.startsWith("claude/")) return;
+        const uuid = topic.slice("claude/".length);
+        if (!uuid || uuid === seenUuid) return;
+        swapToTopic(uuid);
+      }
+      window.addEventListener("katulong:topic-new", onTopicNew);
+      cleanups.push(() => window.removeEventListener("katulong:topic-new", onTopicNew));
+
+      const store = _getSessionStore();
+      if (!store) return; // No store wired — topic-new listener still active.
+
+      function readClaudeMeta() {
+        const { sessions } = store.getState();
+        const s = (sessions || []).find((x) => x.name === sessionName);
+        return s?.meta?.claude || null;
+      }
+
+      // Check once synchronously in case the uuid landed between the
+      // click and mount.
+      const immediate = readClaudeMeta();
+      if (isFreshUuid(immediate)) { swapToTopic(immediate.uuid); return; }
+
+      const unsubscribe = store.subscribe(() => {
+        if (!mounted || swapped) return;
+        const m = readClaudeMeta();
+        if (isFreshUuid(m)) swapToTopic(m.uuid);
+      });
+      cleanups.push(unsubscribe);
+    }
+
     // ── Streaming view ──────────────────────────────────────────
     function startStreaming(topic, meta) {
       if (es) { es.close(); es = null; }
@@ -333,24 +495,76 @@ export const feedRenderer = {
       // State
       const items = new Map();
       let autoKey = 0;
-      const isProgress = topicMeta.type === "progress";
+      const isProgress = topicMeta.type === "progress" || topic.startsWith("claude/");
+
+      // Narrative-first rendering: narrative/summary/attention events are
+      // always visible. Tool-use progress events (active, done, pending,
+      // text, etc.) collapse into expandable <details> groups between
+      // narrative blocks so the feed reads like a blog, not a log.
+      const PROMINENT = new Set(["narrative", "summary", "attention"]);
+      let currentDetails = null; // the open <details> group, if any
+      let detailCount = 0;
+
+      function ensureDetailsGroup() {
+        if (currentDetails) return currentDetails.querySelector(".feed-tile-details-body");
+        currentDetails = document.createElement("details");
+        currentDetails.className = "feed-tile-details-group";
+        const summary = document.createElement("summary");
+        summary.className = "feed-tile-details-summary";
+        summary.textContent = "1 step";
+        currentDetails.appendChild(summary);
+        const body = document.createElement("div");
+        body.className = "feed-tile-details-body";
+        currentDetails.appendChild(body);
+        list.appendChild(currentDetails);
+        detailCount = 0;
+        return body;
+      }
+
+      function updateDetailsSummary() {
+        if (!currentDetails) return;
+        const summary = currentDetails.querySelector("summary");
+        summary.textContent = `${detailCount} step${detailCount === 1 ? "" : "s"}`;
+      }
 
       function handleEvent(envelope) {
         let msg;
         try { msg = JSON.parse(envelope.message); } catch { msg = envelope.message; }
 
+        const status = (typeof msg === "object" && msg.status) || "";
         const key = isProgress && msg.step ? msg.step : `_evt_${autoKey++}`;
-        let row = items.get(key);
 
-        if (!row) {
-          row = document.createElement("div");
-          list.appendChild(row);
-          items.set(key, row);
-        }
+        if (isProgress && PROMINENT.has(status)) {
+          // Close the current details group — next non-prominent events
+          // will start a fresh group after this prominent item.
+          currentDetails = null;
 
-        if (isProgress) {
+          let row = items.get(key);
+          if (!row) {
+            row = document.createElement("div");
+            list.appendChild(row);
+            items.set(key, row);
+          }
+          renderProgressItem(row, msg);
+        } else if (isProgress) {
+          // Non-prominent: tuck into a collapsible group
+          const body = ensureDetailsGroup();
+          let row = items.get(key);
+          if (!row) {
+            row = document.createElement("div");
+            body.appendChild(row);
+            items.set(key, row);
+            detailCount++;
+            updateDetailsSummary();
+          }
           renderProgressItem(row, msg);
         } else {
+          let row = items.get(key);
+          if (!row) {
+            row = document.createElement("div");
+            list.appendChild(row);
+            items.set(key, row);
+          }
           renderLogItem(row, msg, envelope.timestamp);
         }
 

--- a/public/lib/tile-renderers/index.js
+++ b/public/lib/tile-renderers/index.js
@@ -45,12 +45,12 @@ export function isPersistable(type, props = {}) {
 }
 
 /** Initialize all built-in renderers with their deps. */
-export function initRenderers({ terminalPool, createTerminalTile, uiStore }) {
+export function initRenderers({ terminalPool, createTerminalTile, uiStore, getSessionStore }) {
   terminalRenderer.init({ terminalPool });
   fileBrowserRenderer.init({ uiStore });
   documentRenderer.init({});
   clusterRenderer.init({ createTerminalTile });
-  feedRenderer.init({});
+  feedRenderer.init({ getSessionStore });
   localhostBrowserRenderer.init({});
   progressRenderer.init({});
   imageRenderer.init({});

--- a/test/app-routes-meta.test.js
+++ b/test/app-routes-meta.test.js
@@ -131,15 +131,56 @@ describe("applyClaudeMetaFromHook", () => {
     assert.equal(calls.length, 0);
   });
 
-  it("no-ops for unhandled events (PostToolUse, SubagentStart, etc.)", () => {
+  it("adopts uuid from non-SessionStart events when meta.claude.uuid is missing", () => {
+    // Scenario: hooks were installed after Claude started, so SessionStart
+    // already fired and was lost. The next UserPromptSubmit / PreToolUse /
+    // PostToolUse must still let the server learn the uuid, otherwise the
+    // awaiting-Claude feed tile has no signal to swap on and stays blank
+    // forever while events flow into `claude/<uuid>`.
     const { session, calls } = makeSession();
     const verdict = applyClaudeMetaFromHook({
       hook_event_name: "PostToolUse",
       session_id: "11111111-2222-3333-4444-555555555555",
       _tmuxPane: "%3",
     }, makeManager(session));
+    assert.equal(verdict, "set");
+    assert.equal(calls.length, 1);
+    assert.equal(session.meta.claude.uuid, "11111111-2222-3333-4444-555555555555");
+    assert.equal(typeof session.meta.claude.startedAt, "number");
+  });
+
+  it("does NOT overwrite an existing uuid from non-SessionStart events", () => {
+    // Once we have a uuid (from an earlier SessionStart or first adoption),
+    // subsequent tool-use hooks must not thrash it. Only SessionStart is
+    // allowed to replace a known uuid — that's the explicit new-session
+    // signal.
+    const { session, calls } = makeSession();
+    session.meta.claude = {
+      uuid: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      startedAt: 100,
+    };
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "PostToolUse",
+      session_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      _tmuxPane: "%3",
+    }, makeManager(session));
     assert.equal(verdict, null);
     assert.equal(calls.length, 0);
+    assert.equal(session.meta.claude.uuid, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+  });
+
+  it("adopting uuid preserves detection-owned running/detectedAt", () => {
+    const { session } = makeSession();
+    session.meta.claude = { running: true, detectedAt: 100 };
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "UserPromptSubmit",
+      session_id: "11111111-2222-3333-4444-555555555555",
+      _tmuxPane: "%3",
+    }, makeManager(session));
+    assert.equal(verdict, "set");
+    assert.equal(session.meta.claude.running, true);
+    assert.equal(session.meta.claude.detectedAt, 100);
+    assert.equal(session.meta.claude.uuid, "11111111-2222-3333-4444-555555555555");
   });
 
   it("returns null and logs when setMeta throws", () => {

--- a/test/feed-tile.test.js
+++ b/test/feed-tile.test.js
@@ -60,6 +60,29 @@ globalThis.fetch = async (url, opts) => ({
   json: async () => fetchResult,
 });
 
+// Stub global window — the feed tile attaches `katulong:topic-new`
+// listeners to catch new-topic broadcasts.
+const winListeners = {};
+globalThis.window = {
+  addEventListener(evt, fn) { (winListeners[evt] ||= []).push(fn); },
+  removeEventListener(evt, fn) {
+    const arr = winListeners[evt];
+    if (!arr) return;
+    const i = arr.indexOf(fn);
+    if (i >= 0) arr.splice(i, 1);
+  },
+  dispatchEvent(evt) {
+    const arr = winListeners[evt.type] || [];
+    for (const fn of [...arr]) fn(evt);
+  },
+};
+globalThis.CustomEvent = class CustomEvent {
+  constructor(type, init = {}) {
+    this.type = type;
+    this.detail = init.detail;
+  }
+};
+
 const { feedRenderer } = await import(
   new URL("../public/lib/tile-renderers/feed.js", import.meta.url).href
 );
@@ -68,6 +91,7 @@ describe("feedRenderer", () => {
   beforeEach(() => {
     eventSources.length = 0;
     fetchResult = [];
+    for (const k of Object.keys(winListeners)) delete winListeners[k];
   });
 
   describe("structure", () => {
@@ -292,6 +316,396 @@ describe("feedRenderer", () => {
       assert.equal(typeof handle.getSessions, "function");
       assert.deepEqual(handle.getSessions(), []);
       assert.equal(handle.tile, null);
+    });
+  });
+
+  // ── Awaiting-Claude state ──────────────────────────────────────────
+  //
+  // When the user clicks the Claude sparkle before the SessionStart hook
+  // has published a fresh uuid, the feed tile mounts in an awaiting state.
+  // It must subscribe to the session store and transition into a normal
+  // streaming view as soon as a fresh uuid appears.
+
+  describe("mount() — awaiting Claude", () => {
+    // Minimal fake session store — enough for the tile to read state and
+    // register a subscriber. Tests mutate `state.sessions[*].meta.claude`
+    // and call `emit()` to simulate a server-pushed session-updated.
+    function makeFakeSessionStore(sessions) {
+      const state = { sessions };
+      const subs = [];
+      return {
+        _state: state,
+        _subs: subs,
+        getState() { return state; },
+        subscribe(fn) {
+          subs.push(fn);
+          return () => {
+            const i = subs.indexOf(fn);
+            if (i >= 0) subs.splice(i, 1);
+          };
+        },
+        emit() { for (const fn of [...subs]) fn(state); },
+      };
+    }
+
+    it("renders blank stream header and list without opening EventSource", () => {
+      const store = makeFakeSessionStore([
+        { name: "work", meta: { claude: { running: true } } },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          awaitingBaseline: { uuid: null, startedAt: 0 },
+          meta: {},
+        },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      // No EventSource — nothing to subscribe to yet.
+      assert.equal(eventSources.length, 0);
+
+      const root = el.children[0];
+      assert.equal(root.className, "feed-tile-root");
+
+      // Header [back, title, close] + empty list.
+      const header = root.children[0];
+      assert.equal(header.className, "feed-tile-header");
+      assert.equal(header.children.length, 3);
+      assert.equal(header.children[1].textContent, "Claude");
+
+      const list = root.children[1];
+      assert.equal(list.className, "feed-tile-list");
+      assert.equal(list.children.length, 0);
+    });
+
+    it("registers a subscriber on the session store", () => {
+      const store = makeFakeSessionStore([
+        { name: "work", meta: { claude: { running: true } } },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          awaitingBaseline: { uuid: null, startedAt: 0 },
+          meta: {},
+        },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      assert.equal(store._subs.length, 1);
+    });
+
+    it("transitions to streaming when a fresh uuid lands", () => {
+      const store = makeFakeSessionStore([
+        { name: "work", meta: { claude: { running: true } } },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      const dispatched = [];
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          awaitingBaseline: { uuid: null, startedAt: 0 },
+          meta: {},
+        },
+        dispatch: (a) => dispatched.push(a),
+        ctx: {},
+      });
+
+      assert.equal(eventSources.length, 0);
+
+      // Simulate SessionStart hook populating the uuid server-side, then
+      // the session-updated push reaching the client.
+      store._state.sessions[0].meta.claude = {
+        running: true,
+        detectedAt: 1,
+        uuid: "11111111-2222-3333-4444-555555555555",
+        startedAt: 2,
+      };
+      store.emit();
+
+      assert.equal(eventSources.length, 1, "streaming EventSource should open");
+      assert.ok(eventSources[0].url.includes("/sub/claude%2F11111111-2222-3333-4444-555555555555"));
+
+      // Persistence: UPDATE_PROPS dispatched so the tile restores as a
+      // normal streaming tile after a reload.
+      const patchAction = dispatched.find(a => a.type === "ui/UPDATE_PROPS");
+      assert.ok(patchAction, "UPDATE_PROPS should be dispatched");
+      assert.equal(patchAction.patch.topic, "claude/11111111-2222-3333-4444-555555555555");
+      assert.equal(patchAction.patch.awaitingClaudeForSession, null);
+    });
+
+    it("swaps immediately when the uuid is already fresh at mount", () => {
+      const store = makeFakeSessionStore([
+        {
+          name: "work",
+          meta: { claude: {
+            running: true, detectedAt: 1,
+            uuid: "11111111-2222-3333-4444-555555555555",
+            startedAt: 2,
+          } },
+        },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          awaitingBaseline: { uuid: null, startedAt: 0 },
+          meta: {},
+        },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      // Synchronous swap — no subscriber tick required.
+      assert.equal(eventSources.length, 1);
+    });
+
+    it("does NOT swap when the stored uuid matches the baseline (stale)", () => {
+      const uuid = "11111111-2222-3333-4444-555555555555";
+      const store = makeFakeSessionStore([
+        { name: "work", meta: { claude: { running: true, uuid, startedAt: 100 } } },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          // Click-time baseline: we already saw this uuid before opening.
+          awaitingBaseline: { uuid, startedAt: 100 },
+          meta: {},
+        },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      assert.equal(eventSources.length, 0);
+
+      // A store emit with the same meta should be a no-op.
+      store.emit();
+      assert.equal(eventSources.length, 0);
+    });
+
+    it("swaps when the uuid itself changes (new Claude session)", () => {
+      const oldUuid = "11111111-1111-1111-1111-111111111111";
+      const newUuid = "22222222-2222-2222-2222-222222222222";
+      const store = makeFakeSessionStore([
+        { name: "work", meta: { claude: { running: true, uuid: oldUuid, startedAt: 100 } } },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          awaitingBaseline: { uuid: oldUuid, startedAt: 100 },
+          meta: {},
+        },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      store._state.sessions[0].meta.claude = {
+        running: true, uuid: newUuid, startedAt: 200,
+      };
+      store.emit();
+
+      assert.equal(eventSources.length, 1);
+      assert.ok(eventSources[0].url.includes(encodeURIComponent(`claude/${newUuid}`)));
+    });
+
+    it("swaps when startedAt advances even if uuid is unchanged", () => {
+      // This catches the hook-restart case where Claude kept the same
+      // session_id but the server re-wrote startedAt after a flap.
+      const uuid = "11111111-2222-3333-4444-555555555555";
+      const store = makeFakeSessionStore([
+        { name: "work", meta: { claude: { running: true, uuid, startedAt: 100 } } },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          awaitingBaseline: { uuid, startedAt: 100 },
+          meta: {},
+        },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      store._state.sessions[0].meta.claude = {
+        running: true, uuid, startedAt: 200,
+      };
+      store.emit();
+
+      assert.equal(eventSources.length, 1);
+    });
+
+    it("swaps when a katulong:topic-new claude/<uuid> event arrives", () => {
+      // Fallback path: session store never surfaces meta.claude.uuid
+      // (e.g. staging doesn't receive hook events), but the topic itself
+      // gets broadcast via the pub/sub bridge. The awaiting view must
+      // still swap so the user sees live events.
+      const store = makeFakeSessionStore([
+        { name: "work", meta: { claude: { running: true } } },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      const dispatched = [];
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          awaitingBaseline: { uuid: null, startedAt: 0 },
+          meta: {},
+        },
+        dispatch: (a) => dispatched.push(a),
+        ctx: {},
+      });
+
+      assert.equal(eventSources.length, 0);
+
+      const uuid = "33333333-3333-3333-3333-333333333333";
+      globalThis.window.dispatchEvent(new globalThis.CustomEvent("katulong:topic-new", {
+        detail: { topic: `claude/${uuid}`, meta: { type: "progress" } },
+      }));
+
+      assert.equal(eventSources.length, 1, "streaming should open on topic-new");
+      assert.ok(eventSources[0].url.includes(encodeURIComponent(`claude/${uuid}`)));
+
+      const patch = dispatched.find(a => a.type === "ui/UPDATE_PROPS");
+      assert.ok(patch);
+      assert.equal(patch.patch.topic, `claude/${uuid}`);
+      assert.equal(patch.patch.awaitingClaudeForSession, null);
+    });
+
+    it("ignores non-claude topic-new events while awaiting", () => {
+      const store = makeFakeSessionStore([
+        { name: "work", meta: { claude: { running: true } } },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          awaitingBaseline: { uuid: null, startedAt: 0 },
+          meta: {},
+        },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      globalThis.window.dispatchEvent(new globalThis.CustomEvent("katulong:topic-new", {
+        detail: { topic: "build/something", meta: {} },
+      }));
+
+      assert.equal(eventSources.length, 0);
+    });
+
+    it("ignores claude/<uuid> that matches baseline uuid (stale)", () => {
+      const uuid = "44444444-4444-4444-4444-444444444444";
+      const store = makeFakeSessionStore([
+        { name: "work", meta: { claude: { running: true } } },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          awaitingBaseline: { uuid, startedAt: 100 },
+          meta: {},
+        },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      globalThis.window.dispatchEvent(new globalThis.CustomEvent("katulong:topic-new", {
+        detail: { topic: `claude/${uuid}`, meta: {} },
+      }));
+
+      assert.equal(eventSources.length, 0);
+    });
+
+    it("removes the topic-new listener on unmount", () => {
+      const store = makeFakeSessionStore([
+        { name: "work", meta: { claude: { running: true } } },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      const handle = feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          awaitingBaseline: { uuid: null, startedAt: 0 },
+          meta: {},
+        },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      assert.equal((winListeners["katulong:topic-new"] || []).length, 1);
+      handle.unmount();
+      assert.equal((winListeners["katulong:topic-new"] || []).length, 0);
+    });
+
+    it("unsubscribes from the store on unmount", () => {
+      const store = makeFakeSessionStore([
+        { name: "work", meta: { claude: { running: true } } },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      const handle = feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          awaitingBaseline: { uuid: null, startedAt: 0 },
+          meta: {},
+        },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      assert.equal(store._subs.length, 1);
+      handle.unmount();
+      assert.equal(store._subs.length, 0);
     });
   });
 });

--- a/test/feed-tile.test.js
+++ b/test/feed-tile.test.js
@@ -122,9 +122,19 @@ describe("feedRenderer", () => {
       assert.equal(d.title, "My Feed");
     });
 
-    it("is always persistable", () => {
+    it("is persistable for normal props", () => {
       assert.equal(feedRenderer.describe({}).persistable, true);
       assert.equal(feedRenderer.describe({ topic: "some/topic" }).persistable, true);
+    });
+
+    it("is NOT persistable while awaiting Claude (transient state)", () => {
+      // Persisting a waiter with baseline { uuid: null, startedAt: 0 } would
+      // swap to any lingering claude/<uuid> on reload. Dropping the tile
+      // instead keeps restores clean.
+      assert.equal(
+        feedRenderer.describe({ awaitingClaudeForSession: "work" }).persistable,
+        false,
+      );
     });
   });
 
@@ -655,6 +665,84 @@ describe("feedRenderer", () => {
 
       globalThis.window.dispatchEvent(new globalThis.CustomEvent("katulong:topic-new", {
         detail: { topic: `claude/${uuid}`, meta: {} },
+      }));
+
+      assert.equal(eventSources.length, 0);
+    });
+
+    it("drops the awaiting topic-new listener when back → picker transitions view", () => {
+      // Regression: the tile used to register listeners into a flat
+      // cleanups[] array drained only on unmount, so clicking "back" from
+      // the awaiting view into the picker left the awaiting-mode
+      // onTopicNew live. A subsequent claude/<uuid> broadcast would then
+      // silently hijack the tile into streaming mode while the user was
+      // browsing the picker. View-local cleanups drain on transition.
+      const store = makeFakeSessionStore([
+        { name: "work", meta: { claude: { running: true } } },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          awaitingBaseline: { uuid: null, startedAt: 0 },
+          meta: {},
+        },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      // Awaiting view is up — one topic-new listener.
+      assert.equal((winListeners["katulong:topic-new"] || []).length, 1);
+
+      // Simulate "back" button click — calls showTopicPicker internally.
+      const root = el.children[0];
+      const headerBackBtn = root.children[0].children[0];
+      assert.equal(headerBackBtn.className, "feed-tile-back-btn");
+      const clickHandlers = headerBackBtn._listeners.click || [];
+      assert.equal(clickHandlers.length, 1);
+      clickHandlers[0]();
+
+      // Picker has exactly one topic-new listener — the awaiting one was
+      // drained, not accumulated.
+      assert.equal((winListeners["katulong:topic-new"] || []).length, 1);
+
+      // Prove the drained listener is actually gone: dispatching a
+      // claude/<uuid> topic-new must NOT pivot the picker to streaming.
+      const uuid = "55555555-5555-5555-5555-555555555555";
+      globalThis.window.dispatchEvent(new globalThis.CustomEvent("katulong:topic-new", {
+        detail: { topic: `claude/${uuid}`, meta: {} },
+      }));
+      assert.equal(eventSources.length, 0, "picker must not auto-swap to stream");
+    });
+
+    it("rejects topic-new payloads whose uuid is not a valid UUID", () => {
+      const store = makeFakeSessionStore([
+        { name: "work", meta: { claude: { running: true } } },
+      ]);
+      feedRenderer.init({ getSessionStore: () => store });
+
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: {
+          topic: null,
+          awaitingClaudeForSession: "work",
+          awaitingBaseline: { uuid: null, startedAt: 0 },
+          meta: {},
+        },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      globalThis.window.dispatchEvent(new globalThis.CustomEvent("katulong:topic-new", {
+        detail: { topic: "claude/../etc/passwd", meta: {} },
+      }));
+      globalThis.window.dispatchEvent(new globalThis.CustomEvent("katulong:topic-new", {
+        detail: { topic: "claude/not-a-uuid", meta: {} },
       }));
 
       assert.equal(eventSources.length, 0);

--- a/test/feed-tile.test.js
+++ b/test/feed-tile.test.js
@@ -132,7 +132,7 @@ describe("feedRenderer", () => {
       // swap to any lingering claude/<uuid> on reload. Dropping the tile
       // instead keeps restores clean.
       assert.equal(
-        feedRenderer.describe({ awaitingClaudeForSession: "work" }).persistable,
+        feedRenderer.describe({ awaitingClaude: { session: "work" } }).persistable,
         false,
       );
     });
@@ -209,26 +209,9 @@ describe("feedRenderer", () => {
       const header = root.children[0];
       assert.equal(header.className, "feed-tile-header");
       // [backBtn, title, closeBtn]
-      assert.equal(header.children[0].className, "feed-tile-back-btn");
-      assert.equal(header.children[1].textContent, "my/topic");
-      assert.equal(header.children[2].className, "feed-tile-close-btn");
-    });
-
-    it("header has back button, title, and close button", () => {
-      const el = new FakeElement("div");
-      feedRenderer.mount(el, {
-        id: "feed-1",
-        props: { topic: "t", meta: { type: "progress" } },
-        dispatch: () => {},
-        ctx: {},
-      });
-
-      const root = el.children[0];
-      const header = root.children[0];
-      // [backBtn, title, closeBtn]
       assert.equal(header.children.length, 3);
       assert.equal(header.children[0].className, "feed-tile-back-btn");
-      assert.equal(header.children[1].textContent, "t");
+      assert.equal(header.children[1].textContent, "my/topic");
       assert.equal(header.children[2].className, "feed-tile-close-btn");
     });
 
@@ -369,8 +352,10 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          awaitingBaseline: { uuid: null, startedAt: 0 },
+          awaitingClaude: {
+            session: "work",
+            baseline: { uuid: null, startedAt: 0 },
+          },
           meta: {},
         },
         dispatch: () => {},
@@ -405,8 +390,10 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          awaitingBaseline: { uuid: null, startedAt: 0 },
+          awaitingClaude: {
+            session: "work",
+            baseline: { uuid: null, startedAt: 0 },
+          },
           meta: {},
         },
         dispatch: () => {},
@@ -428,8 +415,10 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          awaitingBaseline: { uuid: null, startedAt: 0 },
+          awaitingClaude: {
+            session: "work",
+            baseline: { uuid: null, startedAt: 0 },
+          },
           meta: {},
         },
         dispatch: (a) => dispatched.push(a),
@@ -456,7 +445,7 @@ describe("feedRenderer", () => {
       const patchAction = dispatched.find(a => a.type === "ui/UPDATE_PROPS");
       assert.ok(patchAction, "UPDATE_PROPS should be dispatched");
       assert.equal(patchAction.patch.topic, "claude/11111111-2222-3333-4444-555555555555");
-      assert.equal(patchAction.patch.awaitingClaudeForSession, null);
+      assert.equal(patchAction.patch.awaitingClaude, null);
     });
 
     it("swaps immediately when the uuid is already fresh at mount", () => {
@@ -477,8 +466,10 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          awaitingBaseline: { uuid: null, startedAt: 0 },
+          awaitingClaude: {
+            session: "work",
+            baseline: { uuid: null, startedAt: 0 },
+          },
           meta: {},
         },
         dispatch: () => {},
@@ -501,9 +492,11 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          // Click-time baseline: we already saw this uuid before opening.
-          awaitingBaseline: { uuid, startedAt: 100 },
+          awaitingClaude: {
+            session: "work",
+            // Click-time baseline: we already saw this uuid before opening.
+            baseline: { uuid, startedAt: 100 },
+          },
           meta: {},
         },
         dispatch: () => {},
@@ -530,8 +523,10 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          awaitingBaseline: { uuid: oldUuid, startedAt: 100 },
+          awaitingClaude: {
+            session: "work",
+            baseline: { uuid: oldUuid, startedAt: 100 },
+          },
           meta: {},
         },
         dispatch: () => {},
@@ -561,8 +556,10 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          awaitingBaseline: { uuid, startedAt: 100 },
+          awaitingClaude: {
+            session: "work",
+            baseline: { uuid, startedAt: 100 },
+          },
           meta: {},
         },
         dispatch: () => {},
@@ -593,8 +590,10 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          awaitingBaseline: { uuid: null, startedAt: 0 },
+          awaitingClaude: {
+            session: "work",
+            baseline: { uuid: null, startedAt: 0 },
+          },
           meta: {},
         },
         dispatch: (a) => dispatched.push(a),
@@ -614,7 +613,7 @@ describe("feedRenderer", () => {
       const patch = dispatched.find(a => a.type === "ui/UPDATE_PROPS");
       assert.ok(patch);
       assert.equal(patch.patch.topic, `claude/${uuid}`);
-      assert.equal(patch.patch.awaitingClaudeForSession, null);
+      assert.equal(patch.patch.awaitingClaude, null);
     });
 
     it("ignores non-claude topic-new events while awaiting", () => {
@@ -628,8 +627,10 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          awaitingBaseline: { uuid: null, startedAt: 0 },
+          awaitingClaude: {
+            session: "work",
+            baseline: { uuid: null, startedAt: 0 },
+          },
           meta: {},
         },
         dispatch: () => {},
@@ -655,8 +656,10 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          awaitingBaseline: { uuid, startedAt: 100 },
+          awaitingClaude: {
+            session: "work",
+            baseline: { uuid, startedAt: 100 },
+          },
           meta: {},
         },
         dispatch: () => {},
@@ -687,8 +690,10 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          awaitingBaseline: { uuid: null, startedAt: 0 },
+          awaitingClaude: {
+            session: "work",
+            baseline: { uuid: null, startedAt: 0 },
+          },
           meta: {},
         },
         dispatch: () => {},
@@ -730,8 +735,10 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          awaitingBaseline: { uuid: null, startedAt: 0 },
+          awaitingClaude: {
+            session: "work",
+            baseline: { uuid: null, startedAt: 0 },
+          },
           meta: {},
         },
         dispatch: () => {},
@@ -759,8 +766,10 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          awaitingBaseline: { uuid: null, startedAt: 0 },
+          awaitingClaude: {
+            session: "work",
+            baseline: { uuid: null, startedAt: 0 },
+          },
           meta: {},
         },
         dispatch: () => {},
@@ -783,8 +792,10 @@ describe("feedRenderer", () => {
         id: "feed-1",
         props: {
           topic: null,
-          awaitingClaudeForSession: "work",
-          awaitingBaseline: { uuid: null, startedAt: 0 },
+          awaitingClaude: {
+            session: "work",
+            baseline: { uuid: null, startedAt: 0 },
+          },
           meta: {},
         },
         dispatch: () => {},

--- a/test/feed-tile.test.js
+++ b/test/feed-tile.test.js
@@ -92,6 +92,9 @@ describe("feedRenderer", () => {
     eventSources.length = 0;
     fetchResult = [];
     for (const k of Object.keys(winListeners)) delete winListeners[k];
+    // Reset module-level session store getter so tests that don't need
+    // a store don't inherit one from a prior test.
+    feedRenderer.init({});
   });
 
   describe("structure", () => {

--- a/test/session-child-counter-claude.test.js
+++ b/test/session-child-counter-claude.test.js
@@ -28,6 +28,35 @@ describe("isClaudeCommand", () => {
     assert.equal(isClaudeCommand("claudesh"), false);
   });
 
+  it("matches the semver title that Claude Code sets at runtime", () => {
+    // Observed via `tmux list-panes -F '#{pane_current_command}'` on macOS:
+    // Claude Code overwrites its process title with the running version
+    // (e.g. "2.1.107", "2.1.109"). Tmux's pane_current_command reads the
+    // kinfo_proc p_comm / ucomm field on BSD+macOS, which reflects the
+    // current title — not the original exec name — so plain "claude"
+    // never hits for a live Claude Code pane.
+    assert.equal(isClaudeCommand("2.1.107"), true);
+    assert.equal(isClaudeCommand("2.1.108"), true);
+    assert.equal(isClaudeCommand("2.1.109"), true);
+    assert.equal(isClaudeCommand("2.1.110"), true);
+  });
+
+  it("matches semver with prerelease and build metadata", () => {
+    assert.equal(isClaudeCommand("2.2.0-beta.1"), true);
+    assert.equal(isClaudeCommand("3.0.0-rc.2"), true);
+    assert.equal(isClaudeCommand("2.1.109+build.42"), true);
+  });
+
+  it("does not match arbitrary numeric strings", () => {
+    // The semver matcher must not false-positive on pids, ports, IP
+    // fragments, or short version-like strings Claude Code has never set.
+    assert.equal(isClaudeCommand("1"), false);
+    assert.equal(isClaudeCommand("1.0"), false);
+    assert.equal(isClaudeCommand("12345"), false);
+    assert.equal(isClaudeCommand("127.0.0.1"), false);
+    assert.equal(isClaudeCommand("a.b.c"), false);
+  });
+
   it("handles null / empty / non-string", () => {
     assert.equal(isClaudeCommand(null), false);
     assert.equal(isClaudeCommand(undefined), false);


### PR DESCRIPTION
## Summary

- **Awaiting-Claude tile** — sparkle click before SessionStart opens a blank stream-shaped tile (header + empty list) that swaps to `claude/<uuid>` in place the moment a uuid arrives. No picker, no reshuffle.
- **Two signal paths for uuid arrival** — the tile listens to both the session store AND `katulong:topic-new` broadcasts, so it resolves even when `session.meta.claude.uuid` never surfaces (e.g. staging where hooks land on the primary server). Whichever signal arrives first wins; swap guarded to happen exactly once.
- **Uuid adoption from any hook event** — if hooks were installed after Claude already started, the first `UserPromptSubmit` / `PreToolUse` / `PostToolUse` now adopts the uuid. Only `SessionStart` may replace a known uuid. Detection-owned keys (`running` / `detectedAt` from pane monitor) preserved through all paths.
- **SemVer `pane_current_command` matching** — Claude Code sets `process.title = <version>` at startup; on macOS tmux's `pane_current_command` reads `p_comm` / `ucomm` which reflects the current title, so plain `claude` never hits for a live pane. Matches `2.1.109`, `2.2.0-beta.1`, etc., with strict regex so pids/ports/IPs don't false-positive.
- **Joystick island** — action buttons + connection dot share one frosted-glass surface rather than floating as separate chips.
- **Narrative-first feed rendering** — `narrative` / `summary` / `attention` events render as prominent blocks; tool-use progress steps collapse into `<details>` groups so the feed reads like a blog rather than a log.

## Test plan

- [x] `npm test` passes (2300/2300 unit + integration, 0 failures)
- [x] `isClaudeCommand` matches SemVer and rejects pids/IPs/short numeric strings
- [x] `applyClaudeMetaFromHook` adopts uuid from non-SessionStart events only when missing; never overwrites; preserves detection-owned keys
- [x] `startAwaitingClaude` swaps on session-store uuid arrival, on `katulong:topic-new` arrival, immediately if already fresh at mount, not on stale baseline match; unsubscribes and removes the topic-new listener on unmount
- [ ] Manual: click sparkle with Claude running — blank tile appears, swaps to live stream when hook fires
- [ ] Manual: sparkle with uuid already known — opens live stream directly
- [ ] Manual: sparkle with no Claude — opens generic picker fallback