### PR TITLE
fix(claude-feed): resolve transcriptPath from hook payload + glob fallback

### DIFF
--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -10,7 +10,7 @@
  */
 
 import { readFileSync, mkdirSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
+import { join, normalize } from "node:path";
 import { randomUUID } from "node:crypto";
 import { loadState } from "../auth.js";
 import {
@@ -53,19 +53,21 @@ const MAX_PASTE_TEXT_LEN = 2000;
  * (arbitrary disk read), so the shape check is strict: must be absolute,
  * must live under `<home>/.claude/projects/<something>/`, must end in
  * `<uuid>.jsonl` where uuid matches the hook's session_id, and must
- * contain no `..` segments after normalization. A malformed path just
- * drops the enrichment — uuid still stamps via the regular flow.
+ * collapse cleanly (no `..` segments survive normalization). A malformed
+ * path just drops the enrichment — uuid still stamps via the regular flow.
  *
- * Returns the path on success, `null` on any validation failure.
+ * Returns the normalized path on success, `null` on any validation failure.
  */
 export function safeTranscriptPath(rawPath, uuid) {
   if (typeof rawPath !== "string" || rawPath.length === 0) return null;
   if (!rawPath.startsWith("/")) return null;
-  if (rawPath.split("/").includes("..")) return null;
-  if (!rawPath.includes("/.claude/projects/")) return null;
+  const norm = normalize(rawPath);
+  if (!norm.startsWith("/")) return null;
+  if (norm.split("/").includes("..")) return null;
+  if (!norm.includes("/.claude/projects/")) return null;
   if (!uuid || !UUID_RE.test(uuid)) return null;
-  if (!rawPath.endsWith(`/${uuid}.jsonl`)) return null;
-  return rawPath;
+  if (!norm.endsWith(`/${uuid}.jsonl`)) return null;
+  return norm;
 }
 
 /**

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -47,16 +47,44 @@ const MAX_PASTE_TOKENS = 50;
 const MAX_PASTE_TEXT_LEN = 2000;
 
 /**
+ * Validate a hook-provided transcript_path before stamping it into meta.
+ *
+ * The path is trusted enough to be read later by the narrative processor
+ * (arbitrary disk read), so the shape check is strict: must be absolute,
+ * must live under `<home>/.claude/projects/<something>/`, must end in
+ * `<uuid>.jsonl` where uuid matches the hook's session_id, and must
+ * contain no `..` segments after normalization. A malformed path just
+ * drops the enrichment — uuid still stamps via the regular flow.
+ *
+ * Returns the path on success, `null` on any validation failure.
+ */
+export function safeTranscriptPath(rawPath, uuid) {
+  if (typeof rawPath !== "string" || rawPath.length === 0) return null;
+  if (!rawPath.startsWith("/")) return null;
+  if (rawPath.split("/").includes("..")) return null;
+  if (!rawPath.includes("/.claude/projects/")) return null;
+  if (!uuid || !UUID_RE.test(uuid)) return null;
+  if (!rawPath.endsWith(`/${uuid}.jsonl`)) return null;
+  return rawPath;
+}
+
+/**
  * Apply a Claude hook payload to `session.meta.claude` via the provided
  * sessionManager. Exported for unit tests — the live /api/claude-events
  * handler is the only production caller.
  *
- * This writer owns ONLY `meta.claude.{uuid, startedAt}` — Claude-specific
- * enrichment needed to resolve the transcript on disk. Baseline presence
- * ("an agent is running in this pane") lives under `meta.agent`, written
- * by the pane monitor from tmux's pane_current_command. The two
- * namespaces don't contend, so this writer replaces the namespace
- * outright rather than merging.
+ * This writer owns ONLY `meta.claude.{uuid, startedAt, transcriptPath}` —
+ * Claude-specific enrichment needed to resolve the transcript on disk.
+ * Baseline presence ("an agent is running in this pane") lives under
+ * `meta.agent`, written by the pane monitor from tmux's
+ * pane_current_command. The two namespaces don't contend, so this writer
+ * replaces the namespace outright rather than merging.
+ *
+ * `transcriptPath` is the ground-truth path Claude Code writes to, taken
+ * directly from the hook payload. Previously we re-derived it by slugging
+ * the live tmux pane cwd — which stalled the feed whenever the shell had
+ * cd'd after Claude launched (worktree vs canonical repo, symlinked
+ * paths, spaces in path). Stamping the hook value removes the guessing.
  *
  * Returns `"set"` / `"cleared"` / `null` describing what happened. Unknown
  * panes, malformed panes, and unrelated events all return `null`.
@@ -96,8 +124,11 @@ export function applyClaudeMetaFromHook(payload, sessionManager, logger = null) 
     // hook payload polluting meta with a non-UUID string.
     const uuid = typeof payload.session_id === "string" ? payload.session_id : null;
     if (!uuid || !UUID_RE.test(uuid)) return null;
+    const transcriptPath = safeTranscriptPath(payload.transcript_path, uuid);
+    const next = { uuid, startedAt: Date.now() };
+    if (transcriptPath) next.transcriptPath = transcriptPath;
     try {
-      session.setMeta("claude", { uuid, startedAt: Date.now() });
+      session.setMeta("claude", next);
       return "set";
     } catch (err) {
       logger?.warn?.("Failed to set meta.claude from hook", {

--- a/lib/routes/claude-feed-routes.js
+++ b/lib/routes/claude-feed-routes.js
@@ -28,35 +28,124 @@
  */
 
 import { join } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { UUID_RE } from "../claude-event-transform.js";
 import { slugifyCwd } from "../claude-transcript-discovery.js";
 
 /**
- * Build a { uuid, transcriptPath } target from an explicit { uuid, cwd }
- * body. This is the only supported shape — the frontend must already know
- * the uuid (populated into `meta.claude.uuid` by the SessionStart hook).
+ * Find `<uuid>.jsonl` anywhere under `<homeDir>/.claude/projects/*`.
  *
- * Returns `{ uuid, transcriptPath }` on success or `{ error }` on failure.
+ * Claude Code's on-disk slug rule is cwd-at-launch. If the cwd the
+ * frontend sends (live tmux pane cwd) has drifted since launch — the
+ * user cd'd into a worktree, a subdirectory, or a symlinked path — the
+ * slug we derive points at an empty directory Claude never wrote to and
+ * the feed stalls silently. This scan recovers from that: since UUIDs
+ * are globally unique, exactly one project directory can contain
+ * `<uuid>.jsonl`. We read each top-level project dir and check for the
+ * file; `readdirSync` plus a single `existsSync` per candidate is cheap
+ * even at a few hundred historical project directories, and this only
+ * runs on the watch-add path (once per sparkle click).
+ *
+ * Returns an absolute path or `null` if no match exists.
  */
-export function resolveWatchTarget({ body, homeDir }) {
+export function findTranscriptByUuid(homeDir, uuid) {
+  if (!homeDir || typeof homeDir !== "string") return null;
+  if (!uuid || !UUID_RE.test(uuid)) return null;
+  const projectsRoot = join(homeDir, ".claude", "projects");
+  let entries;
+  try {
+    entries = readdirSync(projectsRoot, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  const leaf = `${uuid}.jsonl`;
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    const candidate = join(projectsRoot, ent.name, leaf);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Build a { uuid, transcriptPath } target from a watch-add body.
+ *
+ * Resolution precedence (most reliable first):
+ *
+ *   1. `{ uuid, session }` with the session's `meta.claude.transcriptPath`
+ *      stamped from the Claude Code SessionStart hook. This is ground
+ *      truth — Claude Code itself told us where the transcript lives.
+ *
+ *   2. `{ uuid, cwd }` with the slugified cwd-derived path existing on
+ *      disk. Matches Claude Code's on-disk slug rule (see
+ *      `slugifyCwd`) and works for sessions where the cwd at launch
+ *      matches the cwd at click time.
+ *
+ *   3. `{ uuid, cwd }` glob fallback — scan `~/.claude/projects/*` for
+ *      `<uuid>.jsonl`. Handles the case where the frontend's cwd has
+ *      drifted (worktree vs canonical root, post-cd shell state, etc.)
+ *      but the SessionStart hook never fired (install-after-start).
+ *
+ *   4. Slug path anyway — returned even when the file doesn't exist, so
+ *      the watchlist entry can be created and the processor picks the
+ *      transcript up if it materializes later.
+ *
+ * Returns `{ uuid, transcriptPath, source }` on success or `{ error }`
+ * on failure. `source` is one of `"session-meta" | "cwd-slug" | "glob"
+ * | "cwd-slug-missing"` for diagnostic logging.
+ */
+export function resolveWatchTarget({ body, homeDir, sessionManager = null }) {
   if (!body || typeof body !== "object") {
     return { error: "Body must be a JSON object" };
   }
 
   const uuid = typeof body.uuid === "string" ? body.uuid : null;
   const cwd = typeof body.cwd === "string" ? body.cwd : null;
+  const sessionName = typeof body.session === "string" ? body.session : null;
 
-  if (!uuid || !cwd) {
+  if (!uuid) {
     return { error: "Provide { uuid, cwd }" };
   }
   if (!UUID_RE.test(uuid)) {
     return { error: "Invalid uuid" };
   }
+
+  // (1) Session-meta stamped by the SessionStart hook. The session must
+  //     hold the *same* uuid — stale meta from a previous Claude session
+  //     in the same pane doesn't apply to this watch request.
+  if (sessionName && sessionManager?.getSession) {
+    const session = sessionManager.getSession(sessionName);
+    const stamped = session?.meta?.claude;
+    if (stamped?.uuid === uuid && typeof stamped.transcriptPath === "string") {
+      return { uuid, transcriptPath: stamped.transcriptPath, source: "session-meta" };
+    }
+  }
+
+  // Remaining branches need a cwd to derive the slug or to fall back to
+  // glob. Without either a session-meta match or a cwd we have nothing
+  // to try.
+  if (!cwd) {
+    return { error: "Provide { uuid, cwd }" };
+  }
   const slug = slugifyCwd(cwd);
   if (!slug) return { error: "Invalid cwd" };
-  const transcriptPath = join(homeDir, ".claude", "projects", slug, `${uuid}.jsonl`);
-  return { uuid, transcriptPath };
+  const slugPath = join(homeDir, ".claude", "projects", slug, `${uuid}.jsonl`);
+
+  // (2) Slug path exists on disk — trust it.
+  if (existsSync(slugPath)) {
+    return { uuid, transcriptPath: slugPath, source: "cwd-slug" };
+  }
+
+  // (3) Glob fallback — UUIDs are globally unique, so a directory
+  //     containing `<uuid>.jsonl` identifies the right project.
+  const globHit = findTranscriptByUuid(homeDir, uuid);
+  if (globHit) {
+    return { uuid, transcriptPath: globHit, source: "glob" };
+  }
+
+  // (4) Return the slug path anyway so the watchlist can be entered; the
+  //     file may appear if Claude Code creates it after this request.
+  return { uuid, transcriptPath: slugPath, source: "cwd-slug-missing" };
 }
 
 /**
@@ -68,12 +157,14 @@ export function resolveWatchTarget({ body, homeDir }) {
  *   processor      createClaudeProcessor result  (acquire/release/refcount)
  *   topicBroker    createTopicBroker result  (subscribe)
  *   homeDir        absolute path; e.g. os.homedir()
+ *   sessionManager (optional) used to look up stamped meta.claude
+ *                   .transcriptPath from the SessionStart hook
  *   log            logger (optional)
  */
 export function createClaudeFeedRoutes(ctx) {
   const {
     json, parseJSON, auth, csrf,
-    watchlist, processor, topicBroker, homeDir,
+    watchlist, processor, topicBroker, homeDir, sessionManager,
     log,
   } = ctx;
 
@@ -84,26 +175,23 @@ export function createClaudeFeedRoutes(ctx) {
       return json(res, 400, { error: err.message });
     }
 
-    // Only `{ uuid, cwd }` is accepted. A `{ session }` body means the
-    // client didn't have a uuid — which means the SessionStart hook never
-    // fired for that session. Send them to the setup command rather than
-    // guessing a transcript.
+    // A `{ session }` body without a uuid means the SessionStart hook
+    // never fired for that session — we can't pick one of the potentially
+    // many JSONLs for that cwd. Send them to the setup command rather
+    // than guessing.
     if (body && typeof body.session === "string" && !body.uuid) {
       return json(res, 400, {
         error: "Missing uuid. Run `katulong setup claude-hooks` to enable Claude feeds.",
       });
     }
 
-    const target = resolveWatchTarget({ body, homeDir });
+    const target = resolveWatchTarget({ body, homeDir, sessionManager });
     if (target.error) return json(res, 400, { error: target.error });
 
-    // A missing transcript file on watch-add is the most common silent
-    // failure for "I clicked the sparkle and nothing happened": the cwd
-    // the frontend sent slugified to a directory Claude Code never wrote
-    // to (space in path, symlink, worktree vs canonical root). Log it as
-    // a warning so operators can spot the mismatch without attaching a
-    // debugger. We still add to the watchlist — the file may appear.
-    if (!existsSync(target.transcriptPath)) {
+    // Still missing after all three resolution branches — log it so
+    // operators can spot the mismatch. We still add to the watchlist;
+    // the file may appear if Claude Code writes it later.
+    if (target.source === "cwd-slug-missing") {
       log?.warn?.("claude-feed-routes: transcript not found on watch-add", {
         uuid: target.uuid,
         transcriptPath: target.transcriptPath,

--- a/lib/routes/claude-feed-routes.js
+++ b/lib/routes/claude-feed-routes.js
@@ -104,7 +104,7 @@ export function resolveWatchTarget({ body, homeDir, sessionManager = null }) {
   const sessionName = typeof body.session === "string" ? body.session : null;
 
   if (!uuid) {
-    return { error: "Provide { uuid, cwd }" };
+    return { error: "Missing uuid" };
   }
   if (!UUID_RE.test(uuid)) {
     return { error: "Invalid uuid" };
@@ -125,7 +125,7 @@ export function resolveWatchTarget({ body, homeDir, sessionManager = null }) {
   // glob. Without either a session-meta match or a cwd we have nothing
   // to try.
   if (!cwd) {
-    return { error: "Provide { uuid, cwd }" };
+    return { error: "Missing cwd" };
   }
   const slug = slugifyCwd(cwd);
   if (!slug) return { error: "Invalid cwd" };

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -395,7 +395,12 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
      * @returns {{ sessions: object[] }}
      */
     listSessions() {
-      return { sessions: [...sessions.values()].map(s => s.toJSON()) };
+      return {
+        sessions: [...sessions.values()].map(s => {
+          const data = s.toJSON();
+          return { ...data, meta: publicMeta(data.meta) };
+        }),
+      };
     },
 
     /**

--- a/lib/session-meta-filter.js
+++ b/lib/session-meta-filter.js
@@ -7,6 +7,11 @@
  * REST responses, WS pushes — must funnel through `publicMeta` so a
  * single list of private keys governs every outbound surface.
  *
+ * Session meta is structured as `{ [namespace]: { ...fields } }` (e.g.,
+ * `meta.claude = { uuid, transcriptPath, ... }`), so the filter strips
+ * private keys at the top level AND one level deep inside plain-object
+ * namespaces. Arrays and non-plain values pass through unchanged.
+ *
  * Kept in its own module so both `session-manager.js` (WS `session-updated`
  * push) and `routes/app-routes.js` (REST responses) can share the filter
  * without one importing from the other.
@@ -14,11 +19,25 @@
 
 export const PRIVATE_META_KEYS = new Set(["transcriptPath"]);
 
+function isPlainObject(v) {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function stripPrivateKeys(obj) {
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (PRIVATE_META_KEYS.has(k)) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
 export function publicMeta(meta) {
-  if (!meta || typeof meta !== "object") return meta;
+  if (!isPlainObject(meta)) return meta;
   const out = {};
   for (const [k, v] of Object.entries(meta)) {
-    if (!PRIVATE_META_KEYS.has(k)) out[k] = v;
+    if (PRIVATE_META_KEYS.has(k)) continue;
+    out[k] = isPlainObject(v) ? stripPrivateKeys(v) : v;
   }
   return out;
 }

--- a/public/app.js
+++ b/public/app.js
@@ -2020,9 +2020,14 @@
 
       let resolved;
       try {
+        // Include `session` so the server can prefer the transcriptPath
+        // stamped by the SessionStart hook over a slug derived from the
+        // live tmux pane cwd (which drifts when the shell cd's after
+        // Claude launches — worktree vs canonical root, etc.).
         resolved = await api.post("/api/claude/watch", {
           uuid: claudeMeta.uuid,
           cwd,
+          session: sessionName,
         });
       } catch (err) {
         showToast(`Couldn't find a Claude transcript: ${err.message || "unknown"}`, true);

--- a/server.js
+++ b/server.js
@@ -316,6 +316,7 @@ const routes = [
     watchlist: claudeWatchlist,
     processor: claudeProcessor,
     topicBroker,
+    sessionManager,
     homeDir: homedir(),
     log,
   }),

--- a/test/app-routes-meta.test.js
+++ b/test/app-routes-meta.test.js
@@ -35,6 +35,33 @@ describe("publicMeta", () => {
     // paths (see ensureTopicMeta / /api/topics / POST meta).
     assert.ok(PRIVATE_META_KEYS.has("transcriptPath"));
   });
+
+  it("strips private keys one level deep inside namespaces", () => {
+    // session.meta shape is { [ns]: { ...fields } } — e.g.
+    // meta.claude.transcriptPath — so the filter must recurse into
+    // plain-object values, not just filter the top level.
+    const out = publicMeta({
+      claude: {
+        uuid: "11111111-2222-3333-4444-555555555555",
+        startedAt: 1700000000000,
+        transcriptPath: "/Users/x/.claude/projects/y/abc.jsonl",
+      },
+      agent: { kind: "claude", running: true },
+    });
+    assert.deepEqual(out, {
+      claude: { uuid: "11111111-2222-3333-4444-555555555555", startedAt: 1700000000000 },
+      agent: { kind: "claude", running: true },
+    });
+  });
+
+  it("leaves non-plain namespace values unchanged", () => {
+    const out = publicMeta({
+      tags: ["a", "b"],
+      count: 3,
+      label: null,
+    });
+    assert.deepEqual(out, { tags: ["a", "b"], count: 3, label: null });
+  });
 });
 
 describe("safeTranscriptPath", () => {

--- a/test/app-routes-meta.test.js
+++ b/test/app-routes-meta.test.js
@@ -1,6 +1,10 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { publicMeta, PRIVATE_META_KEYS, applyClaudeMetaFromHook } from "../lib/routes/app-routes.js";
+import {
+  publicMeta, PRIVATE_META_KEYS, applyClaudeMetaFromHook, safeTranscriptPath,
+} from "../lib/routes/app-routes.js";
+
+const UUID_A = "11111111-2222-3333-4444-555555555555";
 
 describe("publicMeta", () => {
   it("strips known private keys", () => {
@@ -30,6 +34,47 @@ describe("publicMeta", () => {
     // server-only field should update both the set and the broadcast
     // paths (see ensureTopicMeta / /api/topics / POST meta).
     assert.ok(PRIVATE_META_KEYS.has("transcriptPath"));
+  });
+});
+
+describe("safeTranscriptPath", () => {
+  it("accepts a well-formed path whose uuid matches", () => {
+    const p = `/Users/x/.claude/projects/-Users-x-proj/${UUID_A}.jsonl`;
+    assert.equal(safeTranscriptPath(p, UUID_A), p);
+  });
+
+  it("rejects a path that doesn't start with /", () => {
+    assert.equal(
+      safeTranscriptPath(`Users/x/.claude/projects/s/${UUID_A}.jsonl`, UUID_A),
+      null,
+    );
+  });
+
+  it("rejects paths containing a .. segment", () => {
+    assert.equal(
+      safeTranscriptPath(`/x/.claude/projects/../../etc/${UUID_A}.jsonl`, UUID_A),
+      null,
+    );
+  });
+
+  it("rejects paths outside /.claude/projects/", () => {
+    assert.equal(safeTranscriptPath(`/tmp/${UUID_A}.jsonl`, UUID_A), null);
+  });
+
+  it("rejects when filename uuid mismatches the session_id", () => {
+    assert.equal(
+      safeTranscriptPath(
+        "/Users/x/.claude/projects/s/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl",
+        UUID_A,
+      ),
+      null,
+    );
+  });
+
+  it("rejects non-string / empty input", () => {
+    assert.equal(safeTranscriptPath(null, UUID_A), null);
+    assert.equal(safeTranscriptPath("", UUID_A), null);
+    assert.equal(safeTranscriptPath(123, UUID_A), null);
   });
 });
 
@@ -230,6 +275,73 @@ describe("applyClaudeMetaFromHook", () => {
     assert.deepEqual(session.meta.agent, { kind: "claude", running: true, detectedAt: 100 });
     assert.equal(session.meta.claude.uuid, "11111111-2222-3333-4444-555555555555");
     assert.equal(typeof session.meta.claude.startedAt, "number");
+  });
+
+  it("SessionStart stamps meta.claude.transcriptPath when hook payload is safe", () => {
+    // The SessionStart hook payload includes transcript_path — the
+    // ground-truth location Claude Code writes to. Stamping it into
+    // meta lets the watch route skip the fragile cwd-slug derivation
+    // and read the file Claude Code is actually writing.
+    const { session } = makeSession();
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "SessionStart",
+      session_id: UUID_A,
+      _tmuxPane: "%3",
+      transcript_path: `/Users/x/.claude/projects/-Users-x-proj/${UUID_A}.jsonl`,
+    }, makeManager(session));
+    assert.equal(verdict, "set");
+    assert.equal(session.meta.claude.uuid, UUID_A);
+    assert.equal(
+      session.meta.claude.transcriptPath,
+      `/Users/x/.claude/projects/-Users-x-proj/${UUID_A}.jsonl`,
+    );
+  });
+
+  it("SessionStart drops transcript_path on traversal attempts", () => {
+    const { session } = makeSession();
+    applyClaudeMetaFromHook({
+      hook_event_name: "SessionStart",
+      session_id: UUID_A,
+      _tmuxPane: "%3",
+      transcript_path: `/Users/x/.claude/projects/../../../etc/${UUID_A}.jsonl`,
+    }, makeManager(session));
+    assert.equal(session.meta.claude.uuid, UUID_A);
+    assert.equal(session.meta.claude.transcriptPath, undefined);
+  });
+
+  it("SessionStart drops transcript_path when uuid in filename doesn't match session_id", () => {
+    const { session } = makeSession();
+    applyClaudeMetaFromHook({
+      hook_event_name: "SessionStart",
+      session_id: UUID_A,
+      _tmuxPane: "%3",
+      transcript_path: "/Users/x/.claude/projects/slug/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl",
+    }, makeManager(session));
+    assert.equal(session.meta.claude.transcriptPath, undefined);
+  });
+
+  it("SessionStart drops transcript_path when it isn't under /.claude/projects/", () => {
+    const { session } = makeSession();
+    applyClaudeMetaFromHook({
+      hook_event_name: "SessionStart",
+      session_id: UUID_A,
+      _tmuxPane: "%3",
+      transcript_path: `/tmp/${UUID_A}.jsonl`,
+    }, makeManager(session));
+    assert.equal(session.meta.claude.transcriptPath, undefined);
+  });
+
+  it("SessionStart leaves transcriptPath unset when hook payload has no transcript_path", () => {
+    // Back-compat: older hook shims, or non-SessionStart adoptions, don't
+    // include transcript_path — the enrichment drops cleanly.
+    const { session } = makeSession();
+    applyClaudeMetaFromHook({
+      hook_event_name: "SessionStart",
+      session_id: UUID_A,
+      _tmuxPane: "%3",
+    }, makeManager(session));
+    assert.equal(session.meta.claude.uuid, UUID_A);
+    assert.equal(session.meta.claude.transcriptPath, undefined);
   });
 
   it("SessionEnd is a no-op — preserves meta.claude enrichment", () => {

--- a/test/claude-feed-routes.test.js
+++ b/test/claude-feed-routes.test.js
@@ -127,12 +127,12 @@ describe("resolveWatchTarget", () => {
 
   it("rejects when uuid missing", () => {
     const out = resolveWatchTarget({ body: {}, homeDir: home });
-    assert.match(out.error, /uuid, cwd/);
+    assert.match(out.error, /Missing uuid/);
   });
 
   it("rejects when cwd missing and no session-meta resolves", () => {
     const out = resolveWatchTarget({ body: { uuid: UUID }, homeDir: home });
-    assert.match(out.error, /uuid, cwd/);
+    assert.match(out.error, /Missing cwd/);
   });
 
   it("rejects an invalid uuid", () => {

--- a/test/claude-feed-routes.test.js
+++ b/test/claude-feed-routes.test.js
@@ -9,7 +9,7 @@
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { EventEmitter } from "node:events";
@@ -17,6 +17,7 @@ import { EventEmitter } from "node:events";
 import { createWatchlist } from "../lib/claude-watchlist.js";
 import {
   resolveWatchTarget,
+  findTranscriptByUuid,
   createClaudeFeedRoutes,
 } from "../lib/routes/claude-feed-routes.js";
 import { slugifyCwd } from "../lib/claude-transcript-discovery.js";
@@ -101,33 +102,157 @@ function makeFakeBroker() {
 }
 
 describe("resolveWatchTarget", () => {
-  const homeDir = "/home/felix";
+  let home;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "katulong-resolve-target-home-"));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  // Create `<home>/.claude/projects/<slug>/<uuid>.jsonl` so `existsSync`
+  // checks in resolveWatchTarget see the file.
+  function writeTranscript(slug, uuid) {
+    const dir = join(home, ".claude", "projects", slug);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, `${uuid}.jsonl`);
+    writeFileSync(path, "");
+    return path;
+  }
 
   it("rejects an empty body", () => {
-    const out = resolveWatchTarget({ body: null, homeDir });
+    const out = resolveWatchTarget({ body: null, homeDir: home });
     assert.match(out.error, /JSON object/);
   });
 
-  it("rejects when uuid or cwd missing", () => {
-    const out = resolveWatchTarget({ body: {}, homeDir });
+  it("rejects when uuid missing", () => {
+    const out = resolveWatchTarget({ body: {}, homeDir: home });
+    assert.match(out.error, /uuid, cwd/);
+  });
+
+  it("rejects when cwd missing and no session-meta resolves", () => {
+    const out = resolveWatchTarget({ body: { uuid: UUID }, homeDir: home });
     assert.match(out.error, /uuid, cwd/);
   });
 
   it("rejects an invalid uuid", () => {
-    const out = resolveWatchTarget({ body: { uuid: "nope", cwd: "/x" }, homeDir });
+    const out = resolveWatchTarget({ body: { uuid: "nope", cwd: "/x" }, homeDir: home });
     assert.match(out.error, /Invalid uuid/);
   });
 
-  it("builds a transcriptPath from uuid + cwd", () => {
+  it("returns cwd-slug path when the slug file exists on disk", () => {
+    const cwd = "/Users/felix/Projects/katulong";
+    const slug = slugifyCwd(cwd);
+    const expected = writeTranscript(slug, UUID);
+    const out = resolveWatchTarget({ body: { uuid: UUID, cwd }, homeDir: home });
+    assert.strictEqual(out.transcriptPath, expected);
+    assert.strictEqual(out.source, "cwd-slug");
+  });
+
+  it("prefers session-meta transcriptPath when the session's meta matches the uuid", () => {
+    // Ground truth comes from the SessionStart hook. Even if the cwd
+    // slug path also exists, the stamped path wins because it reflects
+    // what Claude Code actually reported at launch time.
+    const sessionManager = {
+      getSession: () => ({
+        meta: { claude: { uuid: UUID, transcriptPath: "/abs/from/hook.jsonl" } },
+      }),
+    };
+    const cwd = "/Users/felix/Projects/katulong";
+    writeTranscript(slugifyCwd(cwd), UUID); // on-disk, still ignored
     const out = resolveWatchTarget({
-      body: { uuid: UUID, cwd: "/Users/felix/Projects/katulong" },
-      homeDir,
+      body: { uuid: UUID, cwd, session: "work" },
+      homeDir: home,
+      sessionManager,
     });
-    assert.strictEqual(out.uuid, UUID);
-    assert.strictEqual(
-      out.transcriptPath,
-      `${homeDir}/.claude/projects/${slugifyCwd("/Users/felix/Projects/katulong")}/${UUID}.jsonl`,
-    );
+    assert.strictEqual(out.transcriptPath, "/abs/from/hook.jsonl");
+    assert.strictEqual(out.source, "session-meta");
+  });
+
+  it("ignores session-meta when its uuid doesn't match the requested uuid", () => {
+    // Stale meta from a previous Claude run in the same pane must not
+    // hijack a new request — only a meta.claude.uuid that matches the
+    // requested watch-target uuid is trusted.
+    const sessionManager = {
+      getSession: () => ({
+        meta: {
+          claude: {
+            uuid: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            transcriptPath: "/stale/path.jsonl",
+          },
+        },
+      }),
+    };
+    const cwd = "/Users/felix/Projects/katulong";
+    const expected = writeTranscript(slugifyCwd(cwd), UUID);
+    const out = resolveWatchTarget({
+      body: { uuid: UUID, cwd, session: "work" },
+      homeDir: home,
+      sessionManager,
+    });
+    assert.strictEqual(out.transcriptPath, expected);
+    assert.strictEqual(out.source, "cwd-slug");
+  });
+
+  it("falls back to a glob scan when the cwd-slug file doesn't exist", () => {
+    // Typical stall case: the frontend's live cwd slugified into a dir
+    // Claude Code never wrote to (worktree vs canonical repo). The glob
+    // finds the real transcript by UUID — the uuid is globally unique
+    // so exactly one project dir can contain `<uuid>.jsonl`.
+    const realSlug = "-Users-felix-Projects-katulong";
+    const expected = writeTranscript(realSlug, UUID);
+    const out = resolveWatchTarget({
+      body: { uuid: UUID, cwd: "/Users/felix/.claude/worktrees/whatever" },
+      homeDir: home,
+    });
+    assert.strictEqual(out.transcriptPath, expected);
+    assert.strictEqual(out.source, "glob");
+  });
+
+  it("returns cwd-slug-missing when nothing resolves — watchlist still entered", () => {
+    // No hook-stamp, no existing file, no glob match. The handler still
+    // returns a path so the watchlist entry can be created; the file
+    // might appear if Claude Code writes it after the request.
+    const cwd = "/Users/felix/Projects/katulong";
+    const out = resolveWatchTarget({
+      body: { uuid: UUID, cwd },
+      homeDir: home,
+    });
+    assert.strictEqual(out.source, "cwd-slug-missing");
+    assert.ok(out.transcriptPath.endsWith(`${UUID}.jsonl`));
+  });
+});
+
+describe("findTranscriptByUuid", () => {
+  let home;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "katulong-find-transcript-home-"));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("returns null when ~/.claude/projects doesn't exist", () => {
+    assert.strictEqual(findTranscriptByUuid(home, UUID), null);
+  });
+
+  it("returns null for an invalid uuid", () => {
+    assert.strictEqual(findTranscriptByUuid(home, "not-a-uuid"), null);
+  });
+
+  it("returns the path when the file exists in any project directory", () => {
+    const dir = join(home, ".claude", "projects", "-some-slug");
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, `${UUID}.jsonl`);
+    writeFileSync(path, "");
+    assert.strictEqual(findTranscriptByUuid(home, UUID), path);
+  });
+
+  it("returns null when the uuid isn't present in any project directory", () => {
+    const dir = join(home, ".claude", "projects", "-some-slug");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${UUID_B}.jsonl`), "");
+    assert.strictEqual(findTranscriptByUuid(home, UUID), null);
   });
 });
 
@@ -190,6 +315,30 @@ describe("createClaudeFeedRoutes", () => {
     const stored = await watchlist.get(UUID);
     assert.ok(stored);
     assert.ok(stored.transcriptPath.endsWith(`${UUID}.jsonl`));
+  });
+
+  it("POST /api/claude/watch prefers session-meta transcriptPath over cwd slug", async () => {
+    // The SessionStart hook stamped `meta.claude.transcriptPath` — the
+    // route must trust it even when a slug-derived path would also
+    // resolve. This is the fix for the "feed stalled at X AM" bug: the
+    // live tmux pane cwd had drifted, so the slug path was wrong, but
+    // the hook's transcript_path always points at Claude's real file.
+    const stampedPath = "/abs/from/hook.jsonl";
+    ctx.sessionManager = {
+      getSession: () => ({
+        meta: { claude: { uuid: UUID, transcriptPath: stampedPath } },
+      }),
+    };
+    routes = createClaudeFeedRoutes(ctx);
+    const route = routeFor("POST", "/api/claude/watch");
+    const req = makeReq({
+      method: "POST",
+      body: { uuid: UUID, cwd: "/Users/felix/proj", session: "work" },
+    });
+    await route.handler(req, makeRes());
+
+    const stored = await watchlist.get(UUID);
+    assert.strictEqual(stored.transcriptPath, stampedPath);
   });
 
   it("POST /api/claude/watch is idempotent — re-adding preserves cursor", async () => {

--- a/test/session-manager.test.js
+++ b/test/session-manager.test.js
@@ -130,6 +130,24 @@ describe("session manager", () => {
       assert.ok(names.includes("a"));
       assert.ok(names.includes("b"));
     });
+
+    it("strips PRIVATE_META_KEYS (transcriptPath) from returned meta", async () => {
+      const { mgr } = makeManager();
+      await mgr.createSession("a");
+      const session = mgr.getSession("a");
+      session.setMeta("claude", {
+        uuid: "11111111-2222-3333-4444-555555555555",
+        startedAt: Date.now(),
+        transcriptPath: "/Users/x/.claude/projects/y/11111111-2222-3333-4444-555555555555.jsonl",
+      });
+      const result = mgr.listSessions();
+      const entry = result.sessions.find(s => s.name === "a");
+      assert.ok(entry);
+      assert.ok(entry.meta?.claude, "public meta.claude should survive the filter");
+      assert.strictEqual(entry.meta.claude.uuid, "11111111-2222-3333-4444-555555555555");
+      assert.strictEqual(entry.meta.claude.transcriptPath, undefined,
+        "transcriptPath must not cross the REST boundary");
+    });
   });
 
   describe("deleteSession", () => {


### PR DESCRIPTION
## Summary

Fix silent feed freeze when the Claude Code transcript isn't at the slugified-cwd path (shell cd'd after launch, worktree vs canonical repo, symlinked path).

Two-part fix:

1. **Stamp transcriptPath from hook payload.** `applyClaudeMetaFromHook` in `lib/routes/app-routes.js` now extracts the ground-truth `transcript_path` from every SessionStart/resume hook payload and stamps it into `session.meta.claude`. The path is validated by `safeTranscriptPath`: absolute, no `..`, under `/.claude/projects/`, and the filename uuid must match the session_id. A malformed payload drops the enrichment without dropping the uuid stamp.
2. **Glob fallback in the watch resolver.** `resolveWatchTarget` in `lib/routes/claude-feed-routes.js` now tries three sources in order: (a) the stamped `meta.claude.transcriptPath` when `stamped.uuid === requestedUuid`, (b) the slugified-cwd path if it exists on disk, (c) a `findTranscriptByUuid` scan of `~/.claude/projects/*/{uuid}.jsonl`. If all three miss, we still enter the watchlist at the slug path and log the "transcript not found" warning.

Frontend now passes `session: sessionName` when calling `/api/claude/watch` so the resolver can find the stamped meta.

## Why

Frontend fetches live tmux pane cwd. If the shell cd'd after Claude launched, the slugified path points at a directory Claude never wrote to. `readTranscriptEntries` returns empty, processor cursor stalls, no warning fires, feed tile freezes silently. Claude Code embeds the real `transcript_path` in every hook payload — we just weren't using it.

## Test plan

- [x] `npm test` passes (unit + integration + smoke E2E — 164 targeted tests run on pre-push)
- [x] `safeTranscriptPath` — 6 unit tests (valid path, traversal, wrong dir, uuid mismatch, non-string, non-absolute)
- [x] `applyClaudeMetaFromHook` — 5 new tests (stamps when safe, drops bad paths but keeps uuid)
- [x] `resolveWatchTarget` — 9 tests covering all 4 branches (session-meta, cwd-slug, glob, missing)
- [x] `findTranscriptByUuid` — 4 tests (happy path, missing, bad uuid, no projects dir)
- [ ] Manual test end-to-end through staging