### PR TITLE
chore: extract fetchSessionLists + drop dead refs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -26,6 +26,7 @@
     import { createCommandSurface } from "/lib/command-surface.js";
     import { buildCommandTree } from "/lib/command-tree.js";
     import { openCommandPicker } from "/lib/command-picker.js";
+    import { fetchSessionLists } from "/lib/session-fetch.js";
     import { createWindowTabSet } from "/lib/window-tab-set.js";
     import { createPasteHandler } from "/lib/paste-handler.js";
     import { createSettingsHandlers } from "/lib/settings-handlers.js";
@@ -1657,20 +1658,7 @@
       });
       const openIds = new Set(openTiles.map((t) => t.id));
 
-      // Fetch server-side session lists in parallel; show what we have
-      // even if one side fails (the other half is still useful).
-      let managed = [];
-      let unmanaged = [];
-      try {
-        const [sessData, tmuxData] = await Promise.all([
-          api.get(`/sessions?_t=${Date.now()}`).catch(() => []),
-          api.get(`/tmux-sessions?_t=${Date.now()}`).catch(() => []),
-        ]);
-        managed = sessData || [];
-        unmanaged = (tmuxData || []).map((s) => typeof s === "string" ? { name: s, attached: false } : s);
-      } catch (err) {
-        console.error("[picker] fetch error:", err);
-      }
+      const { managed, unmanaged } = await fetchSessionLists();
 
       const closedManaged = managed
         .filter((s) => !openIds.has(s.name))
@@ -1729,8 +1717,8 @@
     };
     const commandTree = buildCommandTree(commandActions);
     const commandMode = createCommandMode({ tree: commandTree });
-    const commandSurface = createCommandSurface({ mountIn: bar, mode: commandMode });
-    void commandSurface;
+    // Surface subscribes to commandMode internally; no further reference needed.
+    createCommandSurface({ mountIn: bar, mode: commandMode });
 
     const renderBar = (name) => shortcutBarInstance.render(name);
 

--- a/public/lib/command-surface.js
+++ b/public/lib/command-surface.js
@@ -7,9 +7,8 @@
  *
  * Rendered state comes from a command-mode subscription: the surface is
  * passive and just draws what the walker is on. Each child of the
- * current node becomes a key pill; keyRange leaves collapse into a
- * single "1-9" pill. The breadcrumb shows how deep we are so the user
- * can read the chord they've typed.
+ * current node becomes a key pill. The breadcrumb shows how deep we
+ * are so the user can read the chord they've typed.
  */
 
 export const COMMAND_SURFACE_CLASS = "command-surface";

--- a/public/lib/session-fetch.js
+++ b/public/lib/session-fetch.js
@@ -1,0 +1,28 @@
+/**
+ * Shared fetch for the server's two session lists.
+ *
+ * Both the shortcut-bar + button dropdown and the Cmd+/ fuzzy picker
+ * need the same pair: managed sessions (/sessions) and unmanaged tmux
+ * sessions (/tmux-sessions). The normalization (tmux list occasionally
+ * returns plain strings instead of objects) was duplicated verbatim in
+ * two places until we hoisted it here.
+ *
+ * Errors from either endpoint degrade to an empty list rather than
+ * aborting the whole fetch — showing half the picker is strictly better
+ * than showing none of it.
+ */
+
+import { api } from "/lib/api-client.js";
+
+export async function fetchSessionLists() {
+  const bust = Date.now();
+  const [sessData, tmuxData] = await Promise.all([
+    api.get(`/sessions?_t=${bust}`).catch(() => []),
+    api.get(`/tmux-sessions?_t=${bust}`).catch(() => []),
+  ]);
+  const managed = sessData || [];
+  const unmanaged = (tmuxData || []).map(
+    (s) => typeof s === "string" ? { name: s, attached: false } : s,
+  );
+  return { managed, unmanaged };
+}

--- a/public/lib/session-fetch.js
+++ b/public/lib/session-fetch.js
@@ -9,16 +9,25 @@
  *
  * Errors from either endpoint degrade to an empty list rather than
  * aborting the whole fetch — showing half the picker is strictly better
- * than showing none of it.
+ * than showing none of it. Shortcut-bar previously used an outer
+ * try/catch that zeroed both lists when either endpoint failed; the
+ * per-fetch .catch here intentionally preserves partial results, which
+ * is the behavior openTilePicker already had.
  */
 
 import { api } from "/lib/api-client.js";
 
 export async function fetchSessionLists() {
-  const bust = Date.now();
+  const cacheBust = Date.now();
   const [sessData, tmuxData] = await Promise.all([
-    api.get(`/sessions?_t=${bust}`).catch(() => []),
-    api.get(`/tmux-sessions?_t=${bust}`).catch(() => []),
+    api.get(`/sessions?_t=${cacheBust}`).catch((err) => {
+      console.warn("[session-fetch] /sessions failed:", err.message);
+      return [];
+    }),
+    api.get(`/tmux-sessions?_t=${cacheBust}`).catch((err) => {
+      console.warn("[session-fetch] /tmux-sessions failed:", err.message);
+      return [];
+    }),
   ]);
   const managed = sessData || [];
   const unmanaged = (tmuxData || []).map(

--- a/public/lib/shortcut-bar.js
+++ b/public/lib/shortcut-bar.js
@@ -10,6 +10,7 @@
 
 import { invalidateSessions } from "/lib/stores.js";
 import { api, invalidateSessionIdCache } from "/lib/api-client.js";
+import { fetchSessionLists } from "/lib/session-fetch.js";
 import { detectPlatform } from "/lib/platform.js";
 import { renderKeyIsland } from "/lib/key-island.js";
 import { COMMAND_SURFACE_CLASS } from "/lib/command-surface.js";
@@ -169,16 +170,7 @@ export function createShortcutBar(options = {}) {
       closeMenu();
       return;
     }
-    let managed = [];
-    let unmanaged = [];
-    try {
-      const [sessData, tmuxData] = await Promise.all([
-        api.get(`/sessions?_t=${Date.now()}`),
-        api.get(`/tmux-sessions?_t=${Date.now()}`),
-      ]);
-      managed = sessData || [];
-      unmanaged = (tmuxData || []).map(s => typeof s === "string" ? { name: s, attached: false } : s);
-    } catch (err) { console.error("[showAddMenu] fetch error:", err); }
+    const { managed, unmanaged } = await fetchSessionLists();
 
     const openTabs = windowTabSet ? new Set(windowTabSet.getTabs()) : new Set();
 


### PR DESCRIPTION
## Summary

Follow-ups from PR #607 review notes:

- Extract `fetchSessionLists()` into `lib/session-fetch.js`. `openTilePicker` (app.js) and `showAddMenu` (shortcut-bar.js) both fetched `/sessions` + `/tmux-sessions` with identical normalization for the tmux string-vs-object quirk. Two call sites, one helper.
- Drop the `void commandSurface` escape-hatch pattern. The surface's lifecycle is self-contained via its command-mode subscription — no dangling name needed.
- Remove the stale `keyRange` sentence from command-surface.js docstring (the 1-9 range feature was cut earlier and the comment never caught up).

## Test plan

- [x] `npm test` — all 2283 tests pass
- [ ] Manual: `Cmd+/` still opens fuzzy picker with open tiles + closed managed + unmanaged tmux
- [ ] Manual: shortcut bar `+` button still shows the same session list