### PR TITLE
fix(feed): dedupe file chips by basename

### DIFF
--- a/lib/claude-narrator.js
+++ b/lib/claude-narrator.js
@@ -19,8 +19,21 @@
  * commands all count. Globs (paths containing `*`) are skipped because
  * they don't point at a single file the user can open.
  *
- * Returns an array of `{ path, line? }`, deduped by path (first line
- * wins). Line is only set for Read at an offset — the only tool whose
+ * Returns an array of `{ path, line? }`, deduped by *basename* (first
+ * occurrence wins, with line promotion — see below).
+ *
+ * Why basename and not full path? The chip the user sees shows the
+ * basename, so two different paths that share a basename (e.g. eight
+ * `SKILL.md` files across directories) previously rendered as eight
+ * identical-looking chips. That's noise, not information. Collapsing
+ * to one chip per basename makes the footer scannable; the user can
+ * still click through to open the first occurrence. Line numbers are
+ * preserved when any occurrence carries one — if the first add saw
+ * no line but a later add has one (e.g. `Edit` followed by `Read +
+ * offset` on the same basename), the line gets promoted onto the
+ * retained entry.
+ *
+ * Line is only set for Read at an offset — the only tool whose
  * arguments carry one we can show.
  *
  * @param {{ tools?: Array<{name: string, input: object}> }} entry
@@ -30,11 +43,28 @@ export function extractFilesFromEntry(entry) {
   if (!entry || !Array.isArray(entry.tools) || entry.tools.length === 0) return [];
   const seen = new Map();
 
+  function basenameOf(p) {
+    const parts = p.split("/").filter(Boolean);
+    return parts.length > 0 ? parts[parts.length - 1] : p;
+  }
+
   function add(path, line) {
     if (typeof path !== "string" || !path) return;
     if (path.includes("*")) return;
-    if (seen.has(path)) return;
-    seen.set(path, typeof line === "number" && line > 0 ? line : undefined);
+    const key = basenameOf(path);
+    const nextLine = typeof line === "number" && line > 0 ? line : undefined;
+    const existing = seen.get(key);
+    if (!existing) {
+      seen.set(key, { path, line: nextLine });
+      return;
+    }
+    // Same basename seen again: keep the first path (so clicks stay
+    // stable) but promote a line number if we now have one and didn't
+    // before. This handles the common Edit-then-Read-with-offset
+    // sequence where the later call is the one carrying the line.
+    if (existing.line === undefined && nextLine !== undefined) {
+      existing.line = nextLine;
+    }
   }
 
   for (const t of entry.tools) {
@@ -61,7 +91,7 @@ export function extractFilesFromEntry(entry) {
         break;
     }
   }
-  return [...seen.entries()].map(([path, line]) =>
+  return [...seen.values()].map(({ path, line }) =>
     line !== undefined ? { path, line } : { path }
   );
 }

--- a/lib/claude-narrator.js
+++ b/lib/claude-narrator.js
@@ -13,6 +13,8 @@
  * decides what to do with the results.
  */
 
+import { basename } from "node:path";
+
 /**
  * Extract unique file paths touched by an assistant entry's tool_use
  * blocks. Read, Write, Edit, Grep, Glob, and plain `cd <path>` Bash
@@ -27,11 +29,12 @@
  * `SKILL.md` files across directories) previously rendered as eight
  * identical-looking chips. That's noise, not information. Collapsing
  * to one chip per basename makes the footer scannable; the user can
- * still click through to open the first occurrence. Line numbers are
- * preserved when any occurrence carries one — if the first add saw
- * no line but a later add has one (e.g. `Edit` followed by `Read +
- * offset` on the same basename), the line gets promoted onto the
- * retained entry.
+ * still click through to open the first occurrence. Line promotion
+ * is intentionally gated on *same path*: an Edit-then-Read-with-offset
+ * sequence on the same file promotes the offset onto the retained
+ * entry, but a line number from a different file that merely shares
+ * a basename does NOT bleed across — it would navigate the user to a
+ * line that was never associated with the retained path.
  *
  * Line is only set for Read at an offset — the only tool whose
  * arguments carry one we can show.
@@ -43,26 +46,21 @@ export function extractFilesFromEntry(entry) {
   if (!entry || !Array.isArray(entry.tools) || entry.tools.length === 0) return [];
   const seen = new Map();
 
-  function basenameOf(p) {
-    const parts = p.split("/").filter(Boolean);
-    return parts.length > 0 ? parts[parts.length - 1] : p;
-  }
-
   function add(path, line) {
     if (typeof path !== "string" || !path) return;
     if (path.includes("*")) return;
-    const key = basenameOf(path);
+    const key = basename(path);
+    if (!key) return;
     const nextLine = typeof line === "number" && line > 0 ? line : undefined;
     const existing = seen.get(key);
     if (!existing) {
       seen.set(key, { path, line: nextLine });
       return;
     }
-    // Same basename seen again: keep the first path (so clicks stay
-    // stable) but promote a line number if we now have one and didn't
-    // before. This handles the common Edit-then-Read-with-offset
-    // sequence where the later call is the one carrying the line.
-    if (existing.line === undefined && nextLine !== undefined) {
+    // Edit-then-Read-with-offset on the *same* path: promote the line so
+    // the chip links to the edited offset. Gated on same path because
+    // line numbers from a different file would mislead the user.
+    if (existing.line === undefined && nextLine !== undefined && existing.path === path) {
       existing.line = nextLine;
     }
   }

--- a/test/claude-narrator.test.js
+++ b/test/claude-narrator.test.js
@@ -120,7 +120,7 @@ describe("extractFilesFromEntry", () => {
     assert.deepEqual(files, [{ path: "/out.txt" }, { path: "/src/mod.js" }]);
   });
 
-  it("dedupes by path — first line wins", () => {
+  it("dedupes by basename — first occurrence wins", () => {
     const files = extractFilesFromEntry({
       role: "assistant",
       tools: [
@@ -130,6 +130,36 @@ describe("extractFilesFromEntry", () => {
       ],
     });
     assert.deepEqual(files, [{ path: "/src/a.js", line: 10 }]);
+  });
+
+  it("collapses different paths that share a basename to one chip", () => {
+    // The chip UI shows the basename — so eight different SKILL.md files
+    // at different paths would render as eight identical-looking chips.
+    // Dedupe by basename to cut that noise; the first path seen is what
+    // the chip opens on click.
+    const files = extractFilesFromEntry({
+      role: "assistant",
+      tools: [
+        { name: "Read", input: { file_path: "/a/SKILL.md" } },
+        { name: "Read", input: { file_path: "/b/SKILL.md" } },
+        { name: "Edit", input: { file_path: "/c/SKILL.md" } },
+      ],
+    });
+    assert.deepEqual(files, [{ path: "/a/SKILL.md" }]);
+  });
+
+  it("promotes a line number onto the retained entry when the first had none", () => {
+    // Edit-then-Read-with-offset on the same basename: the user clicks
+    // one chip, so it should carry the most useful line info available
+    // from anywhere in the turn.
+    const files = extractFilesFromEntry({
+      role: "assistant",
+      tools: [
+        { name: "Edit", input: { file_path: "/src/a.js" } },
+        { name: "Read", input: { file_path: "/other/a.js", offset: 42 } },
+      ],
+    });
+    assert.deepEqual(files, [{ path: "/src/a.js", line: 42 }]);
   });
 
   it("skips Grep/Glob paths containing a glob star", () => {

--- a/test/claude-narrator.test.js
+++ b/test/claude-narrator.test.js
@@ -148,10 +148,25 @@ describe("extractFilesFromEntry", () => {
     assert.deepEqual(files, [{ path: "/a/SKILL.md" }]);
   });
 
-  it("promotes a line number onto the retained entry when the first had none", () => {
-    // Edit-then-Read-with-offset on the same basename: the user clicks
-    // one chip, so it should carry the most useful line info available
-    // from anywhere in the turn.
+  it("promotes a line number onto the retained entry for the same path (Edit then Read+offset)", () => {
+    // Same file touched twice — Edit without a line, then Read with
+    // offset. The user clicks one chip and expects it to land on the
+    // offset they can see in the transcript.
+    const files = extractFilesFromEntry({
+      role: "assistant",
+      tools: [
+        { name: "Edit", input: { file_path: "/src/a.js" } },
+        { name: "Read", input: { file_path: "/src/a.js", offset: 42 } },
+      ],
+    });
+    assert.deepEqual(files, [{ path: "/src/a.js", line: 42 }]);
+  });
+
+  it("does NOT promote a line number across different paths that share a basename", () => {
+    // Guard against cross-file line bleeding: /src/a.js and /other/a.js
+    // are different files. A line number from /other/a.js must not land
+    // on the /src/a.js chip — the user would be sent to a line that was
+    // never associated with that file.
     const files = extractFilesFromEntry({
       role: "assistant",
       tools: [
@@ -159,7 +174,7 @@ describe("extractFilesFromEntry", () => {
         { name: "Read", input: { file_path: "/other/a.js", offset: 42 } },
       ],
     });
-    assert.deepEqual(files, [{ path: "/src/a.js", line: 42 }]);
+    assert.deepEqual(files, [{ path: "/src/a.js" }]);
   });
 
   it("skips Grep/Glob paths containing a glob star", () => {


### PR DESCRIPTION
## Summary
- `extractFilesFromEntry` now dedupes by basename, not full path
- Multiple paths sharing a basename (e.g. 8 different `SKILL.md` files) collapse to one chip
- Line number promotes onto the retained entry when a later occurrence carries one the first didn't

## Why
The chip UI shows only the basename. Eight different `SKILL.md` files at eight paths rendered as eight visually identical "SKILL.md" chips — they looked like dupe toast. Now the footer shows one chip per distinct basename.

## Trade-off
We lose the ability to open the *other* same-basename paths from the feed. Acceptable: chips are a skim-hint, not an audit log.

## Test plan
- [x] `node --test test/claude-narrator.test.js` — 17/17 pass
- [x] Full unit + smoke E2E suite passed on push
- [x] Pre-push review agents passed