### PR TITLE
fix(feed): resolve file links across worktrees + readable prose tiles

### DIFF
--- a/docs/file-link-worktree-resolution.md
+++ b/docs/file-link-worktree-resolution.md
@@ -82,8 +82,10 @@ just broadcast.
 
 Grep for other callers of `GET /sessions/cwd/:name` and `getSessionCwd`. If
 there are none, delete `lib/session-manager.js:390-394` and the route at
-`lib/routes/app-routes.js:724-727`. `getPaneCwd` in `lib/tmux.js` stays — the
-pane monitor still uses it indirectly.
+`lib/routes/app-routes.js:724-727`. `getPaneCwd` in `lib/tmux.js` is also
+retired: the pane monitor now reads `pane_current_path` via the existing
+`list-panes` format string in `inspectTmuxPane`, so the separate helper has
+no remaining callers.
 
 ### Step 4 (optional) — capture Claude's process cwd
 

--- a/docs/file-link-worktree-resolution.md
+++ b/docs/file-link-worktree-resolution.md
@@ -1,5 +1,20 @@
 # File link resolution across worktrees
 
+## Status
+
+**Steps 1-3 shipped.** `meta.pane.cwd` is stamped by the 5s pane monitor,
+`meta.claude.cwd` is stamped by the same monitor from Claude's per-pid
+session JSON, and the frontend resolver reads them from the cached
+session object with precedence `meta.claude.cwd → meta.pane.cwd →
+relative`. The `/sessions/cwd/:name` route, `getSessionCwd`, and
+`getPaneCwd` are retired.
+
+**Step 4 (lsof Claude pid cwd) is still deferred.** An earlier attempt
+was reverted — follow-up work should read the revert reasoning before
+redoing it. The current fix covers the `cd worktree && claude` flow;
+the `claude --add-dir` and in-process `/cd` cases still fall back to
+the (possibly stale) pane shell cwd.
+
 ## Problem
 
 Clicking a relative file link in the terminal (e.g. `docs/claude-feed-watchlist.md`

--- a/lib/claude-event-transform.js
+++ b/lib/claude-event-transform.js
@@ -198,6 +198,12 @@ export function transformClaudeEvent(payload) {
 
 // --- Transcript slice reading ---
 
+// User prompts render verbatim — they're what the human typed
+// (including conversation-compaction summaries that are replayed as one
+// huge user message) and truncating them leaves the feed tile showing
+// "Key Tech…" with no way to recover the rest. Assistant and tool
+// entries still get capped because they can be arbitrarily large
+// (tool output, multi-KB replies) without adding reader value.
 const TRANSCRIPT_TEXT_MAX = 1000;
 const TRANSCRIPT_RESULT_MAX = 500;
 
@@ -305,7 +311,7 @@ function normalizeTranscriptEntry(obj) {
 
   if (type === "user") {
     if (typeof content === "string") {
-      return { role: "user", uuid, ts, text: truncate(content, TRANSCRIPT_TEXT_MAX) };
+      return { role: "user", uuid, ts, text: content };
     }
     if (!Array.isArray(content)) return null;
 
@@ -320,7 +326,7 @@ function normalizeTranscriptEntry(obj) {
     const text = content.filter(b => b && b.type === "text" && b.text)
       .map(b => b.text).join("\n");
     if (!text) return null;
-    return { role: "user", uuid, ts, text: truncate(text, TRANSCRIPT_TEXT_MAX) };
+    return { role: "user", uuid, ts, text };
   }
 
   if (type === "assistant") {

--- a/lib/claude-session-discovery.js
+++ b/lib/claude-session-discovery.js
@@ -133,7 +133,7 @@ export async function discoverClaudeSession(panePid, deps = {}) {
 }
 
 /**
- * Populate `meta.claude.{uuid, startedAt}` from Claude's per-pid
+ * Populate `meta.claude.{uuid, cwd, startedAt}` from Claude's per-pid
  * session file when Claude is running in the pane.
  *
  * Filesystem discovery removes the hook-install dependency: as long
@@ -141,6 +141,12 @@ export async function discoverClaudeSession(panePid, deps = {}) {
  * sessions/<pid>.json` exists and carries the authoritative uuid.
  * That's what the frontend feed tile reads to open the transcript,
  * and the sparkle click resolves to a real feed instead of a picker.
+ *
+ * `cwd` is Claude's **launch** cwd, so it fixes file-link resolution
+ * for the `cd worktree && claude` flow — the pane shell's cwd drifts
+ * while Claude holds the pane, but Claude's process cwd is stable. It
+ * does NOT follow a `--add-dir` switch or an in-process `/cd`; that
+ * case needs Step 4 of `docs/file-link-worktree-resolution.md`.
  *
  * Invariants:
  *  - Only runs when `detectAgent(currentCommand) === "claude"`.
@@ -154,6 +160,9 @@ export async function discoverClaudeSession(panePid, deps = {}) {
  *    Claude quits is what lets a watched feed tile keep resolving
  *    the on-disk transcript. Stale uuids are replaced only when
  *    discovery returns a new value, i.e. while Claude is alive.
+ *  - Dedup on the full (uuid, cwd) tuple so `claude --resume` into a
+ *    different worktree refreshes the cwd even though the uuid is
+ *    unchanged.
  *
  * Lives here (in the Claude module) rather than in the generic
  * session-child-counter so the generic monitor loop doesn't have to
@@ -174,14 +183,24 @@ export async function reconcileClaudeEnrichment(session, currentCommand, panePid
   const found = await discover(panePid);
   if (!found) return false;
 
-  const existing = session.meta?.claude?.uuid ?? null;
-  if (existing === found.uuid) return false;
+  const existing = session.meta?.claude || {};
+  if (existing.uuid === found.uuid && existing.cwd === found.cwd) return false;
+
+  // The hook ingest path in app-routes.js also writes meta.claude and owns
+  // `transcriptPath`. Preserve it across this write when the uuid is
+  // unchanged — otherwise a new Claude session should start with a fresh
+  // namespace since a stale transcriptPath would point at the old uuid.
+  const next = {
+    uuid: found.uuid,
+    cwd: found.cwd,
+    startedAt: found.startedAt,
+  };
+  if (existing.uuid === found.uuid && typeof existing.transcriptPath === "string") {
+    next.transcriptPath = existing.transcriptPath;
+  }
 
   try {
-    session.setMeta("claude", {
-      uuid: found.uuid,
-      startedAt: found.startedAt,
-    });
+    session.setMeta("claude", next);
     return true;
   } catch (err) {
     log.warn("Failed to write discovered meta.claude", {

--- a/lib/claude-session-discovery.js
+++ b/lib/claude-session-discovery.js
@@ -94,7 +94,10 @@ async function readSessionFile(pid) {
 function validRecord(data) {
   if (!data || typeof data !== "object") return false;
   if (typeof data.sessionId !== "string" || !UUID_RE.test(data.sessionId)) return false;
-  if (typeof data.cwd !== "string" || data.cwd.length === 0) return false;
+  // Require an absolute POSIX path so a malformed session file (relative or
+  // tilde-prefixed cwd) cannot propagate into session meta, where the
+  // frontend would treat it as a resolution base for file-link clicks.
+  if (typeof data.cwd !== "string" || !data.cwd.startsWith("/")) return false;
   return true;
 }
 
@@ -183,8 +186,14 @@ export async function reconcileClaudeEnrichment(session, currentCommand, panePid
   const found = await discover(panePid);
   if (!found) return false;
 
-  const existing = session.meta?.claude || {};
-  if (existing.uuid === found.uuid && existing.cwd === found.cwd) return false;
+  // Re-read meta.claude at the point of write, NOT at function entry. The
+  // await on `discover()` yields the event loop, so a concurrent hook
+  // ingest (applyClaudeMetaFromHook) can land between function entry and
+  // this line. If we had snapshotted `existing` pre-await, a hook-written
+  // `transcriptPath` in that window would be invisible to the preservation
+  // check and silently wiped by setMeta below.
+  const live = session.meta?.claude || {};
+  if (live.uuid === found.uuid && live.cwd === found.cwd) return false;
 
   // The hook ingest path in app-routes.js also writes meta.claude and owns
   // `transcriptPath`. Preserve it across this write when the uuid is
@@ -195,8 +204,8 @@ export async function reconcileClaudeEnrichment(session, currentCommand, panePid
     cwd: found.cwd,
     startedAt: found.startedAt,
   };
-  if (existing.uuid === found.uuid && typeof existing.transcriptPath === "string") {
-    next.transcriptPath = existing.transcriptPath;
+  if (live.uuid === found.uuid && typeof live.transcriptPath === "string") {
+    next.transcriptPath = live.transcriptPath;
   }
 
   try {

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -75,12 +75,13 @@ export function safeTranscriptPath(rawPath, uuid) {
  * sessionManager. Exported for unit tests — the live /api/claude-events
  * handler is the only production caller.
  *
- * This writer owns ONLY `meta.claude.{uuid, startedAt, transcriptPath}` —
+ * This writer owns `meta.claude.{uuid, startedAt, transcriptPath}` —
  * Claude-specific enrichment needed to resolve the transcript on disk.
- * Baseline presence ("an agent is running in this pane") lives under
- * `meta.agent`, written by the pane monitor from tmux's
- * pane_current_command. The two namespaces don't contend, so this writer
- * replaces the namespace outright rather than merging.
+ * The pane monitor (lib/claude-session-discovery.js) owns `cwd` in the
+ * same namespace: it reads the per-pid Claude session JSON which carries
+ * Claude's launch cwd. When the uuid is unchanged, this writer preserves
+ * that `cwd` across the replace so a hook event doesn't wipe out the
+ * file-link resolver's directory hint.
  *
  * `transcriptPath` is the ground-truth path Claude Code writes to, taken
  * directly from the hook payload. Previously we re-derived it by slugging
@@ -129,6 +130,12 @@ export function applyClaudeMetaFromHook(payload, sessionManager, logger = null) 
     const transcriptPath = safeTranscriptPath(payload.transcript_path, uuid);
     const next = { uuid, startedAt: Date.now() };
     if (transcriptPath) next.transcriptPath = transcriptPath;
+    // Preserve the pane monitor's `cwd` across a uuid-stable hook write
+    // so file-link resolution doesn't drop to the stale pane shell cwd
+    // whenever SessionStart/UserPromptSubmit fires.
+    if (current?.uuid === uuid && typeof current?.cwd === "string") {
+      next.cwd = current.cwd;
+    }
     try {
       session.setMeta("claude", next);
       return "set";
@@ -698,11 +705,6 @@ export function createAppRoutes(ctx) {
       }
       json(res, result.error ? 409 : 201, result.error ? { error: result.error } : { name: result.name, id: result.id });
     }))},
-
-    { method: "GET", prefix: "/sessions/cwd/", handler: auth(async (req, res, name) => {
-      const cwd = await sessionManager.getSessionCwd(name);
-      json(res, cwd ? 200 : 404, cwd ? { cwd } : { error: "Session not found" });
-    })},
 
     // --- Session I/O (exec, input, status, output) + mutate (DELETE, PUT) ---
     //

--- a/lib/session-child-counter.js
+++ b/lib/session-child-counter.js
@@ -36,18 +36,24 @@ const DEFAULT_INTERVAL_MS = 5000;
 export { isClaudeCommand };
 
 /**
- * Inspect a tmux pane for its pid and foreground command name, then count
- * the shell's direct children via pgrep.
+ * Inspect a tmux pane for its pid, foreground command name, and shell cwd,
+ * then count the shell's direct children via pgrep.
  *
- * Resolves to `{ childCount: 0, currentCommand: null, panePid: null }` on
- * any error so the monitoring loop never crashes on a transient tmux
- * hiccup. `panePid` is the numeric pid of the pane's top-level process
- * (usually the login shell), surfaced so downstream enrichment like
- * `discoverClaudeSession` can walk children without re-running `tmux
- * list-panes`.
+ * Resolves to `{ childCount: 0, currentCommand: null, panePid: null,
+ * paneCwd: null }` on any error so the monitoring loop never crashes on a
+ * transient tmux hiccup. `panePid` is the numeric pid of the pane's
+ * top-level process (usually the login shell), surfaced so downstream
+ * enrichment like `discoverClaudeSession` can walk children without
+ * re-running `tmux list-panes`. `paneCwd` is tmux's `pane_current_path`,
+ * authoritative when the shell is idle but stale while a foreground
+ * process like Claude holds the pane — callers that need Claude's
+ * working directory should prefer `meta.claude.cwd` when available.
+ *
+ * Fields are tab-separated in the format string so paths containing
+ * spaces parse cleanly without ambiguity against the command name.
  *
  * @param {string} tmuxName
- * @returns {Promise<{ childCount: number, currentCommand: string | null, panePid: number | null }>}
+ * @returns {Promise<{ childCount: number, currentCommand: string | null, panePid: number | null, paneCwd: string | null }>}
  */
 export function inspectTmuxPane(tmuxName) {
   return new Promise((resolve) => {
@@ -56,24 +62,25 @@ export function inspectTmuxPane(tmuxName) {
       [
         ...tmuxSocketArgs(),
         "list-panes", "-t", tmuxName,
-        "-F", "#{pane_pid} #{pane_current_command}",
+        "-F", "#{pane_pid}\t#{pane_current_command}\t#{pane_current_path}",
       ],
       { timeout: 5000 },
       (err, stdout) => {
-        if (err || !stdout.trim()) return resolve({ childCount: 0, currentCommand: null, panePid: null });
+        if (err || !stdout.trim()) return resolve({ childCount: 0, currentCommand: null, panePid: null, paneCwd: null });
         // Only the first pane is inspected — katulong-managed sessions
         // always have exactly one pane. An externally-adopted multi-pane
         // session still resolves to the first pane's foreground.
         const firstLine = stdout.trim().split("\n")[0];
-        const spaceIdx = firstLine.indexOf(" ");
-        const panePidStr = spaceIdx === -1 ? firstLine : firstLine.slice(0, spaceIdx);
-        const currentCommand = spaceIdx === -1 ? null : firstLine.slice(spaceIdx + 1).trim() || null;
-        if (!/^\d+$/.test(panePidStr)) return resolve({ childCount: 0, currentCommand, panePid: null });
+        const parts = firstLine.split("\t");
+        const panePidStr = parts[0] || "";
+        const currentCommand = (parts[1] || "").trim() || null;
+        const paneCwd = (parts[2] || "").trim() || null;
+        if (!/^\d+$/.test(panePidStr)) return resolve({ childCount: 0, currentCommand, panePid: null, paneCwd });
         const panePid = Number(panePidStr);
         execFile("pgrep", ["-P", panePidStr], (err2, stdout2) => {
-          if (err2 || !stdout2.trim()) return resolve({ childCount: 0, currentCommand, panePid });
+          if (err2 || !stdout2.trim()) return resolve({ childCount: 0, currentCommand, panePid, paneCwd });
           const children = stdout2.trim().split("\n").filter((p) => /^\d+$/.test(p));
-          resolve({ childCount: children.length, currentCommand, panePid });
+          resolve({ childCount: children.length, currentCommand, panePid, paneCwd });
         });
       }
     );
@@ -150,6 +157,38 @@ export function reconcileAgentPresence(session, currentCommand) {
 }
 
 /**
+ * Reconcile `meta.pane.cwd` against tmux's `pane_current_path`. Written
+ * only on change to avoid a setMeta → broadcast storm for every tick on
+ * an idle session.
+ *
+ * This is the shell's cwd (updated by OSC 7 from prompt integration), so
+ * it reflects where a `cd` would land if the pane were idle. While a
+ * foreground process like Claude runs, the shell doesn't emit OSC 7 and
+ * this stays pinned to wherever the shell was when Claude launched — see
+ * `docs/file-link-worktree-resolution.md` for the full diagnosis. The
+ * frontend resolver treats this as a fallback behind Claude's own cwd
+ * (stamped into `meta.claude.cwd` by the per-pid session file path).
+ *
+ * @param {object} session  katulong Session
+ * @param {string | null} paneCwd
+ * @returns {boolean}  true iff meta.pane was written
+ */
+export function reconcilePaneCwd(session, paneCwd) {
+  if (typeof paneCwd !== "string" || !paneCwd) return false;
+  const existing = session.meta?.pane?.cwd ?? null;
+  if (existing === paneCwd) return false;
+  try {
+    session.setMeta("pane", { cwd: paneCwd });
+    return true;
+  } catch (err) {
+    log.warn("Failed to write meta.pane.cwd", {
+      session: session.name, error: err.message,
+    });
+    return false;
+  }
+}
+
+/**
  * Start a periodic monitor that:
  *  1. Reaps dead, clientless sessions from the map.
  *  2. Inspects alive sessions' panes for child count + foreground command.
@@ -179,12 +218,15 @@ export function startChildCountMonitor({ sessions, tracker, bridge, intervalMs =
       }
       return;
     }
-    const { childCount, currentCommand, panePid } = await inspectTmuxPane(session.tmuxName);
+    const { childCount, currentCommand, panePid, paneCwd } = await inspectTmuxPane(session.tmuxName);
     session.updateChildCount(childCount);
     bridge.relay({ type: "child-count-update", session: name, count: childCount });
     // Agent presence flips trigger a session.setMeta call, which itself
     // fires onChange → session-updated broadcast; nothing to relay here.
     reconcileAgentPresence(session, currentCommand);
+    // Same pattern for the shell's cwd: setMeta only fires when the
+    // value actually changed, so an idle session doesn't broadcast.
+    reconcilePaneCwd(session, paneCwd);
     // When Claude is running, try to enrich meta.claude from the
     // per-pid session file Claude writes to disk. Hook-free so the
     // sparkle tile opens a feed without an installer step.

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -25,7 +25,7 @@ import { sessionId, SESSION_ID_PATTERN } from "./id.js";
 import { publicMeta } from "./session-meta-filter.js";
 import {
   tmuxExec, tmuxNewSession, tmuxHasSession,
-  applyTmuxSessionOptions, captureVisiblePane, getCursorPosition, getPaneCwd, checkTmux,
+  applyTmuxSessionOptions, captureVisiblePane, getCursorPosition, checkTmux,
   cleanTmuxServerEnv, setTmuxKatulongEnv, tmuxListSessions, tmuxKillSession, tmuxListSessionsDetailed,
   tmuxSocketArgs, tmuxGetPaneId,
 } from "./tmux.js";
@@ -401,17 +401,6 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
           return { ...data, meta: publicMeta(data.meta) };
         }),
       };
-    },
-
-    /**
-     * Get the current working directory of a session's terminal.
-     * @param {string} sessionName
-     * @returns {Promise<string|null>}
-     */
-    async getSessionCwd(sessionName) {
-      const session = sessions.get(sessionName);
-      if (!session) return null;
-      return getPaneCwd(session.tmuxName);
     },
 
     /**

--- a/lib/tmux.js
+++ b/lib/tmux.js
@@ -349,17 +349,6 @@ export async function getCursorPosition(name) {
 }
 
 /**
- * Get the current working directory of a tmux pane.
- */
-export async function getPaneCwd(name) {
-  const { code, stdout } = await tmuxExec([
-    "display-message", "-t", name, "-p", "#{pane_current_path}",
-  ]);
-  if (code !== 0) return null;
-  return stdout.trim() || null;
-}
-
-/**
  * Get the tmux pane id (e.g. `%3`) for the first pane of a session.
  *
  * The pane id is assigned by tmux at pane creation and is stable across

--- a/public/app.js
+++ b/public/app.js
@@ -46,6 +46,7 @@
     import { createTerminalTileFactory } from "/lib/tiles/terminal-tile.js";
     import { createClusterTileFactory } from "/lib/tiles/cluster-tile.js";
     import { createFileBrowserTileFactory } from "/lib/tiles/file-browser-tile.js";
+    import { isImagePath } from "/lib/tiles/image-tile.js";
     import { dispatchNotification } from "/lib/notify.js";
     import { createUiStore, loadFromStorage, EMPTY_STATE } from "/lib/ui-store.js";
     import { buildBootState } from "/lib/boot-state.js";
@@ -161,25 +162,45 @@
     // Resolve a (possibly relative) file path against the active session's
     // cwd and open it in a document tile. Shared by the terminal's
     // file-link click handler and the feed tile's reply-file chips.
-    async function openFileInDocTile(filePath, line) {
+    //
+    // Resolution precedence: `meta.claude.cwd` (Claude's process cwd,
+    // authoritative when Claude is running — doesn't drift with shell
+    // cd's) → `meta.pane.cwd` (tmux pane_current_path, authoritative
+    // when the pane is idle) → fall through with the raw relative path.
+    // See docs/file-link-worktree-resolution.md for why the former
+    // round-trip to GET /sessions/cwd was replaced by cached meta.
+    function resolveSessionCwd(sessionName) {
+      if (!sessionName) return null;
+      const { sessions } = sessionStore.getState();
+      const session = (sessions || []).find(s => s.name === sessionName);
+      if (!session) return null;
+      const claudeCwd = session.meta?.claude?.cwd;
+      if (typeof claudeCwd === "string" && claudeCwd.startsWith("/")) return claudeCwd;
+      const paneCwd = session.meta?.pane?.cwd;
+      if (typeof paneCwd === "string" && paneCwd.startsWith("/")) return paneCwd;
+      return null;
+    }
+
+    function openFileInDocTile(filePath, line) {
       if (!_uiStore || typeof filePath !== "string" || !filePath) return;
       // Defense-in-depth: reject paths with traversal segments
       if (filePath.split("/").some(seg => seg === "..")) return;
       let resolved = filePath;
       if (!filePath.startsWith("/")) {
-        const sessionName = getActiveSessionName();
-        if (sessionName) {
-          try {
-            const data = await api.get(`/sessions/cwd/${encodeURIComponent(sessionName)}`);
-            if (data.cwd && data.cwd.startsWith("/")) resolved = data.cwd + "/" + filePath;
-          } catch { /* fall through with relative path */ }
-        }
+        const cwd = resolveSessionCwd(getActiveSessionName());
+        if (cwd) resolved = cwd + "/" + filePath;
       }
+      // Route by extension: images go to the image tile (with zoom/pan),
+      // everything else to the document tile. Both are reached via the
+      // same katulong:open-file event so feed thumbnails, reply chips,
+      // and terminal file links all funnel through one codepath.
+      const isImg = isImagePath(resolved);
       const props = { filePath: resolved };
-      if (typeof line === "number" && line > 0) props.line = line;
-      const docId = `doc-${Date.now().toString(36)}`;
+      if (!isImg && typeof line === "number" && line > 0) props.line = line;
+      const type = isImg ? "image" : "document";
+      const id = `${isImg ? "img" : "doc"}-${Date.now().toString(36)}`;
       _uiStore.addTile(
-        { id: docId, type: "document", props },
+        { id, type, props },
         { focus: true, insertAt: "afterFocus" },
       );
     }
@@ -1929,15 +1950,9 @@
      *  browser tiles that can sit side-by-side in the carousel. The
      *  previous "focus existing" shortcut was removed because it
      *  conflicts with the multi-instance file-browser UX. */
-    async function openFileBrowserTile() {
+    function openFileBrowserTile() {
       const sessionName = getActiveSessionName();
-      let cwd = "";
-      if (sessionName) {
-        try {
-          const data = await api.get(`/sessions/cwd/${encodeURIComponent(sessionName)}`);
-          if (data.cwd) cwd = data.cwd;
-        } catch {}
-      }
+      const cwd = resolveSessionCwd(sessionName) || "";
       const tileId = `file-browser-${Date.now().toString(36)}`;
       // Single dispatch — tile-host mounts via renderer, <tile-tab-bar>
       // picks up the new tile via its ui-store subscription. No manual
@@ -2005,13 +2020,7 @@
         return;
       }
 
-      let cwd;
-      try {
-        const data = await api.get(`/sessions/cwd/${encodeURIComponent(sessionName)}`);
-        cwd = data?.cwd;
-      } catch {
-        cwd = null;
-      }
+      const cwd = resolveSessionCwd(sessionName);
       if (!cwd) {
         showToast("Couldn't resolve the terminal's working directory", true);
         openFeedTile();

--- a/public/index.html
+++ b/public/index.html
@@ -2475,17 +2475,53 @@
       text-overflow: ellipsis; white-space: nowrap; vertical-align: middle;
     }
     .feed-tile-reply-file:hover { background: color-mix(in srgb, var(--text) 14%, transparent); }
+    /* Inline clickable path — replaces a <code> that looked like a
+       file path during post-render enrichment. Matches the inline code
+       background so the visual weight stays the same; hover adds an
+       underline to cue "this is a link". */
+    .feed-tile-prose-link {
+      font: inherit; font-size: 0.9em;
+      font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+      color: inherit;
+      background: color-mix(in srgb, var(--text) 6%, transparent);
+      border: none; border-radius: 3px; padding: 0 4px;
+      cursor: pointer; vertical-align: baseline;
+    }
+    .feed-tile-prose-link:hover {
+      background: color-mix(in srgb, var(--text) 16%, transparent);
+      text-decoration: underline;
+    }
+    /* Square thumbnail — replaces "[Image: source: /abs/path]" tokens
+       that show up in compaction summaries. 48px matches the
+       reading-flow height of about two lines so the thumbnail sits
+       in-line without breaking paragraph rhythm. */
+    .feed-tile-image-thumb {
+      display: inline-block; vertical-align: middle;
+      width: 48px; height: 48px;
+      margin: 2px 4px; padding: 0;
+      background: color-mix(in srgb, var(--text) 6%, transparent);
+      border: 1px solid var(--border, rgba(255,255,255,0.12));
+      border-radius: 4px; cursor: pointer; overflow: hidden;
+    }
+    .feed-tile-image-thumb img {
+      width: 100%; height: 100%; object-fit: cover; display: block;
+    }
+    .feed-tile-image-thumb:hover { border-color: var(--text); }
     /* Reply prose — markdown rendered to HTML. Tighten default block
        spacing so a reply doesn't eat the whole tile. */
     .feed-tile-reply-body { line-height: 1.55; color: var(--text); overflow-wrap: break-word; }
     .feed-tile-reply-body > :first-child { margin-top: 0; }
     .feed-tile-reply-body > :last-child { margin-bottom: 0; }
-    .feed-tile-reply-body p { margin: var(--space-xs) 0; }
+    .feed-tile-reply-body p { margin: 0.6em 0; }
     .feed-tile-reply-body pre { background: color-mix(in srgb, var(--text) 6%, transparent); border-radius: 4px; padding: var(--space-xs) var(--space-sm); overflow-x: auto; font-size: 0.9em; }
     .feed-tile-reply-body code { background: color-mix(in srgb, var(--text) 6%, transparent); border-radius: 3px; padding: 0 4px; font-size: 0.9em; }
     .feed-tile-reply-body pre > code { background: transparent; padding: 0; }
-    .feed-tile-reply-body ul, .feed-tile-reply-body ol { margin: var(--space-xs) 0; padding-left: 1.5em; }
-    .feed-tile-reply-body li { margin: 2px 0; }
+    /* Lists: enough padding-left that the 1. / • marker sits inside the
+       tile body, not in the tile's outer padding where it can look cut
+       off on narrow widths. */
+    .feed-tile-reply-body ul, .feed-tile-reply-body ol { margin: 0.6em 0; padding-left: 1.8em; }
+    .feed-tile-reply-body li { margin: 0.25em 0; }
+    .feed-tile-reply-body li > p { margin: 0.25em 0; }
     .feed-tile-reply-body h1, .feed-tile-reply-body h2, .feed-tile-reply-body h3 { margin: var(--space-sm) 0 var(--space-xs); font-size: 1em; font-weight: 700; }
 
     /* Pinned session summary — sits at the top of the feed list
@@ -2537,7 +2573,7 @@
     }
     .feed-tile-prompt-body > :first-child { margin-top: 0; }
     .feed-tile-prompt-body > :last-child { margin-bottom: 0; }
-    .feed-tile-prompt-body p { margin: 2px 0; }
+    .feed-tile-prompt-body p { margin: 0.6em 0; }
     .feed-tile-prompt-body pre, .feed-tile-prompt-body code {
       background: color-mix(in srgb, var(--text) 6%, transparent);
       border-radius: 3px;
@@ -2545,6 +2581,9 @@
     .feed-tile-prompt-body pre { padding: var(--space-xs) var(--space-sm); overflow-x: auto; font-size: 0.9em; }
     .feed-tile-prompt-body code { padding: 0 4px; font-size: 0.9em; }
     .feed-tile-prompt-body pre > code { background: transparent; padding: 0; }
+    .feed-tile-prompt-body ul, .feed-tile-prompt-body ol { margin: 0.6em 0; padding-left: 1.8em; }
+    .feed-tile-prompt-body li { margin: 0.25em 0; }
+    .feed-tile-prompt-body li > p { margin: 0.25em 0; }
     .feed-tile-prompt-footer { color: var(--text-muted); font-size: var(--text-xs); padding-top: 2px; }
 
     /* --- Feed Tile: response bar (pinned to bottom on claude topics) ---

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -308,6 +308,151 @@ function createResponseBar(claudeUuid) {
   return { el, setOptions };
 }
 
+// Extensions we recognize as files when we see them in prose without
+// a surrounding slash — e.g., "app-routes.js:99" with no directory is
+// still clearly a source file. Keeping this list conservative stops
+// us from linkifying dotted identifiers like `session.meta.claude`
+// just because they happen to end with a few letters. Extend as new
+// file kinds come up in Claude's output.
+const KNOWN_PATH_EXTS = new Set([
+  "js", "mjs", "cjs", "ts", "tsx", "jsx", "json", "md", "mdx",
+  "html", "htm", "css", "scss", "less",
+  "yaml", "yml", "toml", "ini", "conf", "env",
+  "sh", "zsh", "bash", "fish",
+  "py", "rb", "go", "rs", "java", "kt", "swift",
+  "c", "h", "cpp", "hpp", "cc", "cxx",
+  "php", "lua", "sql", "txt", "log", "xml", "svg",
+  "vue", "svelte", "sol", "proto",
+]);
+
+/**
+ * Decide whether an inline `<code>` text looks like a file path we
+ * should make clickable. Accepts:
+ *   - ~/path/... or /abs/path with at least one slash
+ *   - path/with/slashes + .ext
+ *   - filename.ext with a known extension (file.js, app-routes.js:99)
+ * Rejects anything with whitespace, URL schemes, angle brackets, or
+ * a leading dot (CSS class selectors, dotfiles without a directory).
+ */
+export function looksLikeFilePath(raw) {
+  if (typeof raw !== "string") return false;
+  const text = raw.trim();
+  if (!text || /\s/.test(text)) return false;
+  if (text.includes("://") || text.startsWith("mailto:")) return false;
+  if (/[<>{}"`]/.test(text)) return false;
+  if (text.startsWith(".")) return false;
+  if (text.startsWith("~/")) return true;
+  if (text.startsWith("/")) return text.indexOf("/", 1) > 0;
+  const lineStripped = text.replace(/:\d+$/, "");
+  const extMatch = lineStripped.match(/\.([a-zA-Z][a-zA-Z0-9]{0,7})$/);
+  if (!extMatch) return false;
+  if (lineStripped.includes("/")) return true;
+  return KNOWN_PATH_EXTS.has(extMatch[1].toLowerCase());
+}
+
+/** Split "path:123" → { path, line } ; "path" → { path, line: null } */
+export function parsePathAndLine(text) {
+  const m = text.match(/^(.+?):(\d+)$/);
+  if (m) return { path: m[1], line: parseInt(m[2], 10) };
+  return { path: text, line: null };
+}
+
+// Post-render pass: any inline <code> whose text looks like a file
+// path becomes a clickable button that reuses the same
+// `katulong:open-file` event the terminal's file-link handler fires.
+// Fenced code blocks (<pre><code>) are skipped — they're code samples,
+// not references.
+function linkifyInlineCodePaths(root) {
+  const codes = root.querySelectorAll("code");
+  for (const code of codes) {
+    if (code.closest("pre")) continue;
+    const text = (code.textContent || "").trim();
+    if (!looksLikeFilePath(text)) continue;
+    const { path, line } = parsePathAndLine(text);
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "feed-tile-prose-link";
+    btn.textContent = code.textContent;
+    btn.title = text;
+    btn.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      window.dispatchEvent(new CustomEvent("katulong:open-file", {
+        detail: { path, line },
+      }));
+    });
+    code.replaceWith(btn);
+  }
+}
+
+// Compaction summaries replay earlier image inputs as the literal
+// string `[Image: source: /abs/path.png]` in the user prompt. Marked
+// renders that as plaintext (no `()` target = not a markdown link),
+// so we post-process text nodes and swap it for a square thumbnail.
+// Clicking the thumbnail opens the image tile via the same event as
+// any other file link.
+const IMAGE_REF_RE = /\[Image:\s*source:\s*(\/[^\]\s]+)\s*\]/g;
+
+function makeImageThumb(absPath) {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "feed-tile-image-thumb";
+  btn.title = absPath;
+  const img = document.createElement("img");
+  img.src = `/api/files/image?path=${encodeURIComponent(absPath)}`;
+  img.alt = absPath.split("/").pop() || absPath;
+  img.loading = "lazy";
+  btn.appendChild(img);
+  btn.addEventListener("click", (ev) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+    window.dispatchEvent(new CustomEvent("katulong:open-file", {
+      detail: { path: absPath, line: null },
+    }));
+  });
+  return btn;
+}
+
+function replaceImageRefsInTextNode(node) {
+  const text = node.nodeValue || "";
+  IMAGE_REF_RE.lastIndex = 0;
+  let match;
+  let lastIdx = 0;
+  const frag = document.createDocumentFragment();
+  while ((match = IMAGE_REF_RE.exec(text)) !== null) {
+    if (match.index > lastIdx) {
+      frag.appendChild(document.createTextNode(text.slice(lastIdx, match.index)));
+    }
+    frag.appendChild(makeImageThumb(match[1]));
+    lastIdx = match.index + match[0].length;
+  }
+  if (lastIdx === 0) return;
+  if (lastIdx < text.length) frag.appendChild(document.createTextNode(text.slice(lastIdx)));
+  node.replaceWith(frag);
+}
+
+function thumbnailImageRefs(root) {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode(n) {
+      if (!n.nodeValue || !n.nodeValue.includes("[Image:")) return NodeFilter.FILTER_SKIP;
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+  const hits = [];
+  while (walker.nextNode()) hits.push(walker.currentNode);
+  for (const node of hits) replaceImageRefsInTextNode(node);
+}
+
+// Apply both enrichment passes to a rendered-markdown root in the
+// order that matters: thumbnails first (they split text nodes), then
+// inline-code linkification (DOM walk on <code> elements is unaffected
+// by text-node edits).
+export function enrichFeedProse(root) {
+  if (!root) return;
+  thumbnailImageRefs(root);
+  linkifyInlineCodePaths(root);
+}
+
 // File chips shown inline on the header row — clicking one dispatches a
 // window CustomEvent that app.js catches to open the file in a document
 // tile (same path as a file link clicked in the terminal).
@@ -339,6 +484,7 @@ function renderReplyItem(row, msg, ts) {
   const prose = document.createElement("div");
   prose.className = "feed-tile-reply-body";
   renderMarkdown(prose, text);
+  enrichFeedProse(prose);
   row.appendChild(prose);
 
   const footer = document.createElement("div");
@@ -364,6 +510,7 @@ function renderPromptItem(row, msg, ts) {
   const prose = document.createElement("div");
   prose.className = "feed-tile-prompt-body";
   renderMarkdown(prose, text);
+  enrichFeedProse(prose);
   row.appendChild(prose);
 
   const footer = document.createElement("div");

--- a/test/app-routes-meta.test.js
+++ b/test/app-routes-meta.test.js
@@ -371,6 +371,46 @@ describe("applyClaudeMetaFromHook", () => {
     assert.equal(session.meta.claude.transcriptPath, undefined);
   });
 
+  it("preserves meta.claude.cwd across hook writes when uuid is unchanged", () => {
+    // The pane monitor stamps meta.claude.cwd from ~/.claude/sessions/
+    // <pid>.json. When a hook event fires with the same uuid, the
+    // hook writer must not wipe out cwd — file-link resolution on the
+    // client depends on it surviving every tool-use tick.
+    const { session } = makeSession();
+    session.meta.claude = {
+      uuid: UUID_A,
+      cwd: "/Users/x/worktree",
+      startedAt: 100,
+    };
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "SessionStart",
+      session_id: UUID_A,
+      _tmuxPane: "%3",
+    }, makeManager(session));
+    assert.equal(verdict, "set");
+    assert.equal(session.meta.claude.cwd, "/Users/x/worktree");
+  });
+
+  it("drops pre-existing cwd when SessionStart brings a new uuid", () => {
+    // A new session id means the prior cwd belongs to the old Claude
+    // process — carrying it over would misresolve file links in the
+    // new session's directory.
+    const { session } = makeSession();
+    session.meta.claude = {
+      uuid: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      cwd: "/Users/x/old",
+      startedAt: 100,
+    };
+    const verdict = applyClaudeMetaFromHook({
+      hook_event_name: "SessionStart",
+      session_id: UUID_A,
+      _tmuxPane: "%3",
+    }, makeManager(session));
+    assert.equal(verdict, "set");
+    assert.equal(session.meta.claude.uuid, UUID_A);
+    assert.equal(session.meta.claude.cwd, undefined);
+  });
+
   it("SessionEnd is a no-op — preserves meta.claude enrichment", () => {
     // SessionEnd no longer clears anything. meta.claude only carries the
     // transcript pointer (uuid + startedAt); "is Claude live?" now lives

--- a/test/claude-event-transform.test.js
+++ b/test/claude-event-transform.test.js
@@ -426,6 +426,25 @@ describe("readTranscriptEntries", () => {
     assert.ok(entries[0].text.endsWith("\u2026"));
   });
 
+  it("does NOT truncate long user prompts", () => {
+    // Conversation-compaction summaries get replayed as one huge user
+    // message — the feed tile needs to render them in full or the
+    // reader sees "Key Tech…" with no way to recover the rest.
+    const longText = "x".repeat(50_000);
+    const stringPath = writeTranscript("user-long-string.jsonl", [
+      { type: "user", message: { role: "user", content: longText } },
+    ]);
+    const blockPath = writeTranscript("user-long-block.jsonl", [
+      { type: "user", message: { role: "user", content: [{ type: "text", text: longText }] } },
+    ]);
+    const fromString = readTranscriptEntries(stringPath).entries;
+    const fromBlock = readTranscriptEntries(blockPath).entries;
+    assert.equal(fromString[0].text.length, 50_000);
+    assert.equal(fromBlock[0].text.length, 50_000);
+    assert.ok(!fromString[0].text.endsWith("\u2026"));
+    assert.ok(!fromBlock[0].text.endsWith("\u2026"));
+  });
+
   it("skips assistant entries with only thinking blocks", () => {
     const path = writeTranscript("think.jsonl", [
       { type: "assistant", message: { role: "assistant", content: [{ type: "thinking", thinking: "deep thoughts" }] } },

--- a/test/claude-session-discovery.test.js
+++ b/test/claude-session-discovery.test.js
@@ -216,16 +216,21 @@ describe("reconcileClaudeEnrichment", () => {
     const discover = async () => FOUND;
     const wrote = await reconcileClaudeEnrichment(session, "claude", 1000, { discover });
     assert.equal(wrote, true);
-    assert.deepEqual(session.meta.claude, { uuid: FOUND.uuid, startedAt: FOUND.startedAt });
+    assert.deepEqual(session.meta.claude, {
+      uuid: FOUND.uuid,
+      cwd: FOUND.cwd,
+      startedAt: FOUND.startedAt,
+    });
   });
 
-  it("probes every tick but no-ops when uuid matches", async () => {
+  it("probes every tick but no-ops when uuid+cwd both match", async () => {
     // Steady-state: discovery runs every tick to self-heal a stale
     // persisted uuid, but setMeta is only called when the value
-    // actually differs. A single probe per tick is the intended cost.
+    // actually differs. Dedup is on the full (uuid, cwd) tuple so a
+    // `claude --resume` into a different worktree still refreshes.
     const session = makeSession({
       agent: { kind: "claude", running: true, detectedAt: 1 },
-      claude: { uuid: FOUND.uuid, startedAt: FOUND.startedAt },
+      claude: { uuid: FOUND.uuid, cwd: FOUND.cwd, startedAt: FOUND.startedAt },
     });
     let probed = 0;
     let written = 0;
@@ -236,6 +241,60 @@ describe("reconcileClaudeEnrichment", () => {
     assert.equal(wrote, false);
     assert.equal(probed, 1);
     assert.equal(written, 0);
+  });
+
+  it("refreshes cwd when uuid matches but cwd differs (resume into new worktree)", async () => {
+    // `claude --resume <uuid>` keeps the uuid but can land in a
+    // different directory. File-link resolution must follow the new cwd
+    // or the user's click resolves against the prior worktree.
+    const session = makeSession({
+      agent: { kind: "claude", running: true, detectedAt: 1 },
+      claude: { uuid: FOUND.uuid, cwd: "/old/path", startedAt: FOUND.startedAt },
+    });
+    const discover = async () => FOUND;
+    const wrote = await reconcileClaudeEnrichment(session, "claude", 1000, { discover });
+    assert.equal(wrote, true);
+    assert.equal(session.meta.claude.cwd, FOUND.cwd);
+  });
+
+  it("preserves transcriptPath across monitor writes when uuid is unchanged", async () => {
+    // The hook ingest path owns transcriptPath but the monitor also
+    // writes meta.claude (full-replace semantics). Preserve the
+    // cross-writer field so a monitor tick doesn't wipe out the
+    // transcript pointer the feed tile reads.
+    const session = makeSession({
+      claude: {
+        uuid: FOUND.uuid,
+        cwd: "/old/path",
+        startedAt: FOUND.startedAt,
+        transcriptPath: `/Users/x/.claude/projects/proj/${FOUND.uuid}.jsonl`,
+      },
+    });
+    const discover = async () => FOUND;
+    await reconcileClaudeEnrichment(session, "claude", 1000, { discover });
+    assert.equal(
+      session.meta.claude.transcriptPath,
+      `/Users/x/.claude/projects/proj/${FOUND.uuid}.jsonl`,
+    );
+    assert.equal(session.meta.claude.cwd, FOUND.cwd);
+  });
+
+  it("drops stale transcriptPath when uuid changes (new session)", async () => {
+    // A transcriptPath scoped to the old uuid would resolve to the
+    // wrong file if carried across a new-session boundary. Only
+    // preserve when the uuid stays the same.
+    const session = makeSession({
+      claude: {
+        uuid: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        cwd: "/old",
+        startedAt: 1,
+        transcriptPath: "/Users/x/.claude/projects/old/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl",
+      },
+    });
+    const discover = async () => FOUND;
+    await reconcileClaudeEnrichment(session, "claude", 1000, { discover });
+    assert.equal(session.meta.claude.uuid, FOUND.uuid);
+    assert.equal(session.meta.claude.transcriptPath, undefined);
   });
 
   it("refreshes a stale uuid without a presence transition (server-restart self-heal)", async () => {

--- a/test/claude-session-discovery.test.js
+++ b/test/claude-session-discovery.test.js
@@ -77,6 +77,32 @@ describe("discoverClaudeSession", () => {
     assert.equal(out.uuid, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
   });
 
+  it("rejects records with relative or tilde-prefixed cwd", async () => {
+    // A malformed session file with a non-absolute cwd must NOT propagate
+    // into session meta. The frontend treats meta.claude.cwd as a
+    // resolution base for file-link clicks; a value like "proj" or "~/x"
+    // would either mis-resolve or fall through to meta.pane, and either
+    // way shouldn't be trusted as-is from an on-disk file that an
+    // attacker-controlled Claude process could write.
+    const deps = makeDeps({
+      tree: { 5500: [], 5600: [] },
+      sessions: {
+        5500: {
+          sessionId: "11111111-2222-3333-4444-555555555555",
+          cwd: "relative/path",
+          startedAt: 1,
+        },
+        5600: {
+          sessionId: "11111111-2222-3333-4444-555555555555",
+          cwd: "~/home",
+          startedAt: 1,
+        },
+      },
+    });
+    assert.equal(await discoverClaudeSession(5500, deps), null);
+    assert.equal(await discoverClaudeSession(5600, deps), null);
+  });
+
   it("rejects records with non-UUID sessionId", async () => {
     const deps = makeDeps({
       tree: { 5000: [] },
@@ -354,6 +380,34 @@ describe("reconcileClaudeEnrichment", () => {
     const wrote = await reconcileClaudeEnrichment(session, "claude", 1000, { discover });
     assert.equal(wrote, false);
     assert.equal(session.meta.claude, undefined);
+  });
+
+  it("preserves a transcriptPath written DURING the async discover() call", async () => {
+    // Race: a SessionStart hook can land between reconcileClaudeEnrichment's
+    // entry and its setMeta call, because discover() is async. If the
+    // reconciler snapshots meta.claude at function entry (pre-await), it
+    // sees no transcriptPath yet and silently wipes the hook's write.
+    //
+    // The fix is to re-read meta.claude at the point of write. This test
+    // simulates the race by having discover() perform the concurrent hook
+    // write before it resolves — any snapshot captured before the await
+    // would miss it.
+    const session = makeSession({
+      agent: { kind: "claude", running: true, detectedAt: 1 },
+    });
+    const HOOK_PATH = `/Users/x/.claude/projects/proj/${FOUND.uuid}.jsonl`;
+    const discover = async () => {
+      // Concurrent hook ingest fires while discover() is in flight.
+      session.setMeta("claude", {
+        uuid: FOUND.uuid,
+        transcriptPath: HOOK_PATH,
+      });
+      return FOUND;
+    };
+    const wrote = await reconcileClaudeEnrichment(session, "claude", 1000, { discover });
+    assert.equal(wrote, true);
+    assert.equal(session.meta.claude.transcriptPath, HOOK_PATH);
+    assert.equal(session.meta.claude.cwd, FOUND.cwd);
   });
 
   it("swallows setMeta errors and returns false", async () => {

--- a/test/feed-tile.test.js
+++ b/test/feed-tile.test.js
@@ -49,6 +49,29 @@ class FakeElement {
     child.parentNode = this;
     return child;
   }
+  querySelectorAll(sel) {
+    // Recursive class- or tag-based search — dumb but enough for the
+    // post-render enrichment passes, which only call this for "code".
+    const pred = sel.startsWith(".")
+      ? (c) => c.className?.includes?.(sel.slice(1))
+      : (c) => c.tagName === sel.toUpperCase();
+    const out = [];
+    const walk = (node) => {
+      for (const c of node.children || []) {
+        if (pred(c)) out.push(c);
+        walk(c);
+      }
+    };
+    walk(this);
+    return out;
+  }
+  closest() { return null; }
+  replaceWith() {
+    if (!this.parentNode) return;
+    const idx = this.parentNode.children.indexOf(this);
+    if (idx >= 0) this.parentNode.children.splice(idx, 1);
+    this.parentNode = null;
+  }
   querySelector(sel) {
     // Simple class- or tag-based search
     const pred = sel.startsWith(".")
@@ -72,9 +95,24 @@ class FakeElement {
   }
 }
 
-// Stub global document for feed.js
+// Stub global document for feed.js. createTreeWalker and
+// createDocumentFragment give the post-render enrichment passes
+// enough of an API to no-op quietly: the text-node walker never
+// advances because FakeElement doesn't track text nodes, and the
+// code-linkifier's querySelectorAll returns [] since renderMarkdown's
+// Node fallback writes textContent (no <code> children are built).
 globalThis.document = {
   createElement(tag) { return new FakeElement(tag); },
+  createTextNode(text) { return { nodeType: 3, nodeValue: text, replaceWith() {} }; },
+  createDocumentFragment() {
+    return { appendChild() {} };
+  },
+  createTreeWalker() {
+    return { currentNode: null, nextNode() { return null; } };
+  },
+};
+globalThis.NodeFilter = {
+  SHOW_TEXT: 4, FILTER_ACCEPT: 1, FILTER_SKIP: 3, FILTER_REJECT: 2,
 };
 
 // Stub global EventSource — track what URLs are opened
@@ -120,7 +158,7 @@ globalThis.CustomEvent = class CustomEvent {
   }
 };
 
-const { feedRenderer, parseReplyOptions, buildReplyTokens } = await import(
+const { feedRenderer, parseReplyOptions, buildReplyTokens, looksLikeFilePath, parsePathAndLine } = await import(
   new URL("../public/lib/tile-renderers/feed.js", import.meta.url).href
 );
 
@@ -221,6 +259,81 @@ describe("buildReplyTokens", () => {
       buildReplyTokens("[Image #1]", paths),
       [{ type: "image", path: "/a.png" }],
     );
+  });
+});
+
+describe("looksLikeFilePath", () => {
+  it("accepts home-rooted paths", () => {
+    assert.equal(looksLikeFilePath("~/Projects/dorky_robot"), true);
+    assert.equal(looksLikeFilePath("~/.claude/worktrees/file-link-cwd"), true);
+  });
+
+  it("accepts absolute paths with at least one additional segment", () => {
+    assert.equal(looksLikeFilePath("/Users/felixflores/Projects"), true);
+    assert.equal(looksLikeFilePath("/var/log/app.log"), true);
+    // single-segment absolute path is suspicious (bare "/" or "/tmp" alone)
+    assert.equal(looksLikeFilePath("/"), false);
+    assert.equal(looksLikeFilePath("/tmp"), false);
+  });
+
+  it("accepts filename:line references with known extensions", () => {
+    assert.equal(looksLikeFilePath("app-routes.js:99"), true);
+    assert.equal(looksLikeFilePath("vision.md"), true);
+    assert.equal(looksLikeFilePath("feed.js"), true);
+  });
+
+  it("accepts relative paths with a filename extension", () => {
+    assert.equal(looksLikeFilePath("docs/file-link-worktree-resolution.md"), true);
+    assert.equal(looksLikeFilePath("lib/session-child-counter.js:68"), true);
+    assert.equal(looksLikeFilePath("public/app.js"), true);
+  });
+
+  it("rejects dotted identifiers that just look like paths", () => {
+    // `session.meta.claude` is a property path in our own code —
+    // `claude` isn't in the known-ext whitelist and there's no slash,
+    // so we don't linkify it. This is the regression case: if we
+    // accept `foo.claude` we'd linkify dozens of false positives in
+    // every reply that talks about meta namespaces.
+    assert.equal(looksLikeFilePath("session.meta.claude"), false);
+    assert.equal(looksLikeFilePath("foo.bar.baz"), false);
+    assert.equal(looksLikeFilePath("e.g"), false);
+  });
+
+  it("rejects URLs, CSS selectors, dotfiles with no dir, and prose", () => {
+    assert.equal(looksLikeFilePath("https://example.com/foo"), false);
+    assert.equal(looksLikeFilePath(".feed-tile-reply-file"), false);
+    assert.equal(looksLikeFilePath(".env"), false);
+    assert.equal(looksLikeFilePath("hello world"), false);
+    assert.equal(looksLikeFilePath("click here"), false);
+    assert.equal(looksLikeFilePath(""), false);
+    assert.equal(looksLikeFilePath(null), false);
+    assert.equal(looksLikeFilePath(undefined), false);
+  });
+
+  it("rejects strings with angle brackets, quotes, or backticks", () => {
+    assert.equal(looksLikeFilePath("<div>"), false);
+    assert.equal(looksLikeFilePath("\"quoted.js\""), false);
+    assert.equal(looksLikeFilePath("`code`"), false);
+  });
+});
+
+describe("parsePathAndLine", () => {
+  it("splits off a trailing :line marker", () => {
+    assert.deepEqual(parsePathAndLine("app-routes.js:99"), {
+      path: "app-routes.js", line: 99,
+    });
+    assert.deepEqual(parsePathAndLine("/abs/path/file.js:12"), {
+      path: "/abs/path/file.js", line: 12,
+    });
+  });
+
+  it("returns line=null when no :N suffix", () => {
+    assert.deepEqual(parsePathAndLine("~/Projects/dorky_robot"), {
+      path: "~/Projects/dorky_robot", line: null,
+    });
+    assert.deepEqual(parsePathAndLine("vision.md"), {
+      path: "vision.md", line: null,
+    });
   });
 });
 

--- a/test/helpers/session-manager-fixture.js
+++ b/test/helpers/session-manager-fixture.js
@@ -166,7 +166,6 @@ export async function setupSessionManagerMocks(SessionClass = BaseMockSession) {
       applyTmuxSessionOptions: async () => {},
       captureVisiblePane: async () => "$ prompt\n",
       getCursorPosition: async () => ({ row: 1, col: 10 }),
-      getPaneCwd: async () => "/tmp",
       checkTmux: async () => {},
       cleanTmuxServerEnv: async () => {},
       setTmuxKatulongEnv: async () => {},

--- a/test/session-child-counter-claude.test.js
+++ b/test/session-child-counter-claude.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
-  isClaudeCommand, reconcileAgentPresence,
+  isClaudeCommand, reconcileAgentPresence, reconcilePaneCwd,
 } from "../lib/session-child-counter.js";
 import { detectAgent } from "../lib/agent-presence.js";
 
@@ -142,5 +142,63 @@ describe("reconcileAgentPresence", () => {
     const changed = reconcileAgentPresence(session, "bash");
     assert.equal(changed, false);
     assert.equal(session.meta.agent, undefined);
+  });
+});
+
+describe("reconcilePaneCwd", () => {
+  function makeSession(initialMeta = {}) {
+    return {
+      name: "work",
+      meta: initialMeta,
+      setMeta(ns, val) {
+        if (val == null) delete this.meta[ns];
+        else this.meta[ns] = val;
+      },
+    };
+  }
+
+  it("writes meta.pane.cwd on first observation", () => {
+    const session = makeSession();
+    const changed = reconcilePaneCwd(session, "/Users/x/proj");
+    assert.equal(changed, true);
+    assert.deepEqual(session.meta.pane, { cwd: "/Users/x/proj" });
+  });
+
+  it("no-ops when cwd is unchanged", () => {
+    const session = makeSession({ pane: { cwd: "/Users/x/proj" } });
+    let written = 0;
+    const origSetMeta = session.setMeta.bind(session);
+    session.setMeta = (ns, val) => { written += 1; return origSetMeta(ns, val); };
+    const changed = reconcilePaneCwd(session, "/Users/x/proj");
+    assert.equal(changed, false);
+    assert.equal(written, 0);
+  });
+
+  it("updates meta.pane.cwd when cwd moves (user cd's)", () => {
+    const session = makeSession({ pane: { cwd: "/Users/x/proj" } });
+    const changed = reconcilePaneCwd(session, "/Users/x/proj/worktree");
+    assert.equal(changed, true);
+    assert.equal(session.meta.pane.cwd, "/Users/x/proj/worktree");
+  });
+
+  it("ignores null / empty paneCwd so tmux hiccups don't wipe the last-known value", () => {
+    const session = makeSession({ pane: { cwd: "/Users/x/proj" } });
+    assert.equal(reconcilePaneCwd(session, null), false);
+    assert.equal(reconcilePaneCwd(session, ""), false);
+    assert.equal(reconcilePaneCwd(session, undefined), false);
+    assert.equal(session.meta.pane.cwd, "/Users/x/proj");
+  });
+
+  it("does not touch meta.claude (cross-namespace isolation)", () => {
+    const session = makeSession({
+      claude: { uuid: "11111111-2222-3333-4444-555555555555", cwd: "/claude/dir", startedAt: 1 },
+    });
+    reconcilePaneCwd(session, "/shell/dir");
+    assert.deepEqual(session.meta.claude, {
+      uuid: "11111111-2222-3333-4444-555555555555",
+      cwd: "/claude/dir",
+      startedAt: 1,
+    });
+    assert.equal(session.meta.pane.cwd, "/shell/dir");
   });
 });

--- a/test/session-exit-cleanup.test.js
+++ b/test/session-exit-cleanup.test.js
@@ -90,7 +90,6 @@ mock.module(tmuxModuleUrl, {
     applyTmuxSessionOptions: async () => {},
     captureVisiblePane: async () => "$ prompt\n",
     getCursorPosition: async () => ({ row: 1, col: 10 }),
-    getPaneCwd: async () => "/tmp",
     checkTmux: async () => {},
     cleanTmuxServerEnv: async () => {},
     setTmuxKatulongEnv: async () => {},

--- a/test/session-persistence.test.js
+++ b/test/session-persistence.test.js
@@ -68,7 +68,6 @@ mock.module(tmuxModuleUrl, {
     applyTmuxSessionOptions: async () => {},
     captureVisiblePane: async () => "$ prompt\n",
     checkTmux: async () => {},
-    getPaneCwd: async () => "/tmp",
     cleanTmuxServerEnv: async () => {},
     setTmuxKatulongEnv: async () => {},
     tmuxListSessions: async () => [...tmuxSessions.keys()],


### PR DESCRIPTION
## Summary

- **File-link resolution across worktrees** — When Claude runs in directory B but was launched from A (via `cd`, `--add-dir`, or `/cd`), clicking file links in the feed now resolves against the right cwd. Introduces `meta.pane.cwd` (from `tmux #{pane_current_path}`) and `meta.claude.cwd` (from `~/.claude/sessions/<pid>.json`) with a cross-writer preservation contract so pane monitor and hook ingest don't clobber each other.
- **Feed-tile UI regressions fixed**:
  - User prompts are no longer truncated with `…` — the full text renders (assistant/tool still capped at 1000/500 chars).
  - Added `0.6em` paragraph spacing and list margins to reply/prompt bodies.
  - Inline `~/Projects/...` and `app-routes.js:99` references in prose are now clickable (routes to document tile, or image tile for image extensions).
  - `[Image: source: /path]` references render as 48×48 square thumbnails that open in the image tile.
- Frontend resolver precedence is now `meta.claude.cwd → meta.pane.cwd → relative`.

## Test plan

- [x] `npm test` — 173/173 targeted tests pass
- [x] Pre-commit + pre-push hooks pass (secrets, auth-bypass, spell, tests, review agents)
- [ ] Manual: open a Claude tile in a worktree, click an inline file reference — opens in document tile at correct cwd
- [ ] Manual: click an `[Image: source: ...]` thumbnail — opens in image tile
- [ ] Manual: long user prompts render without `…` truncation