### PR TITLE
fix(tiles): route file-browser opens through /api/resolve-file

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -188,18 +188,18 @@
       if (filePath.split("/").some(seg => seg === "..")) return;
 
       const sessionName = getActiveSessionName();
-      let resolved = filePath;
+      let resolvedPath = filePath;
       let worktreeLabel = null;
       try {
         const out = await resolveFilePathForTile(api, filePath, sessionName);
-        resolved = out.resolvedPath;
+        resolvedPath = out.resolvedPath;
         worktreeLabel = out.worktreeLabel;
       } catch {
         // Resolver unreachable (offline / server restart) — fall back to
         // naive cwd-relative join so the tile at least opens.
         if (!filePath.startsWith("/")) {
           const cwd = resolveSessionCwd(sessionName);
-          if (cwd) resolved = cwd + "/" + filePath;
+          if (cwd) resolvedPath = cwd + "/" + filePath;
         }
       }
 
@@ -207,8 +207,8 @@
       // everything else to the document tile. Both are reached via the
       // same katulong:open-file event so feed thumbnails, reply chips,
       // and terminal file links all funnel through one codepath.
-      const isImg = isImagePath(resolved);
-      const props = { filePath: resolved };
+      const isImg = isImagePath(resolvedPath);
+      const props = { filePath: resolvedPath };
       if (worktreeLabel) props.worktreeLabel = worktreeLabel;
       if (!isImg && typeof line === "number" && line > 0) props.line = line;
       const type = isImg ? "image" : "document";

--- a/public/app.js
+++ b/public/app.js
@@ -47,6 +47,7 @@
     import { createClusterTileFactory } from "/lib/tiles/cluster-tile.js";
     import { createFileBrowserTileFactory } from "/lib/tiles/file-browser-tile.js";
     import { isImagePath } from "/lib/tiles/image-tile.js";
+    import { resolveFilePathForTile } from "/lib/tiles/resolve-file-for-tile.js";
     import { dispatchNotification } from "/lib/notify.js";
     import { createUiStore, loadFromStorage, EMPTY_STATE } from "/lib/ui-store.js";
     import { buildBootState } from "/lib/boot-state.js";
@@ -190,13 +191,9 @@
       let resolved = filePath;
       let worktreeLabel = null;
       try {
-        const q = `path=${encodeURIComponent(filePath)}` +
-          (sessionName ? `&session=${encodeURIComponent(sessionName)}` : "");
-        const res = await api.get(`/api/resolve-file?${q}`);
-        if (res && typeof res.absPath === "string" && res.absPath) {
-          resolved = res.absPath;
-          worktreeLabel = res.worktreeLabel || null;
-        }
+        const out = await resolveFilePathForTile(api, filePath, sessionName);
+        resolved = out.resolvedPath;
+        worktreeLabel = out.worktreeLabel;
       } catch {
         // Resolver unreachable (offline / server restart) — fall back to
         // naive cwd-relative join so the tile at least opens.

--- a/public/lib/tile-renderers/file-browser.js
+++ b/public/lib/tile-renderers/file-browser.js
@@ -45,8 +45,6 @@ export const fileBrowserRenderer = {
   mount(el, { id, props, dispatch, ctx }) {
     if (!factory) throw new Error("fileBrowserRenderer.init() not called");
 
-    // --- File open: open a document or image tile adjacent to this browser ---
-    //
     // Awaits `/api/resolve-file` before opening, same pattern as
     // `openFileInDocTile` in app.js (terminal file-link clicks + feed reply
     // chips). File-browser click paths are already absolute, so the

--- a/public/lib/tile-renderers/file-browser.js
+++ b/public/lib/tile-renderers/file-browser.js
@@ -10,6 +10,8 @@
 import { createFileBrowserTileFactory } from "../tiles/file-browser-tile.js";
 import { isImagePath } from "../tiles/image-tile.js";
 import { findAdjacentPreviewToSwap } from "../selectors.js";
+import { resolveFilePathForTile } from "../tiles/resolve-file-for-tile.js";
+import { api } from "/lib/api-client.js";
 
 let factory = null;
 let _uiStore = null;
@@ -44,11 +46,34 @@ export const fileBrowserRenderer = {
     if (!factory) throw new Error("fileBrowserRenderer.init() not called");
 
     // --- File open: open a document or image tile adjacent to this browser ---
-    function onFileOpen(filePath) {
-      if (!_uiStore) return;
-      const state = _uiStore.getState();
+    //
+    // Awaits `/api/resolve-file` before opening, same pattern as
+    // `openFileInDocTile` in app.js (terminal file-link clicks + feed reply
+    // chips). File-browser click paths are already absolute, so the
+    // resolver doesn't change `absPath` here — but it still classifies the
+    // path against `git worktree list` and returns a `worktreeLabel` when
+    // the file lives in a sibling worktree. That label is what drives the
+    // worktree badge on the document/image tile; without this call the
+    // badge never appears for files opened via the file browser. See
+    // `docs/file-link-worktree-resolution.md`.
+    async function onFileOpen(filePath) {
+      if (!_uiStore || typeof filePath !== "string" || !filePath) return;
 
-      const isImage = isImagePath(filePath);
+      const sessionName = props.sessionName || null;
+      let resolvedPath = filePath;
+      let worktreeLabel = null;
+      try {
+        const out = await resolveFilePathForTile(api, filePath, sessionName);
+        resolvedPath = out.resolvedPath;
+        worktreeLabel = out.worktreeLabel;
+      } catch {
+        // Resolver unreachable (offline / server restart) — fall through
+        // with the raw (absolute) filePath so the tile still opens. The
+        // only loss is the worktree badge, which is a display hint.
+      }
+
+      const state = _uiStore.getState();
+      const isImage = isImagePath(resolvedPath);
       const previewType = isImage ? "image" : "document";
 
       // Swap semantics: if the column immediately to the right is a
@@ -61,8 +86,10 @@ export const fileBrowserRenderer = {
       // this browser tile. focus:true sets focusedId in the store;
       // tile-host reacts and tells the carousel to scroll to it.
       const tileId = `${isImage ? "img" : "doc"}-${Date.now().toString(36)}`;
+      const tileProps = { filePath: resolvedPath };
+      if (worktreeLabel) tileProps.worktreeLabel = worktreeLabel;
       _uiStore.addTile(
-        { id: tileId, type: previewType, props: { filePath } },
+        { id: tileId, type: previewType, props: tileProps },
         { focus: true, insertAfter: id },
       );
     }

--- a/public/lib/tiles/resolve-file-for-tile.js
+++ b/public/lib/tiles/resolve-file-for-tile.js
@@ -1,0 +1,43 @@
+/**
+ * Shared resolver call for the document/image tile open paths.
+ *
+ * Two concrete consumers go through this helper:
+ *   - `openFileInDocTile` in `public/app.js` — terminal file-link clicks
+ *     and feed reply/thumbnail chips (relative paths, resolver also does
+ *     cwd + worktree-fallback resolution).
+ *   - `onFileOpen` in `public/lib/tile-renderers/file-browser.js` — file
+ *     browser row clicks (paths are already absolute, but the resolver
+ *     still returns the `worktreeLabel` so the tile's worktree badge
+ *     lights up for files in sibling worktrees).
+ *
+ * Only the `/api/resolve-file` call and response normalization are
+ * shared here. Each caller keeps its own try/catch because their
+ * fallback strategies differ: the terminal path can still join against
+ * the cached session cwd when the server is unreachable, file-browser
+ * paths are absolute so there is nothing to join. Extract pushed any
+ * further would have to carry a fallback strategy parameter, which is
+ * more indirection than two 10-line callers justify.
+ *
+ * See `lib/worktree-resolver.js` and `docs/file-link-worktree-resolution.md`
+ * for the server side.
+ *
+ * @param {{ get: (url: string) => Promise<any> }} api
+ * @param {string} filePath  absolute or relative path the user clicked
+ * @param {string | null} [sessionName]  scopes cwd lookup on the server
+ * @returns {Promise<{ resolvedPath: string, worktreeLabel: string | null }>}
+ */
+export async function resolveFilePathForTile(api, filePath, sessionName) {
+  if (typeof filePath !== "string" || !filePath) {
+    return { resolvedPath: filePath || "", worktreeLabel: null };
+  }
+  const q = `path=${encodeURIComponent(filePath)}`
+    + (sessionName ? `&session=${encodeURIComponent(sessionName)}` : "");
+  const res = await api.get(`/api/resolve-file?${q}`);
+  if (res && typeof res.absPath === "string" && res.absPath) {
+    return {
+      resolvedPath: res.absPath,
+      worktreeLabel: res.worktreeLabel || null,
+    };
+  }
+  return { resolvedPath: filePath, worktreeLabel: null };
+}

--- a/test/resolve-file-for-tile.test.js
+++ b/test/resolve-file-for-tile.test.js
@@ -1,0 +1,103 @@
+/**
+ * Tests for `resolveFilePathForTile` — the shared `/api/resolve-file`
+ * call used by both document/image tile open paths (terminal file-link
+ * clicks in app.js and file-browser row clicks in the file-browser
+ * renderer). The helper is a thin wrapper: URL building + response
+ * normalization. These tests cover the contract both callers depend on
+ * so either can move without the other regressing.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveFilePathForTile } from "../public/lib/tiles/resolve-file-for-tile.js";
+
+/** Record every `get` call and return whatever the caller specified. */
+function fakeApi(responses) {
+  const calls = [];
+  const queue = [...responses];
+  return {
+    calls,
+    get(url) {
+      calls.push(url);
+      if (queue.length === 0) {
+        throw new Error(`fakeApi: unexpected GET ${url}`);
+      }
+      const next = queue.shift();
+      return next instanceof Error ? Promise.reject(next) : Promise.resolve(next);
+    },
+  };
+}
+
+describe("resolveFilePathForTile", () => {
+  it("hits /api/resolve-file with path + session query params", async () => {
+    const api = fakeApi([{ absPath: "/abs/foo.md", exists: true, worktreeLabel: null }]);
+    const out = await resolveFilePathForTile(api, "docs/foo.md", "sess1");
+
+    assert.equal(api.calls.length, 1);
+    assert.equal(
+      api.calls[0],
+      "/api/resolve-file?path=docs%2Ffoo.md&session=sess1",
+    );
+    assert.deepEqual(out, { resolvedPath: "/abs/foo.md", worktreeLabel: null });
+  });
+
+  it("omits the session query param when sessionName is missing", async () => {
+    const api = fakeApi([{ absPath: "/abs/bar.md", worktreeLabel: null }]);
+    await resolveFilePathForTile(api, "bar.md", null);
+    assert.equal(api.calls[0], "/api/resolve-file?path=bar.md");
+  });
+
+  it("threads worktreeLabel through when the resolver returns one", async () => {
+    // The actual motivation for this helper: a file-browser click on a
+    // .md that lives in a sibling worktree needs to surface the badge.
+    const api = fakeApi([{
+      absPath: "/root/.claude/worktrees/feat-a/docs/plan.md",
+      exists: true,
+      worktreeLabel: "feat-a",
+    }]);
+    const out = await resolveFilePathForTile(
+      api,
+      "/root/.claude/worktrees/feat-a/docs/plan.md",
+      "sess",
+    );
+    assert.equal(out.resolvedPath, "/root/.claude/worktrees/feat-a/docs/plan.md");
+    assert.equal(out.worktreeLabel, "feat-a");
+  });
+
+  it("falls back to the raw filePath when the response has no absPath", async () => {
+    // The server only returns `{absPath: ""}` for empty input, but we
+    // still want to behave sanely if the shape drifts — never hand a
+    // falsy filePath to the tile.
+    const api = fakeApi([{ absPath: "", worktreeLabel: null }]);
+    const out = await resolveFilePathForTile(api, "something.md", null);
+    assert.equal(out.resolvedPath, "something.md");
+    assert.equal(out.worktreeLabel, null);
+  });
+
+  it("propagates rejections so callers can apply their own fallback", async () => {
+    // openFileInDocTile (app.js) does a cwd-relative join on network
+    // failure; the file-browser renderer skips the fallback because its
+    // paths are absolute. Keeping the reject contract lets each caller
+    // diverge without pushing a strategy parameter into the helper.
+    const api = fakeApi([new Error("offline")]);
+    await assert.rejects(
+      resolveFilePathForTile(api, "docs/foo.md", "sess"),
+      /offline/,
+    );
+  });
+
+  it("short-circuits on empty filePath without calling the resolver", async () => {
+    const api = fakeApi([]);
+    const out = await resolveFilePathForTile(api, "", "sess");
+    assert.equal(api.calls.length, 0);
+    assert.deepEqual(out, { resolvedPath: "", worktreeLabel: null });
+  });
+
+  it("treats non-string filePath defensively", async () => {
+    const api = fakeApi([]);
+    const out = await resolveFilePathForTile(api, null, "sess");
+    assert.equal(api.calls.length, 0);
+    assert.equal(out.worktreeLabel, null);
+  });
+});


### PR DESCRIPTION
## Summary

- Extracted the `/api/resolve-file` call into a shared helper (`public/lib/tiles/resolve-file-for-tile.js`) used by both document/image tile open paths.
- Routed the file-browser tile's `onFileOpen` through the helper — it was the one remaining UI surface that opened doc/image tiles without hitting the resolver, so the worktree badge never appeared for files opened via the file browser and any future relative-path consumer would have 404'd against the main-checkout fallback.
- `openFileInDocTile` (terminal file-link clicks + feed reply chips) now uses the same helper. No behaviour change there, just deduplication.

Follows up on #628 (`fix(tiles): make file-link resolution worktree-aware`) — that PR covered the terminal/feed paths but didn't touch file-browser clicks.

## Test plan

- [x] `npm test` — 2557/2557 pass (unchanged).
- [x] New `test/resolve-file-for-tile.test.js` covers URL building (path + optional session), response normalization, `worktreeLabel` passthrough, empty-response fallback, rejection propagation, and empty/non-string short-circuits (7 cases).
- [ ] Manual: from the main-checkout Files tile, navigate into `.claude/worktrees/<feature>/docs/`, click a .md — confirm the doc tile opens with the worktree badge in the header.
- [ ] Manual: terminal file-link clicks + feed reply chips still open correctly (same helper, same endpoint, no behavioural change expected).