### PR TITLE
feat(feed): render Bash/Read/Edit tool cards with live state borders

### DIFF
--- a/lib/claude-event-transform.js
+++ b/lib/claude-event-transform.js
@@ -201,11 +201,16 @@ export function transformClaudeEvent(payload) {
 // User prompts render verbatim — they're what the human typed
 // (including conversation-compaction summaries that are replayed as one
 // huge user message) and truncating them leaves the feed tile showing
-// "Key Tech…" with no way to recover the rest. Assistant and tool
-// entries still get capped because they can be arbitrarily large
-// (tool output, multi-KB replies) without adding reader value.
+// "Key Tech…" with no way to recover the rest. Assistant replies still
+// get capped because they can be arbitrarily large without adding
+// reader value.
 const TRANSCRIPT_TEXT_MAX = 1000;
-const TRANSCRIPT_RESULT_MAX = 500;
+// Tool output is capped *for the narrator's summary view only* via the
+// normalized `text` field. The full untruncated output lives in each
+// per-tool record so feed cards can show it in their expand body —
+// capping there would hide exactly the detail the user wants when they
+// tap into a failing Bash call.
+const TRANSCRIPT_RESULT_SUMMARY_MAX = 500;
 
 /**
  * Read transcript JSONL entries starting from a given line index and
@@ -294,8 +299,14 @@ export function readTranscriptEntries(transcriptPath, fromLine = 0, limit) {
  *
  * Shapes:
  *   user prompt     → { role: "user", uuid, ts, text }
- *   tool result     → { role: "tool_result", uuid, ts, text }
- *   assistant turn  → { role: "assistant", uuid, ts, text?, tools?: [{ name, input }] }
+ *   tool result     → { role: "tool_result", uuid, ts, text,
+ *                        results: [{ toolUseId, text, isError }] }
+ *                     `text` is the narrator-truncated summary (joined across
+ *                     blocks) kept for the summarizer; `results[]` carries
+ *                     each block untruncated with its originating tool_use id
+ *                     so the feed can correlate running/ok/error state back
+ *                     to the card it stamped when the tool_use arrived.
+ *   assistant turn  → { role: "assistant", uuid, ts, text?, tools?: [{ id, name, input }] }
  */
 function normalizeTranscriptEntry(obj) {
   if (!obj || typeof obj !== "object") return null;
@@ -318,9 +329,21 @@ function normalizeTranscriptEntry(obj) {
     // tool_result blocks mean this "user" entry is actually a tool response
     const toolResults = content.filter(b => b && b.type === "tool_result");
     if (toolResults.length > 0) {
-      const text = toolResults.map(b => stringifyContent(b.content)).filter(Boolean).join("\n");
-      if (!text) return null;
-      return { role: "tool_result", uuid, ts, text: truncate(text, TRANSCRIPT_RESULT_MAX) };
+      const results = toolResults
+        .map((b) => ({
+          toolUseId: typeof b.tool_use_id === "string" ? b.tool_use_id : null,
+          text: stringifyContent(b.content),
+          isError: b.is_error === true,
+        }))
+        .filter((r) => r.text);
+      if (results.length === 0) return null;
+      const joined = results.map((r) => r.text).join("\n");
+      return {
+        role: "tool_result",
+        uuid, ts,
+        text: truncate(joined, TRANSCRIPT_RESULT_SUMMARY_MAX),
+        results,
+      };
     }
 
     const text = content.filter(b => b && b.type === "text" && b.text)
@@ -334,7 +357,11 @@ function normalizeTranscriptEntry(obj) {
     const text = content.filter(b => b && b.type === "text" && b.text)
       .map(b => b.text).join("\n");
     const tools = content.filter(b => b && b.type === "tool_use")
-      .map(b => ({ name: b.name, input: b.input || {} }));
+      .map(b => ({
+        id: typeof b.id === "string" ? b.id : null,
+        name: b.name,
+        input: b.input || {},
+      }));
     if (!text && tools.length === 0) return null;
     const out = { role: "assistant", uuid, ts };
     if (text) out.text = truncate(text, TRANSCRIPT_TEXT_MAX);

--- a/lib/claude-event-transform.js
+++ b/lib/claude-event-transform.js
@@ -33,30 +33,49 @@ const MAX_DETAIL_LENGTH = 200;
 export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
- * Extract a short target description from tool_input.
+ * Extract a short target description from tool_input for the *hook*
+ * narration path. Truncates aggressively (40 chars) because the hook
+ * event carries a single `step` string rendered in a narrow strip.
  * @param {string} toolName
  * @param {object} toolInput
  * @returns {string}
  */
 function extractTarget(toolName, toolInput) {
-  if (!toolInput || typeof toolInput !== "object") return "";
+  const raw = toolTargetLabel(toolName, toolInput);
+  if (!raw) return "";
+  if (toolName === "Edit" || toolName === "Read" || toolName === "Write") return raw;
+  return truncate(raw, 40);
+}
 
+/**
+ * Pick a short, human-readable target label off a tool_use input blob.
+ * Shared by both the hook narration path (via `extractTarget`) and the
+ * transcript/tool-card path (via `normalizeTranscriptEntry`). No
+ * truncation — callers decide whether to cap based on where the label
+ * is rendered (feed cards use CSS ellipsis; hook narration caps to 40).
+ *
+ * Recognized shapes: Edit/Read/Write → basename(file_path); Bash → command;
+ * Grep/Glob → pattern; Agent → description. Returns "" for anything else
+ * so the caller can fall back to just the tool name.
+ *
+ * @param {string} toolName
+ * @param {object} toolInput
+ * @returns {string}
+ */
+export function toolTargetLabel(toolName, toolInput) {
+  if (!toolInput || typeof toolInput !== "object") return "";
   switch (toolName) {
     case "Edit":
     case "Read":
     case "Write":
-      if (toolInput.file_path) return basename(toolInput.file_path);
-      return "";
+      return typeof toolInput.file_path === "string" ? basename(toolInput.file_path) : "";
     case "Bash":
-      if (toolInput.command) return truncate(toolInput.command, 40);
-      return "";
+      return typeof toolInput.command === "string" ? toolInput.command : "";
     case "Grep":
     case "Glob":
-      if (toolInput.pattern) return truncate(toolInput.pattern, 40);
-      return "";
+      return typeof toolInput.pattern === "string" ? toolInput.pattern : "";
     case "Agent":
-      if (toolInput.description) return truncate(toolInput.description, 40);
-      return "";
+      return typeof toolInput.description === "string" ? toolInput.description : "";
     default:
       return "";
   }
@@ -206,11 +225,19 @@ export function transformClaudeEvent(payload) {
 // reader value.
 const TRANSCRIPT_TEXT_MAX = 1000;
 // Tool output is capped *for the narrator's summary view only* via the
-// normalized `text` field. The full untruncated output lives in each
-// per-tool record so feed cards can show it in their expand body —
-// capping there would hide exactly the detail the user wants when they
-// tap into a failing Bash call.
+// normalized `text` field. The full per-block output lives in each
+// tool record so feed cards can show it in their expand body — capping
+// there too aggressively would hide exactly the detail the user wants
+// when they tap into a failing Bash call.
 const TRANSCRIPT_RESULT_SUMMARY_MAX = 500;
+// Hard ceiling on the per-block text we carry through to the tool card.
+// Without this a single multi-megabyte Bash stdout gets JSON-stringified
+// into every SSE envelope and broadcast to every subscriber — cheap to
+// produce, expensive to fan out. 64KB is roughly a full terminal screen
+// at 80x500 and comfortably more than any legitimate command summary;
+// truly large output is on disk anyway, the card just shows enough to
+// know what happened.
+const TRANSCRIPT_RESULT_BLOCK_MAX = 64 * 1024;
 
 /**
  * Read transcript JSONL entries starting from a given line index and
@@ -306,7 +333,11 @@ export function readTranscriptEntries(transcriptPath, fromLine = 0, limit) {
  *                     each block untruncated with its originating tool_use id
  *                     so the feed can correlate running/ok/error state back
  *                     to the card it stamped when the tool_use arrived.
- *   assistant turn  → { role: "assistant", uuid, ts, text?, tools?: [{ id, name, input }] }
+ *   assistant turn  → { role: "assistant", uuid, ts, text?, tools?: [{ id, name, input, target }] }
+ *                     `target` is a pre-computed short label (filename,
+ *                     command, pattern, description) so the feed tile
+ *                     renders without needing to know Claude's tool
+ *                     input shapes.
  */
 function normalizeTranscriptEntry(obj) {
   if (!obj || typeof obj !== "object") return null;
@@ -332,7 +363,7 @@ function normalizeTranscriptEntry(obj) {
       const results = toolResults
         .map((b) => ({
           toolUseId: typeof b.tool_use_id === "string" ? b.tool_use_id : null,
-          text: stringifyContent(b.content),
+          text: truncate(stringifyContent(b.content), TRANSCRIPT_RESULT_BLOCK_MAX),
           isError: b.is_error === true,
         }))
         .filter((r) => r.text);
@@ -361,6 +392,7 @@ function normalizeTranscriptEntry(obj) {
         id: typeof b.id === "string" ? b.id : null,
         name: b.name,
         input: b.input || {},
+        target: toolTargetLabel(b.name, b.input || {}),
       }));
     if (!text && tools.length === 0) return null;
     const out = { role: "assistant", uuid, ts };

--- a/lib/claude-processor.js
+++ b/lib/claude-processor.js
@@ -204,8 +204,9 @@ export function createClaudeProcessor({
       // User prompts get their own feed event so the reader can see the
       // conversation flow, not just Claude's half. `tool_result` entries
       // (Claude Code synthesizes these as role:"user" transcript lines)
-      // have their own normalized role and are skipped — they're
-      // invisible plumbing, not something the user typed.
+      // have their own normalized role and are handled below — they
+      // drive the ok/error flip on the tool cards stamped when the
+      // matching tool_use was emitted.
       //
       // A new user prompt also resets the file accumulator: whatever
       // tool-touched files were waiting belonged to the PREVIOUS turn
@@ -225,8 +226,41 @@ export function createClaudeProcessor({
         continue;
       }
 
+      if (e.role === "tool_result" && Array.isArray(e.results)) {
+        for (const r of e.results) {
+          if (!r.toolUseId) continue;
+          const toolEvent = {
+            status: "tool",
+            toolUseId: r.toolUseId,
+            state: r.isError ? "error" : "ok",
+            output: r.text,
+            ts: e.ts,
+          };
+          topicBroker.publish(w.topic, JSON.stringify(toolEvent), { timestamp: e.ts });
+          publishedAny = true;
+        }
+        continue;
+      }
+
       if (e.role !== "assistant") continue;
       mergeFiles(extractFilesFromEntry(e));
+
+      if (Array.isArray(e.tools) && e.tools.length > 0) {
+        for (const t of e.tools) {
+          if (!t.id) continue;
+          const toolEvent = {
+            status: "tool",
+            toolUseId: t.id,
+            state: "running",
+            name: t.name,
+            input: t.input,
+            ts: e.ts,
+          };
+          topicBroker.publish(w.topic, JSON.stringify(toolEvent), { timestamp: e.ts });
+          publishedAny = true;
+        }
+      }
+
       if (!e.text) continue;
 
       const replyEvent = {

--- a/lib/claude-processor.js
+++ b/lib/claude-processor.js
@@ -253,7 +253,7 @@ export function createClaudeProcessor({
             toolUseId: t.id,
             state: "running",
             name: t.name,
-            input: t.input,
+            target: t.target || "",
             ts: e.ts,
           };
           topicBroker.publish(w.topic, JSON.stringify(toolEvent), { timestamp: e.ts });

--- a/public/index.html
+++ b/public/index.html
@@ -2586,6 +2586,84 @@
     .feed-tile-prompt-body li > p { margin: 0.25em 0; }
     .feed-tile-prompt-footer { color: var(--text-muted); font-size: var(--text-xs); padding-top: 2px; }
 
+    /* --- Feed Tile: tool card ---
+       Intermediate tool calls (Bash, Read, Edit, Grep, …) render as a
+       collapsed card between replies/prompts. The left border encodes
+       state so the reader can scan a long feed:
+         running → animated blue pulse
+         ok      → solid green
+         error   → solid red
+       Tap the header row to expand and see the full output. The card
+       is thin on purpose — tool calls should stay secondary to the
+       reply prose unless the reader deliberately drills in. */
+    .feed-status-tool {
+      display: block;
+      border-left: 2px solid var(--border, rgba(255,255,255,0.12));
+      padding-left: var(--space-sm);
+      padding-top: 2px;
+      padding-bottom: 2px;
+    }
+    .feed-tile-tool { margin: 0; }
+    .feed-tile-tool > summary {
+      display: flex; align-items: center; gap: var(--space-xs);
+      cursor: pointer;
+      list-style: none;
+      padding: 2px 0;
+      color: var(--text-muted);
+      font-size: var(--text-xs);
+      flex-wrap: wrap;
+    }
+    .feed-tile-tool > summary::-webkit-details-marker { display: none; }
+    .feed-tile-tool > summary::marker { content: ""; }
+    .feed-tile-tool-name { font-weight: 600; color: var(--text); }
+    .feed-tile-tool-target {
+      font-family: var(--font-mono, ui-monospace, Menlo, monospace);
+      color: var(--text);
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      max-width: 100%;
+    }
+    .feed-tile-tool-state {
+      font-size: 0.8em; padding: 0 6px; border-radius: 999px;
+      background: color-mix(in srgb, var(--text) 8%, transparent);
+      text-transform: lowercase;
+    }
+    .feed-tile-tool--running .feed-tile-tool-state {
+      background: color-mix(in srgb, var(--accent-strong, #6f87b3) 25%, transparent);
+      color: var(--text);
+    }
+    .feed-tile-tool--ok .feed-tile-tool-state {
+      background: color-mix(in srgb, #3fb950 25%, transparent); color: var(--text);
+    }
+    .feed-tile-tool--error .feed-tile-tool-state {
+      background: color-mix(in srgb, #f85149 30%, transparent); color: var(--text);
+    }
+    .feed-tile-tool-body { padding: var(--space-xs) 0 var(--space-xs) var(--space-xs); }
+    .feed-tile-tool-output {
+      margin: 0; padding: var(--space-xs) var(--space-sm);
+      background: color-mix(in srgb, var(--text) 5%, transparent);
+      border-radius: 4px;
+      white-space: pre-wrap; word-break: break-word;
+      font-family: var(--font-mono, ui-monospace, Menlo, monospace);
+      font-size: 0.85em;
+      max-height: 360px; overflow-y: auto;
+    }
+    .feed-tile-tool-hint { color: var(--text-muted); font-size: var(--text-xs); font-style: italic; }
+
+    /* State borders override the default. Running uses a keyframed
+       pulse so an in-flight call is visually alive without screaming
+       for attention; ok/error are solid and calm. */
+    .feed-tile-tool--running { border-left-color: var(--accent-strong, #6f87b3); animation: feed-tool-pulse 1.6s ease-in-out infinite; }
+    .feed-tile-tool--ok      { border-left-color: #3fb950; }
+    .feed-tile-tool--error   { border-left-color: #f85149; }
+
+    @keyframes feed-tool-pulse {
+      0%, 100% { border-left-color: color-mix(in srgb, var(--accent-strong, #6f87b3) 40%, transparent); }
+      50%      { border-left-color: var(--accent-strong, #6f87b3); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .feed-tile-tool--running { animation: none; }
+    }
+
     /* --- Feed Tile: response bar (pinned to bottom on claude topics) ---
        Large textarea, no Send button. Enter submits; Shift+Enter
        inserts a newline. Quick-pick buttons appear above when the

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -499,34 +499,6 @@ function renderReplyItem(row, msg, ts) {
   row.appendChild(footer);
 }
 
-// Derive a short header label for a tool card from the raw tool_use
-// input blob. Mirrors the per-tool heuristics in
-// `claude-event-transform.js` so the UI shows the same concise target
-// (filename, first 40 chars of a command, glob pattern, etc.) that the
-// narrator would for a PostToolUse event.
-function toolTargetLabel(name, input) {
-  if (!input || typeof input !== "object") return "";
-  switch (name) {
-    case "Edit":
-    case "Read":
-    case "Write": {
-      const fp = input.file_path;
-      if (typeof fp !== "string") return "";
-      const i = fp.lastIndexOf("/");
-      return i >= 0 ? fp.slice(i + 1) : fp;
-    }
-    case "Bash":
-      return typeof input.command === "string" ? input.command : "";
-    case "Grep":
-    case "Glob":
-      return typeof input.pattern === "string" ? input.pattern : "";
-    case "Agent":
-      return typeof input.description === "string" ? input.description : "";
-    default:
-      return "";
-  }
-}
-
 // Tool card. Collapsed by default — just the header row showing
 // name + target + state — taps expand to reveal the full output. The
 // state class (`feed-tile-tool--running|ok|error`) drives the border
@@ -538,6 +510,10 @@ function toolTargetLabel(name, input) {
 // output payload only lands on the terminal tool_result event —
 // holding a reference to the inner body and mutating it would mean
 // threading more state through handleEvent than it's worth.
+//
+// `info.target` is pre-computed server-side (see toolTargetLabel in
+// claude-event-transform.js) so this renderer stays ignorant of
+// Claude's tool input shapes.
 function renderToolItem(row, info, ts) {
   row.innerHTML = "";
   const state = info.state === "ok" || info.state === "error" ? info.state : "running";
@@ -547,24 +523,22 @@ function renderToolItem(row, info, ts) {
   details.className = "feed-tile-tool";
 
   const header = document.createElement("summary");
-  header.className = "feed-tile-tool-header";
 
   const name = document.createElement("span");
   name.className = "feed-tile-tool-name";
   name.textContent = info.name || "Tool";
   header.appendChild(name);
 
-  const target = toolTargetLabel(info.name, info.input);
-  if (target) {
+  if (typeof info.target === "string" && info.target) {
     const tgt = document.createElement("span");
     tgt.className = "feed-tile-tool-target";
-    tgt.textContent = target;
+    tgt.textContent = info.target;
     header.appendChild(tgt);
   }
 
   const stateLabel = document.createElement("span");
   stateLabel.className = "feed-tile-tool-state";
-  stateLabel.textContent = state === "running" ? "running" : state === "ok" ? "ok" : "error";
+  stateLabel.textContent = state;
   header.appendChild(stateLabel);
 
   header.appendChild(makeTimeSpan(ts));

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -499,6 +499,94 @@ function renderReplyItem(row, msg, ts) {
   row.appendChild(footer);
 }
 
+// Derive a short header label for a tool card from the raw tool_use
+// input blob. Mirrors the per-tool heuristics in
+// `claude-event-transform.js` so the UI shows the same concise target
+// (filename, first 40 chars of a command, glob pattern, etc.) that the
+// narrator would for a PostToolUse event.
+function toolTargetLabel(name, input) {
+  if (!input || typeof input !== "object") return "";
+  switch (name) {
+    case "Edit":
+    case "Read":
+    case "Write": {
+      const fp = input.file_path;
+      if (typeof fp !== "string") return "";
+      const i = fp.lastIndexOf("/");
+      return i >= 0 ? fp.slice(i + 1) : fp;
+    }
+    case "Bash":
+      return typeof input.command === "string" ? input.command : "";
+    case "Grep":
+    case "Glob":
+      return typeof input.pattern === "string" ? input.pattern : "";
+    case "Agent":
+      return typeof input.description === "string" ? input.description : "";
+    default:
+      return "";
+  }
+}
+
+// Tool card. Collapsed by default — just the header row showing
+// name + target + state — taps expand to reveal the full output. The
+// state class (`feed-tile-tool--running|ok|error`) drives the border
+// style (animated / green / red) so the user can scan a long feed and
+// see at a glance which tool calls are still in flight and which
+// completed, without opening every card.
+//
+// The row is rebuilt on every update (running → ok/error) because the
+// output payload only lands on the terminal tool_result event —
+// holding a reference to the inner body and mutating it would mean
+// threading more state through handleEvent than it's worth.
+function renderToolItem(row, info, ts) {
+  row.innerHTML = "";
+  const state = info.state === "ok" || info.state === "error" ? info.state : "running";
+  row.className = `feed-tile-item feed-status-tool feed-tile-tool--${state}`;
+
+  const details = document.createElement("details");
+  details.className = "feed-tile-tool";
+
+  const header = document.createElement("summary");
+  header.className = "feed-tile-tool-header";
+
+  const name = document.createElement("span");
+  name.className = "feed-tile-tool-name";
+  name.textContent = info.name || "Tool";
+  header.appendChild(name);
+
+  const target = toolTargetLabel(info.name, info.input);
+  if (target) {
+    const tgt = document.createElement("span");
+    tgt.className = "feed-tile-tool-target";
+    tgt.textContent = target;
+    header.appendChild(tgt);
+  }
+
+  const stateLabel = document.createElement("span");
+  stateLabel.className = "feed-tile-tool-state";
+  stateLabel.textContent = state === "running" ? "running" : state === "ok" ? "ok" : "error";
+  header.appendChild(stateLabel);
+
+  header.appendChild(makeTimeSpan(ts));
+  details.appendChild(header);
+
+  const body = document.createElement("div");
+  body.className = "feed-tile-tool-body";
+  if (typeof info.output === "string" && info.output) {
+    const pre = document.createElement("pre");
+    pre.className = "feed-tile-tool-output";
+    pre.textContent = info.output;
+    body.appendChild(pre);
+  } else if (state === "running") {
+    const hint = document.createElement("div");
+    hint.className = "feed-tile-tool-hint";
+    hint.textContent = "Running\u2026";
+    body.appendChild(hint);
+  }
+  details.appendChild(body);
+  row.appendChild(details);
+}
+
 // The user's side of the conversation. Same structural shape as a
 // reply (body + time footer) but styled differently so the reader
 // can eyeball the back-and-forth without reading every word.
@@ -796,6 +884,13 @@ export const feedRenderer = {
       // republished reply (e.g. after a processor catch-up) updates the
       // existing row in place rather than duplicating it.
       const replyItems = new Map();
+      // Tool cards are keyed by their tool_use id. A running card is
+      // stamped on the tool_use event; the matching tool_result event
+      // flips state (ok/error) and fills the output body. Values hold
+      // the merged info so an out-of-order republish (running event
+      // delivered AFTER its result, e.g. during a catch-up slice)
+      // doesn't clobber the terminal state.
+      const toolItems = new Map();
       // Ephemeral non-reply events (generic log topics or pre-rewrite
       // persisted events) get auto-keyed row slots.
       const logItems = new Map();
@@ -858,6 +953,36 @@ export const feedRenderer = {
         if (isProgress) {
           if (status === "session-summary") {
             applySummary(msg);
+            return;
+          }
+          if (status === "tool" && typeof msg.toolUseId === "string") {
+            const existing = toolItems.get(msg.toolUseId);
+            let entry;
+            if (!existing) {
+              const row = document.createElement("div");
+              list.appendChild(row);
+              entry = { row, info: { ...msg } };
+              toolItems.set(msg.toolUseId, entry);
+            } else {
+              entry = existing;
+              // Merge so running metadata (name/input, stamped first)
+              // survives when a later ok/error event carries only the
+              // output — and conversely, a running republish doesn't
+              // drop a terminal state that already landed. Snapshot
+              // prev BEFORE the spread since `entry.info` is the object
+              // being overwritten.
+              const prevState = entry.info.state;
+              const prevOutput = entry.info.output;
+              const wasTerminal = prevState === "ok" || prevState === "error";
+              const isTerminal = msg.state === "ok" || msg.state === "error";
+              entry.info = { ...entry.info, ...msg };
+              if (wasTerminal && !isTerminal) {
+                entry.info.state = prevState;
+                if (typeof prevOutput === "string") entry.info.output = prevOutput;
+              }
+            }
+            renderToolItem(entry.row, entry.info, envelope.timestamp);
+            list.scrollTop = list.scrollHeight;
             return;
           }
           if (status === "reply" && typeof msg.entryId === "string") {

--- a/test/claude-event-transform.test.js
+++ b/test/claude-event-transform.test.js
@@ -336,7 +336,12 @@ describe("readTranscriptEntries", () => {
     assert.equal(entries[0].role, "assistant");
     assert.equal(entries[0].text, "Looking at the auth module.");
     assert.deepEqual(entries[0].tools, [
-      { id: "toolu_01ABC", name: "Read", input: { file_path: "/src/auth.js", offset: 42 } },
+      {
+        id: "toolu_01ABC",
+        name: "Read",
+        input: { file_path: "/src/auth.js", offset: 42 },
+        target: "auth.js",
+      },
     ]);
   });
 
@@ -404,6 +409,57 @@ describe("readTranscriptEntries", () => {
     assert.ok(entries[0].text.length <= 500, "narrator text is capped");
     assert.equal(entries[0].results[0].text.length, 2000, "per-result text is full");
     assert.equal(entries[0].results[0].isError, false);
+  });
+
+  it("caps per-block tool_result text at 64KB to bound SSE payload size", () => {
+    // A single pathological tool output (multi-MB bash stdout, binary
+    // dump mistakenly piped to stdout) would otherwise be JSON-encoded
+    // into every SSE envelope and fanned out to every subscriber. Cap
+    // per-block so the feed card shows enough to identify what happened
+    // without broadcasting the whole thing.
+    const huge = "y".repeat(200 * 1024);
+    const path = writeTranscript("huge.jsonl", [
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_01Y", content: huge }],
+        },
+      },
+    ]);
+    const { entries } = readTranscriptEntries(path);
+    assert.equal(entries.length, 1);
+    const cap = 64 * 1024;
+    assert.ok(entries[0].results[0].text.length <= cap, `capped, got ${entries[0].results[0].text.length}`);
+    // Truncation marker is the ellipsis inserted by `truncate()`.
+    assert.ok(entries[0].results[0].text.endsWith("\u2026"), "ends with ellipsis");
+  });
+
+  it("attaches a pre-computed target label to each tool_use in the normalized entry", () => {
+    // The feed-tile renderer used to re-derive this label client-side
+    // from tool.input, which meant every new tool shape needed a
+    // frontend change. Emit it from the transform so the UI stays
+    // ignorant of Claude's input schemas.
+    const path = writeTranscript("targets.jsonl", [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_B", name: "Bash", input: { command: "ls -la /tmp" } },
+            { type: "tool_use", id: "toolu_G", name: "Grep", input: { pattern: "TODO" } },
+            { type: "tool_use", id: "toolu_W", name: "Write", input: { file_path: "/a/b/c.js" } },
+            { type: "tool_use", id: "toolu_X", name: "Unknown", input: { foo: "bar" } },
+          ],
+        },
+      },
+    ]);
+    const { entries } = readTranscriptEntries(path);
+    const tools = entries[0].tools;
+    assert.equal(tools.find((t) => t.id === "toolu_B").target, "ls -la /tmp");
+    assert.equal(tools.find((t) => t.id === "toolu_G").target, "TODO");
+    assert.equal(tools.find((t) => t.id === "toolu_W").target, "c.js");
+    assert.equal(tools.find((t) => t.id === "toolu_X").target, "");
   });
 
   it("normalizes a user string-content entry", () => {

--- a/test/claude-event-transform.test.js
+++ b/test/claude-event-transform.test.js
@@ -325,7 +325,7 @@ describe("readTranscriptEntries", () => {
           role: "assistant",
           content: [
             { type: "text", text: "Looking at the auth module." },
-            { type: "tool_use", name: "Read", input: { file_path: "/src/auth.js", offset: 42 } },
+            { type: "tool_use", id: "toolu_01ABC", name: "Read", input: { file_path: "/src/auth.js", offset: 42 } },
           ],
         },
       },
@@ -336,8 +336,74 @@ describe("readTranscriptEntries", () => {
     assert.equal(entries[0].role, "assistant");
     assert.equal(entries[0].text, "Looking at the auth module.");
     assert.deepEqual(entries[0].tools, [
-      { name: "Read", input: { file_path: "/src/auth.js", offset: 42 } },
+      { id: "toolu_01ABC", name: "Read", input: { file_path: "/src/auth.js", offset: 42 } },
     ]);
+  });
+
+  it("preserves tool_use.id and correlates tool_result.tool_use_id", () => {
+    // The frontend keys tool cards on toolUseId to flip running→ok/error
+    // when the matching result lands. A transform that drops either id
+    // side breaks that correlation silently (cards stuck mid-animation).
+    const path = writeTranscript("pair.jsonl", [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_01AAA", name: "Bash", input: { command: "ls -la" } },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_01AAA", content: "total 8\ndrwx...", is_error: false },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_01BBB", content: "command failed", is_error: true },
+          ],
+        },
+      },
+    ]);
+    const { entries } = readTranscriptEntries(path);
+    assert.equal(entries.length, 3);
+    assert.equal(entries[0].tools[0].id, "toolu_01AAA");
+    assert.equal(entries[1].role, "tool_result");
+    assert.deepEqual(entries[1].results, [
+      { toolUseId: "toolu_01AAA", text: "total 8\ndrwx...", isError: false },
+    ]);
+    assert.equal(entries[2].results[0].toolUseId, "toolu_01BBB");
+    assert.equal(entries[2].results[0].isError, true);
+  });
+
+  it("keeps tool_result full output on results[] even when text is truncated", () => {
+    // The narrator's `text` field is capped at 500 chars so the
+    // summarizer doesn't eat a whole bash log, but the feed card's
+    // expand body needs the full output. `results[].text` must carry
+    // the untruncated content per block.
+    const big = "x".repeat(2000);
+    const path = writeTranscript("big.jsonl", [
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_01X", content: big }],
+        },
+      },
+    ]);
+    const { entries } = readTranscriptEntries(path);
+    assert.equal(entries.length, 1);
+    assert.ok(entries[0].text.length <= 500, "narrator text is capped");
+    assert.equal(entries[0].results[0].text.length, 2000, "per-result text is full");
+    assert.equal(entries[0].results[0].isError, false);
   });
 
   it("normalizes a user string-content entry", () => {

--- a/test/claude-processor.test.js
+++ b/test/claude-processor.test.js
@@ -524,13 +524,16 @@ describe("createClaudeProcessor", () => {
       .filter((m) => m.status === "tool");
     assert.equal(toolEvents.length, 2, "ignores tool_use blocks with no id");
     assert.deepEqual(
-      toolEvents.map((e) => ({ id: e.toolUseId, state: e.state, name: e.name })),
+      toolEvents.map((e) => ({ id: e.toolUseId, state: e.state, name: e.name, target: e.target })),
       [
-        { id: "toolu_RUN_1", state: "running", name: "Bash" },
-        { id: "toolu_RUN_2", state: "running", name: "Read" },
+        { id: "toolu_RUN_1", state: "running", name: "Bash", target: "ls -la" },
+        { id: "toolu_RUN_2", state: "running", name: "Read", target: "auth.js" },
       ],
     );
-    assert.deepEqual(toolEvents[0].input, { command: "ls -la" });
+    // Raw input is no longer broadcast — the pre-computed `target` is
+    // what the feed card renders, so subscribers don't need the full
+    // tool input blob.
+    assert.ok(!("input" in toolEvents[0]), "raw tool input is not on the wire");
 
     processor.destroy();
   });

--- a/test/claude-processor.test.js
+++ b/test/claude-processor.test.js
@@ -88,6 +88,17 @@ function fakeAssistantToolOnly(tools) {
   };
 }
 
+function fakeToolResultLine(toolUseId, content, { isError = false } = {}) {
+  return {
+    type: "user",
+    message: {
+      content: [
+        { type: "tool_result", tool_use_id: toolUseId, content, is_error: isError },
+      ],
+    },
+  };
+}
+
 async function waitFor(predicate, { timeoutMs = 2000, intervalMs = 10 } = {}) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -479,6 +490,142 @@ describe("createClaudeProcessor", () => {
     assert.ok(paths.includes("/a.js"));
     const authFile = reply.files.find((f) => f.path === "/src/auth.js");
     assert.equal(authFile.line, 1);
+
+    processor.destroy();
+  });
+
+  it("publishes a running tool event for each tool_use block with an id", async () => {
+    // Tool cards in the feed need a "running" stamp the moment a
+    // tool_use lands so the user sees the in-progress state before
+    // the result arrives. Blocks without an id are ignored (legacy
+    // transcripts, malformed entries) since the frontend keys cards
+    // on toolUseId and can't correlate a result without one.
+    writeTranscript(transcriptPath, [
+      fakeAssistantToolOnly([
+        { id: "toolu_RUN_1", name: "Bash", input: { command: "ls -la" } },
+        { id: "toolu_RUN_2", name: "Read", input: { file_path: "/src/auth.js" } },
+        { name: "NoId", input: {} },
+      ]),
+    ]);
+    await watchlist.add(UUID, { transcriptPath });
+
+    const broker = makeBroker();
+    const processor = createClaudeProcessor({
+      watchlist, topicBroker: broker, pollIntervalMs: 50,
+    });
+
+    await processor.acquire(UUID);
+    await waitFor(() =>
+      broker.published.filter((p) => JSON.parse(p.message).status === "tool").length >= 2,
+    );
+
+    const toolEvents = broker.published
+      .map((p) => JSON.parse(p.message))
+      .filter((m) => m.status === "tool");
+    assert.equal(toolEvents.length, 2, "ignores tool_use blocks with no id");
+    assert.deepEqual(
+      toolEvents.map((e) => ({ id: e.toolUseId, state: e.state, name: e.name })),
+      [
+        { id: "toolu_RUN_1", state: "running", name: "Bash" },
+        { id: "toolu_RUN_2", state: "running", name: "Read" },
+      ],
+    );
+    assert.deepEqual(toolEvents[0].input, { command: "ls -la" });
+
+    processor.destroy();
+  });
+
+  it("flips running→ok on matching tool_result (is_error false)", async () => {
+    writeTranscript(transcriptPath, [
+      fakeAssistantToolOnly([{ id: "toolu_OK_1", name: "Bash", input: { command: "echo hi" } }]),
+      fakeToolResultLine("toolu_OK_1", "hi\n"),
+    ]);
+    await watchlist.add(UUID, { transcriptPath });
+
+    const broker = makeBroker();
+    const processor = createClaudeProcessor({
+      watchlist, topicBroker: broker, pollIntervalMs: 50,
+    });
+
+    await processor.acquire(UUID);
+    await waitFor(() =>
+      broker.published.filter((p) => JSON.parse(p.message).status === "tool").length >= 2,
+    );
+
+    const toolEvents = broker.published
+      .map((p) => JSON.parse(p.message))
+      .filter((m) => m.status === "tool");
+    assert.equal(toolEvents.length, 2);
+    assert.deepEqual(
+      toolEvents.map((e) => ({ id: e.toolUseId, state: e.state })),
+      [
+        { id: "toolu_OK_1", state: "running" },
+        { id: "toolu_OK_1", state: "ok" },
+      ],
+    );
+    assert.equal(toolEvents[1].output, "hi\n");
+
+    processor.destroy();
+  });
+
+  it("flips running→error on matching tool_result (is_error true)", async () => {
+    writeTranscript(transcriptPath, [
+      fakeAssistantToolOnly([{ id: "toolu_ERR_1", name: "Bash", input: { command: "false" } }]),
+      fakeToolResultLine("toolu_ERR_1", "command failed", { isError: true }),
+    ]);
+    await watchlist.add(UUID, { transcriptPath });
+
+    const broker = makeBroker();
+    const processor = createClaudeProcessor({
+      watchlist, topicBroker: broker, pollIntervalMs: 50,
+    });
+
+    await processor.acquire(UUID);
+    await waitFor(() =>
+      broker.published.filter((p) => JSON.parse(p.message).status === "tool" && JSON.parse(p.message).state === "error").length >= 1,
+    );
+
+    const errorEvent = broker.published
+      .map((p) => JSON.parse(p.message))
+      .find((m) => m.status === "tool" && m.state === "error");
+    assert.equal(errorEvent.toolUseId, "toolu_ERR_1");
+    assert.equal(errorEvent.output, "command failed");
+
+    processor.destroy();
+  });
+
+  it("emits tool events straddling a slice boundary in order", async () => {
+    // Backlog catch-up reads in sliceLimit-sized chunks. A tool_use
+    // landing in chunk N with its tool_result in chunk N+1 must still
+    // surface as running then ok/error — the accumulator lives on the
+    // worker across cycles, so the correlation holds.
+    writeTranscript(transcriptPath, [
+      fakeAssistantToolOnly([{ id: "toolu_SPLIT", name: "Bash", input: { command: "date" } }]),
+      fakeToolResultLine("toolu_SPLIT", "today"),
+    ]);
+    await watchlist.add(UUID, { transcriptPath });
+
+    const broker = makeBroker();
+    const processor = createClaudeProcessor({
+      watchlist, topicBroker: broker, pollIntervalMs: 500, sliceLimit: 1,
+    });
+
+    await processor.acquire(UUID);
+    await waitFor(async () => {
+      const entry = await watchlist.get(UUID);
+      return entry.lastProcessedLine === 2;
+    });
+
+    const toolEvents = broker.published
+      .map((p) => JSON.parse(p.message))
+      .filter((m) => m.status === "tool");
+    assert.deepEqual(
+      toolEvents.map((e) => ({ id: e.toolUseId, state: e.state })),
+      [
+        { id: "toolu_SPLIT", state: "running" },
+        { id: "toolu_SPLIT", state: "ok" },
+      ],
+    );
 
     processor.destroy();
   });

--- a/test/feed-tile.test.js
+++ b/test/feed-tile.test.js
@@ -708,7 +708,7 @@ describe("feedRenderer", () => {
             toolUseId: "toolu_R1",
             state: "running",
             name: "Bash",
-            input: { command: "ls -la" },
+            target: "ls -la",
             ts: 1_700_000_000_000,
           }),
           timestamp: 1_700_000_000_000,
@@ -748,7 +748,7 @@ describe("feedRenderer", () => {
 
       send({
         status: "tool", toolUseId: "toolu_OK", state: "running",
-        name: "Read", input: { file_path: "/src/auth.js" },
+        name: "Read", target: "auth.js",
         ts: 1_700_000_000_000,
       });
       send({
@@ -790,7 +790,7 @@ describe("feedRenderer", () => {
 
       send({
         status: "tool", toolUseId: "toolu_ERR", state: "running",
-        name: "Bash", input: { command: "false" },
+        name: "Bash", target: "false",
         ts: 1_700_000_000_000,
       });
       send({
@@ -828,7 +828,7 @@ describe("feedRenderer", () => {
 
       send({
         status: "tool", toolUseId: "toolu_KEEP", state: "running",
-        name: "Bash", input: { command: "ls" }, ts: 1_700_000_000_000,
+        name: "Bash", target: "ls", ts: 1_700_000_000_000,
       });
       send({
         status: "tool", toolUseId: "toolu_KEEP", state: "ok",
@@ -837,7 +837,7 @@ describe("feedRenderer", () => {
       // Late running republish — must not clobber the ok state.
       send({
         status: "tool", toolUseId: "toolu_KEEP", state: "running",
-        name: "Bash", input: { command: "ls" }, ts: 1_700_000_000_000,
+        name: "Bash", target: "ls", ts: 1_700_000_000_000,
       });
 
       const row = el.children[0].children[1].children[0];

--- a/test/feed-tile.test.js
+++ b/test/feed-tile.test.js
@@ -688,6 +688,164 @@ describe("feedRenderer", () => {
       assert.equal(list.children[0].children[0].textContent, "second");
     });
 
+    it("renders a running tool card with state class and tool name", () => {
+      // A tool_use event stamps a "running" card so the user sees the
+      // in-progress state before the result arrives. The state class
+      // drives the animated left border in CSS.
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "claude/abc", meta: { type: "progress" } },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      eventSources[0].onmessage({
+        data: JSON.stringify({
+          seq: 1, topic: "claude/abc",
+          message: JSON.stringify({
+            status: "tool",
+            toolUseId: "toolu_R1",
+            state: "running",
+            name: "Bash",
+            input: { command: "ls -la" },
+            ts: 1_700_000_000_000,
+          }),
+          timestamp: 1_700_000_000_000,
+        }),
+      });
+
+      const list = el.children[0].children[1];
+      assert.equal(list.children.length, 1);
+      const row = list.children[0];
+      assert.ok(row.className.includes("feed-status-tool"), row.className);
+      assert.ok(row.className.includes("feed-tile-tool--running"), row.className);
+      // row → <details> → [<summary>, <body>]
+      const details = row.children[0];
+      const header = details.children[0];
+      // header → [name, target, state, time]
+      assert.equal(header.children[0].textContent, "Bash");
+      assert.equal(header.children[1].textContent, "ls -la");
+      assert.equal(header.children[2].textContent, "running");
+    });
+
+    it("flips running → ok when a matching tool_result lands", () => {
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "claude/abc", meta: { type: "progress" } },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      const send = (body) => eventSources[0].onmessage({
+        data: JSON.stringify({
+          seq: 1, topic: "claude/abc",
+          message: JSON.stringify(body),
+          timestamp: 1_700_000_000_000,
+        }),
+      });
+
+      send({
+        status: "tool", toolUseId: "toolu_OK", state: "running",
+        name: "Read", input: { file_path: "/src/auth.js" },
+        ts: 1_700_000_000_000,
+      });
+      send({
+        status: "tool", toolUseId: "toolu_OK", state: "ok",
+        output: "file contents here",
+        ts: 1_700_000_000_001,
+      });
+
+      const list = el.children[0].children[1];
+      assert.equal(list.children.length, 1, "same toolUseId updates in place");
+      const row = list.children[0];
+      assert.ok(row.className.includes("feed-tile-tool--ok"), row.className);
+      const header = row.children[0].children[0];
+      // Name/target from the running event must survive merge with the
+      // ok-only payload (which only carries output + state).
+      assert.equal(header.children[0].textContent, "Read");
+      assert.equal(header.children[1].textContent, "auth.js");
+      assert.equal(header.children[2].textContent, "ok");
+      const body = row.children[0].children[1];
+      assert.equal(body.children[0].textContent, "file contents here");
+    });
+
+    it("flips running → error on is_error result", () => {
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "claude/abc", meta: { type: "progress" } },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      const send = (body) => eventSources[0].onmessage({
+        data: JSON.stringify({
+          seq: 1, topic: "claude/abc",
+          message: JSON.stringify(body),
+          timestamp: 1_700_000_000_000,
+        }),
+      });
+
+      send({
+        status: "tool", toolUseId: "toolu_ERR", state: "running",
+        name: "Bash", input: { command: "false" },
+        ts: 1_700_000_000_000,
+      });
+      send({
+        status: "tool", toolUseId: "toolu_ERR", state: "error",
+        output: "exit 1",
+        ts: 1_700_000_000_001,
+      });
+
+      const row = el.children[0].children[1].children[0];
+      assert.ok(row.className.includes("feed-tile-tool--error"), row.className);
+      assert.equal(row.children[0].children[0].children[2].textContent, "error");
+    });
+
+    it("does not regress a terminal card back to running on a late republish", () => {
+      // Replay order: during a catch-up, the processor can republish
+      // events out of order (running → ok, then on the NEXT cycle
+      // running again when the slice boundary spans the same turn).
+      // The ok state must stick — otherwise a completed card briefly
+      // animates like it's still running after the result came in.
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "claude/abc", meta: { type: "progress" } },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      const send = (body) => eventSources[0].onmessage({
+        data: JSON.stringify({
+          seq: 1, topic: "claude/abc",
+          message: JSON.stringify(body),
+          timestamp: 1_700_000_000_000,
+        }),
+      });
+
+      send({
+        status: "tool", toolUseId: "toolu_KEEP", state: "running",
+        name: "Bash", input: { command: "ls" }, ts: 1_700_000_000_000,
+      });
+      send({
+        status: "tool", toolUseId: "toolu_KEEP", state: "ok",
+        output: "a\nb", ts: 1_700_000_000_001,
+      });
+      // Late running republish — must not clobber the ok state.
+      send({
+        status: "tool", toolUseId: "toolu_KEEP", state: "running",
+        name: "Bash", input: { command: "ls" }, ts: 1_700_000_000_000,
+      });
+
+      const row = el.children[0].children[1].children[0];
+      assert.ok(row.className.includes("feed-tile-tool--ok"), row.className);
+      const body = row.children[0].children[1];
+      assert.equal(body.children[0].textContent, "a\nb");
+    });
+
     it("silently drops legacy narrative / completion / summary / reply-title events", () => {
       // Old topic logs (from the pre-flatten narrator) still contain
       // these event types. New renderers ignore them rather than


### PR DESCRIPTION
## Summary

- Preserve `tool_use.id` and `tool_result.tool_use_id` through the transform so the feed can correlate a running tool call with its result.
- Processor emits `{status:\"tool\", state:\"running\"|\"ok\"|\"error\", name, input, output, toolUseId}` events so intermediate Bash/Read/Edit/Grep calls surface between prompts and replies.
- Frontend renders collapsible tool cards keyed by `toolUseId`: animated blue left border while running, solid green on ok, red on error. Taps expand to show full output.
- Merge invariant: a late `running` republish never regresses a terminal `ok`/`error` state — important when running and result straddle a slice boundary during catch-up.

Before: feed jumped from "I'll research this" to "Found it" with dozens of tool calls invisible in between.

## Test plan

- [x] `test/claude-event-transform.test.js` — id preservation on both sides, untruncated `results[].text`
- [x] `test/claude-processor.test.js` — running event per tool_use.id; ok/error flip; slice-boundary ordering; skips ids-less blocks
- [x] `test/feed-tile.test.js` — running card DOM shape; running→ok/error transitions; late-running doesn't clobber terminal state
- [x] `npm run test:unit` passes (2488 tests)
- [x] Pre-push hook (unit + integration + smoke E2E) passes
- [ ] Manual verify: open a Claude session, watch Bash/Read cards appear with animated border then flip green/red