### PR TITLE
feat(feed): inline image paste in Claude reply composer

### DIFF
--- a/lib/paste-sequence.js
+++ b/lib/paste-sequence.js
@@ -1,0 +1,131 @@
+/**
+ * Replay an ordered sequence of text + image tokens into a tmux session,
+ * as if a human were typing and pasting into the pane.
+ *
+ * Used by the `/paste` route to back two flavors of paste:
+ *
+ *   - Legacy image-only paste (xterm clipboard bridge): tokens are all
+ *     `{ type: "image", path }` — for each, set clipboard, bridge to
+ *     containers, write Ctrl+V to the pane.
+ *
+ *   - Interleaved text + image paste (feed tile reply): tokens alternate
+ *     text chunks and image references in the order the user entered
+ *     them, optionally followed by a real Enter (`submit: true`).
+ *
+ * Sequential per-session: the clipboard is a global resource (host +
+ * container), so two images in flight would race. `\x16` is written only
+ * after the clipboard set succeeds on either the host or a bridged
+ * container — otherwise Claude Code would read stale clipboard content.
+ *
+ * No I/O outside injected callbacks. Accepts the file-system primitives
+ * (setClipboard, bridge*) as deps so the route handler and the unit
+ * tests can share one implementation.
+ */
+
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+
+const DEFAULT_PASTE_DELAY_MS = 50;
+const PASTE_BYTE = "\x16"; // Ctrl+V — triggers Claude Code's paste handler
+
+/**
+ * @param {object} opts
+ * @param {Array<{type: "text", value: string} | {type: "image", path: string}>} opts.tokens
+ * @param {object} [opts.session]             Live Session — must have .alive + .write().
+ *                                             If absent, the host clipboard is
+ *                                             still set for image tokens
+ *                                             (legacy drag-drop), but \x16 /
+ *                                             text writes / submit are skipped.
+ * @param {string} [opts.sessionName]         Used for container-bridge targeting.
+ * @param {object} [opts.sessionManager]      For bridgePaneContainer.
+ * @param {string} opts.uploadsDir            Root dir for image paths (scope guard).
+ * @param {boolean} [opts.submit]             Append real Enter (\r) at the end.
+ * @param {function} opts.setClipboard        (filePath, ext, logger) => Promise<boolean>
+ * @param {function} opts.bridgeClipboardToContainers (filename, mimeType, logger) => Promise<boolean>
+ * @param {function} opts.bridgePaneContainer         (sessionName, sessionManager, filePath, mimeType, logger) => Promise<boolean>
+ * @param {function} opts.imageMimeType       (ext) => string
+ * @param {object} [opts.logger]              { warn, info }
+ * @param {function} [opts.sleep]             (ms) => Promise — injectable for tests.
+ * @param {function} [opts.onImagePasted]     (path) => void — per-image progress callback (WS relay).
+ * @param {number} [opts.pasteDelayMs]        Settle delay after each image.
+ * @returns {Promise<{pasted: number, aborted: boolean}>}
+ */
+export async function replayPasteSequence(opts) {
+  const {
+    tokens,
+    session,
+    sessionName,
+    sessionManager,
+    uploadsDir,
+    submit = false,
+    setClipboard,
+    bridgeClipboardToContainers,
+    bridgePaneContainer,
+    imageMimeType,
+    logger = { warn: () => {}, info: () => {} },
+    sleep = defaultSleep,
+    onImagePasted,
+    pasteDelayMs = DEFAULT_PASTE_DELAY_MS,
+  } = opts;
+
+  if (!Array.isArray(tokens) || tokens.length === 0) {
+    return { pasted: 0, aborted: false };
+  }
+
+  const canWrite = Boolean(session && typeof session.write === "function");
+  let pasted = 0;
+
+  for (const t of tokens) {
+    if (canWrite && !session.alive) return { pasted, aborted: true };
+
+    if (t?.type === "text") {
+      if (canWrite && typeof t.value === "string" && t.value.length > 0) {
+        session.write(t.value);
+      }
+      continue;
+    }
+
+    if (t?.type !== "image" || typeof t.path !== "string") continue;
+
+    // Scope the path under uploadsDir to prevent traversal.
+    const filePath = join(uploadsDir, t.path.replace(/^\/uploads\//, ""));
+    if (!filePath.startsWith(uploadsDir) || !existsSync(filePath)) {
+      logger.warn("replayPasteSequence: image path out of scope or missing", { path: t.path });
+      continue;
+    }
+
+    const ext = filePath.split(".").pop();
+    const filename = filePath.split("/").pop();
+    const mimeType = imageMimeType(ext);
+
+    let clipboardOk = await setClipboard(filePath, ext, logger);
+    const bridged = await bridgeClipboardToContainers(filename, mimeType, logger);
+    if (bridged) clipboardOk = true;
+    if (!bridged && sessionName) {
+      const paneBridged = await bridgePaneContainer(sessionName, sessionManager, filePath, mimeType, logger);
+      if (paneBridged) clipboardOk = true;
+    }
+
+    if (clipboardOk && canWrite && session.alive) {
+      session.write(PASTE_BYTE);
+      pasted++;
+      if (typeof onImagePasted === "function") onImagePasted(t.path);
+    } else if (typeof onImagePasted === "function") {
+      // Even without a session, report the clipboard-set so WS consumers
+      // get the same completion event they always got.
+      onImagePasted(t.path);
+    }
+
+    await sleep(pasteDelayMs);
+  }
+
+  if (submit && canWrite && session.alive) {
+    session.write("\r");
+  }
+
+  return { pasted, aborted: false };
+}
+
+function defaultSleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/lib/paste-sequence.js
+++ b/lib/paste-sequence.js
@@ -12,21 +12,30 @@
  *     text chunks and image references in the order the user entered
  *     them, optionally followed by a real Enter (`submit: true`).
  *
- * Sequential per-session: the clipboard is a global resource (host +
- * container), so two images in flight would race. `\x16` is written only
- * after the clipboard set succeeds on either the host or a bridged
- * container — otherwise Claude Code would read stale clipboard content.
+ * Process-wide serialization: every call runs on a single promise chain
+ * so two concurrent requests never race on the host clipboard (a global
+ * resource) and two text replays into the same session never interleave
+ * bytes. The serial latency is well inside human-paced use (one paste
+ * per reply) and matches the "behaves like a person at a keyboard"
+ * intent. `\x16` is written only after the clipboard set succeeds on
+ * either the host or a bridged container — otherwise Claude Code would
+ * read stale clipboard content.
  *
- * No I/O outside injected callbacks. Accepts the file-system primitives
- * (setClipboard, bridge*) as deps so the route handler and the unit
- * tests can share one implementation.
+ * No I/O outside injected callbacks and a scoped existsSync. Accepts
+ * the file-system primitives (setClipboard, bridge*) as deps so the
+ * route handler and the unit tests can share one implementation.
  */
 
-import { join } from "node:path";
+import { join, extname, basename, sep } from "node:path";
 import { existsSync } from "node:fs";
 
 const DEFAULT_PASTE_DELAY_MS = 50;
 const PASTE_BYTE = "\x16"; // Ctrl+V — triggers Claude Code's paste handler
+
+// Single process-wide serialization point. Both /paste and
+// /api/claude/respond/:uuid feed into this, which also guards against
+// two in-flight replays clobbering each other's clipboard state.
+let replayChain = Promise.resolve();
 
 /**
  * @param {object} opts
@@ -46,11 +55,23 @@ const PASTE_BYTE = "\x16"; // Ctrl+V — triggers Claude Code's paste handler
  * @param {function} opts.imageMimeType       (ext) => string
  * @param {object} [opts.logger]              { warn, info }
  * @param {function} [opts.sleep]             (ms) => Promise — injectable for tests.
- * @param {function} [opts.onImagePasted]     (path) => void — per-image progress callback (WS relay).
+ * @param {function} [opts.onImagePasted]     (path) => void — fired only after a
+ *                                             successful clipboard set, per
+ *                                             image, so WS consumers don't see
+ *                                             false-success signals.
  * @param {number} [opts.pasteDelayMs]        Settle delay after each image.
  * @returns {Promise<{pasted: number, aborted: boolean}>}
  */
 export async function replayPasteSequence(opts) {
+  const task = () => runReplayPasteSequence(opts);
+  const next = replayChain.then(task, task);
+  // Swallow rejections so one bad replay doesn't poison the chain; the
+  // caller still observes the error via the returned promise.
+  replayChain = next.catch(() => {});
+  return next;
+}
+
+async function runReplayPasteSequence(opts) {
   const {
     tokens,
     session,
@@ -74,28 +95,41 @@ export async function replayPasteSequence(opts) {
 
   const canWrite = Boolean(session && typeof session.write === "function");
   let pasted = 0;
+  // Tracks whether the session died at any point during the replay, so
+  // that the final return value accurately describes whether the caller
+  // should treat the reply as lost (even if we happened to be on the
+  // last token when it died).
+  let sessionDied = false;
 
-  for (const t of tokens) {
-    if (canWrite && !session.alive) return { pasted, aborted: true };
+  for (const token of tokens) {
+    if (canWrite && !session.alive) { sessionDied = true; break; }
 
-    if (t?.type === "text") {
-      if (canWrite && typeof t.value === "string" && t.value.length > 0) {
-        session.write(t.value);
+    if (token?.type === "text") {
+      if (canWrite && typeof token.value === "string" && token.value.length > 0) {
+        session.write(token.value);
       }
       continue;
     }
 
-    if (t?.type !== "image" || typeof t.path !== "string") continue;
+    if (token?.type !== "image" || typeof token.path !== "string") continue;
 
-    // Scope the path under uploadsDir to prevent traversal.
-    const filePath = join(uploadsDir, t.path.replace(/^\/uploads\//, ""));
-    if (!filePath.startsWith(uploadsDir) || !existsSync(filePath)) {
-      logger.warn("replayPasteSequence: image path out of scope or missing", { path: t.path });
+    // Scope the path under uploadsDir to prevent traversal. Trailing
+    // separator on the prefix check guards against a sibling directory
+    // like `<uploadsDir>-evil` passing the prefix match, and the
+    // !==-uploadsDir check rejects bare `/uploads/` that would resolve
+    // to the uploads root itself.
+    const filePath = join(uploadsDir, token.path.replace(/^\/uploads\//, ""));
+    if (
+      filePath === uploadsDir ||
+      !filePath.startsWith(uploadsDir + sep) ||
+      !existsSync(filePath)
+    ) {
+      logger.warn("replayPasteSequence: image path out of scope or missing", { path: token.path });
       continue;
     }
 
-    const ext = filePath.split(".").pop();
-    const filename = filePath.split("/").pop();
+    const ext = extname(filePath).slice(1);
+    const filename = basename(filePath);
     const mimeType = imageMimeType(ext);
 
     let clipboardOk = await setClipboard(filePath, ext, logger);
@@ -106,24 +140,30 @@ export async function replayPasteSequence(opts) {
       if (paneBridged) clipboardOk = true;
     }
 
-    if (clipboardOk && canWrite && session.alive) {
-      session.write(PASTE_BYTE);
-      pasted++;
-      if (typeof onImagePasted === "function") onImagePasted(t.path);
-    } else if (typeof onImagePasted === "function") {
-      // Even without a session, report the clipboard-set so WS consumers
-      // get the same completion event they always got.
-      onImagePasted(t.path);
+    // Re-check session.alive after the clipboard/bridge awaits — it
+    // could have died in that window. Without this the final return
+    // would claim aborted:false even though the write was skipped.
+    if (canWrite && !session.alive) { sessionDied = true; break; }
+
+    if (clipboardOk) {
+      if (canWrite) {
+        session.write(PASTE_BYTE);
+        pasted++;
+      }
+      if (typeof onImagePasted === "function") onImagePasted(token.path);
     }
+    // If the clipboard did NOT get set, don't fire onImagePasted —
+    // matches the pre-refactor behavior where the WS `paste-complete`
+    // message only went out on success.
 
     await sleep(pasteDelayMs);
   }
 
-  if (submit && canWrite && session.alive) {
+  if (!sessionDied && submit && canWrite && session.alive) {
     session.write("\r");
   }
 
-  return { pasted, aborted: false };
+  return { pasted, aborted: sessionDied };
 }
 
 function defaultSleep(ms) {

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -29,6 +29,7 @@ import { getClaudeHooksStatus, installClaudeHooks } from "../claude-hooks.js";
 import {
   MAX_UPLOAD_BYTES, detectImage, imageMimeType, setClipboard,
 } from "./upload.js";
+import { replayPasteSequence } from "../paste-sequence.js";
 import { PRIVATE_META_KEYS, publicMeta } from "../session-meta-filter.js";
 
 // Re-export so existing route tests and callers continue to import these
@@ -279,55 +280,52 @@ export function createAppRoutes(ctx) {
 
     // --- Paste (set clipboard + write Ctrl+V to PTY for each image) ---
     //
-    // Accepts an array of uploaded paths and a session name. For each path,
-    // sets the clipboard, bridges to containers, and writes Ctrl+V directly
-    // to the tmux session. All done server-side in a single HTTP request to
-    // avoid per-file tunnel round-trips.
+    // Accepts one of two request shapes:
+    //
+    //   { paths: [...], session }            — image-only (xterm clipboard bridge)
+    //   { tokens: [...], session, submit }   — interleaved text + image
+    //                                           (feed tile reply). Tokens are
+    //                                           `{ type: "text", value }` and
+    //                                           `{ type: "image", path }` in
+    //                                           the order they should land in
+    //                                           the pane. `submit: true` appends
+    //                                           a real Enter (\r) at the end.
+    //
+    // Sequencing, clipboard bridging, and pane delivery live in
+    // `lib/paste-sequence.js` so both shapes share one implementation.
 
     { method: "POST", path: "/paste", handler: auth(csrf(async (req, res) => {
       const data = await parseJSON(req);
-      const paths = Array.isArray(data.paths) ? data.paths : data.path ? [data.path] : [];
-      if (paths.length === 0) return json(res, 400, { error: "Missing paths" });
+      const rawTokens = Array.isArray(data.tokens) ? data.tokens : null;
+      const rawPaths = Array.isArray(data.paths) ? data.paths : data.path ? [data.path] : [];
+      const tokens = rawTokens
+        ? rawTokens.filter((t) => t && (t.type === "text" || t.type === "image"))
+        : rawPaths.filter((p) => typeof p === "string").map((path) => ({ type: "image", path }));
+
+      if (tokens.length === 0) return json(res, 400, { error: "Missing paths or tokens" });
 
       const pasteSession = data.session ? SessionName.tryCreate(data.session)?.toString() : null;
+      const session = pasteSession ? sessionManager.getSession(pasteSession) : null;
+      // No 404 if session is missing — legacy drag-drop sets the host clipboard
+      // without a target session. The replayer skips \x16 / text writes when
+      // the session is absent.
+
       const uploadsDir = join(DATA_DIR, "uploads");
-      const PASTE_DELAY_MS = 50;
+      const submit = data.submit === true;
+      const imageCount = tokens.filter((t) => t.type === "image").length;
 
-      // Respond immediately — pastes happen async with WS progress updates
-      json(res, 200, { queued: paths.length });
+      // Respond immediately — replay happens async with WS progress updates
+      json(res, 200, { queued: imageCount, tokens: tokens.length });
 
-      // Process pastes sequentially in the background
-      (async () => {
-        for (const p of paths) {
-          if (typeof p !== "string") continue;
-          const filePath = join(uploadsDir, p.replace(/^\/uploads\//, ""));
-          if (!filePath.startsWith(uploadsDir) || !existsSync(filePath)) continue;
-
-          const ext = filePath.split(".").pop();
-          const filename = filePath.split("/").pop();
-          const mimeType = imageMimeType(ext);
-
-          let clipboard = await setClipboard(filePath, ext, log);
-          const bridged = await bridgeClipboardToContainers(filename, mimeType, log);
-          if (bridged) clipboard = true;
-
-          // Bridge to docker-exec'd container in this session's pane
-          if (!bridged && pasteSession) {
-            const paneBridged = await bridgePaneContainer(pasteSession, sessionManager, filePath, mimeType, log);
-            if (paneBridged) clipboard = true;
-          }
-
-          if (clipboard && pasteSession) {
-            const session = sessionManager.getSession(pasteSession);
-            if (session?.alive) session.write("\x16");
-          }
-
-          // Notify client via WebSocket that this file was pasted
-          bridge.relay({ type: "paste-complete", session: data.session, path: p });
-
-          await new Promise(r => setTimeout(r, PASTE_DELAY_MS));
-        }
-      })();
+      replayPasteSequence({
+        tokens, session, sessionName: pasteSession, sessionManager,
+        uploadsDir, submit,
+        setClipboard, bridgeClipboardToContainers, bridgePaneContainer, imageMimeType,
+        logger: log,
+        onImagePasted: (path) => bridge.relay({ type: "paste-complete", session: data.session, path }),
+      }).catch((err) => {
+        log.warn("paste-sequence replay failed", { session: data.session, error: err.message });
+      });
     }))},
 
     // --- Shortcuts ---
@@ -576,18 +574,37 @@ export function createAppRoutes(ctx) {
     })},
 
     // Respond to a Claude session by uuid — find the katulong session
-    // whose `meta.claude.uuid` matches, write text + Enter to its pane.
+    // whose `meta.claude.uuid` matches, write the reply into its pane.
     // This is the feed tile's "send response" path: the user reads a
     // Claude question and types back without leaving the feed.
+    //
+    // Accepts either `{ text }` (simple text reply, appends Enter) or
+    // `{ tokens }` (ordered `text`/`image` sequence for inline-image
+    // replies — uploaded via POST /upload first). Both always end with
+    // a real Enter; this endpoint is always submit-intent.
     { method: "POST", prefix: "/api/claude/respond/", handler: auth(csrf(async (req, res, uuid) => {
       if (!UUID_RE.test(uuid)) return json(res, 400, { error: "Invalid uuid" });
       let body;
-      try { body = await parseJSON(req, 8192); } catch (err) {
+      try { body = await parseJSON(req, 16384); } catch (err) {
         return json(res, 400, { error: err.message });
       }
+
+      const hasTokens = Array.isArray(body?.tokens);
       const text = typeof body?.text === "string" ? body.text : null;
-      if (!text) return json(res, 400, { error: "Missing text" });
-      if (text.length > 2000) return json(res, 400, { error: "Response too long" });
+      if (!hasTokens && !text) return json(res, 400, { error: "Missing text or tokens" });
+      if (text && text.length > 2000) return json(res, 400, { error: "Response too long" });
+
+      let tokens;
+      if (hasTokens) {
+        tokens = body.tokens.filter((t) => t && (t.type === "text" || t.type === "image"));
+        if (tokens.length === 0) return json(res, 400, { error: "Empty tokens" });
+        const totalText = tokens
+          .filter((t) => t.type === "text" && typeof t.value === "string")
+          .reduce((n, t) => n + t.value.length, 0);
+        if (totalText > 2000) return json(res, 400, { error: "Response too long" });
+      } else {
+        tokens = [{ type: "text", value: text }];
+      }
 
       const allSessions = sessionManager.listSessions().sessions;
       const target = allSessions.find(
@@ -597,9 +614,20 @@ export function createAppRoutes(ctx) {
 
       const session = sessionManager.getSession(target.name);
       if (!session?.alive) return json(res, 404, { error: "Session no longer alive" });
-      session.write(text + "\r");
 
-      json(res, 200, { ok: true, session: target.name });
+      // Ack the POST immediately; replay happens async with WS progress.
+      json(res, 200, { ok: true, session: target.name, tokens: tokens.length });
+
+      replayPasteSequence({
+        tokens, session, sessionName: target.name, sessionManager,
+        uploadsDir: join(DATA_DIR, "uploads"),
+        submit: true,
+        setClipboard, bridgeClipboardToContainers, bridgePaneContainer, imageMimeType,
+        logger: log,
+        onImagePasted: (path) => bridge.relay({ type: "paste-complete", session: target.name, path }),
+      }).catch((err) => {
+        log.warn("claude-respond replay failed", { session: target.name, error: err.message });
+      });
     }))},
 
     // --- Sessions ---

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -337,7 +337,7 @@ export function createAppRoutes(ctx) {
         uploadsDir, submit,
         setClipboard, bridgeClipboardToContainers, bridgePaneContainer, imageMimeType,
         logger: log,
-        onImagePasted: (path) => bridge.relay({ type: "paste-complete", session: data.session, path }),
+        onImagePasted: (path) => bridge.relay({ type: "paste-complete", session: pasteSession, path }),
       }).catch((err) => {
         log.warn("paste-sequence replay failed", { session: data.session, error: err.message });
       });
@@ -607,7 +607,7 @@ export function createAppRoutes(ctx) {
       const hasTokens = Array.isArray(body?.tokens);
       const text = typeof body?.text === "string" ? body.text : null;
       if (!hasTokens && !text) return json(res, 400, { error: "Missing text or tokens" });
-      if (text && text.length > 2000) return json(res, 400, { error: "Response too long" });
+      if (text && text.length > MAX_PASTE_TEXT_LEN) return json(res, 400, { error: "Response too long" });
 
       let tokens;
       if (hasTokens) {
@@ -617,7 +617,7 @@ export function createAppRoutes(ctx) {
         const totalText = tokens
           .filter((t) => t.type === "text" && typeof t.value === "string")
           .reduce((n, t) => n + t.value.length, 0);
-        if (totalText > 2000) return json(res, 400, { error: "Response too long" });
+        if (totalText > MAX_PASTE_TEXT_LEN) return json(res, 400, { error: "Response too long" });
       } else {
         tokens = [{ type: "text", value: text }];
       }

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -38,6 +38,14 @@ import { PRIVATE_META_KEYS, publicMeta } from "../session-meta-filter.js";
 // reverse dependency on this module.
 export { PRIVATE_META_KEYS, publicMeta };
 
+// Caps applied at the paste entrypoints. 50 tokens accommodates a
+// text-heavy reply with several interleaved images without letting an
+// authenticated caller queue an unbounded chain of subprocess-spawning
+// clipboard ops. 2000 chars matches the /api/claude/respond text cap so
+// both entrypoints have a consistent envelope.
+const MAX_PASTE_TOKENS = 50;
+const MAX_PASTE_TEXT_LEN = 2000;
+
 /**
  * Apply a Claude hook payload to `session.meta.claude` via the provided
  * sessionManager. Exported for unit tests — the live /api/claude-events
@@ -303,6 +311,13 @@ export function createAppRoutes(ctx) {
         : rawPaths.filter((p) => typeof p === "string").map((path) => ({ type: "image", path }));
 
       if (tokens.length === 0) return json(res, 400, { error: "Missing paths or tokens" });
+      // Bound token array so an authenticated caller can't queue an
+      // unbounded chain of subprocess-spawning clipboard ops.
+      if (tokens.length > MAX_PASTE_TOKENS) return json(res, 400, { error: "Too many tokens" });
+      const textTotal = tokens
+        .filter((t) => t.type === "text" && typeof t.value === "string")
+        .reduce((n, t) => n + t.value.length, 0);
+      if (textTotal > MAX_PASTE_TEXT_LEN) return json(res, 400, { error: "Paste text too long" });
 
       const pasteSession = data.session ? SessionName.tryCreate(data.session)?.toString() : null;
       const session = pasteSession ? sessionManager.getSession(pasteSession) : null;
@@ -598,6 +613,7 @@ export function createAppRoutes(ctx) {
       if (hasTokens) {
         tokens = body.tokens.filter((t) => t && (t.type === "text" || t.type === "image"));
         if (tokens.length === 0) return json(res, 400, { error: "Empty tokens" });
+        if (tokens.length > MAX_PASTE_TOKENS) return json(res, 400, { error: "Too many tokens" });
         const totalText = tokens
           .filter((t) => t.type === "text" && typeof t.value === "string")
           .reduce((n, t) => n + t.value.length, 0);

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -103,9 +103,38 @@ function makeTimeSpan(ts) {
   return t;
 }
 
+// Split a textarea value around `[Image #N]` placeholders into an
+// ordered token list the server can replay. Unknown N (placeholder
+// text that points to nothing in the stash) passes through as literal
+// text — so a user who pastes the string `[Image #99]` from somewhere
+// else doesn't get their reply silently gutted.
+export function buildReplyTokens(value, imagePaths) {
+  if (typeof value !== "string" || value.length === 0) return [];
+  const parts = value.split(/(\[Image #\d+\])/g);
+  const out = [];
+  function pushText(s) {
+    if (!s) return;
+    const last = out[out.length - 1];
+    if (last && last.type === "text") last.value += s;
+    else out.push({ type: "text", value: s });
+  }
+  for (const part of parts) {
+    const m = part.match(/^\[Image #(\d+)\]$/);
+    if (m) {
+      const path = imagePaths.get(parseInt(m[1], 10));
+      if (path) { out.push({ type: "image", path }); continue; }
+    }
+    pushText(part);
+  }
+  return out;
+}
+
 // A pinned-to-bottom composer for Claude topics. Shows quick-pick
 // buttons when the latest reply ends in a numbered options list, plus
-// a textarea + Send button for typed responses.
+// a textarea + Send button for typed responses. Inline images: paste
+// an image into the textarea, we upload it to /upload and insert an
+// `[Image #N]` placeholder — on send, the server replays the text +
+// image tokens into the Claude pane in the same order.
 function createResponseBar(claudeUuid) {
   const el = document.createElement("div");
   el.className = "feed-tile-response-bar";
@@ -118,12 +147,25 @@ function createResponseBar(claudeUuid) {
   const textarea = document.createElement("textarea");
   textarea.className = "feed-tile-response-textarea";
   textarea.rows = 4;
-  textarea.placeholder = "Reply to Claude — Enter to send, Shift+Enter for newline";
+  textarea.placeholder = "Reply to Claude — paste images inline, Enter to send, Shift+Enter for newline";
   el.appendChild(textarea);
 
   const status = document.createElement("div");
   status.className = "feed-tile-response-status";
   el.appendChild(status);
+
+  // Inline-image state. `imagePaths` maps a placeholder number to the
+  // server-side path returned from /upload. Cleared after a successful
+  // send; orphaned entries (user deleted the placeholder text) are
+  // dropped at send time because buildReplyTokens only emits image
+  // tokens for N values still present in the textarea.
+  const imagePaths = new Map();
+  let imageCounter = 0;
+
+  function resetImageState() {
+    imagePaths.clear();
+    imageCounter = 0;
+  }
 
   let sending = false;
   async function send(text) {
@@ -137,10 +179,13 @@ function createResponseBar(claudeUuid) {
       const csrfMeta = document.querySelector('meta[name="csrf-token"]');
       const headers = { "Content-Type": "application/json" };
       if (csrfMeta?.content) headers["X-CSRF-Token"] = csrfMeta.content;
+      const tokens = buildReplyTokens(text, imagePaths);
+      const hasImages = tokens.some((t) => t.type === "image");
+      const payload = hasImages ? { tokens } : { text };
       const res = await fetch(`/api/claude/respond/${encodeURIComponent(claudeUuid)}`, {
         method: "POST",
         headers,
-        body: JSON.stringify({ text }),
+        body: JSON.stringify(payload),
         credentials: "same-origin",
         redirect: "error",
       });
@@ -150,6 +195,7 @@ function createResponseBar(claudeUuid) {
         throw new Error(msg);
       }
       textarea.value = "";
+      resetImageState();
       status.textContent = "Sent.";
       setTimeout(() => {
         if (status.textContent === "Sent.") status.textContent = "";
@@ -163,6 +209,64 @@ function createResponseBar(claudeUuid) {
       textarea.focus();
     }
   }
+
+  async function uploadReplyImage(file) {
+    const headers = { "Content-Type": "application/octet-stream" };
+    const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+    if (csrfMeta?.content) headers["x-csrf-token"] = csrfMeta.content;
+    const res = await fetch("/upload", {
+      method: "POST", headers, body: file,
+      credentials: "same-origin", redirect: "error",
+    });
+    if (!res.ok) {
+      let msg = `Upload failed (${res.status})`;
+      try { msg = (await res.json()).error || msg; } catch { /* non-JSON */ }
+      throw new Error(msg);
+    }
+    const data = await res.json();
+    return data.path;
+  }
+
+  function insertAtCursor(ta, s) {
+    const start = ta.selectionStart ?? ta.value.length;
+    const end = ta.selectionEnd ?? ta.value.length;
+    ta.value = ta.value.slice(0, start) + s + ta.value.slice(end);
+    ta.selectionStart = ta.selectionEnd = start + s.length;
+  }
+
+  textarea.addEventListener("paste", async (ev) => {
+    const dt = ev.clipboardData;
+    if (!dt) return;
+    const images = [];
+    // Safari only exposes pasted images via `items`; Chrome/Firefox
+    // fill `files` too. Check both, de-duping on reference identity so
+    // a browser that populates both doesn't double-upload.
+    const seen = new Set();
+    for (const item of dt.items || []) {
+      if (item.type?.startsWith("image/")) {
+        const f = item.getAsFile();
+        if (f && !seen.has(f)) { images.push(f); seen.add(f); }
+      }
+    }
+    for (const f of dt.files || []) {
+      if (f.type?.startsWith("image/") && !seen.has(f)) { images.push(f); seen.add(f); }
+    }
+    if (images.length === 0) return;  // fall through to default text paste
+    ev.preventDefault();
+    status.textContent = images.length === 1 ? "Uploading image…" : `Uploading ${images.length} images…`;
+    try {
+      for (const f of images) {
+        const path = await uploadReplyImage(f);
+        const n = ++imageCounter;
+        imagePaths.set(n, path);
+        insertAtCursor(textarea, `[Image #${n}]`);
+      }
+      status.textContent = "";
+    } catch (err) {
+      status.textContent = err.message || "Upload failed";
+      status.classList.add("feed-tile-response-status-error");
+    }
+  });
 
   textarea.addEventListener("keydown", (ev) => {
     // Enter alone sends — matching chat apps' default and how a user

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -213,7 +213,7 @@ function createResponseBar(claudeUuid) {
   async function uploadReplyImage(file) {
     const headers = { "Content-Type": "application/octet-stream" };
     const csrfMeta = document.querySelector('meta[name="csrf-token"]');
-    if (csrfMeta?.content) headers["x-csrf-token"] = csrfMeta.content;
+    if (csrfMeta?.content) headers["X-CSRF-Token"] = csrfMeta.content;
     const res = await fetch("/upload", {
       method: "POST", headers, body: file,
       credentials: "same-origin", redirect: "error",

--- a/test/feed-tile.test.js
+++ b/test/feed-tile.test.js
@@ -120,7 +120,7 @@ globalThis.CustomEvent = class CustomEvent {
   }
 };
 
-const { feedRenderer, parseReplyOptions } = await import(
+const { feedRenderer, parseReplyOptions, buildReplyTokens } = await import(
   new URL("../public/lib/tile-renderers/feed.js", import.meta.url).href
 );
 
@@ -153,6 +153,74 @@ describe("parseReplyOptions", () => {
       { key: "1", label: "A" },
       { key: "2", label: "B" },
     ]);
+  });
+});
+
+describe("buildReplyTokens", () => {
+  it("returns [] for empty input", () => {
+    assert.deepEqual(buildReplyTokens("", new Map()), []);
+  });
+
+  it("returns a single text token when there are no placeholders", () => {
+    assert.deepEqual(
+      buildReplyTokens("hello claude", new Map()),
+      [{ type: "text", value: "hello claude" }],
+    );
+  });
+
+  it("splits around placeholders that have a mapped path", () => {
+    const paths = new Map([[1, "/uploads/a.png"], [2, "/uploads/b.png"]]);
+    assert.deepEqual(
+      buildReplyTokens("before [Image #1] middle [Image #2] after", paths),
+      [
+        { type: "text", value: "before " },
+        { type: "image", path: "/uploads/a.png" },
+        { type: "text", value: " middle " },
+        { type: "image", path: "/uploads/b.png" },
+        { type: "text", value: " after" },
+      ],
+    );
+  });
+
+  it("keeps placeholders with no mapped path as literal text", () => {
+    // User pastes `[Image #99]` from somewhere else — we have no stash
+    // for N=99, so we leave the text untouched rather than silently
+    // dropping it.
+    const paths = new Map([[1, "/uploads/a.png"]]);
+    assert.deepEqual(
+      buildReplyTokens("see [Image #99] and [Image #1]", paths),
+      [
+        { type: "text", value: "see [Image #99] and " },
+        { type: "image", path: "/uploads/a.png" },
+      ],
+    );
+  });
+
+  it("coalesces adjacent text segments (literal placeholder + prose)", () => {
+    const paths = new Map();
+    assert.deepEqual(
+      buildReplyTokens("a [Image #5] b", paths),
+      [{ type: "text", value: "a [Image #5] b" }],
+    );
+  });
+
+  it("handles back-to-back placeholders with no text between", () => {
+    const paths = new Map([[1, "/a.png"], [2, "/b.png"]]);
+    assert.deepEqual(
+      buildReplyTokens("[Image #1][Image #2]", paths),
+      [
+        { type: "image", path: "/a.png" },
+        { type: "image", path: "/b.png" },
+      ],
+    );
+  });
+
+  it("handles a textarea that is only a placeholder", () => {
+    const paths = new Map([[1, "/a.png"]]);
+    assert.deepEqual(
+      buildReplyTokens("[Image #1]", paths),
+      [{ type: "image", path: "/a.png" }],
+    );
   });
 });
 

--- a/test/paste-sequence.test.js
+++ b/test/paste-sequence.test.js
@@ -111,7 +111,7 @@ describe("replayPasteSequence", () => {
     assert.deepEqual(session.writes, ["hi", "\r"]);
   });
 
-  it("does NOT write \\x16 when both clipboard-set and bridges fail", async () => {
+  it("does NOT write \\x16 or fire onImagePasted when both clipboard-set and bridges fail", async () => {
     const session = makeSession();
     const deps = makeDeps({
       setClipboard: async () => false,
@@ -124,8 +124,9 @@ describe("replayPasteSequence", () => {
     });
     assert.equal(out.pasted, 0);
     assert.deepEqual(session.writes, []);
-    // Still reports progress so the client isn't stuck waiting.
-    assert.deepEqual(deps.calls.imagePasted, [imgA]);
+    // Pre-refactor behavior: no `paste-complete` WS event on failure,
+    // so the xterm clipboard bridge doesn't show a false success.
+    assert.deepEqual(deps.calls.imagePasted, []);
   });
 
   it("uses \\x16 if clipboard failed but a container bridge succeeded", async () => {
@@ -182,6 +183,41 @@ describe("replayPasteSequence", () => {
     assert.equal(out.aborted, true);
     assert.deepEqual(session.writes, ["kill"]);
     assert.equal(deps.calls.setClipboard.length, 0);
+  });
+
+  it("returns aborted:true and skips the write when the session dies during clipboard/bridge awaits", async () => {
+    const session = makeSession();
+    const deps = makeDeps({
+      // Simulate a slow clipboard/bridge — session dies in the meantime.
+      setClipboard: async () => { session.alive = false; return true; },
+    });
+    const out = await replayPasteSequence({
+      tokens: [{ type: "image", path: imgA }],
+      session, uploadsDir, submit: true, ...deps,
+    });
+    assert.equal(out.aborted, true);
+    assert.equal(out.pasted, 0);
+    // No \x16 (session died after clipboard set) and no trailing \r.
+    assert.deepEqual(session.writes, []);
+  });
+
+  it("does not submit Enter when the session died mid-replay", async () => {
+    const session = makeSession();
+    const deps = makeDeps();
+    const origWrite = session.write.bind(session);
+    session.write = (bytes) => {
+      origWrite(bytes);
+      if (bytes === "kill") session.alive = false;
+    };
+    const out = await replayPasteSequence({
+      tokens: [
+        { type: "text", value: "kill" },
+        { type: "text", value: "never" },
+      ],
+      session, uploadsDir, submit: true, ...deps,
+    });
+    assert.equal(out.aborted, true);
+    assert.deepEqual(session.writes, ["kill"]);
   });
 
   it("ignores image tokens with paths outside uploadsDir", async () => {

--- a/test/paste-sequence.test.js
+++ b/test/paste-sequence.test.js
@@ -1,0 +1,237 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { replayPasteSequence } from "../lib/paste-sequence.js";
+
+function makeSession() {
+  const writes = [];
+  return {
+    alive: true,
+    write(bytes) { writes.push(bytes); },
+    writes,
+  };
+}
+
+function makeDeps(overrides = {}) {
+  const calls = { setClipboard: [], bridgeClipboard: [], bridgePane: [], sleeps: [], imagePasted: [] };
+  return {
+    calls,
+    setClipboard: overrides.setClipboard || (async (p, e) => { calls.setClipboard.push({ p, e }); return true; }),
+    bridgeClipboardToContainers: overrides.bridgeClipboardToContainers
+      || (async (f, m) => { calls.bridgeClipboard.push({ f, m }); return false; }),
+    bridgePaneContainer: overrides.bridgePaneContainer
+      || (async (n, sm, p, m) => { calls.bridgePane.push({ n, p, m }); return false; }),
+    imageMimeType: overrides.imageMimeType || ((e) => `image/${e}`),
+    logger: { warn: () => {}, info: () => {} },
+    sleep: (ms) => { calls.sleeps.push(ms); return Promise.resolve(); },
+    onImagePasted: (p) => { calls.imagePasted.push(p); },
+  };
+}
+
+let uploadsDir;
+const imgA = "/uploads/a.png";
+const imgB = "/uploads/b.png";
+
+before(() => {
+  uploadsDir = mkdtempSync(join(tmpdir(), "paste-seq-"));
+  writeFileSync(join(uploadsDir, "a.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  writeFileSync(join(uploadsDir, "b.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+});
+
+after(() => {
+  rmSync(uploadsDir, { recursive: true, force: true });
+});
+
+describe("replayPasteSequence", () => {
+  it("returns early on empty/missing tokens", async () => {
+    const out = await replayPasteSequence({ tokens: [], uploadsDir, ...makeDeps() });
+    assert.deepEqual(out, { pasted: 0, aborted: false });
+  });
+
+  it("writes text tokens verbatim to the session", async () => {
+    const session = makeSession();
+    const deps = makeDeps();
+    await replayPasteSequence({
+      tokens: [
+        { type: "text", value: "hello " },
+        { type: "text", value: "world\nline two" },
+      ],
+      session, uploadsDir, ...deps,
+    });
+    assert.deepEqual(session.writes, ["hello ", "world\nline two"]);
+  });
+
+  it("for images: sets clipboard, bridges, writes \\x16, sleeps", async () => {
+    const session = makeSession();
+    const deps = makeDeps();
+    const out = await replayPasteSequence({
+      tokens: [{ type: "image", path: imgA }],
+      session, uploadsDir, ...deps,
+    });
+    assert.equal(out.pasted, 1);
+    assert.equal(deps.calls.setClipboard.length, 1);
+    assert.equal(deps.calls.bridgeClipboard.length, 1);
+    assert.deepEqual(session.writes, ["\x16"]);
+    assert.deepEqual(deps.calls.sleeps, [50]);
+    assert.deepEqual(deps.calls.imagePasted, [imgA]);
+  });
+
+  it("interleaves text and image in order", async () => {
+    const session = makeSession();
+    const deps = makeDeps();
+    await replayPasteSequence({
+      tokens: [
+        { type: "text", value: "before " },
+        { type: "image", path: imgA },
+        { type: "text", value: " middle " },
+        { type: "image", path: imgB },
+        { type: "text", value: " after" },
+      ],
+      session, uploadsDir, ...deps,
+    });
+    assert.deepEqual(session.writes, [
+      "before ",
+      "\x16",
+      " middle ",
+      "\x16",
+      " after",
+    ]);
+  });
+
+  it("appends real Enter (\\r) when submit: true", async () => {
+    const session = makeSession();
+    const deps = makeDeps();
+    await replayPasteSequence({
+      tokens: [{ type: "text", value: "hi" }],
+      session, uploadsDir, submit: true, ...deps,
+    });
+    assert.deepEqual(session.writes, ["hi", "\r"]);
+  });
+
+  it("does NOT write \\x16 when both clipboard-set and bridges fail", async () => {
+    const session = makeSession();
+    const deps = makeDeps({
+      setClipboard: async () => false,
+      bridgeClipboardToContainers: async () => false,
+      bridgePaneContainer: async () => false,
+    });
+    const out = await replayPasteSequence({
+      tokens: [{ type: "image", path: imgA }],
+      session, uploadsDir, ...deps,
+    });
+    assert.equal(out.pasted, 0);
+    assert.deepEqual(session.writes, []);
+    // Still reports progress so the client isn't stuck waiting.
+    assert.deepEqual(deps.calls.imagePasted, [imgA]);
+  });
+
+  it("uses \\x16 if clipboard failed but a container bridge succeeded", async () => {
+    const session = makeSession();
+    const deps = makeDeps({
+      setClipboard: async () => false,
+      bridgeClipboardToContainers: async () => true,
+    });
+    await replayPasteSequence({
+      tokens: [{ type: "image", path: imgA }],
+      session, uploadsDir, ...deps,
+    });
+    assert.deepEqual(session.writes, ["\x16"]);
+  });
+
+  it("tries pane-container bridge only when global bridge fails", async () => {
+    const session = makeSession();
+    const deps = makeDeps({ bridgeClipboardToContainers: async () => true });
+    await replayPasteSequence({
+      tokens: [{ type: "image", path: imgA }],
+      session, sessionName: "work", sessionManager: {}, uploadsDir, ...deps,
+    });
+    assert.equal(deps.calls.bridgePane.length, 0);
+  });
+
+  it("calls pane-container bridge when global bridge failed", async () => {
+    const session = makeSession();
+    const deps = makeDeps();
+    await replayPasteSequence({
+      tokens: [{ type: "image", path: imgA }],
+      session, sessionName: "work", sessionManager: {}, uploadsDir, ...deps,
+    });
+    assert.equal(deps.calls.bridgePane.length, 1);
+    assert.equal(deps.calls.bridgePane[0].n, "work");
+  });
+
+  it("aborts mid-sequence when the session dies", async () => {
+    const session = makeSession();
+    const deps = makeDeps();
+    // After the first text chunk, kill the session.
+    const origWrite = session.write.bind(session);
+    session.write = (bytes) => {
+      origWrite(bytes);
+      if (bytes === "kill") session.alive = false;
+    };
+    const out = await replayPasteSequence({
+      tokens: [
+        { type: "text", value: "kill" },
+        { type: "text", value: "unreachable" },
+        { type: "image", path: imgA },
+      ],
+      session, uploadsDir, ...deps,
+    });
+    assert.equal(out.aborted, true);
+    assert.deepEqual(session.writes, ["kill"]);
+    assert.equal(deps.calls.setClipboard.length, 0);
+  });
+
+  it("ignores image tokens with paths outside uploadsDir", async () => {
+    const session = makeSession();
+    const deps = makeDeps();
+    await replayPasteSequence({
+      tokens: [{ type: "image", path: "/uploads/../../../etc/passwd" }],
+      session, uploadsDir, ...deps,
+    });
+    assert.deepEqual(session.writes, []);
+    assert.equal(deps.calls.setClipboard.length, 0);
+  });
+
+  it("ignores image tokens whose file is missing", async () => {
+    const session = makeSession();
+    const deps = makeDeps();
+    await replayPasteSequence({
+      tokens: [{ type: "image", path: "/uploads/ghost.png" }],
+      session, uploadsDir, ...deps,
+    });
+    assert.deepEqual(session.writes, []);
+    assert.equal(deps.calls.setClipboard.length, 0);
+  });
+
+  it("ignores unknown token shapes without throwing", async () => {
+    const session = makeSession();
+    const deps = makeDeps();
+    await replayPasteSequence({
+      tokens: [
+        null,
+        { type: "audio", path: "/foo" },
+        { type: "text" },                 // missing value
+        { type: "image" },                // missing path
+        { type: "text", value: "ok" },
+      ],
+      session, uploadsDir, ...deps,
+    });
+    assert.deepEqual(session.writes, ["ok"]);
+  });
+
+  it("without a session: still sets clipboard for image tokens, skips text + submit", async () => {
+    const deps = makeDeps();
+    await replayPasteSequence({
+      tokens: [
+        { type: "text", value: "dropped" },
+        { type: "image", path: imgA },
+      ],
+      uploadsDir, submit: true, ...deps,
+    });
+    assert.equal(deps.calls.setClipboard.length, 1);
+    assert.deepEqual(deps.calls.imagePasted, [imgA]);
+  });
+});

--- a/test/timeout-constants.test.js
+++ b/test/timeout-constants.test.js
@@ -32,9 +32,9 @@ describe("reduced timeout constants", () => {
     assert.match(src, /if \(ps\.pending\) \{ ps\.pending = false; pull\(name\); \}\n\s*\}, 100\)/);
   });
 
-  it("routes: PASTE_DELAY_MS = 50", () => {
-    const src = readSource("lib/routes/app-routes.js");
-    assert.match(src, /const PASTE_DELAY_MS = 50;/);
+  it("paste-sequence: DEFAULT_PASTE_DELAY_MS = 50", () => {
+    const src = readSource("lib/paste-sequence.js");
+    assert.match(src, /const DEFAULT_PASTE_DELAY_MS = 50;/);
   });
 
   it("key-mapping: inter-key delay = 50ms", () => {


### PR DESCRIPTION
## Summary

- Paste images into the Claude feed tile's reply textarea — each one inserts an `[Image #N]` placeholder at the caret (matching Claude Code's own paste format).
- On send, the text+image sequence is replayed into the tmux pane exactly as a human would: text typed verbatim, images pasted via Ctrl+V at their placeholder slots, Enter to submit.
- New `lib/paste-sequence.js` owns the replay orchestration (clipboard + container-bridge fallbacks, session-alive guards, path scope checks). `/paste` and `/api/claude/respond/:uuid` both delegate to it.

## Test plan

- [x] `npm test` — 14 new `replayPasteSequence` tests + 6 `buildReplyTokens` tests all pass
- [x] Manual end-to-end in this very conversation: pasted multiple screenshots into the feed reply textarea, confirmed placeholders landed at the caret position, Claude Code received each image at the correct slot and could describe them back
- [x] Legacy `/paste` shape (xterm clipboard bridge via `{paths, session}`) still works — same replayer, same clipboard bridge, just wrapped as `{type:"image", path}` tokens under the hood

## Notes

- Design sidesteps Claude Code's private `~/.claude/image-cache/<uuid>/N.png` layout: Claude Code's own paste handler assigns the `[Image #N]` numbers from the clipboard, so we just drive the same flow a human would.
- Unknown `[Image #N]` in the textarea (placeholder text that doesn't map to an uploaded path) passes through as literal text, so a hand-typed `[Image #99]` isn't silently dropped.
- While testing, the feed tile appeared to freeze — turned out to be a pre-existing worktree-vs-canonical-root transcriptPath bug in `claude-feed-routes.js` watch-add (already documented in a `log.warn` at line 100 of that file). Orthogonal; will file separately.