### PR TITLE
fix(stage): auto-detect worktree — drop REPO_ROOT override from /stage

### DIFF
--- a/bin/katulong-stage
+++ b/bin/katulong-stage
@@ -74,11 +74,19 @@ resolve_repo_root() {
   fi
   local main_root main_common cwd_top cwd_common
   main_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  # Anchor every git call to an explicit -C <dir> so relative paths emitted
+  # by --git-common-dir (".git" in a main checkout, "../.git" from a subdir,
+  # absolute paths in linked worktrees) all resolve against the same base
+  # the subsequent `cd` normalization uses. Without anchoring, running from
+  # a main-checkout subdir emits "../.git" relative to the original cwd, but
+  # the normalization `cd "$cwd_top" && cd <path>` resolves it against the
+  # worktree toplevel — the two don't align and the cd lands nowhere,
+  # silently disabling worktree detection.
   main_common="$(git -C "$main_root" rev-parse --git-common-dir 2>/dev/null)" || { echo "$main_root"; return 0; }
-  main_common="$(cd "$main_root" && cd "$main_common" && pwd)"
+  main_common="$(cd "$main_root" && cd "$main_common" && pwd 2>/dev/null)" || { echo "$main_root"; return 0; }
   cwd_top="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "$main_root"; return 0; }
-  cwd_common="$(git rev-parse --git-common-dir 2>/dev/null)" || { echo "$main_root"; return 0; }
-  cwd_common="$(cd "$cwd_top" && cd "$cwd_common" && pwd)"
+  cwd_common="$(git -C "$cwd_top" rev-parse --git-common-dir 2>/dev/null)" || { echo "$main_root"; return 0; }
+  cwd_common="$(cd "$cwd_top" && cd "$cwd_common" && pwd 2>/dev/null)" || { echo "$main_root"; return 0; }
   if [[ "$main_common" == "$cwd_common" ]]; then
     echo "$cwd_top"
   else

--- a/bin/katulong-stage
+++ b/bin/katulong-stage
@@ -58,8 +58,34 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 STAGE_BASE="/tmp/katulong-stage"
+
+# Resolve REPO_ROOT: explicit env var wins. Otherwise, if the caller's cwd is
+# inside a git worktree that shares the same .git common dir as the main
+# checkout (the script's own parent dir), use that worktree's root. This lets
+# `katulong-stage start` work zero-argument from any worktree — the name
+# defaults from the worktree's branch, server.js and node_modules resolve to
+# the worktree's copies, and staging serves whatever version is checked out
+# there. Falls back to the main checkout when run from outside any worktree.
+resolve_repo_root() {
+  if [[ -n "${REPO_ROOT:-}" ]]; then
+    echo "$REPO_ROOT"
+    return 0
+  fi
+  local main_root main_common cwd_top cwd_common
+  main_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  main_common="$(git -C "$main_root" rev-parse --git-common-dir 2>/dev/null)" || { echo "$main_root"; return 0; }
+  main_common="$(cd "$main_root" && cd "$main_common" && pwd)"
+  cwd_top="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "$main_root"; return 0; }
+  cwd_common="$(git rev-parse --git-common-dir 2>/dev/null)" || { echo "$main_root"; return 0; }
+  cwd_common="$(cd "$cwd_top" && cd "$cwd_common" && pwd)"
+  if [[ "$main_common" == "$cwd_common" ]]; then
+    echo "$cwd_top"
+  else
+    echo "$main_root"
+  fi
+}
+REPO_ROOT="$(resolve_repo_root)"
 
 # User-level config lives in the prod katulong's data dir, NOT in the per-staging
 # dir we're about to create. Honor KATULONG_DATA_DIR if the user has overridden


### PR DESCRIPTION
## Summary

- `katulong-stage` resolved `REPO_ROOT` from its own install location (`$SCRIPT_DIR/..`), which is always the main checkout. Running `bin/katulong-stage start` from inside a worktree silently staged main's code: wrong branch name default, main's `server.js`, main's `package.json` / version, main's `node_modules`.
- Fix: `resolve_repo_root()` uses `git rev-parse --git-common-dir` equivalence to detect when the caller's cwd sits inside a linked worktree of this repo, and uses the worktree's toplevel as `REPO_ROOT`. Explicit `REPO_ROOT=` env var still wins.
- Benefits every in-flight worktree (`feed-completion-prominent`, `rewrite-rust-leptos`, anything future).

## Why `git-common-dir` equivalence

The common-dir identity is exactly what "linked worktree of the same repo" means in git's own data model, so the check handles symlinks, path normalization, and nested subdirs for free. Simpler alternatives (prefix-matching `git worktree list` output, or "is there a server.js here") are either brittle or require ordering assumptions.

## Test plan
- [x] From main checkout → resolves to main
- [x] From `rewrite-rust-leptos` worktree → resolves to the worktree
- [x] From a subdir inside the worktree → resolves to the worktree root
- [x] From `/tmp` (no repo) → falls back to main
- [x] From an unrelated home dir → falls back to main
- [x] End-to-end: `bin/katulong-stage start` with no args from worktree → name auto-detected, `server.js` launched from worktree, `v0.58.5-rust1` version marker showed up in client footer
- [ ] Explicit `REPO_ROOT=$PWD bin/katulong-stage start` still works (preserved by early-return in `resolve_repo_root`)