### PR TITLE
fix: new tile opens right of active, not at end

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -28,6 +28,7 @@
     import { openCommandPicker } from "/lib/command-picker.js";
     import { fetchSessionLists } from "/lib/session-fetch.js";
     import { createWindowTabSet } from "/lib/window-tab-set.js";
+    import { installTabOrderSync } from "/lib/tab-order-sync.js";
     import { createPasteHandler } from "/lib/paste-handler.js";
     import { createSettingsHandlers } from "/lib/settings-handlers.js";
     import { createTerminalKeyboard } from "/lib/terminal-keyboard.js";
@@ -957,9 +958,18 @@
         if (sidebar?.classList.contains("collapsed")) {
           setSidebarCollapsed(false);
         }
-        // routeToSession dispatches ADD_TILE with insertAt: "afterFocus"
+        // routeToSession dispatches ADD_TILE with insertAt: "afterFocus".
+        // Mirror the same anchor index into windowTabSet so the sidebar
+        // session list (which reads from windowTabSet.getTabs()) shows the
+        // new tab right of the active one too. Other addTab call sites
+        // (activateSession, onAdoptSession, the WS session-adopted handler)
+        // append intentionally — they're adopting sessions uiStore hasn't
+        // placed yet, so there's no positioned insertion to mirror.
+        const activeName = getActiveSessionName();
+        const priorTabs = windowTabSet.getTabs();
+        const anchorIdx = activeName ? priorTabs.indexOf(activeName) : -1;
         routeToSession(data.name);
-        windowTabSet.addTab(data.name);
+        windowTabSet.addTab(data.name, anchorIdx >= 0 ? anchorIdx + 1 : undefined);
         cm.reconnectNow();
       } catch (err) {
         console.error("Failed to create session:", err);
@@ -1480,13 +1490,7 @@
       uiStore,
     });
 
-    // Sync ui-store order when tabs are reordered via the legacy shortcut bar.
-    // Routes through ui-store so tile-host drives carousel.reorderCards.
-    if (windowTabSet) {
-      windowTabSet.subscribe(() => {
-        uiStore.reorder(windowTabSet.getTabs());
-      });
-    }
+    installTabOrderSync({ windowTabSet, uiStore });
 
     // ── <tile-tab-bar> event handlers ──────────────────────────────────
     // The web component dispatches CustomEvents for actions that need

--- a/public/lib/tab-order-sync.js
+++ b/public/lib/tab-order-sync.js
@@ -1,0 +1,55 @@
+/**
+ * Keep uiStore's column order in sync with windowTabSet reorders.
+ *
+ * windowTabSet and uiStore are two parallel stores that record the same
+ * set of session tabs. windowTabSet persists to sessionStorage and
+ * coordinates cross-window events; uiStore is the authoritative source
+ * for carousel/tile layout.
+ *
+ * The only mutation that belongs in this sync is a **pure permutation**
+ * — the set of tab ids is unchanged, only their order differs. The one
+ * call site that produces that today is the session-list drag-reorder
+ * in session-list-component.js, which ends by calling
+ * windowTabSet.reorderTabs(...).
+ *
+ * Additions and removals must NOT flow through here. Naively piping
+ * every windowTabSet.notify() into uiStore.reorder() clobbers
+ * afterFocus-placed insertions: uiStore.addTile("D", afterFocus=B)
+ * correctly produces [A, B, D, C] in uiStore; then
+ * windowTabSet.addTab("D") appends, producing [A, B, C, D]; then the
+ * ungated subscriber reorders uiStore to [A, B, C, D] — the new tile
+ * jumps to the end of the carousel. This regressed the Chrome-style
+ * insertion behavior originally fixed in PR #499 and rediscovered
+ * during the MC3 ui-store rewrite. The permutation-only gate makes the
+ * subscriber idempotent for add/remove traffic.
+ */
+
+export function installTabOrderSync({ windowTabSet, uiStore } = {}) {
+  if (!windowTabSet || !uiStore) return () => {};
+
+  let prev = windowTabSet.getTabs().slice();
+
+  return windowTabSet.subscribe(() => {
+    const current = windowTabSet.getTabs();
+    if (sameOrder(prev, current)) return;
+    const previous = prev;
+    prev = current.slice();
+
+    // Pure permutation = same length, same set. Sets of distinct tab
+    // names short-circuit on the first foreign id.
+    if (current.length !== previous.length) return;
+    const previousSet = new Set(previous);
+    for (const id of current) {
+      if (!previousSet.has(id)) return;
+    }
+    uiStore.reorder(current);
+  });
+}
+
+function sameOrder(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/test/tab-order-sync.test.js
+++ b/test/tab-order-sync.test.js
@@ -37,6 +37,8 @@ globalThis.BroadcastChannel = class {
 
 const { createWindowTabSet } = await import("../public/lib/window-tab-set.js");
 const { navigateTab, moveTab, jumpToTab } = await import("../public/lib/navigation.js");
+const { installTabOrderSync } = await import("../public/lib/tab-order-sync.js");
+const { createUiStore } = await import("../public/lib/ui-store.js");
 
 function makeTabSet(initialTabs = []) {
   stores.session = {};
@@ -207,13 +209,13 @@ describe("windowTabSet syncs to carousel order after restore", () => {
   });
 });
 
-describe("drag reorder syncs carousel via windowTabSet subscriber", () => {
+describe("windowTabSet.subscribe — raw callback wiring (sanity check)", () => {
   beforeEach(() => {
     stores.session = {};
     stores.local = {};
   });
 
-  it("windowTabSet subscriber can trigger carousel reorder", () => {
+  it("a subscriber callback can mirror reorderTabs into a parallel array", () => {
     const ts = makeTabSet(["a", "b", "c"]);
     let carouselCards = ["a", "b", "c"];
 
@@ -229,5 +231,101 @@ describe("drag reorder syncs carousel via windowTabSet subscriber", () => {
 
     assert.deepEqual(ts.getTabs(), ["c", "a", "b"]);
     assert.deepEqual(carouselCards, ["c", "a", "b"]);
+  });
+});
+
+/**
+ * Regression for the "new tile jumps to end of carousel" bug. The ui-store
+ * addTile + "afterFocus" inserts the new column right of the focused tile;
+ * windowTabSet.addTab appends. Before the permutation gate in
+ * installTabOrderSync, the subscriber would immediately overwrite
+ * ui-store's correctly-positioned order with windowTabSet's append-ordered
+ * list. These tests exercise the real installTabOrderSync wiring with a
+ * real uiStore + a real windowTabSet, asserting both the regression path
+ * and the legitimate drag-reorder sync path.
+ */
+describe("installTabOrderSync — ADD_TILE afterFocus must survive windowTabSet.addTab", () => {
+  beforeEach(() => {
+    stores.session = {};
+    stores.local = {};
+  });
+
+  function buildStoreWithOrder(ids, focusedId) {
+    const uiStore = createUiStore();
+    for (const id of ids) {
+      uiStore.addTile({ id, type: "terminal", props: {} });
+    }
+    if (focusedId) uiStore.focusTile(focusedId);
+    return uiStore;
+  }
+
+  const orderOf = (uiStore) => uiStore.getState().order;
+
+  it("new tile opens right of focused tile (not at end) when windowTabSet.addTab also fires", () => {
+    // Three tabs, B focused. createNewSession will dispatch addTile
+    // afterFocus then addTab — both must agree on placement.
+    const uiStore = buildStoreWithOrder(["A", "B", "C"], "B");
+    const ts = makeTabSet(["A", "B", "C"]);
+    installTabOrderSync({ windowTabSet: ts, uiStore });
+
+    uiStore.addTile({ id: "D", type: "terminal", props: {} }, { focus: true, insertAt: "afterFocus" });
+    ts.addTab("D");
+
+    assert.deepEqual(
+      orderOf(uiStore),
+      ["A", "B", "D", "C"],
+      "uiStore.reorder must NOT fire on addTab — afterFocus placement has to win",
+    );
+    assert.deepEqual(ts.getTabs(), ["A", "B", "C", "D"]);
+  });
+
+  it("new tile opens at end when no tab is focused", () => {
+    const uiStore = buildStoreWithOrder(["A", "B", "C"], null);
+    const ts = makeTabSet(["A", "B", "C"]);
+    installTabOrderSync({ windowTabSet: ts, uiStore });
+
+    uiStore.addTile({ id: "D", type: "terminal", props: {} }, { focus: true, insertAt: "afterFocus" });
+    ts.addTab("D");
+
+    assert.deepEqual(orderOf(uiStore), ["A", "B", "C", "D"]);
+  });
+
+  it("removeTab does not trigger uiStore.reorder either", () => {
+    const uiStore = buildStoreWithOrder(["A", "B", "C"], "B");
+    const ts = makeTabSet(["A", "B", "C"]);
+    installTabOrderSync({ windowTabSet: ts, uiStore });
+
+    uiStore.removeTile("B");
+    ts.removeTab("B");
+
+    assert.deepEqual(orderOf(uiStore), ["A", "C"]);
+    assert.deepEqual(ts.getTabs(), ["A", "C"]);
+  });
+
+  it("pure reorder (session-list drag) does propagate to uiStore", () => {
+    const uiStore = buildStoreWithOrder(["A", "B", "C"], "A");
+    const ts = makeTabSet(["A", "B", "C"]);
+    installTabOrderSync({ windowTabSet: ts, uiStore });
+
+    ts.reorderTabs(["C", "A", "B"]);
+
+    assert.deepEqual(orderOf(uiStore), ["C", "A", "B"]);
+    assert.deepEqual(ts.getTabs(), ["C", "A", "B"]);
+  });
+
+  it("returns an unsubscribe handle", () => {
+    const uiStore = buildStoreWithOrder(["A", "B"], "A");
+    const ts = makeTabSet(["A", "B"]);
+    const unsubscribe = installTabOrderSync({ windowTabSet: ts, uiStore });
+    assert.equal(typeof unsubscribe, "function");
+
+    unsubscribe();
+    ts.reorderTabs(["B", "A"]);
+    assert.deepEqual(orderOf(uiStore), ["A", "B"]);
+  });
+
+  it("no-ops when called without windowTabSet or uiStore", () => {
+    assert.equal(typeof installTabOrderSync(), "function");
+    assert.equal(typeof installTabOrderSync({ windowTabSet: null, uiStore: null }), "function");
   });
 });


### PR DESCRIPTION
## Summary

- **Regression**: new tiles jumped to the end of the carousel instead of opening right of the active one (Chrome-style). Root cause: a blanket `windowTabSet.subscribe → uiStore.reorder(getTabs())` subscriber overwrote `addTile`'s `afterFocus` placement with `windowTabSet`'s append-ordered list.
- **Fix**: extract subscriber into `installTabOrderSync()` module gated on **pure permutations** — only propagates when tab set is unchanged but order differs (i.e., session-list drag). Add/remove operations short-circuit.
- **Also**: `createNewSession` now passes anchor index to `windowTabSet.addTab()` so the sidebar session list stays in sync with the carousel.

## Files changed

- `public/lib/tab-order-sync.js` (new) — extracted permutation-gated subscriber
- `public/app.js` — import + use `installTabOrderSync`; pass insertion index in `createNewSession`
- `test/tab-order-sync.test.js` — 6 new regression tests with real `uiStore` + real `windowTabSet`

## Test plan

- [x] 2289 unit tests pass (0 failures)
- [x] Regression test: "new tile opens right of focused tile (not at end) when windowTabSet.addTab also fires"
- [x] Drag-reorder still propagates to uiStore
- [x] removeTab does not trigger spurious reorder
- [ ] Manual: open 3+ tabs, focus middle one, press +, verify new tab appears right of focused