### PR TITLE
feat(feed): open-terminal button + fold tools into replies

### DIFF
--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -9,7 +9,7 @@
  * ./middleware.js. Image upload helpers live in ./upload.js.
  */
 
-import { readFileSync, mkdirSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
+import { readFileSync, mkdirSync, writeFileSync, existsSync, unlinkSync, statSync } from "node:fs";
 import { join, normalize } from "node:path";
 import { randomUUID } from "node:crypto";
 import { loadState } from "../auth.js";
@@ -694,11 +694,34 @@ export function createAppRoutes(ctx) {
     })},
 
     { method: "POST", path: "/sessions", handler: auth(csrf(async (req, res) => {
-      const { name, copyFrom } = await parseJSON(req);
+      const { name, copyFrom, cwd } = await parseJSON(req);
       const sessionName = SessionName.tryCreate(name);
       if (!sessionName) return json(res, 400, { error: "Invalid name" });
       const copyFromName = copyFrom ? SessionName.tryCreate(copyFrom)?.toString() : null;
-      const result = await sessionManager.createSession(sessionName.toString(), 120, 40, copyFromName);
+
+      // `cwd` lets a caller (currently the feed tile's open-terminal
+      // button) spawn a shell in a specific directory without first
+      // needing a donor session to copyFrom. Strict validation: must
+      // be an absolute path string with no null bytes or newlines, and
+      // must exist on disk. Passing an unchecked string through to tmux
+      // would let a bad cwd kill the spawn silently.
+      let resolvedCwd = null;
+      if (cwd != null) {
+        if (typeof cwd !== "string" || cwd.length === 0 || cwd.length > 4096) {
+          return json(res, 400, { error: "Invalid cwd" });
+        }
+        if (!cwd.startsWith("/")) return json(res, 400, { error: "cwd must be absolute" });
+        if (cwd.includes("\0") || /[\r\n]/.test(cwd)) return json(res, 400, { error: "Invalid cwd" });
+        try {
+          const st = statSync(cwd);
+          if (!st.isDirectory()) return json(res, 400, { error: "cwd is not a directory" });
+        } catch { return json(res, 400, { error: "cwd does not exist" }); }
+        resolvedCwd = cwd;
+      }
+
+      const result = await sessionManager.createSession(
+        sessionName.toString(), 120, 40, copyFromName, resolvedCwd,
+      );
       if (!result.error && req._apiKeyAuth) {
         const session = sessionManager.getSession(result.name);
         if (session) session.setIcon("robot");

--- a/lib/routes/claude-feed-routes.js
+++ b/lib/routes/claude-feed-routes.js
@@ -356,14 +356,6 @@ export function createClaudeFeedRoutes(ctx) {
     res.on("close", cleanup);
   }
 
-  // Delete the topic's persisted log + rewind the watchlist cursor so the
-  // next processor cycle re-reads the whole transcript from line 0. Used
-  // by the "clear old Ollama output and reprocess" workflow — without
-  // this, flipping from the pre-rewire narrator to the new reply-first
-  // shape would leave a mix of old narrative/summary events and new reply
-  // events in the same log. Deleting the log is safe: the transcript on
-  // disk is the source of truth, so events are reconstructible on the
-  // next subscribe.
   // Surface the cwd a Claude session was launched in so the UI can spawn
   // a fresh terminal in the right directory and run `claude --resume`.
   // The watchlist tracks transcriptPath per-uuid; we sniff the head of
@@ -378,6 +370,14 @@ export function createClaudeFeedRoutes(ctx) {
     return json(res, 200, { uuid, cwd });
   }
 
+  // Delete the topic's persisted log + rewind the watchlist cursor so the
+  // next processor cycle re-reads the whole transcript from line 0. Used
+  // by the "clear old Ollama output and reprocess" workflow — without
+  // this, flipping from the pre-rewire narrator to the new reply-first
+  // shape would leave a mix of old narrative/summary events and new reply
+  // events in the same log. Deleting the log is safe: the transcript on
+  // disk is the source of truth, so events are reconstructible on the
+  // next subscribe.
   async function handleReprocess(_req, res, uuid) {
     if (!watchlist || !topicBroker) {
       return json(res, 503, { error: "Claude feed not available" });

--- a/lib/routes/claude-feed-routes.js
+++ b/lib/routes/claude-feed-routes.js
@@ -28,9 +28,58 @@
  */
 
 import { join } from "node:path";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, openSync, readSync, closeSync } from "node:fs";
 import { UUID_RE } from "../claude-event-transform.js";
 import { slugifyCwd } from "../claude-transcript-discovery.js";
+
+// Size cap when sniffing a transcript for its cwd. User/system entries
+// that carry `cwd` tend to land in the first few lines of a JSONL, so
+// peeking at the head is enough to avoid slurping a multi-MB file when
+// all we need is one field.
+const TRANSCRIPT_CWD_SNIFF_BYTES = 64 * 1024;
+
+/**
+ * Read the head of a Claude transcript and return the first absolute
+ * `cwd` string we find. Returns `null` if the file is unreadable, the
+ * head chunk contains no parseable JSON lines, or none of them carry a
+ * cwd field.
+ *
+ * Only reads the first TRANSCRIPT_CWD_SNIFF_BYTES bytes — enough for
+ * the session_init / first user entry that stamps cwd, without blowing
+ * the request budget on a huge transcript. If cwd lives past that
+ * point in an unusual transcript, the caller can fall back to manual
+ * entry; Claude itself resumes the right directory via `--resume` so
+ * the only consumer of this helper is the "where should the new shell
+ * start?" prompt.
+ */
+function readTranscriptCwd(transcriptPath) {
+  let fd;
+  try {
+    fd = openSync(transcriptPath, "r");
+  } catch {
+    return null;
+  }
+  try {
+    const buf = Buffer.alloc(TRANSCRIPT_CWD_SNIFF_BYTES);
+    const bytesRead = readSync(fd, buf, 0, buf.length, 0);
+    const text = buf.slice(0, bytesRead).toString("utf8");
+    // Drop the final partial line — it may have been truncated by the
+    // size cap and JSON.parse would throw on it.
+    const lines = text.split("\n");
+    if (lines.length > 0 && bytesRead === buf.length) lines.pop();
+    for (const line of lines) {
+      if (!line) continue;
+      let entry;
+      try { entry = JSON.parse(line); } catch { continue; }
+      if (entry && typeof entry.cwd === "string" && entry.cwd.startsWith("/")) {
+        return entry.cwd;
+      }
+    }
+    return null;
+  } finally {
+    try { closeSync(fd); } catch { /* ignore */ }
+  }
+}
 
 /**
  * Find `<uuid>.jsonl` anywhere under `<homeDir>/.claude/projects/*`.
@@ -315,6 +364,20 @@ export function createClaudeFeedRoutes(ctx) {
   // events in the same log. Deleting the log is safe: the transcript on
   // disk is the source of truth, so events are reconstructible on the
   // next subscribe.
+  // Surface the cwd a Claude session was launched in so the UI can spawn
+  // a fresh terminal in the right directory and run `claude --resume`.
+  // The watchlist tracks transcriptPath per-uuid; we sniff the head of
+  // that file for the first entry with a cwd field.
+  async function handleSessionInfo(_req, res, uuid) {
+    if (!watchlist) return json(res, 503, { error: "Watchlist not available" });
+    if (!UUID_RE.test(uuid)) return json(res, 400, { error: "Invalid uuid" });
+    const entry = await watchlist.get(uuid);
+    if (!entry) return json(res, 404, { error: "Not on watchlist" });
+    const cwd = readTranscriptCwd(entry.transcriptPath);
+    if (!cwd) return json(res, 404, { error: "Cwd not found in transcript" });
+    return json(res, 200, { uuid, cwd });
+  }
+
   async function handleReprocess(_req, res, uuid) {
     if (!watchlist || !topicBroker) {
       return json(res, 503, { error: "Claude feed not available" });
@@ -337,6 +400,7 @@ export function createClaudeFeedRoutes(ctx) {
     { method: "POST", path: "/api/claude/watch", handler: auth(csrf(handleWatchPost)) },
     { method: "DELETE", prefix: "/api/claude/watch/", handler: auth(csrf(handleWatchDelete)) },
     { method: "GET", path: "/api/claude/watchlist", handler: auth(handleWatchlistGet) },
+    { method: "GET", prefix: "/api/claude/session-info/", handler: auth(handleSessionInfo) },
     { method: "GET", prefix: "/api/claude/stream/", handler: auth(handleStream) },
     { method: "POST", prefix: "/api/claude/reprocess/", handler: auth(csrf(handleReprocess)) },
   ];

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -485,14 +485,16 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
      * @param {number} [cols=120]
      * @param {number} [rows=40]
      * @param {string} [copyFrom] - Copy cwd from this session
+     * @param {string} [cwd] - Explicit cwd. Takes precedence over copyFrom.
+     *                        Caller is responsible for validating the path.
      * @returns {Promise<{ name: string } | { error: string }>}
      */
-    async createSession(name, cols = DEFAULT_COLS, rows = DEFAULT_ROWS, copyFrom = null) {
+    async createSession(name, cols = DEFAULT_COLS, rows = DEFAULT_ROWS, copyFrom = null, cwd = null) {
       if (aliveSessionCount() >= MAX_SESSIONS) return { error: `Maximum session limit (${MAX_SESSIONS}) reached` };
       if (sessions.has(name)) return { error: "Session already exists" };
 
-      let cwd = null;
-      if (copyFrom) {
+      let resolvedCwd = cwd;
+      if (!resolvedCwd && copyFrom) {
         const source = sessions.get(copyFrom);
         if (source) {
           const result = await new Promise((resolve) => {
@@ -501,11 +503,11 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
                 resolve(err ? null : stdout.trim());
               });
           });
-          cwd = result;
+          resolvedCwd = result;
         }
       }
 
-      const session = await spawnSession(name, cols, rows, cwd);
+      const session = await spawnSession(name, cols, rows, resolvedCwd);
       scheduleSave();
       return { name, id: session.id };
     },

--- a/public/app.js
+++ b/public/app.js
@@ -2053,6 +2053,75 @@
       if (isOverlayViewport()) setOverlaySidebar(false);
     }
 
+    // Reverse of openAgentFeedTile — jump from a feed back to the terminal
+    // running that Claude session. Three cases:
+    //   A. A live session exists with matching meta.claude.uuid AND its
+    //      terminal tile is already mounted → focus the tile. Carousel
+    //      slides it into view so feed + terminal sit side-by-side.
+    //   B. Live session exists but no tile → routeToSession adds one.
+    //   C. No live session → look up the launch cwd from the transcript
+    //      (stored by `/api/claude/session-info/:uuid`), spawn a fresh
+    //      session there, and `claude --resume <uuid>` in it.
+    // Dispatched by the feed tile's open-terminal-button. The feed tile
+    // never touches uiStore/sessionStore directly — it only announces
+    // intent.
+    const CLAUDE_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    async function openTerminalForClaudeUuid(uuid) {
+      if (typeof uuid !== "string" || !CLAUDE_UUID_RE.test(uuid)) return;
+
+      const { sessions } = sessionStore.getState();
+      const match = (sessions || []).find((s) => s?.meta?.claude?.uuid === uuid);
+      if (match) {
+        routeToSession(match.name);
+        if (isOverlayViewport()) setOverlaySidebar(false);
+        return;
+      }
+
+      let cwd;
+      try {
+        const info = await api.get(`/api/claude/session-info/${encodeURIComponent(uuid)}`);
+        cwd = info?.cwd;
+      } catch (err) {
+        showToast(`Couldn't look up session cwd: ${err.message || "unknown"}`, true);
+        return;
+      }
+      if (typeof cwd !== "string" || !cwd) {
+        showToast("No cwd recorded for that Claude session", true);
+        return;
+      }
+
+      let created;
+      try {
+        const name = generateSessionName();
+        created = await api.post("/sessions", { name, cwd });
+      } catch (err) {
+        showToast(`Couldn't create terminal: ${err.message || "unknown"}`, true);
+        return;
+      }
+
+      // Mirror createNewSession's tab-bar placement so the new tab
+      // appears right of the active one, matching the + button behavior.
+      const activeName = getActiveSessionName();
+      const priorTabs = windowTabSet.getTabs();
+      const anchorIdx = activeName ? priorTabs.indexOf(activeName) : -1;
+      routeToSession(created.name);
+      windowTabSet.addTab(created.name, anchorIdx >= 0 ? anchorIdx + 1 : undefined);
+
+      try {
+        await api.post(`/sessions/by-id/${encodeURIComponent(created.id)}/exec`, {
+          input: `claude --resume ${uuid}`,
+        });
+      } catch (err) {
+        showToast(`Resume command failed: ${err.message || "unknown"}`, true);
+      }
+      if (isOverlayViewport()) setOverlaySidebar(false);
+    }
+
+    window.addEventListener("katulong:open-terminal-for-uuid", (ev) => {
+      const { uuid } = ev.detail || {};
+      openTerminalForClaudeUuid(uuid);
+    });
+
     // --- Localhost Browser (tile) ---
 
     function openLocalhostBrowserTile() {

--- a/public/app.js
+++ b/public/app.js
@@ -2066,55 +2066,65 @@
     // never touches uiStore/sessionStore directly — it only announces
     // intent.
     const CLAUDE_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    // Per-uuid in-flight guard. A rapid double-click (before session-info
+    // and POST /sessions resolve) would otherwise spawn two terminals
+    // both running `claude --resume <uuid>`. Dropped once the open
+    // attempt resolves — on failure the user can retry.
+    const openingTerminalForUuid = new Set();
     async function openTerminalForClaudeUuid(uuid) {
       if (typeof uuid !== "string" || !CLAUDE_UUID_RE.test(uuid)) return;
+      if (openingTerminalForUuid.has(uuid)) return;
+      openingTerminalForUuid.add(uuid);
+      try {
+        const { sessions } = sessionStore.getState();
+        const match = (sessions || []).find((s) => s?.meta?.claude?.uuid === uuid);
+        if (match) {
+          routeToSession(match.name);
+          if (isOverlayViewport()) setOverlaySidebar(false);
+          return;
+        }
 
-      const { sessions } = sessionStore.getState();
-      const match = (sessions || []).find((s) => s?.meta?.claude?.uuid === uuid);
-      if (match) {
-        routeToSession(match.name);
+        let cwd;
+        try {
+          const info = await api.get(`/api/claude/session-info/${encodeURIComponent(uuid)}`);
+          cwd = info?.cwd;
+        } catch (err) {
+          showToast(`Couldn't look up session cwd: ${err.message || "unknown"}`, true);
+          return;
+        }
+        if (typeof cwd !== "string" || !cwd) {
+          showToast("No cwd recorded for that Claude session", true);
+          return;
+        }
+
+        let created;
+        try {
+          const name = generateSessionName();
+          created = await api.post("/sessions", { name, cwd });
+        } catch (err) {
+          showToast(`Couldn't create terminal: ${err.message || "unknown"}`, true);
+          return;
+        }
+
+        // Mirror createNewSession's tab-bar placement so the new tab
+        // appears right of the active one, matching the + button behavior.
+        const activeName = getActiveSessionName();
+        const priorTabs = windowTabSet.getTabs();
+        const anchorIdx = activeName ? priorTabs.indexOf(activeName) : -1;
+        routeToSession(created.name);
+        windowTabSet.addTab(created.name, anchorIdx >= 0 ? anchorIdx + 1 : undefined);
+
+        try {
+          await api.post(`/sessions/by-id/${encodeURIComponent(created.id)}/exec`, {
+            input: `claude --resume ${uuid}`,
+          });
+        } catch (err) {
+          showToast(`Resume command failed: ${err.message || "unknown"}`, true);
+        }
         if (isOverlayViewport()) setOverlaySidebar(false);
-        return;
+      } finally {
+        openingTerminalForUuid.delete(uuid);
       }
-
-      let cwd;
-      try {
-        const info = await api.get(`/api/claude/session-info/${encodeURIComponent(uuid)}`);
-        cwd = info?.cwd;
-      } catch (err) {
-        showToast(`Couldn't look up session cwd: ${err.message || "unknown"}`, true);
-        return;
-      }
-      if (typeof cwd !== "string" || !cwd) {
-        showToast("No cwd recorded for that Claude session", true);
-        return;
-      }
-
-      let created;
-      try {
-        const name = generateSessionName();
-        created = await api.post("/sessions", { name, cwd });
-      } catch (err) {
-        showToast(`Couldn't create terminal: ${err.message || "unknown"}`, true);
-        return;
-      }
-
-      // Mirror createNewSession's tab-bar placement so the new tab
-      // appears right of the active one, matching the + button behavior.
-      const activeName = getActiveSessionName();
-      const priorTabs = windowTabSet.getTabs();
-      const anchorIdx = activeName ? priorTabs.indexOf(activeName) : -1;
-      routeToSession(created.name);
-      windowTabSet.addTab(created.name, anchorIdx >= 0 ? anchorIdx + 1 : undefined);
-
-      try {
-        await api.post(`/sessions/by-id/${encodeURIComponent(created.id)}/exec`, {
-          input: `claude --resume ${uuid}`,
-        });
-      } catch (err) {
-        showToast(`Resume command failed: ${err.message || "unknown"}`, true);
-      }
-      if (isOverlayViewport()) setOverlaySidebar(false);
     }
 
     window.addEventListener("katulong:open-terminal-for-uuid", (ev) => {

--- a/public/index.html
+++ b/public/index.html
@@ -2398,8 +2398,8 @@
     .feed-tile-root { display: flex; flex-direction: column; height: 100%; width: 100%; overflow: hidden; background: var(--bg); color: var(--text); font-family: var(--font-sans, -apple-system, sans-serif); font-size: var(--text-sm); }
     .feed-tile-header { display: flex; align-items: center; gap: var(--space-sm); padding: var(--space-xs) var(--space-sm); border-bottom: 1px solid var(--border); flex-shrink: 0; background: var(--bg-surface); color: var(--text-secondary); font-size: var(--text-xs); font-weight: 600; min-width: 0; overflow: hidden; }
     .feed-tile-header-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-    .feed-tile-back-btn, .feed-tile-close-btn { flex-shrink: 0; background: none; border: none; color: var(--text-secondary); cursor: pointer; padding: 2px; font-size: 0.85rem; line-height: 1; border-radius: var(--radius-sm, 4px); }
-    .feed-tile-back-btn:hover, .feed-tile-close-btn:hover { color: var(--text); background: var(--bg-hover, rgba(255,255,255,0.1)); }
+    .feed-tile-back-btn, .feed-tile-close-btn, .feed-tile-open-terminal-btn { flex-shrink: 0; background: none; border: none; color: var(--text-secondary); cursor: pointer; padding: 2px; font-size: 0.85rem; line-height: 1; border-radius: var(--radius-sm, 4px); }
+    .feed-tile-back-btn:hover, .feed-tile-close-btn:hover, .feed-tile-open-terminal-btn:hover { color: var(--text); background: var(--bg-hover, rgba(255,255,255,0.1)); }
     .feed-tile-badge { flex-shrink: 0; padding: 1px 6px; border-radius: 3px; background: var(--accent, #58a6ff); color: var(--bg); font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
     /* Empty-state hint — shown between mount and first event so a dead
        stream (e.g. watchlist entry missing) doesn't leave a blank pane. */
@@ -2507,6 +2507,37 @@
       width: 100%; height: 100%; object-fit: cover; display: block;
     }
     .feed-tile-image-thumb:hover { border-color: var(--text); }
+    /* Reply block — contains a clickable header (prose + footer) and a
+       nested tool list that folds intermediate tool calls UNDER the
+       reply that kicked them off. Tap the header to toggle the nested
+       list; while at least one tool is still running the block's left
+       border pulses to signal work in progress. The most recent reply
+       auto-expands (is-active + is-expanded); prior replies collapse
+       when a new one lands but can be reopened via tap. */
+    .feed-tile-reply-block { /* inherits border/padding from feed-status-reply */ }
+    .feed-tile-reply-header { display: flex; flex-direction: column; gap: 4px; }
+    .feed-tile-reply-block.has-tools .feed-tile-reply-header { cursor: pointer; }
+    .feed-tile-reply-tools { display: none; margin-top: var(--space-xs); padding-left: var(--space-sm); border-left: 1px dashed var(--border, rgba(255,255,255,0.12)); }
+    .feed-tile-reply-block.is-expanded > .feed-tile-reply-tools { display: block; }
+    /* Nested tools don't get the sibling `+` rule from .feed-tile-list,
+       so hand-roll a small gap between stacked tool cards. */
+    .feed-tile-reply-tools > * + * { margin-top: var(--space-xs); }
+    .feed-tile-reply-tool-count { color: var(--text-muted); font-size: var(--text-xs); }
+    .feed-tile-reply-chevron { display: inline-flex; align-items: center; color: var(--text-muted); font-size: 0.85em; transition: transform 0.15s ease; margin-left: auto; }
+    .feed-tile-reply-block.is-expanded .feed-tile-reply-chevron { transform: rotate(180deg); }
+    /* Active-work pulse — while any tool under this reply is still
+       running, the left border animates so a reader scanning the feed
+       can spot live work at a glance. Goes solid/muted once every tool
+       has landed an ok/error result. */
+    .feed-tile-reply-block.is-running { border-left-color: var(--accent-strong, #6f87b3); animation: feed-reply-pulse 1.6s ease-in-out infinite; }
+    @keyframes feed-reply-pulse {
+      0%, 100% { border-left-color: color-mix(in srgb, var(--accent-strong, #6f87b3) 40%, transparent); }
+      50%      { border-left-color: var(--accent-strong, #6f87b3); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .feed-tile-reply-block.is-running { animation: none; }
+    }
+
     /* Reply prose — markdown rendered to HTML. Tighten default block
        spacing so a reply doesn't eat the whole tile. */
     .feed-tile-reply-body { line-height: 1.55; color: var(--text); overflow-wrap: break-word; }

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -518,7 +518,9 @@ function createReplyEntry() {
     entry.expanded = !entry.expanded;
     applyReplyClasses(entry);
   });
-  applyReplyClasses(entry);
+  // className is set by the caller via applyReplyClasses() after it
+  // configures isActive/expanded — skipping it here avoids a write
+  // that would be immediately overwritten.
   return entry;
 }
 

--- a/public/lib/tile-renderers/feed.js
+++ b/public/lib/tile-renderers/feed.js
@@ -473,30 +473,96 @@ function makeFileChip(file) {
   return chip;
 }
 
-function renderReplyItem(row, msg, ts) {
-  row.innerHTML = "";
-  row.className = "feed-tile-item feed-status-reply";
-  const text = msg.step || "";
-
-  // Prose first, metadata below — the reply IS the content. The footer
-  // is reference material (when it happened, what it touched) that a
-  // reader glances at after skimming the body.
-  const prose = document.createElement("div");
-  prose.className = "feed-tile-reply-body";
-  renderMarkdown(prose, text);
-  enrichFeedProse(prose);
-  row.appendChild(prose);
-
+// Reply block. A reply now owns the intermediate tool calls that ran
+// UNDER it (Option B folding: tools land after the reply that kicked
+// them off and belong to that reply). Structure:
+//
+//   <div class="feed-tile-reply-block feed-status-reply ...">
+//     <div class="feed-tile-reply-header">        ← clickable
+//       <div class="feed-tile-reply-body">…</div>
+//       <div class="feed-tile-reply-footer">time · files · chevron</div>
+//     </div>
+//     <div class="feed-tile-reply-tools">        ← nested tool rows
+//       <div class="feed-tile-item feed-status-tool …">…</div>
+//     </div>
+//   </div>
+//
+// Modifier classes toggled at runtime:
+//   is-active    — most recent reply; next reply strips this
+//   is-expanded  — tools list revealed (auto for active, toggle via tap)
+//   has-tools    — at least one tool attached (shows chevron, enables tap)
+//   is-running   — at least one tool still in flight (animates border)
+function createReplyEntry() {
+  const block = document.createElement("div");
+  const header = document.createElement("div");
+  header.className = "feed-tile-reply-header";
+  const body = document.createElement("div");
+  body.className = "feed-tile-reply-body";
   const footer = document.createElement("div");
   footer.className = "feed-tile-reply-footer";
-  footer.appendChild(makeTimeSpan(ts));
-  if (Array.isArray(msg.files) && msg.files.length > 0) {
+  const toolsEl = document.createElement("div");
+  toolsEl.className = "feed-tile-reply-tools";
+  header.appendChild(body);
+  header.appendChild(footer);
+  block.appendChild(header);
+  block.appendChild(toolsEl);
+  const entry = {
+    kind: "reply",
+    block, header, body, footer, toolsEl,
+    tools: new Map(),       // toolUseId → current state
+    msg: null, ts: null,
+    isActive: false,
+    expanded: false,
+  };
+  header.addEventListener("click", () => {
+    entry.expanded = !entry.expanded;
+    applyReplyClasses(entry);
+  });
+  applyReplyClasses(entry);
+  return entry;
+}
+
+function applyReplyClasses(entry) {
+  const cls = ["feed-tile-item", "feed-status-reply", "feed-tile-reply-block"];
+  if (entry.tools.size > 0) cls.push("has-tools");
+  if (entry.isActive) cls.push("is-active");
+  if (entry.expanded) cls.push("is-expanded");
+  let anyRunning = false;
+  for (const state of entry.tools.values()) {
+    if (state !== "ok" && state !== "error") { anyRunning = true; break; }
+  }
+  if (anyRunning) cls.push("is-running");
+  entry.block.className = cls.join(" ");
+}
+
+function renderReplyBody(entry) {
+  if (!entry.msg) return;
+  entry.body.innerHTML = "";
+  renderMarkdown(entry.body, entry.msg.step || "");
+  enrichFeedProse(entry.body);
+}
+
+function renderReplyFooter(entry) {
+  entry.footer.innerHTML = "";
+  entry.footer.appendChild(makeTimeSpan(entry.ts));
+  const msg = entry.msg;
+  if (msg && Array.isArray(msg.files) && msg.files.length > 0) {
     const files = document.createElement("span");
     files.className = "feed-tile-reply-files";
     for (const f of msg.files) files.appendChild(makeFileChip(f));
-    footer.appendChild(files);
+    entry.footer.appendChild(files);
   }
-  row.appendChild(footer);
+  if (entry.tools.size > 0) {
+    const n = entry.tools.size;
+    const count = document.createElement("span");
+    count.className = "feed-tile-reply-tool-count";
+    count.textContent = `${n} step${n === 1 ? "" : "s"}`;
+    entry.footer.appendChild(count);
+    const chev = document.createElement("span");
+    chev.className = "feed-tile-reply-chevron";
+    chev.innerHTML = '<i class="ph ph-caret-down"></i>';
+    entry.footer.appendChild(chev);
+  }
 }
 
 // Tool card. Collapsed by default — just the header row showing
@@ -631,7 +697,7 @@ export const feedRenderer = {
     root.className = "feed-tile-root";
     el.appendChild(root);
 
-    function buildStreamHeader(titleText) {
+    function buildStreamHeader(titleText, { claudeUuid = null, topic = null } = {}) {
       const header = document.createElement("div");
       header.className = "feed-tile-header";
 
@@ -646,6 +712,26 @@ export const feedRenderer = {
       headerTitle.className = "feed-tile-header-title";
       headerTitle.textContent = titleText;
       header.appendChild(headerTitle);
+
+      // Jump to (or spawn) the terminal session running this Claude
+      // transcript. The feed tile doesn't own the UI store, so this just
+      // announces intent — app.js owns the find-or-create decision
+      // (focus existing tile / add tile for live session / create new
+      // session with cwd + `claude --resume`). Rendered only for claude
+      // topics since only they have a uuid worth resuming.
+      if (claudeUuid) {
+        const openTerminalBtn = document.createElement("button");
+        openTerminalBtn.className = "feed-tile-open-terminal-btn";
+        openTerminalBtn.innerHTML = '<i class="ph ph-terminal-window"></i>';
+        openTerminalBtn.title = "Open terminal session";
+        openTerminalBtn.addEventListener("click", (ev) => {
+          ev.stopPropagation();
+          window.dispatchEvent(new CustomEvent("katulong:open-terminal-for-uuid", {
+            detail: { uuid: claudeUuid, topic },
+          }));
+        });
+        header.appendChild(openTerminalBtn);
+      }
 
       const closeBtn = document.createElement("button");
       closeBtn.className = "feed-tile-close-btn";
@@ -846,7 +932,17 @@ export const feedRenderer = {
       root.innerHTML = "";
       const topicMeta = meta || {};
 
-      const { header } = buildStreamHeader(topic);
+      // Claude-topic extraction. `claudeUuid` drives two pieces of the
+      // header chrome: the response bar (pinned textarea) and the
+      // open-terminal button. Compute it up-front so buildStreamHeader
+      // can render the terminal button without knowing the topic format.
+      const claudeUuid = (() => {
+        if (!topic.startsWith("claude/")) return null;
+        const u = topic.slice("claude/".length);
+        return UUID_RE.test(u) ? u : null;
+      })();
+
+      const { header } = buildStreamHeader(topic, { claudeUuid, topic });
       root.appendChild(header);
 
       const list = document.createElement("div");
@@ -854,16 +950,24 @@ export const feedRenderer = {
       list.tabIndex = 0;
       root.appendChild(list);
 
-      // Reply cards are keyed by their transcript entry uuid so that a
-      // republished reply (e.g. after a processor catch-up) updates the
-      // existing row in place rather than duplicating it.
-      const replyItems = new Map();
+      // Reply/prompt entries are keyed by their transcript entry uuid so
+      // a republished turn (e.g. after a processor catch-up) updates the
+      // existing card in place rather than duplicating it. Each value is
+      // `{ kind: "reply"|"prompt", ... }` — reply entries carry the full
+      // block structure (header/body/footer/toolsEl + tools map); prompt
+      // entries are just `{ kind: "prompt", row }`.
+      const entryItems = new Map();
+      // Most recent reply entryId — tools that arrive after it fold into
+      // its nested tool list. Stays null until the first reply lands.
+      let activeReplyId = null;
       // Tool cards are keyed by their tool_use id. A running card is
       // stamped on the tool_use event; the matching tool_result event
       // flips state (ok/error) and fills the output body. Values hold
       // the merged info so an out-of-order republish (running event
       // delivered AFTER its result, e.g. during a catch-up slice)
-      // doesn't clobber the terminal state.
+      // doesn't clobber the terminal state. `ownerReplyId` records the
+      // reply the tool was folded into — null means the tool landed
+      // before any reply and is currently shown as a top-level orphan.
       const toolItems = new Map();
       // Ephemeral non-reply events (generic log topics or pre-rewrite
       // persisted events) get auto-keyed row slots.
@@ -875,11 +979,6 @@ export const feedRenderer = {
       // type back to the Claude session without leaving the feed, and
       // offers quick-pick buttons when the latest reply ends in a
       // numbered options list.
-      const claudeUuid = (() => {
-        if (!topic.startsWith("claude/")) return null;
-        const u = topic.slice("claude/".length);
-        return UUID_RE.test(u) ? u : null;
-      })();
       const responseBar = claudeUuid ? createResponseBar(claudeUuid) : null;
 
       // Pinned summary at the top of the list. Rendered only for
@@ -934,9 +1033,23 @@ export const feedRenderer = {
             let entry;
             if (!existing) {
               const row = document.createElement("div");
-              list.appendChild(row);
-              entry = { row, info: { ...msg } };
+              entry = { row, info: { ...msg }, ownerReplyId: null };
               toolItems.set(msg.toolUseId, entry);
+              // Fold into the active reply if one has landed; otherwise
+              // show as an orphan at the top of the list and adopt it
+              // when the first reply arrives. In practice Claude always
+              // emits a preamble reply before running tools, so orphan
+              // tools are rare (early-start slices, mostly).
+              if (activeReplyId && entryItems.has(activeReplyId)) {
+                const owner = entryItems.get(activeReplyId);
+                owner.toolsEl.appendChild(row);
+                owner.tools.set(msg.toolUseId, msg.state || "running");
+                entry.ownerReplyId = activeReplyId;
+                renderReplyFooter(owner);
+                applyReplyClasses(owner);
+              } else {
+                list.appendChild(row);
+              }
             } else {
               entry = existing;
               // Merge so running metadata (name/input, stamped first)
@@ -954,19 +1067,54 @@ export const feedRenderer = {
                 entry.info.state = prevState;
                 if (typeof prevOutput === "string") entry.info.output = prevOutput;
               }
+              // Mirror the merged state into the owning reply so its
+              // is-running / tool-count indicators stay accurate.
+              if (entry.ownerReplyId && entryItems.has(entry.ownerReplyId)) {
+                const owner = entryItems.get(entry.ownerReplyId);
+                owner.tools.set(msg.toolUseId, entry.info.state);
+                applyReplyClasses(owner);
+              }
             }
             renderToolItem(entry.row, entry.info, envelope.timestamp);
             list.scrollTop = list.scrollHeight;
             return;
           }
           if (status === "reply" && typeof msg.entryId === "string") {
-            let row = replyItems.get(msg.entryId);
-            if (!row) {
-              row = document.createElement("div");
-              list.appendChild(row);
-              replyItems.set(msg.entryId, row);
+            let entry = entryItems.get(msg.entryId);
+            const firstRender = !entry || entry.kind !== "reply";
+            if (firstRender) {
+              entry = createReplyEntry();
+              entryItems.set(msg.entryId, entry);
+              list.appendChild(entry.block);
+              // Adopt any orphan tools that landed before this reply.
+              for (const [toolUseId, toolEntry] of toolItems) {
+                if (!toolEntry.ownerReplyId) {
+                  toolEntry.ownerReplyId = msg.entryId;
+                  entry.toolsEl.appendChild(toolEntry.row);
+                  entry.tools.set(toolUseId, toolEntry.info.state || "running");
+                }
+              }
+              // Deactivate the prior reply — it stops pulsing, collapses
+              // its tools, and makes room for the new one to claim the
+              // "current work" border. Tapping a prior reply later still
+              // re-expands it.
+              if (activeReplyId && entryItems.has(activeReplyId)) {
+                const prior = entryItems.get(activeReplyId);
+                if (prior.kind === "reply") {
+                  prior.isActive = false;
+                  prior.expanded = false;
+                  applyReplyClasses(prior);
+                }
+              }
+              activeReplyId = msg.entryId;
+              entry.isActive = true;
+              entry.expanded = true;
             }
-            renderReplyItem(row, msg, envelope.timestamp);
+            entry.msg = msg;
+            entry.ts = envelope.timestamp;
+            renderReplyBody(entry);
+            renderReplyFooter(entry);
+            applyReplyClasses(entry);
             // Re-evaluate quick-pick options from the latest reply. The
             // "latest" is always the most recent publish on the topic
             // log — for a live stream that's also the last message
@@ -976,17 +1124,14 @@ export const feedRenderer = {
             // maintaining a full ordered index client-side.)
             if (responseBar) responseBar.setOptions(msg.step || "");
           } else if (status === "prompt" && typeof msg.entryId === "string") {
-            // Share the same items map as replies — entryId space is
-            // per-transcript and doesn't collide, and keying both lets
-            // a republished prompt update its row in place just like
-            // replies do.
-            let row = replyItems.get(msg.entryId);
-            if (!row) {
-              row = document.createElement("div");
+            let entry = entryItems.get(msg.entryId);
+            if (!entry || entry.kind !== "prompt") {
+              const row = document.createElement("div");
               list.appendChild(row);
-              replyItems.set(msg.entryId, row);
+              entry = { kind: "prompt", row };
+              entryItems.set(msg.entryId, entry);
             }
-            renderPromptItem(row, msg, envelope.timestamp);
+            renderPromptItem(entry.row, msg, envelope.timestamp);
           }
           list.scrollTop = list.scrollHeight;
           return;

--- a/test/claude-feed-routes.test.js
+++ b/test/claude-feed-routes.test.js
@@ -294,9 +294,67 @@ describe("createClaudeFeedRoutes", () => {
       ["POST", "/api/claude/watch"],
       ["DELETE", "/api/claude/watch/"],
       ["GET", "/api/claude/watchlist"],
+      ["GET", "/api/claude/session-info/"],
       ["GET", "/api/claude/stream/"],
       ["POST", "/api/claude/reprocess/"],
     ]);
+  });
+
+  it("GET /api/claude/session-info/:uuid returns cwd sniffed from the transcript head", async () => {
+    // Claude Code writes per-turn entries with a `cwd` field. The feed
+    // tile's open-terminal button needs to know where to spawn a shell
+    // when the original Claude session is no longer live — the head of
+    // the transcript is authoritative and cheap to read.
+    const transcriptDir = join(home, ".claude", "projects", "-Users-felix-proj");
+    mkdirSync(transcriptDir, { recursive: true });
+    const transcriptPath = join(transcriptDir, `${UUID}.jsonl`);
+    const lines = [
+      JSON.stringify({ type: "permission-mode", permissionMode: "default" }),
+      JSON.stringify({ type: "user", cwd: "/Users/felix/Projects/katulong", message: "hi" }),
+    ];
+    writeFileSync(transcriptPath, lines.join("\n") + "\n");
+    await watchlist.add(UUID, { transcriptPath });
+
+    const route = routeFor("GET", "/api/claude/session-info/");
+    const res = makeRes();
+    await route.handler(makeReq(), res, UUID);
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(JSON.parse(res.chunks[0]), {
+      uuid: UUID,
+      cwd: "/Users/felix/Projects/katulong",
+    });
+  });
+
+  it("GET /api/claude/session-info/:uuid returns 404 when uuid isn't on the watchlist", async () => {
+    const route = routeFor("GET", "/api/claude/session-info/");
+    const res = makeRes();
+    await route.handler(makeReq(), res, UUID);
+    assert.strictEqual(res.status, 404);
+  });
+
+  it("GET /api/claude/session-info/:uuid returns 404 when transcript has no cwd", async () => {
+    // A transcript that only contains system-y entries (no user turn
+    // ever recorded) has no cwd we can trust. Return 404 so the caller
+    // can show a clear toast instead of spawning a shell in an arbitrary
+    // directory.
+    const transcriptDir = join(home, ".claude", "projects", "-no-cwd");
+    mkdirSync(transcriptDir, { recursive: true });
+    const transcriptPath = join(transcriptDir, `${UUID}.jsonl`);
+    writeFileSync(transcriptPath, JSON.stringify({ type: "permission-mode" }) + "\n");
+    await watchlist.add(UUID, { transcriptPath });
+
+    const route = routeFor("GET", "/api/claude/session-info/");
+    const res = makeRes();
+    await route.handler(makeReq(), res, UUID);
+    assert.strictEqual(res.status, 404);
+    assert.match(JSON.parse(res.chunks[0]).error, /Cwd not found/);
+  });
+
+  it("GET /api/claude/session-info/:uuid rejects an invalid uuid with 400", async () => {
+    const route = routeFor("GET", "/api/claude/session-info/");
+    const res = makeRes();
+    await route.handler(makeReq(), res, "not-a-uuid");
+    assert.strictEqual(res.status, 400);
   });
 
   it("POST /api/claude/watch adds by { uuid, cwd } and returns the entry", async () => {

--- a/test/feed-tile.test.js
+++ b/test/feed-tile.test.js
@@ -476,11 +476,67 @@ describe("feedRenderer", () => {
       const root = el.children[0];
       const header = root.children[0];
       assert.equal(header.className, "feed-tile-header");
+      // Generic topic — no claudeUuid, so no open-terminal button:
       // [backBtn, title, closeBtn]
       assert.equal(header.children.length, 3);
       assert.equal(header.children[0].className, "feed-tile-back-btn");
       assert.equal(header.children[1].textContent, "my/topic");
       assert.equal(header.children[2].className, "feed-tile-close-btn");
+    });
+
+    it("adds an open-terminal button for claude/<uuid> topics that dispatches katulong:open-terminal-for-uuid", () => {
+      // The terminal button is the reverse of openAgentFeedTile — from a
+      // feed tile, jump back to the terminal running that Claude
+      // session. The feed doesn't own the ui-store, so it only announces
+      // intent; app.js owns the find-or-create decision.
+      const uuid = "11111111-2222-3333-4444-555555555555";
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: `claude/${uuid}`, meta: { type: "progress" } },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      const header = el.children[0].children[0];
+      assert.equal(header.children.length, 4, "claude topic header has 4 children");
+      const openTerminalBtn = header.children[2];
+      assert.equal(openTerminalBtn.className, "feed-tile-open-terminal-btn");
+      assert.equal(openTerminalBtn.tagName, "BUTTON");
+
+      // Clicking fires a CustomEvent with { uuid, topic } and stops
+      // propagation so the carousel doesn't eat the click as a drag.
+      const dispatched = [];
+      const orig = globalThis.window.dispatchEvent;
+      globalThis.window.dispatchEvent = (ev) => { dispatched.push(ev); };
+      try {
+        const clickListener = openTerminalBtn._listeners.click?.[0];
+        assert.ok(clickListener, "click listener registered");
+        let propagated = true;
+        clickListener({ stopPropagation: () => { propagated = false; } });
+        assert.equal(propagated, false, "stopPropagation called");
+        assert.equal(dispatched.length, 1);
+        assert.equal(dispatched[0].type, "katulong:open-terminal-for-uuid");
+        assert.deepEqual(dispatched[0].detail, { uuid, topic: `claude/${uuid}` });
+      } finally {
+        globalThis.window.dispatchEvent = orig;
+      }
+    });
+
+    it("omits the open-terminal button when the topic isn't a claude/<uuid>", () => {
+      // Defense-in-depth: the topic shape decides whether we offer
+      // terminal resume. A bare topic has no uuid to pass along.
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "claude/not-a-uuid", meta: {} },
+        dispatch: () => {},
+        ctx: {},
+      });
+      const header = el.children[0].children[0];
+      for (const child of header.children) {
+        assert.notEqual(child.className, "feed-tile-open-terminal-btn");
+      }
     });
 
     it("processes SSE events via onmessage", () => {
@@ -508,11 +564,14 @@ describe("feedRenderer", () => {
       assert.equal(list.children.length, 1);
     });
 
-    it("renders reply events as a flat card — prose on top, time footer below", () => {
-      // One `reply` event → one div with [body, footer]. Body shows the
-      // reply text (rendered as HTML through the markdown pipeline);
-      // footer carries the formatted time so the reader's eye lands on
-      // the reply first.
+    it("renders reply events as a block — clickable header wraps prose + footer", () => {
+      // One `reply` event → one reply block with:
+      //   block.children = [header, toolsEl]
+      //   header.children = [body, footer]
+      // The header is clickable so the user can toggle the nested tools
+      // list; the toolsEl is empty until a tool event arrives. Footer
+      // carries the formatted time so the reader's eye lands on the
+      // reply prose first.
       const el = new FakeElement("div");
       feedRenderer.mount(el, {
         id: "feed-1",
@@ -537,24 +596,39 @@ describe("feedRenderer", () => {
 
       const list = el.children[0].children[1];
       assert.equal(list.children.length, 1);
-      const row = list.children[0];
-      assert.equal(row.tagName, "DIV");
+      const block = list.children[0];
+      assert.equal(block.tagName, "DIV");
       assert.ok(
-        row.className.includes("feed-status-reply"),
-        `expected feed-status-reply, got: ${row.className}`,
+        block.className.includes("feed-status-reply"),
+        `expected feed-status-reply, got: ${block.className}`,
       );
+      assert.ok(
+        block.className.includes("feed-tile-reply-block"),
+        `expected feed-tile-reply-block, got: ${block.className}`,
+      );
+      // First reply is marked is-active (pulse border + auto-expand),
+      // but has-tools / is-running only kick in once a tool lands.
+      assert.ok(block.className.includes("is-active"), block.className);
+      assert.ok(!block.className.includes("has-tools"), block.className);
+      assert.ok(!block.className.includes("is-running"), block.className);
 
-      const body = row.children[0];
+      const header = block.children[0];
+      assert.equal(header.className, "feed-tile-reply-header");
+      const body = header.children[0];
       assert.equal(body.className, "feed-tile-reply-body");
       // In Node the markdown pipeline can't load and feed.js uses the
       // textContent fallback — so the test asserts against that path.
       assert.equal(body.textContent, "All tests pass.");
 
-      const footer = row.children[1];
+      const footer = header.children[1];
       assert.equal(footer.className, "feed-tile-reply-footer");
       const timeSpan = footer.children[0];
       assert.equal(timeSpan.className, "feed-tile-row-time");
       assert.ok(timeSpan.textContent, "time span renders a formatted timestamp");
+
+      const toolsEl = block.children[1];
+      assert.equal(toolsEl.className, "feed-tile-reply-tools");
+      assert.equal(toolsEl.children.length, 0, "no tools yet");
     });
 
     it("renders file chips for reply.files and fires katulong:open-file on click", () => {
@@ -584,8 +658,10 @@ describe("feedRenderer", () => {
       });
 
       const list = el.children[0].children[1];
-      // Row is [body, footer]; footer is [time, files-wrapper].
-      const footer = list.children[0].children[1];
+      // Block → [header, toolsEl]; header → [body, footer];
+      // footer → [time, files-wrapper].
+      const header = list.children[0].children[0];
+      const footer = header.children[1];
       assert.equal(footer.className, "feed-tile-reply-footer");
       const filesWrapper = footer.children[1];
       assert.equal(filesWrapper.className, "feed-tile-reply-files");
@@ -683,9 +759,149 @@ describe("feedRenderer", () => {
       publish("second");
 
       const list = el.children[0].children[1];
-      assert.equal(list.children.length, 1, "no duplicate row for same entryId");
-      // children[0] is the body (prose first); assert its updated text.
-      assert.equal(list.children[0].children[0].textContent, "second");
+      assert.equal(list.children.length, 1, "no duplicate block for same entryId");
+      // block → header → body (prose first); assert its updated text.
+      const body = list.children[0].children[0].children[0];
+      assert.equal(body.className, "feed-tile-reply-body");
+      assert.equal(body.textContent, "second");
+    });
+
+    it("folds a tool that arrives after a reply into that reply's nested tools list", () => {
+      // Option B folding: a tool_use event that lands AFTER a reply
+      // belongs to that reply (the reply is what kicked the tool off).
+      // The tool row is appended to reply.toolsEl, not to the top-level
+      // list — so the list still has one child (the reply block). The
+      // reply picks up has-tools + is-running modifier classes so the
+      // border animates while work is live.
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "claude/abc", meta: { type: "progress" } },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      const send = (body) => eventSources[0].onmessage({
+        data: JSON.stringify({
+          seq: 1, topic: "claude/abc",
+          message: JSON.stringify(body),
+          timestamp: 1_700_000_000_000,
+        }),
+      });
+
+      send({ status: "reply", entryId: "r-1", step: "Now running tests.", ts: 1 });
+      send({
+        status: "tool", toolUseId: "toolu_A", state: "running",
+        name: "Bash", target: "npm test", ts: 2,
+      });
+
+      const list = el.children[0].children[1];
+      assert.equal(list.children.length, 1, "tool folds under reply, not a sibling");
+      const block = list.children[0];
+      const toolsEl = block.children[1];
+      assert.equal(toolsEl.className, "feed-tile-reply-tools");
+      assert.equal(toolsEl.children.length, 1, "tool rendered inside the reply");
+      assert.ok(
+        block.className.includes("has-tools"),
+        `expected has-tools, got: ${block.className}`,
+      );
+      assert.ok(
+        block.className.includes("is-running"),
+        `expected is-running while tool is live, got: ${block.className}`,
+      );
+    });
+
+    it("drops is-running once every nested tool has a terminal state", () => {
+      // While at least one tool under the reply is still running we
+      // pulse the border (is-running). As soon as every tool has
+      // landed an ok/error result the class is removed and the border
+      // goes solid — signalling the reply's work finished.
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "claude/abc", meta: { type: "progress" } },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      const send = (body) => eventSources[0].onmessage({
+        data: JSON.stringify({
+          seq: 1, topic: "claude/abc",
+          message: JSON.stringify(body),
+          timestamp: 1_700_000_000_000,
+        }),
+      });
+
+      send({ status: "reply", entryId: "r-1", step: "Running.", ts: 1 });
+      send({ status: "tool", toolUseId: "toolu_A", state: "running", name: "Bash", target: "a", ts: 2 });
+      send({ status: "tool", toolUseId: "toolu_A", state: "ok", output: "done", ts: 3 });
+
+      const block = el.children[0].children[1].children[0];
+      assert.ok(block.className.includes("has-tools"), block.className);
+      assert.ok(!block.className.includes("is-running"), block.className);
+    });
+
+    it("a new reply takes is-active from the prior reply", () => {
+      // Only the most recent reply pulses. When the next reply lands,
+      // the prior one drops is-active (border goes calm) and collapses
+      // its tools; the new reply inherits the active slot and auto-
+      // expands.
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "claude/abc", meta: { type: "progress" } },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      const send = (body) => eventSources[0].onmessage({
+        data: JSON.stringify({
+          seq: 1, topic: "claude/abc",
+          message: JSON.stringify(body),
+          timestamp: 1_700_000_000_000,
+        }),
+      });
+
+      send({ status: "reply", entryId: "r-1", step: "First.", ts: 1 });
+      send({ status: "reply", entryId: "r-2", step: "Second.", ts: 2 });
+
+      const list = el.children[0].children[1];
+      assert.equal(list.children.length, 2);
+      const first = list.children[0];
+      const second = list.children[1];
+      assert.ok(!first.className.includes("is-active"), `first: ${first.className}`);
+      assert.ok(!first.className.includes("is-expanded"), `first: ${first.className}`);
+      assert.ok(second.className.includes("is-active"), `second: ${second.className}`);
+      assert.ok(second.className.includes("is-expanded"), `second: ${second.className}`);
+    });
+
+    it("tapping a reply header toggles is-expanded", () => {
+      const el = new FakeElement("div");
+      feedRenderer.mount(el, {
+        id: "feed-1",
+        props: { topic: "claude/abc", meta: { type: "progress" } },
+        dispatch: () => {},
+        ctx: {},
+      });
+
+      const send = (body) => eventSources[0].onmessage({
+        data: JSON.stringify({
+          seq: 1, topic: "claude/abc",
+          message: JSON.stringify(body),
+          timestamp: 1_700_000_000_000,
+        }),
+      });
+
+      send({ status: "reply", entryId: "r-1", step: "Only.", ts: 1 });
+      const block = el.children[0].children[1].children[0];
+      const header = block.children[0];
+      // Active reply is auto-expanded; one tap collapses, another
+      // reopens.
+      assert.ok(block.className.includes("is-expanded"), block.className);
+      header._listeners.click[0]();
+      assert.ok(!block.className.includes("is-expanded"), block.className);
+      header._listeners.click[0]();
+      assert.ok(block.className.includes("is-expanded"), block.className);
     });
 
     it("renders a running tool card with state class and tool name", () => {


### PR DESCRIPTION
## Summary

Two related polish changes to the Claude feed tile.

### Open-terminal button

Feed tiles for `claude/<uuid>` topics gain a terminal-window button in the
header that jumps to (or creates) the terminal session running that
transcript:
- Terminal tile already exists → focus it.
- tmux session exists but no tile → add a tile for it.
- Neither exists → POST /sessions with cwd, then `claude --resume <uuid>`.

cwd is looked up via a new endpoint `GET /api/claude/session-info/:uuid`
that sniffs the first 64KB of the transcript for the `cwd` field.
session-manager / POST /sessions accept an optional `cwd` with strict
validation (absolute path, existing directory, no nulls/newlines).

### Fold tools into the previous reply

Intermediate tool calls no longer render as top-level rows. Each reply
is now a tap-to-toggle block that owns the tools that ran under it. The
most recent reply auto-expands and its left border pulses while any
tool is still running; it goes solid once every tool has landed an
ok/error result. Prior replies collapse on new-reply arrival but stay
tappable.

## Test plan

- [x] `npm test` passes (82 targeted tests green; flaky `file-browser`
      SSE test unrelated, passes in isolation)
- [x] Unit tests cover: open-terminal button presence/absence/click,
      session-info route, tool folding, is-active transfer, is-running
      derivation, tap-to-toggle
- [ ] Manual: mount a feed tile for a live Claude session; verify the
      terminal button jumps correctly across all three cases
- [ ] Manual: verify tools fold under the correct reply and the border
      pulses while a Bash/Read call is in flight