### PR TITLE
fix(tmux): dedicate LaunchAgent and dev-server tmux to -L katulong socket

### DIFF
--- a/lib/cli/commands/service.js
+++ b/lib/cli/commands/service.js
@@ -47,6 +47,8 @@ function buildPlist() {
     <string>${port}</string>
     <key>KATULONG_DATA_DIR</key>
     <string>${dataDir}</string>
+    <key>KATULONG_TMUX_SOCKET</key>
+    <string>katulong</string>
     <key>PATH</key>
     <string>${process.env.PATH}</string>
   </dict>

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -130,7 +130,7 @@ cmd_start() {
   # SessionStart hook, breaking the Claude feed narration pipeline.
   : > "$LOG_FILE"
   nohup env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_EXECPATH \
-    PORT="$PORT" node server.js >> "$LOG_FILE" 2>&1 </dev/null &
+    PORT="$PORT" KATULONG_TMUX_SOCKET="katulong" node server.js >> "$LOG_FILE" 2>&1 </dev/null &
   local pid=$!
   echo "$pid" > "$PID_FILE"
   disown 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Installed service (`com.dorkyrobot.katulong`) and `scripts/dev-server.sh` now set `KATULONG_TMUX_SOCKET=katulong`, so every tmux call from katulong routes through `-L katulong` instead of sharing `/tmp/tmux-$UID/default` with interactive shells, IDE control clients, and test-sweep `kill-server` runs.
- Closes the remaining trigger surface for the tmux 3.6a UAF in `control_notify_client_detached` that's been causing katulong segfaults (seven reports since 2026-04-14, all with the same `control_write +142 → SIGSEGV reading 0x20` stack). #489 closed our abrupt-kill paths in `lib/session.js`; this fix ensures nothing *else* touching the default socket can trigger the same UAF.
- Uses existing `tmuxSocketArgs()` plumbing in `lib/tmux.js` (already validated against `/^[A-Za-z0-9_-]+$/`). Same mechanism the staging harness uses (`-L stage-<name>`).

## Notes
- Ephemeral: tmux sessions never survive a server restart, so moving sockets is no more disruptive than a normal upgrade. On first restart after this change, `restoreSessions()` probes the new socket, sees no matches, and any records persisted from the default-socket run are silently abandoned.
- Follow-up in #627: audit `lib/tmux-socket-sweep.js:79` `tmux -L <name> kill-server`, another abrupt-kill path that could reproduce the UAF on whichever socket a sweep targets.

Refs #627

## Test plan
- [x] `npm run test:unit` passes (2550/2550)
- [ ] Install service, restart, verify `ps aux | grep tmux` shows `-L katulong`
- [ ] Run `scripts/dev-server.sh`, confirm new sessions land on the same `-L katulong` server