### PR TITLE
feed tile: narrower default width

### DIFF
--- a/public/lib/tile-host.js
+++ b/public/lib/tile-host.js
@@ -25,7 +25,7 @@ import { selectClusterView } from "./selectors.js";
 // a user-dragged width saved in localStorage always wins.
 const DEFAULT_CARD_WIDTHS = {
   "file-browser": 420,
-  "feed": 480,
+  "feed": 380,
 };
 
 function defaultCardWidthForType(type) {


### PR DESCRIPTION
## Summary

- Default feed tile width: 480px → 380px
- More portrait-proportioned, reads better alongside the terminal
- User-dragged widths in localStorage still win (only affects first-open sizing)

## Test plan

- [ ] Open a new feed tile — it should be noticeably narrower
- [ ] Existing feed tiles keep their saved width