### PR TITLE
fix(tiles): make file-link resolution worktree-aware

### DIFF
--- a/docs/file-link-worktree-resolution.md
+++ b/docs/file-link-worktree-resolution.md
@@ -9,11 +9,24 @@ session object with precedence `meta.claude.cwd → meta.pane.cwd →
 relative`. The `/sessions/cwd/:name` route, `getSessionCwd`, and
 `getPaneCwd` are retired.
 
+**Worktree-aware search fallback shipped (PR #628).** Originally listed
+as a non-goal below, the fallback was reconsidered after the
+`claude --add-dir` / in-process `/cd` / `git -C <worktree>` paths
+continued to 404 clicks even with the meta-based resolver. Rather than
+enumerating every channel by which Claude might redirect its effective
+cwd, we let the filesystem answer: when `join(cwd, relpath)` doesn't
+exist, `resolveFilePath` (lib/worktree-resolver.js) tries the same
+relpath under every sibling worktree that `git worktree list` knows
+about and returns the first hit. Ambiguity (same relpath in multiple
+worktrees) is resolved by preferring the session's cwd worktree first,
+then the order git reports. Tiles surface a `worktreeLabel` badge when
+the resolved file lives in a non-primary worktree so the resolution is
+visible, not implicit.
+
 **Step 4 (lsof Claude pid cwd) is still deferred.** An earlier attempt
 was reverted — follow-up work should read the revert reasoning before
-redoing it. The current fix covers the `cd worktree && claude` flow;
-the `claude --add-dir` and in-process `/cd` cases still fall back to
-the (possibly stale) pane shell cwd.
+redoing it. It is now less urgent: the worktree-search fallback covers
+the common `--add-dir` / `/cd` / `git -C` cases.
 
 ## Problem
 
@@ -115,12 +128,12 @@ worktree).
 - **No reactive OSC 7 parser.** 5s polling is fine for this UX; a file link
   click that follows a `cd` within 5s is rare and self-corrects on the next
   tick.
-- **No worktree-aware search fallback.** "If the file 404s, search sibling
-  worktrees" is tempting but ambiguous when the same path exists in several
-  worktrees. Prefer explicit state over heuristics.
 - **No client-side project root override UI.** If the meta-based resolution
   still misses, the user can always click the absolute path Claude prints in
   parallel — no need for a dedicated selector.
+
+(The former "No worktree-aware search fallback" non-goal has been
+superseded — see the Status section and PR #628.)
 
 ## Open questions
 

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -783,11 +783,14 @@ export function createAppRoutes(ctx) {
       const url = new URL(req.url, `http://${req.headers.host}`);
       const sessionName = url.searchParams.get("session");
       const path = url.searchParams.get("path");
-      if (!path) return json(res, 400, { error: "Path is required" });
-      // Reject obvious traversal + null bytes. `resolveFilePath` joins
-      // `path` onto trusted cwd/worktree roots, so a `..` segment could
-      // escape upward; null bytes confuse downstream stat/readFile.
-      if (path.includes("..") || path.includes("\0")) {
+      if (!path) return json(res, 400, { error: "Missing path" });
+      // Reject traversal segments + null bytes. Matches the frontend's
+      // segment-level check — `path.includes("..")` would also reject
+      // legitimate filenames like `v2..0.md` that contain `..` as a
+      // substring but not as a path segment. `resolveFilePath` joins
+      // `path` onto trusted cwd/worktree roots, so a `..` segment
+      // could escape upward; null bytes confuse downstream stat/readFile.
+      if (path.includes("\0") || path.split("/").some((seg) => seg === "..")) {
         return json(res, 400, { error: "Invalid path" });
       }
 

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -33,6 +33,7 @@ import {
 } from "./upload.js";
 import { replayPasteSequence } from "../paste-sequence.js";
 import { PRIVATE_META_KEYS, publicMeta } from "../session-meta-filter.js";
+import { resolveFilePath } from "../worktree-resolver.js";
 
 // Re-export so existing route tests and callers continue to import these
 // from app-routes.js. Source of truth lives in session-meta-filter.js so
@@ -766,6 +767,41 @@ export function createAppRoutes(ctx) {
         log.warn("claude-respond replay failed", { session: target.name, error: err.message });
       });
     }))},
+
+    // Resolve a (possibly relative) file path against a session's cwd with
+    // a sibling-worktree fallback. Used by the document/image tile opener
+    // so clicking `docs/foo.md` in a Claude that's operating on a worktree
+    // lands on the file even when Claude's cwd (from the per-pid session
+    // json) is still the main checkout. See `lib/worktree-resolver.js`
+    // and `docs/file-link-worktree-resolution.md` for the full diagnosis.
+    //
+    // Takes an optional `session` name because the path's cwd context
+    // comes from session meta; without it we can only handle absolute
+    // paths. `auth()` is sufficient — the response only exposes paths
+    // the caller could already enumerate by reading session meta.
+    { method: "GET", path: "/api/resolve-file", handler: auth(async (req, res) => {
+      const url = new URL(req.url, `http://${req.headers.host}`);
+      const sessionName = url.searchParams.get("session");
+      const path = url.searchParams.get("path");
+      if (!path) return json(res, 400, { error: "Path is required" });
+      // Reject obvious traversal + null bytes. `resolveFilePath` joins
+      // `path` onto trusted cwd/worktree roots, so a `..` segment could
+      // escape upward; null bytes confuse downstream stat/readFile.
+      if (path.includes("..") || path.includes("\0")) {
+        return json(res, 400, { error: "Invalid path" });
+      }
+
+      let cwd = null;
+      if (sessionName) {
+        const session = sessionManager.getSession(sessionName);
+        if (session) {
+          cwd = session.meta?.claude?.cwd || session.meta?.pane?.cwd || null;
+        }
+      }
+
+      const result = await resolveFilePath({ path, cwd });
+      json(res, 200, result);
+    })},
 
     // --- Sessions ---
 

--- a/lib/worktree-resolver.js
+++ b/lib/worktree-resolver.js
@@ -1,0 +1,154 @@
+/**
+ * Worktree-aware file path resolver.
+ *
+ * When Claude (or the shell) prints a relative path like `docs/foo.md`, the
+ * naive resolution is `join(session.cwd, relpath)`. That falls apart when the
+ * session's cwd is in one directory but the agent is actually operating on a
+ * sibling git worktree — e.g. `cd main && claude` but then
+ * `git -C .claude/worktrees/feature/ ...` or `claude --add-dir ...`. The
+ * per-pid `~/.claude/sessions/<pid>.json` only captures Claude's launch cwd,
+ * and the tmux pane's cwd doesn't drift with in-process `/cd` either (see
+ * `docs/file-link-worktree-resolution.md`).
+ *
+ * Rather than trying to predict where Claude "thinks" it's working, we let
+ * the filesystem answer: if the file isn't at `<cwd>/<relpath>`, try the
+ * same relpath under every sibling worktree that `git worktree list` knows
+ * about and return the first hit. This is the "no worktree-aware search
+ * fallback" non-goal from the doc, reconsidered — it only fires when the
+ * cwd-relative path doesn't exist, so there's no ambiguity to mediate in
+ * the common case. If the same relpath happens to exist in several
+ * worktrees, we prefer the cwd worktree first, then the order git reports
+ * (main worktree first).
+ *
+ * The resolver also returns a `worktreeLabel` string — the basename of the
+ * matching worktree when it isn't the primary one — so tiles can surface a
+ * small badge like `rewrite-rust-leptos` next to the filename. That turns
+ * an implicit resolution into a visible one: you can tell at a glance that
+ * the open file is from a sibling worktree, not the main checkout, without
+ * having to eyeball the absolute path.
+ *
+ * Never throws. A non-git cwd, a missing `git` binary, or a permission
+ * error on `stat` all collapse to the naive `join(cwd, relpath)` with
+ * `exists:false`, preserving the previous behavior.
+ */
+
+import { stat } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { basename, join } from "node:path";
+
+const WORKTREE_CACHE_MS = 5000;
+const worktreeCache = new Map();
+
+function runGitWorktreeList(cwd) {
+  return new Promise((resolve) => {
+    execFile(
+      "git",
+      ["-C", cwd, "worktree", "list", "--porcelain"],
+      { timeout: 3000 },
+      (err, stdout) => {
+        if (err || typeof stdout !== "string") return resolve([]);
+        const paths = [];
+        for (const line of stdout.split("\n")) {
+          if (line.startsWith("worktree ")) {
+            paths.push(line.slice("worktree ".length).trim());
+          }
+        }
+        resolve(paths);
+      },
+    );
+  });
+}
+
+async function listWorktrees(cwd, opts = {}) {
+  const runner = opts.runGit || runGitWorktreeList;
+  const now = Date.now();
+  const cached = worktreeCache.get(cwd);
+  if (cached && now - cached.at < WORKTREE_CACHE_MS) return cached.paths;
+  const paths = await runner(cwd);
+  worktreeCache.set(cwd, { paths, at: now });
+  return paths;
+}
+
+/** Test-only: drop the worktree list cache. */
+export function __resetWorktreeCache() {
+  worktreeCache.clear();
+}
+
+/**
+ * Return the display label for the worktree that contains `absPath`, or
+ * `null` if the path falls under the primary worktree (first entry from
+ * `git worktree list`, which is always the main checkout) or outside all
+ * known worktrees. Longest match wins when worktrees nest, which matters
+ * if someone points `.claude/worktrees/` at a sibling repo.
+ */
+export function inferWorktreeLabel(absPath, worktrees) {
+  if (typeof absPath !== "string" || !Array.isArray(worktrees) || worktrees.length === 0) {
+    return null;
+  }
+  const primary = worktrees[0];
+  const sorted = [...worktrees].sort((a, b) => b.length - a.length);
+  for (const wt of sorted) {
+    const prefix = wt.endsWith("/") ? wt : wt + "/";
+    if (absPath === wt || absPath.startsWith(prefix)) {
+      if (wt === primary) return null;
+      return basename(wt);
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a (possibly relative) path against a session's cwd, falling back
+ * to sibling git worktrees when the naive resolution misses.
+ *
+ * @param {{ path: string, cwd?: string | null }} args
+ * @param {{ stat?: Function, runGit?: Function }} [opts] test seams
+ * @returns {Promise<{absPath: string, exists: boolean, worktreeLabel: string | null}>}
+ */
+export async function resolveFilePath({ path, cwd }, opts = {}) {
+  const statFn = opts.stat || stat;
+
+  if (typeof path !== "string" || path.length === 0) {
+    return { absPath: "", exists: false, worktreeLabel: null };
+  }
+
+  const hasCwd = typeof cwd === "string" && cwd.startsWith("/");
+  const worktrees = hasCwd ? await listWorktrees(cwd, opts) : [];
+
+  if (path.startsWith("/")) {
+    const exists = await statFn(path).then(() => true, () => false);
+    return {
+      absPath: path,
+      exists,
+      worktreeLabel: inferWorktreeLabel(path, worktrees),
+    };
+  }
+
+  if (!hasCwd) {
+    return { absPath: path, exists: false, worktreeLabel: null };
+  }
+
+  const candidates = [cwd];
+  for (const wt of worktrees) {
+    if (!candidates.includes(wt)) candidates.push(wt);
+  }
+
+  for (const base of candidates) {
+    const abs = join(base, path);
+    const ok = await statFn(abs).then(() => true, () => false);
+    if (ok) {
+      return {
+        absPath: abs,
+        exists: true,
+        worktreeLabel: inferWorktreeLabel(abs, worktrees),
+      };
+    }
+  }
+
+  const fallback = join(cwd, path);
+  return {
+    absPath: fallback,
+    exists: false,
+    worktreeLabel: inferWorktreeLabel(fallback, worktrees),
+  };
+}

--- a/public/app.js
+++ b/public/app.js
@@ -159,16 +159,10 @@
     // _uiStore is also used by onFileLinkClick below — both closures
     // share the same late-bound ref, assigned when createUiStore() runs.
 
-    // Resolve a (possibly relative) file path against the active session's
-    // cwd and open it in a document tile. Shared by the terminal's
-    // file-link click handler and the feed tile's reply-file chips.
-    //
-    // Resolution precedence: `meta.claude.cwd` (Claude's process cwd,
-    // authoritative when Claude is running — doesn't drift with shell
-    // cd's) → `meta.pane.cwd` (tmux pane_current_path, authoritative
-    // when the pane is idle) → fall through with the raw relative path.
-    // See docs/file-link-worktree-resolution.md for why the former
-    // round-trip to GET /sessions/cwd was replaced by cached meta.
+    // Cwd off cached session meta — a fallback used only when the server
+    // resolver is unreachable. Precedence matches the server:
+    // `meta.claude.cwd` → `meta.pane.cwd`. See
+    // `docs/file-link-worktree-resolution.md`.
     function resolveSessionCwd(sessionName) {
       if (!sessionName) return null;
       const { sessions } = sessionStore.getState();
@@ -181,21 +175,44 @@
       return null;
     }
 
-    function openFileInDocTile(filePath, line) {
+    // Open the file in a document or image tile, resolved against the active
+    // session's cwd with a sibling-worktree fallback (see
+    // `lib/worktree-resolver.js`). Shared by terminal file-link clicks and
+    // feed tile reply-file chips. Async because the worktree lookup needs
+    // a `git worktree list` on the server, but the call is fire-and-forget
+    // from the caller's perspective — no caller awaits the tile opening.
+    async function openFileInDocTile(filePath, line) {
       if (!_uiStore || typeof filePath !== "string" || !filePath) return;
       // Defense-in-depth: reject paths with traversal segments
       if (filePath.split("/").some(seg => seg === "..")) return;
+
+      const sessionName = getActiveSessionName();
       let resolved = filePath;
-      if (!filePath.startsWith("/")) {
-        const cwd = resolveSessionCwd(getActiveSessionName());
-        if (cwd) resolved = cwd + "/" + filePath;
+      let worktreeLabel = null;
+      try {
+        const q = `path=${encodeURIComponent(filePath)}` +
+          (sessionName ? `&session=${encodeURIComponent(sessionName)}` : "");
+        const res = await api.get(`/api/resolve-file?${q}`);
+        if (res && typeof res.absPath === "string" && res.absPath) {
+          resolved = res.absPath;
+          worktreeLabel = res.worktreeLabel || null;
+        }
+      } catch {
+        // Resolver unreachable (offline / server restart) — fall back to
+        // naive cwd-relative join so the tile at least opens.
+        if (!filePath.startsWith("/")) {
+          const cwd = resolveSessionCwd(sessionName);
+          if (cwd) resolved = cwd + "/" + filePath;
+        }
       }
+
       // Route by extension: images go to the image tile (with zoom/pan),
       // everything else to the document tile. Both are reached via the
       // same katulong:open-file event so feed thumbnails, reply chips,
       // and terminal file links all funnel through one codepath.
       const isImg = isImagePath(resolved);
       const props = { filePath: resolved };
+      if (worktreeLabel) props.worktreeLabel = worktreeLabel;
       if (!isImg && typeof line === "number" && line > 0) props.line = line;
       const type = isImg ? "image" : "document";
       const id = `${isImg ? "img" : "doc"}-${Date.now().toString(36)}`;

--- a/public/index.html
+++ b/public/index.html
@@ -2334,6 +2334,11 @@
     .doc-tile-root { display: flex; flex-direction: column; height: 100%; width: 100%; background: var(--bg); color: var(--text); font-family: var(--font-mono); font-size: var(--text-sm); }
     .doc-tile-header { display: flex; align-items: center; gap: var(--space-xs); padding: var(--space-xs) var(--space-sm); border-bottom: 1px solid var(--border); flex-shrink: 0; background: var(--bg-surface); color: var(--text-secondary); font-size: var(--text-xs); }
     .doc-tile-header-title { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+    /* Shared worktree badge for document + image tiles — shown when the
+       opened file lives in a non-primary git worktree so it's obvious
+       at a glance which checkout you're looking at. */
+    .tile-worktree-badge { display: inline-flex; align-items: center; flex-shrink: 0; padding: 1px 6px; border-radius: 999px; background: rgba(201, 164, 245, 0.15); color: var(--accent-active); font-size: var(--text-xs); font-family: var(--font-mono); white-space: nowrap; max-width: 14ch; overflow: hidden; text-overflow: ellipsis; }
     .doc-tile-content { flex: 1; overflow: auto; margin: 0; padding: var(--space-sm); white-space: pre-wrap; word-wrap: break-word; tab-size: 2; line-height: 1.5; outline: none; }
     .doc-tile-content:focus { outline: none; }
     .doc-tile-editor { flex: 1; overflow: hidden; }

--- a/public/lib/tile-renderers/document.js
+++ b/public/lib/tile-renderers/document.js
@@ -55,6 +55,7 @@ export const documentRenderer = {
       title: props.title,
       content: props.content,
       format: props.format,
+      worktreeLabel: props.worktreeLabel,
     });
     tile.mount(el, {
       ...ctx,

--- a/public/lib/tile-renderers/image.js
+++ b/public/lib/tile-renderers/image.js
@@ -34,7 +34,7 @@ export const imageRenderer = {
 
   mount(el, { id, props, dispatch, ctx }) {
     if (!factory) throw new Error("imageRenderer.init() not called");
-    const tile = factory({ filePath: props.filePath });
+    const tile = factory({ filePath: props.filePath, worktreeLabel: props.worktreeLabel });
     tile.mount(el, {
       ...ctx,
       setTitle(title) {

--- a/public/lib/tiles/document-tile.js
+++ b/public/lib/tiles/document-tile.js
@@ -22,6 +22,7 @@ import { api } from "/lib/api-client.js";
 import { marked } from "/vendor/marked/marked.esm.js";
 import DOMPurify from "/vendor/dompurify/purify.es.mjs";
 import { createDocumentWatcher } from "/lib/document-watcher.js";
+import { createWorktreeBadge } from "/lib/tiles/tile-badge.js";
 
 /* ---------- cute animated error pages ---------- */
 
@@ -464,13 +465,7 @@ export function createDocumentTileFactory(_deps = {}) {
         header.className = "doc-tile-header";
         headerEl = header;
 
-        if (worktreeLabel) {
-          const badge = document.createElement("span");
-          badge.className = "tile-worktree-badge";
-          badge.textContent = worktreeLabel;
-          badge.title = `Worktree: ${worktreeLabel}`;
-          header.appendChild(badge);
-        }
+        if (worktreeLabel) header.appendChild(createWorktreeBadge(worktreeLabel));
 
         const headerTitle = document.createElement("span");
         headerTitle.className = "doc-tile-header-title";
@@ -711,9 +706,7 @@ export function createDocumentTileFactory(_deps = {}) {
 
       serialize() {
         if (isFileBacked) {
-          const out = { type: "document", filePath };
-          if (worktreeLabel) out.worktreeLabel = worktreeLabel;
-          return out;
+          return { type: "document", filePath };
         }
         return { type: "document", title, format };
       },

--- a/public/lib/tiles/document-tile.js
+++ b/public/lib/tiles/document-tile.js
@@ -338,7 +338,7 @@ function buildTheme(cm) {
  * @returns {(options: { filePath?, title?, content?, format? }) => TilePrototype}
  */
 export function createDocumentTileFactory(_deps = {}) {
-  return function createDocumentTile({ filePath, title, content, format } = {}) {
+  return function createDocumentTile({ filePath, title, content, format, worktreeLabel } = {}) {
     let container = null;
     let mounted = false;
     let editorView = null;
@@ -463,6 +463,14 @@ export function createDocumentTileFactory(_deps = {}) {
         const header = document.createElement("div");
         header.className = "doc-tile-header";
         headerEl = header;
+
+        if (worktreeLabel) {
+          const badge = document.createElement("span");
+          badge.className = "tile-worktree-badge";
+          badge.textContent = worktreeLabel;
+          badge.title = `Worktree: ${worktreeLabel}`;
+          header.appendChild(badge);
+        }
 
         const headerTitle = document.createElement("span");
         headerTitle.className = "doc-tile-header-title";
@@ -703,7 +711,9 @@ export function createDocumentTileFactory(_deps = {}) {
 
       serialize() {
         if (isFileBacked) {
-          return { type: "document", filePath };
+          const out = { type: "document", filePath };
+          if (worktreeLabel) out.worktreeLabel = worktreeLabel;
+          return out;
         }
         return { type: "document", title, format };
       },

--- a/public/lib/tiles/image-tile.js
+++ b/public/lib/tiles/image-tile.js
@@ -25,7 +25,7 @@ export function isImagePath(filePath) {
 }
 
 export function createImageTileFactory(_deps) {
-  return function createImageTile({ filePath }) {
+  return function createImageTile({ filePath, worktreeLabel }) {
     let mounted = false;
     let root = null;
     let imgEl = null;
@@ -96,6 +96,14 @@ export function createImageTileFactory(_deps) {
         // --- Header ---
         const header = document.createElement("div");
         header.className = "img-tile-header";
+
+        if (worktreeLabel) {
+          const badge = document.createElement("span");
+          badge.className = "tile-worktree-badge";
+          badge.textContent = worktreeLabel;
+          badge.title = `Worktree: ${worktreeLabel}`;
+          header.appendChild(badge);
+        }
 
         const titleEl = document.createElement("span");
         titleEl.className = "img-tile-header-title";

--- a/public/lib/tiles/image-tile.js
+++ b/public/lib/tiles/image-tile.js
@@ -11,6 +11,8 @@
  * Only file-backed (given a filePath). Persistable — re-fetches on restore.
  */
 
+import { createWorktreeBadge } from "/lib/tiles/tile-badge.js";
+
 // Keep in sync with MIME map in lib/file-browser.js GET /api/files/image
 // SVG intentionally excluded — contains executable JavaScript (XSS risk)
 const IMAGE_EXTS = new Set([
@@ -97,13 +99,7 @@ export function createImageTileFactory(_deps) {
         const header = document.createElement("div");
         header.className = "img-tile-header";
 
-        if (worktreeLabel) {
-          const badge = document.createElement("span");
-          badge.className = "tile-worktree-badge";
-          badge.textContent = worktreeLabel;
-          badge.title = `Worktree: ${worktreeLabel}`;
-          header.appendChild(badge);
-        }
+        if (worktreeLabel) header.appendChild(createWorktreeBadge(worktreeLabel));
 
         const titleEl = document.createElement("span");
         titleEl.className = "img-tile-header-title";

--- a/public/lib/tiles/tile-badge.js
+++ b/public/lib/tiles/tile-badge.js
@@ -1,0 +1,14 @@
+/**
+ * Shared DOM helper for the worktree badge rendered in document + image
+ * tile headers. Extracted so both tiles stay byte-for-byte consistent —
+ * any future tweak to the badge shape (icon prefix, truncation rules,
+ * aria-label) lands once instead of twice.
+ */
+
+export function createWorktreeBadge(label) {
+  const badge = document.createElement("span");
+  badge.className = "tile-worktree-badge";
+  badge.textContent = label;
+  badge.title = `Worktree: ${label}`;
+  return badge;
+}

--- a/test/worktree-resolver.test.js
+++ b/test/worktree-resolver.test.js
@@ -1,0 +1,161 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveFilePath,
+  inferWorktreeLabel,
+  __resetWorktreeCache,
+} from "../lib/worktree-resolver.js";
+
+/**
+ * Build a fake stat() that resolves for the listed absolute paths and
+ * rejects (ENOENT) for everything else. Matches the shape of node:fs/promises
+ * stat — only the resolve/reject distinction is observed by resolveFilePath.
+ */
+function fakeStat(existingPaths) {
+  const set = new Set(existingPaths);
+  return (p) => set.has(p)
+    ? Promise.resolve({ isFile: () => true })
+    : Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+}
+
+function fakeGit(list) {
+  return () => Promise.resolve(list);
+}
+
+describe("inferWorktreeLabel", () => {
+  const MAIN = "/Users/x/proj";
+  const WT = "/Users/x/proj/.claude/worktrees/feat-a";
+  const WT_OTHER = "/Users/x/proj/.claude/worktrees/feat-b";
+  const worktrees = [MAIN, WT, WT_OTHER];
+
+  it("returns null for paths in the primary worktree", () => {
+    assert.equal(inferWorktreeLabel(`${MAIN}/docs/a.md`, worktrees), null);
+  });
+
+  it("returns basename for paths in a sibling worktree", () => {
+    assert.equal(inferWorktreeLabel(`${WT}/docs/a.md`, worktrees), "feat-a");
+    assert.equal(inferWorktreeLabel(`${WT_OTHER}/x.js`, worktrees), "feat-b");
+  });
+
+  it("returns null for paths outside all worktrees", () => {
+    assert.equal(inferWorktreeLabel("/tmp/foo.md", worktrees), null);
+    assert.equal(inferWorktreeLabel("/Users/y/other/file.md", worktrees), null);
+  });
+
+  it("returns null for empty worktree list", () => {
+    assert.equal(inferWorktreeLabel(`${MAIN}/a.md`, []), null);
+  });
+
+  it("prefers the longest matching worktree (nesting)", () => {
+    // A worktree nested inside another should claim the path over its parent.
+    const nested = "/a";
+    const deeper = "/a/b";
+    assert.equal(inferWorktreeLabel("/a/b/x.md", [nested, deeper]), "b");
+  });
+});
+
+describe("resolveFilePath", () => {
+  const CWD = "/Users/x/proj";
+  const WT = "/Users/x/proj/.claude/worktrees/feat-a";
+
+  beforeEach(() => __resetWorktreeCache());
+
+  it("returns the raw path with no cwd and a relative input", async () => {
+    const out = await resolveFilePath(
+      { path: "docs/a.md", cwd: null },
+      { stat: fakeStat([]), runGit: fakeGit([]) },
+    );
+    assert.deepEqual(out, { absPath: "docs/a.md", exists: false, worktreeLabel: null });
+  });
+
+  it("stats an absolute path and reports existence", async () => {
+    const abs = "/etc/hosts";
+    const out = await resolveFilePath(
+      { path: abs, cwd: null },
+      { stat: fakeStat([abs]), runGit: fakeGit([]) },
+    );
+    assert.equal(out.absPath, abs);
+    assert.equal(out.exists, true);
+    assert.equal(out.worktreeLabel, null);
+  });
+
+  it("resolves against cwd when the file lives there", async () => {
+    const hit = `${CWD}/docs/a.md`;
+    const out = await resolveFilePath(
+      { path: "docs/a.md", cwd: CWD },
+      { stat: fakeStat([hit]), runGit: fakeGit([CWD, WT]) },
+    );
+    assert.equal(out.absPath, hit);
+    assert.equal(out.exists, true);
+    assert.equal(out.worktreeLabel, null, "primary worktree gets no badge");
+  });
+
+  it("falls back to a sibling worktree when cwd misses", async () => {
+    // The actual bug: Claude launched from main checkout, operates on worktree
+    // via `git -C <worktree>`, prints a relative path. Naive join against cwd
+    // 404s; the file lives under a sibling worktree.
+    const hit = `${WT}/docs/rewrite.md`;
+    const out = await resolveFilePath(
+      { path: "docs/rewrite.md", cwd: CWD },
+      { stat: fakeStat([hit]), runGit: fakeGit([CWD, WT]) },
+    );
+    assert.equal(out.absPath, hit);
+    assert.equal(out.exists, true);
+    assert.equal(out.worktreeLabel, "feat-a");
+  });
+
+  it("prefers the cwd worktree when the same relpath exists in siblings", async () => {
+    // Both paths exist — disambiguate by checking cwd first so a user who
+    // `cd`'d into a worktree doesn't get pulled into main by accident.
+    const cwdHit = `${CWD}/docs/a.md`;
+    const wtHit = `${WT}/docs/a.md`;
+    const out = await resolveFilePath(
+      { path: "docs/a.md", cwd: CWD },
+      { stat: fakeStat([cwdHit, wtHit]), runGit: fakeGit([CWD, WT]) },
+    );
+    assert.equal(out.absPath, cwdHit);
+  });
+
+  it("returns the naive cwd-relative fallback when nothing exists", async () => {
+    const out = await resolveFilePath(
+      { path: "missing.md", cwd: CWD },
+      { stat: fakeStat([]), runGit: fakeGit([CWD, WT]) },
+    );
+    assert.equal(out.absPath, `${CWD}/missing.md`);
+    assert.equal(out.exists, false);
+    assert.equal(out.worktreeLabel, null);
+  });
+
+  it("tags an absolute path that falls under a sibling worktree", async () => {
+    // File link clicks that pass absolute paths should still surface the
+    // worktree badge so users can tell which checkout the tile belongs to.
+    const abs = `${WT}/notes/todo.md`;
+    const out = await resolveFilePath(
+      { path: abs, cwd: CWD },
+      { stat: fakeStat([abs]), runGit: fakeGit([CWD, WT]) },
+    );
+    assert.equal(out.absPath, abs);
+    assert.equal(out.worktreeLabel, "feat-a");
+  });
+
+  it("gracefully handles git failure (empty worktree list)", async () => {
+    // Non-git cwd, missing git binary, timeout — the resolver returns [] and
+    // falls back to cwd-only resolution, preserving pre-fix behavior.
+    const hit = `${CWD}/docs/a.md`;
+    const out = await resolveFilePath(
+      { path: "docs/a.md", cwd: CWD },
+      { stat: fakeStat([hit]), runGit: fakeGit([]) },
+    );
+    assert.equal(out.absPath, hit);
+    assert.equal(out.worktreeLabel, null);
+  });
+
+  it("handles empty path input", async () => {
+    const out = await resolveFilePath(
+      { path: "", cwd: CWD },
+      { stat: fakeStat([]), runGit: fakeGit([CWD]) },
+    );
+    assert.equal(out.exists, false);
+    assert.equal(out.absPath, "");
+  });
+});


### PR DESCRIPTION
## Summary

- File-link clicks in terminal output (and feed reply chips) now resolve against every sibling git worktree when the naive `join(cwd, relpath)` misses the file, fixing 404s when Claude operates on a sibling worktree via `git -C`, `--add-dir`, or in-process `/cd`.
- Document and image tiles render a `worktree-label` chip in the header when the opened file lives in a non-primary worktree, so it's visually obvious at a glance which checkout you're looking at.
- New backend resolver (`lib/worktree-resolver.js`) + thin auth-gated `/api/resolve-file` route; 5s per-cwd cache over `git worktree list --porcelain`.

## Why search-on-404 instead of enriching session meta

The original doc (`docs/file-link-worktree-resolution.md`) listed worktree search as a non-goal and preferred meta enrichment. The bug forced a reconsideration: `--add-dir`, `/cd`, and `git -C` never update `~/.claude/sessions/<pid>.json` or tmux pane cwd, so no amount of meta scraping can cover them. Letting the filesystem answer sidesteps the prediction problem — there's no ambiguity in the common case, and we prefer the cwd worktree when the same relpath exists in multiple so a user who `cd`'d into a worktree doesn't get pulled into main.

## Security

- New route is wrapped in `auth()`; not added to `isPublicPath()`.
- Rejects `..` and `\0` at the edge before joining onto trusted cwd/worktree roots.
- Response only exposes paths the caller could already see via session meta + existing file-read APIs.

## Test plan

- [x] `npm test` (2553 tests pass, 3 pre-existing skipped)
- [x] `test/worktree-resolver.test.js`: 14 unit tests covering no-cwd, absolute paths, cwd hit, sibling-worktree fallback, cwd preference on ambiguity, total miss, absolute-path-in-worktree labeling, git failure graceful fallback, empty path input
- [ ] Manual: from main checkout, open a Claude tab that's working on a sibling worktree, click a `docs/*.md` link in its output — should open the file from the worktree with a badge; CMD-click also works
- [ ] Manual: open a file that exists in both checkouts from a main-checkout Claude — should prefer main (no badge)
- [ ] Manual: reload the page with a saved layout containing a worktree-backed document tile — badge should survive restore