### PR TITLE
rewrite(auth): slice 3 — WebAuthn ceremonies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,7 +128,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http",
@@ -135,6 +180,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -144,6 +195,17 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "base64urlsafedata"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f7f6be94fa637132933fd0a68b9140bcb60e3d46164cb68e82a2bb8d102b3a"
+dependencies = [
+ "base64 0.21.7",
+ "pastey",
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -183,6 +245,16 @@ name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -331,6 +403,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive-where"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,10 +493,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -525,13 +641,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -607,6 +735,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -882,7 +1016,8 @@ dependencies = [
 name = "katulong-auth"
 version = "0.1.0"
 dependencies = [
- "rand_core",
+ "base64 0.22.1",
+ "rand_core 0.6.4",
  "scrypt",
  "serde",
  "serde_json",
@@ -890,6 +1025,9 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "url",
+ "uuid",
+ "webauthn-rs",
 ]
 
 [[package]]
@@ -1058,7 +1196,7 @@ version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4161acbf80f59219d8d14182371f57302bc7ff81ee41aba8ba1ff7295727f23"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "cfg-if",
  "futures",
  "indexmap",
@@ -1215,6 +1353,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "oco_ref"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,10 +1397,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "pad-adapter"
@@ -1266,7 +1485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1275,6 +1494,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pathdiff"
@@ -1325,6 +1550,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1563,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1473,6 +1710,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1484,8 +1727,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1495,7 +1748,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1505,6 +1768,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1564,6 +1836,15 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "rustix"
@@ -1666,6 +1947,16 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_cbor_2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aec2709de9078e077090abd848e967abab63c9fb3fdb5d4799ad359d8d482c"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -1829,6 +2120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +2259,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2157,7 +2485,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.6",
  "sha1",
  "thiserror",
  "utf-8",
@@ -2217,6 +2545,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2245,6 +2574,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -2253,6 +2583,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2407,6 +2743,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "webauthn-attestation-ca"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fafcf13f7dc1fb292ed4aea22cdd3757c285d7559e9748950ee390249da4da6b"
+dependencies = [
+ "base64urlsafedata",
+ "openssl",
+ "openssl-sys",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "webauthn-rs"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b24d082d3360258fefb6ffe56123beef7d6868c765c779f97b7a2fcf06727f8"
+dependencies = [
+ "base64urlsafedata",
+ "serde",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-rs-core",
+]
+
+[[package]]
+name = "webauthn-rs-core"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15784340a24c170ce60567282fb956a0938742dbfbf9eff5df793a686a009b8b"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "der-parser",
+ "hex",
+ "nom",
+ "openssl",
+ "openssl-sys",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "serde",
+ "serde_cbor_2",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-attestation-ca",
+ "webauthn-rs-proto",
+ "x509-parser",
+]
+
+[[package]]
+name = "webauthn-rs-proto"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a1fb2580ce73baa42d3011a24de2ceab0d428de1879ece06e02e8c416e497c"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,6 +2942,23 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -14,3 +14,7 @@ tempfile = { workspace = true }
 scrypt = { version = "0.11", default-features = false, features = ["simple"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 subtle = { version = "2", default-features = false }
+webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation"] }
+url = "2"
+uuid = { version = "1", features = ["v4", "serde"] }
+base64 = "0.22"

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -14,6 +14,16 @@ tempfile = { workspace = true }
 scrypt = { version = "0.11", default-features = false, features = ["simple"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 subtle = { version = "2", default-features = false }
+# SAFETY: the `danger-allow-state-serialisation` feature enables Serde derives
+# on `PasskeyRegistration` / `PasskeyAuthentication` so they can live inside
+# the `Mutex<HashMap<...>>` challenge stores in `webauthn.rs`. That in-memory
+# use is safe. Persisting those types to disk or sending them over the wire
+# would open a ceremony-replay vector — upstream named the flag `danger-*` for
+# exactly that reason. The flag is ALSO required to serialize finished
+# `Passkey` blobs into `Credential.public_key`, which IS long-lived on-disk
+# state — that's fine because the completed passkey is what the spec expects
+# us to store. Do NOT extend the flag's reach to persist pending ceremony
+# state without a security review.
 webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation"] }
 url = "2"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/auth/src/error.rs
+++ b/crates/auth/src/error.rs
@@ -29,11 +29,31 @@ pub enum AuthError {
     #[error("password-hash error: {0}")]
     Hash(String),
 
+    /// WebAuthn service misconfiguration surfaced at startup — bad origin
+    /// URL, RP-id mismatch, missing feature on the relying-party builder.
+    /// Maps to a 500-class response if it ever reached an HTTP layer, but
+    /// in practice should panic the process at init rather than be served.
+    /// Kept distinct from `WebAuthn` so a 401-class ceremony failure isn't
+    /// indistinguishable from a startup bug via string-matching.
+    #[error("webauthn configuration error: {0}")]
+    WebAuthnConfig(String),
+
+    /// Runtime WebAuthn ceremony failure — signature verification failed,
+    /// challenge response malformed, counter regressed, etc. Caller should
+    /// render this as 401 and prompt the user to retry.
     #[error("webauthn error: {0}")]
     WebAuthn(String),
 
     #[error("challenge not found or expired")]
     ChallengeNotFound,
+
+    /// The server is at capacity for pending registration/authentication
+    /// ceremonies. Caller should render as 503 and ask the user to retry in
+    /// a few seconds. See the `MAX_PENDING_CHALLENGES` cap in `webauthn.rs`
+    /// — this variant exists so an HTTP handler can distinguish "retry
+    /// shortly" from "something is permanently broken."
+    #[error("too many pending challenges")]
+    TooManyPendingChallenges,
 }
 
 impl AuthError {

--- a/crates/auth/src/error.rs
+++ b/crates/auth/src/error.rs
@@ -28,6 +28,12 @@ pub enum AuthError {
 
     #[error("password-hash error: {0}")]
     Hash(String),
+
+    #[error("webauthn error: {0}")]
+    WebAuthn(String),
+
+    #[error("challenge not found or expired")]
+    ChallengeNotFound,
 }
 
 impl AuthError {

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -17,6 +17,7 @@ mod session;
 mod setup_token;
 mod state;
 mod store;
+mod webauthn;
 
 pub use credential::Credential;
 pub use error::AuthError;
@@ -24,5 +25,6 @@ pub use session::Session;
 pub use setup_token::{PlaintextToken, SetupToken};
 pub use state::AuthState;
 pub use store::AuthStore;
+pub use webauthn::{AuthenticationOutcome, ChallengeId, WebAuthnCeremony};
 
 pub type Result<T> = std::result::Result<T, AuthError>;

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -13,6 +13,7 @@
 
 mod credential;
 mod error;
+mod random;
 mod session;
 mod setup_token;
 mod state;
@@ -25,6 +26,6 @@ pub use session::Session;
 pub use setup_token::{PlaintextToken, SetupToken};
 pub use state::AuthState;
 pub use store::AuthStore;
-pub use webauthn::{AuthenticationOutcome, ChallengeId, WebAuthnCeremony};
+pub use webauthn::{ChallengeId, VerifiedAuthentication, WebAuthnService};
 
 pub type Result<T> = std::result::Result<T, AuthError>;

--- a/crates/auth/src/random.rs
+++ b/crates/auth/src/random.rs
@@ -1,0 +1,21 @@
+//! Shared cryptographic-grade random helpers.
+//!
+//! Factored out so that every `bytes → hex` callsite in the crate pulls from
+//! the same RNG and encodes the same way. Divergence here was already
+//! mechanical (two copies in `setup_token.rs` and `webauthn.rs` would have
+//! drifted the first time someone swapped encoders) — one place beats two.
+
+use rand_core::{OsRng, RngCore};
+use std::fmt::Write as _;
+
+/// Return `bytes` random bytes from the OS CSPRNG, encoded as lowercase hex.
+/// Result length is `bytes * 2`.
+pub(crate) fn random_hex(bytes: usize) -> String {
+    let mut buf = vec![0u8; bytes];
+    OsRng.fill_bytes(&mut buf);
+    let mut out = String::with_capacity(bytes * 2);
+    for b in buf {
+        write!(&mut out, "{b:02x}").expect("write to String cannot fail");
+    }
+    out
+}

--- a/crates/auth/src/setup_token.rs
+++ b/crates/auth/src/setup_token.rs
@@ -1,9 +1,9 @@
+use crate::random::random_hex;
 use crate::{AuthError, Result};
-use rand_core::{OsRng, RngCore};
+use rand_core::OsRng;
 use scrypt::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
 use scrypt::{Params, Scrypt};
 use serde::{Deserialize, Serialize};
-use std::fmt::Write;
 use std::time::{Duration, SystemTime};
 
 /// A single-use, time-limited token used to pair a new device.
@@ -121,16 +121,6 @@ fn hash_token(plaintext: &str) -> Result<String> {
         .hash_password_customized(plaintext.as_bytes(), None, None, params, &salt)
         .map(|h| h.to_string())
         .map_err(|e| AuthError::Hash(e.to_string()))
-}
-
-fn random_hex(bytes: usize) -> String {
-    let mut buf = vec![0u8; bytes];
-    OsRng.fill_bytes(&mut buf);
-    let mut out = String::with_capacity(bytes * 2);
-    for b in buf {
-        write!(&mut out, "{b:02x}").expect("write to String cannot fail");
-    }
-    out
 }
 
 #[cfg(test)]

--- a/crates/auth/src/webauthn.rs
+++ b/crates/auth/src/webauthn.rs
@@ -33,11 +33,10 @@
 //! we pass only `Passkey` values we already stored, which encode the same
 //! intent.
 
+use crate::random::random_hex;
 use crate::{AuthError, Credential, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use rand_core::{OsRng, RngCore};
 use std::collections::HashMap;
-use std::fmt::Write as _;
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
 use url::Url;
@@ -51,38 +50,76 @@ use webauthn_rs::{Webauthn, WebauthnBuilder};
 /// linger for an attacker to replay.
 const CHALLENGE_TTL: Duration = Duration::from_secs(5 * 60);
 
+/// Upper bound on the number of pending registration or authentication
+/// challenges the service will track at once. Each `start_*` call
+/// opportunistically prunes expired entries from its map; if the map is
+/// STILL at the cap after pruning, further `start_*` calls surface
+/// `TooManyPendingChallenges` rather than growing unbounded.
+///
+/// The number is deliberately generous — katulong is single-user, so 1024
+/// concurrent pending ceremonies is already 3 orders of magnitude above
+/// legitimate use. The cap exists purely to blunt an unauthenticated
+/// attacker who holds open registration/auth starts without ever finishing,
+/// which would otherwise consume memory until OOM.
+const MAX_PENDING_CHALLENGES: usize = 1024;
+
 /// Opaque handle returned to the client after `start_*`. The client passes it
 /// back on `finish_*` so we can look up the corresponding webauthn-rs state.
 /// 16 random bytes, hex-encoded (32 chars).
 pub type ChallengeId = String;
 
-/// Materialised outcome of `finish_authentication`: the caller is expected
-/// to persist the counter update via `AuthStore::transact` and then mint a
-/// session.
+/// Materialised outcome of `finish_authentication`.
+///
+/// `updated_credential` carries the `Passkey` blob rewritten with the
+/// counter/backup-state update produced by the authenticator. The caller
+/// MUST persist it via `AuthStore::transact(|s| Ok((s.upsert_credential(
+/// updated), ())))` before minting a session — without that write, the
+/// stored `public_key` blob's counter baseline never advances, and
+/// webauthn-rs's clone-detection monotonicity check (which compares
+/// incoming counters against the baseline INSIDE the stored blob) is
+/// silently inert for every subsequent login. `None` means the
+/// authenticator reported no change and the blob does not need to be
+/// rewritten (e.g., counterless synced passkeys with identical backup
+/// state) — this is the `Passkey::update_credential` returning
+/// `Some(false)` case, not an error.
 #[derive(Debug, Clone)]
-pub struct AuthenticationOutcome {
+pub struct VerifiedAuthentication {
     pub credential_id: String,
     pub new_counter: u32,
     pub user_verified: bool,
+    pub updated_credential: Option<Credential>,
 }
 
-pub struct WebAuthnCeremony {
+/// Long-lived WebAuthn ceremony coordinator.
+///
+/// Construct ONCE at application startup and share via `Arc<WebAuthnService>`
+/// across all request handlers — `start_*` and `finish_*` for the same
+/// ceremony must observe the same in-memory challenge store, so
+/// reconstructing per-request would silently drop every pending challenge.
+/// Named `*Service` rather than `*Ceremony` because in the WebAuthn spec a
+/// "ceremony" is a single exchange; this struct is the coordinator, not the
+/// exchange.
+pub struct WebAuthnService {
     webauthn: Webauthn,
     pending_registrations: Mutex<HashMap<ChallengeId, (PasskeyRegistration, SystemTime)>>,
     pending_authentications: Mutex<HashMap<ChallengeId, (PasskeyAuthentication, SystemTime)>>,
 }
 
-impl WebAuthnCeremony {
-    /// Build a ceremony bound to a specific RP ID + origin. `rp_name` is the
+impl WebAuthnService {
+    /// Build a service bound to a specific RP ID + origin. `rp_name` is the
     /// human-readable string that shows up in the browser's passkey dialogue.
+    ///
+    /// Intended to be called once at startup; share the result via `Arc`
+    /// across request handlers so pending challenges persist between
+    /// `start_*` and `finish_*` calls on the same ceremony.
     pub fn new(rp_id: &str, rp_name: &str, origin: &str) -> Result<Self> {
-        let origin_url =
-            Url::parse(origin).map_err(|e| AuthError::WebAuthn(format!("bad origin: {e}")))?;
+        let origin_url = Url::parse(origin)
+            .map_err(|e| AuthError::WebAuthnConfig(format!("bad origin: {e}")))?;
         let webauthn = WebauthnBuilder::new(rp_id, &origin_url)
-            .map_err(|e| AuthError::WebAuthn(e.to_string()))?
+            .map_err(|e| AuthError::WebAuthnConfig(e.to_string()))?
             .rp_name(rp_name)
             .build()
-            .map_err(|e| AuthError::WebAuthn(e.to_string()))?;
+            .map_err(|e| AuthError::WebAuthnConfig(e.to_string()))?;
         Ok(Self {
             webauthn,
             pending_registrations: Mutex::new(HashMap::new()),
@@ -117,10 +154,13 @@ impl WebAuthnCeremony {
             .map_err(|e| AuthError::WebAuthn(e.to_string()))?;
 
         let id = random_hex(16);
-        self.pending_registrations
-            .lock()
-            .expect("challenge store mutex poisoned")
-            .insert(id.clone(), (reg_state, now + CHALLENGE_TTL));
+        insert_pending(
+            &self.pending_registrations,
+            id.clone(),
+            reg_state,
+            now + CHALLENGE_TTL,
+            now,
+        )?;
         Ok((id, ccr))
     }
 
@@ -206,23 +246,37 @@ impl WebAuthnCeremony {
             .map_err(|e| AuthError::WebAuthn(e.to_string()))?;
 
         let id = random_hex(16);
-        self.pending_authentications
-            .lock()
-            .expect("challenge store mutex poisoned")
-            .insert(id.clone(), (auth_state, now + CHALLENGE_TTL));
+        insert_pending(
+            &self.pending_authentications,
+            id.clone(),
+            auth_state,
+            now + CHALLENGE_TTL,
+            now,
+        )?;
         Ok((id, rcr))
     }
 
-    /// Finish an authentication ceremony. Caller must persist the returned
-    /// counter update — a signature counter regressing is webauthn-rs's
-    /// signal that the credential has been cloned (or replayed from an
-    /// older interaction) and further use should be refused.
+    /// Finish an authentication ceremony.
+    ///
+    /// Takes the caller's current credential set so we can look up the
+    /// stored `Passkey` by its cred-id, apply the counter/backup-state
+    /// update from the authenticator's assertion, and hand the refreshed
+    /// `Credential` back for the caller to persist. Without this refresh,
+    /// webauthn-rs's clone-detection baseline (stored inside the serialized
+    /// `Passkey` blob) never advances and monotonicity enforcement is
+    /// inert on every login after the first — a cloned authenticator could
+    /// then replay indefinitely.
+    ///
+    /// `updated_credential` is `None` when `Passkey::update_credential`
+    /// reports no change (counterless synced passkeys with matching backup
+    /// state are the common case) — the caller can then skip the write.
     pub fn finish_authentication(
         &self,
         challenge_id: &str,
         response: &PublicKeyCredential,
+        credentials: &[Credential],
         now: SystemTime,
-    ) -> Result<AuthenticationOutcome> {
+    ) -> Result<VerifiedAuthentication> {
         let (auth_state, expires_at) = self
             .pending_authentications
             .lock()
@@ -238,14 +292,35 @@ impl WebAuthnCeremony {
             .finish_passkey_authentication(response, &auth_state)
             .map_err(|e| AuthError::WebAuthn(e.to_string()))?;
 
-        Ok(AuthenticationOutcome {
-            credential_id: encode_credential_id(result.cred_id()),
-            new_counter: result.counter(),
-            user_verified: result.user_verified(),
+        let credential_id = encode_credential_id(result.cred_id());
+        let new_counter = result.counter();
+        let user_verified = result.user_verified();
+
+        // Find the matching stored credential so we can advance its
+        // Passkey blob's internal counter. Not finding it would be surprising
+        // — `finish_passkey_authentication` only succeeds against a cred_id
+        // we included in the `auth_state` at start — but we handle it
+        // defensively rather than panicking, since a concurrent delete
+        // between start and finish is theoretically possible.
+        let updated_credential = credentials
+            .iter()
+            .find(|c| c.id == credential_id)
+            .and_then(|cred| apply_auth_result(cred, &result).transpose())
+            .transpose()?;
+
+        Ok(VerifiedAuthentication {
+            credential_id,
+            new_counter,
+            user_verified,
+            updated_credential,
         })
     }
 
     /// Drop challenges whose TTL has elapsed. Cheap to call periodically.
+    /// The HTTP / server layer is expected to schedule this (e.g. every
+    /// minute via `tokio::time::interval`); `start_*` also runs an
+    /// opportunistic prune before the capacity check to keep the maps from
+    /// filling up between scheduled sweeps.
     pub fn prune_expired_challenges(&self, now: SystemTime) {
         self.pending_registrations
             .lock()
@@ -256,12 +331,66 @@ impl WebAuthnCeremony {
             .expect("challenge store mutex poisoned")
             .retain(|_, (_, exp)| now < *exp);
     }
+}
 
-    /// Produce the JSON bytes representing a `Passkey` for a fresh
-    /// `Credential`. Exposed for tests and for internal tooling that needs
-    /// to reconstruct the full passkey from stored material.
-    pub fn passkey_from_credential(cred: &Credential) -> Result<Passkey> {
-        serde_json::from_slice(&cred.public_key).map_err(|e| AuthError::WebAuthn(e.to_string()))
+/// Apply a WebAuthn authentication assertion to the stored `Passkey`
+/// blob and return the resulting `Credential` if anything changed.
+///
+/// `None` means the authenticator reported no counter / backup-state
+/// delta (common for counterless synced passkeys), so the caller should
+/// skip the write. `Some(updated)` means the `Passkey` advanced and the
+/// caller must upsert — failing to persist leaves clone-detection stuck
+/// at the previous baseline.
+fn apply_auth_result(cred: &Credential, result: &AuthenticationResult) -> Result<Option<Credential>> {
+    let mut passkey = cred.to_passkey()?;
+    match passkey.update_credential(result) {
+        Some(true) => {
+            let material =
+                serde_json::to_vec(&passkey).map_err(|e| AuthError::WebAuthn(e.to_string()))?;
+            Ok(Some(Credential {
+                public_key: material,
+                counter: result.counter(),
+                ..cred.clone()
+            }))
+        }
+        // `Some(false)` — cred id matched but nothing to update.
+        // `None` — cred id didn't match, which would mean webauthn-rs
+        // verified against one passkey but we're looking up a different
+        // credential; treat as "nothing to persist on THIS record" so we
+        // don't write a same-bytes blob on an unrelated credential.
+        Some(false) | None => Ok(None),
+    }
+}
+
+/// Insert `(value, expires_at)` at `id`, first pruning expired entries
+/// and then refusing if the map is still at `MAX_PENDING_CHALLENGES`.
+/// The prune runs before the cap check so an organic build-up of stale
+/// entries doesn't lock out legitimate starts.
+fn insert_pending<T>(
+    store: &Mutex<HashMap<ChallengeId, (T, SystemTime)>>,
+    id: ChallengeId,
+    value: T,
+    expires_at: SystemTime,
+    now: SystemTime,
+) -> Result<()> {
+    let mut guard = store.lock().expect("challenge store mutex poisoned");
+    guard.retain(|_, (_, exp)| now < *exp);
+    if guard.len() >= MAX_PENDING_CHALLENGES {
+        return Err(AuthError::TooManyPendingChallenges);
+    }
+    guard.insert(id, (value, expires_at));
+    Ok(())
+}
+
+impl Credential {
+    /// Deserialize the stored `Passkey` blob.
+    ///
+    /// Lives on `Credential` rather than `WebAuthnService` because the
+    /// conversion is pure value-to-value and has no relationship to
+    /// ceremony state — a caller with just a `Credential` shouldn't need
+    /// to hold the service to read its own blob.
+    pub fn to_passkey(&self) -> Result<Passkey> {
+        serde_json::from_slice(&self.public_key).map_err(|e| AuthError::WebAuthn(e.to_string()))
     }
 }
 
@@ -276,55 +405,40 @@ fn decode_credential_id(s: &str) -> Result<CredentialID> {
     Ok(CredentialID::from(bytes))
 }
 
-fn random_hex(bytes: usize) -> String {
-    let mut buf = vec![0u8; bytes];
-    OsRng.fill_bytes(&mut buf);
-    let mut out = String::with_capacity(bytes * 2);
-    for b in buf {
-        write!(&mut out, "{b:02x}").expect("write to String cannot fail");
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn ceremony() -> WebAuthnCeremony {
-        WebAuthnCeremony::new(
-            "katulong.test",
-            "katulong",
-            "https://katulong.test",
-        )
-        .expect("ceremony should build with a well-formed origin")
+    fn service() -> WebAuthnService {
+        WebAuthnService::new("katulong.test", "katulong", "https://katulong.test")
+            .expect("service should build with a well-formed origin")
     }
 
-    // `WebAuthnCeremony` wraps `webauthn_rs::Webauthn`, which doesn't
-    // implement `Debug`, so we can't `#[derive(Debug)]` on the ceremony and
-    // therefore can't use `Result::unwrap_err` on `WebAuthnCeremony::new`'s
+    // `WebAuthnService` wraps `webauthn_rs::Webauthn`, which doesn't
+    // implement `Debug`, so we can't `#[derive(Debug)]` on the service and
+    // therefore can't use `Result::unwrap_err` on `WebAuthnService::new`'s
     // return. Pattern-match the error variant directly — same coverage,
     // doesn't require the Ok type to be printable.
     #[test]
     fn new_rejects_bad_origin() {
-        let Err(err) = WebAuthnCeremony::new("katulong.test", "katulong", "not a url") else {
-            panic!("expected WebAuthnCeremony::new to reject a non-URL origin");
+        let Err(err) = WebAuthnService::new("katulong.test", "katulong", "not a url") else {
+            panic!("expected WebAuthnService::new to reject a non-URL origin");
         };
-        assert!(matches!(err, AuthError::WebAuthn(_)));
+        assert!(matches!(err, AuthError::WebAuthnConfig(_)));
     }
 
     #[test]
     fn new_rejects_rp_mismatch() {
         // RP id must be a registrable domain suffix of the origin host.
-        let Err(err) = WebAuthnCeremony::new("other.example", "x", "https://katulong.test")
-        else {
-            panic!("expected WebAuthnCeremony::new to reject an rp_id that doesn't suffix the origin host");
+        let Err(err) = WebAuthnService::new("other.example", "x", "https://katulong.test") else {
+            panic!("expected WebAuthnService::new to reject an rp_id that doesn't suffix the origin host");
         };
-        assert!(matches!(err, AuthError::WebAuthn(_)));
+        assert!(matches!(err, AuthError::WebAuthnConfig(_)));
     }
 
     #[test]
     fn start_registration_returns_unique_challenge_ids() {
-        let svc = ceremony();
+        let svc = service();
         let (id1, _) = svc
             .start_registration(
                 Uuid::new_v4(),
@@ -349,7 +463,7 @@ mod tests {
 
     #[test]
     fn finish_registration_rejects_unknown_challenge() {
-        let svc = ceremony();
+        let svc = service();
         let fake = fake_register_response();
         let err = svc
             .finish_registration("nope", &fake, SystemTime::UNIX_EPOCH)
@@ -359,7 +473,7 @@ mod tests {
 
     #[test]
     fn finish_registration_rejects_expired_challenge() {
-        let svc = ceremony();
+        let svc = service();
         let start = SystemTime::UNIX_EPOCH;
         let (id, _) = svc
             .start_registration(Uuid::new_v4(), "u", "U", &[], start)
@@ -374,7 +488,7 @@ mod tests {
     fn finish_registration_consumes_challenge_on_failure() {
         // A bogus response must still burn the challenge — otherwise an
         // attacker could keep trying against the same server-side state.
-        let svc = ceremony();
+        let svc = service();
         let start = SystemTime::UNIX_EPOCH;
         let (id, _) = svc
             .start_registration(Uuid::new_v4(), "u", "U", &[], start)
@@ -388,7 +502,7 @@ mod tests {
 
     #[test]
     fn start_authentication_rejects_empty_credential_set() {
-        let svc = ceremony();
+        let svc = service();
         let err = svc.start_authentication(&[], SystemTime::UNIX_EPOCH).unwrap_err();
         assert!(matches!(err, AuthError::WebAuthn(_)));
     }
@@ -398,7 +512,7 @@ mod tests {
         // A stored row with non-JSON material must not poison the ceremony —
         // it just gets silently dropped from the allowCredentials list.
         // With no other credentials, that reduces to the empty-set error.
-        let svc = ceremony();
+        let svc = service();
         let bad = Credential {
             id: "cred-bad".into(),
             public_key: b"not-json".to_vec(),
@@ -416,7 +530,7 @@ mod tests {
 
     #[test]
     fn prune_expired_challenges_removes_stale_entries() {
-        let svc = ceremony();
+        let svc = service();
         let start = SystemTime::UNIX_EPOCH;
         let (_, _) = svc
             .start_registration(Uuid::new_v4(), "u", "U", &[], start)
@@ -424,6 +538,50 @@ mod tests {
         assert_eq!(svc.pending_registrations.lock().unwrap().len(), 1);
         svc.prune_expired_challenges(start + CHALLENGE_TTL + Duration::from_secs(1));
         assert_eq!(svc.pending_registrations.lock().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn insert_pending_caps_the_map_after_pruning() {
+        // Uses a bare `Mutex<HashMap<_, ((), SystemTime)>>` so we can
+        // exercise the cap without needing real webauthn-rs state objects.
+        let store: Mutex<HashMap<ChallengeId, ((), SystemTime)>> = Mutex::new(HashMap::new());
+        let now = SystemTime::UNIX_EPOCH;
+        let future = now + Duration::from_secs(600);
+
+        // Fill to capacity with live entries.
+        for i in 0..MAX_PENDING_CHALLENGES {
+            insert_pending(&store, format!("k{i}"), (), future, now)
+                .expect("fill to capacity should succeed");
+        }
+
+        // One more live entry should be rejected.
+        let err = insert_pending(&store, "overflow".into(), (), future, now).unwrap_err();
+        assert!(matches!(err, AuthError::TooManyPendingChallenges));
+
+        // After the TTL has elapsed, stale entries prune on insert and
+        // a new entry is accepted.
+        let later = future + Duration::from_secs(1);
+        insert_pending(&store, "after-prune".into(), (), later + Duration::from_secs(60), later)
+            .expect("prune should reclaim space");
+        let guard = store.lock().unwrap();
+        assert_eq!(guard.len(), 1, "prune should have dropped expired entries");
+        assert!(guard.contains_key("after-prune"));
+    }
+
+    #[test]
+    fn credential_to_passkey_roundtrips_via_blob() {
+        // Deserializing a hand-rolled non-JSON blob must fail cleanly with
+        // a WebAuthn error, not panic.
+        let bad = Credential {
+            id: "x".into(),
+            public_key: b"not-json".to_vec(),
+            name: None,
+            counter: 0,
+            created_at: SystemTime::UNIX_EPOCH,
+            setup_token_id: None,
+        };
+        let err = bad.to_passkey().unwrap_err();
+        assert!(matches!(err, AuthError::WebAuthn(_)));
     }
 
     fn fake_register_response() -> RegisterPublicKeyCredential {

--- a/crates/auth/src/webauthn.rs
+++ b/crates/auth/src/webauthn.rs
@@ -1,0 +1,446 @@
+//! WebAuthn registration and authentication ceremonies.
+//!
+//! Thin wrapper over `webauthn-rs` that owns the in-memory challenge store
+//! between `start_*` and `finish_*` requests. Challenges are time-limited
+//! and single-use: `finish_*` removes the entry before verifying, so a
+//! replayed response against a valid challenge ID fails by missing state
+//! rather than by re-verifying against a resident challenge.
+//!
+//! # RP ID and origin come from configuration
+//!
+//! WebAuthn binds credentials to the relying-party ID (hostname) and validates
+//! assertions against the exact origin (`scheme://host:port`). Both must come
+//! from operator-controlled configuration — NOT from request headers.
+//!
+//! This is a deliberate departure from the Node implementation, which
+//! trusted `X-Forwarded-Proto` as a fallback for tunnel deployments
+//! (`21045b2`). That tradeoff made sense when "we only trust it for
+//! origin matching, the cryptographic assertion is the real auth gate," but
+//! katulong's current posture is "never trust forwarded headers for anything
+//! security-adjacent." In the Rust port we require the operator to set the
+//! public origin at startup (likely the same URL the tunnel exposes); that
+//! way spoofing `X-Forwarded-Proto` can't trick us into accepting assertions
+//! from a different origin.
+//!
+//! # Registration vs login API asymmetry
+//!
+//! Platform-authenticator preference is expressed differently on the two
+//! ceremonies. On registration we can steer the UI toward the platform
+//! authenticator via `authenticatorAttachment: "platform"`; on login that
+//! field doesn't exist, and the steering is done by `allowCredentials`
+//! `transports: ["internal"]`. Node learned this the hard way in `9198b6e`.
+//! webauthn-rs handles the registration side for us; on the login side
+//! we pass only `Passkey` values we already stored, which encode the same
+//! intent.
+
+use crate::{AuthError, Credential, Result};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use rand_core::{OsRng, RngCore};
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime};
+use url::Url;
+use uuid::Uuid;
+use webauthn_rs::prelude::*;
+use webauthn_rs::{Webauthn, WebauthnBuilder};
+
+/// How long a generated challenge stays valid on the server. Five minutes
+/// is comfortably longer than any real user would take to respond to a
+/// biometric prompt, and short enough that a captured challenge ID can't
+/// linger for an attacker to replay.
+const CHALLENGE_TTL: Duration = Duration::from_secs(5 * 60);
+
+/// Opaque handle returned to the client after `start_*`. The client passes it
+/// back on `finish_*` so we can look up the corresponding webauthn-rs state.
+/// 16 random bytes, hex-encoded (32 chars).
+pub type ChallengeId = String;
+
+/// Materialised outcome of `finish_authentication`: the caller is expected
+/// to persist the counter update via `AuthStore::transact` and then mint a
+/// session.
+#[derive(Debug, Clone)]
+pub struct AuthenticationOutcome {
+    pub credential_id: String,
+    pub new_counter: u32,
+    pub user_verified: bool,
+}
+
+pub struct WebAuthnCeremony {
+    webauthn: Webauthn,
+    pending_registrations: Mutex<HashMap<ChallengeId, (PasskeyRegistration, SystemTime)>>,
+    pending_authentications: Mutex<HashMap<ChallengeId, (PasskeyAuthentication, SystemTime)>>,
+}
+
+impl WebAuthnCeremony {
+    /// Build a ceremony bound to a specific RP ID + origin. `rp_name` is the
+    /// human-readable string that shows up in the browser's passkey dialogue.
+    pub fn new(rp_id: &str, rp_name: &str, origin: &str) -> Result<Self> {
+        let origin_url =
+            Url::parse(origin).map_err(|e| AuthError::WebAuthn(format!("bad origin: {e}")))?;
+        let webauthn = WebauthnBuilder::new(rp_id, &origin_url)
+            .map_err(|e| AuthError::WebAuthn(e.to_string()))?
+            .rp_name(rp_name)
+            .build()
+            .map_err(|e| AuthError::WebAuthn(e.to_string()))?;
+        Ok(Self {
+            webauthn,
+            pending_registrations: Mutex::new(HashMap::new()),
+            pending_authentications: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Start a registration ceremony. `existing` is the current list of
+    /// credentials so the browser can reject re-registration of the same
+    /// authenticator via `excludeCredentials`.
+    ///
+    /// Malformed stored credential IDs are filtered out rather than causing
+    /// the whole ceremony to abort — one bad row shouldn't poison
+    /// registration for the rest of the instance (Node scar: `2d73b6c`).
+    pub fn start_registration(
+        &self,
+        user_unique_id: Uuid,
+        user_name: &str,
+        user_display_name: &str,
+        existing: &[Credential],
+        now: SystemTime,
+    ) -> Result<(ChallengeId, CreationChallengeResponse)> {
+        let exclude: Vec<CredentialID> = existing
+            .iter()
+            .filter_map(|c| decode_credential_id(&c.id).ok())
+            .collect();
+        let exclude = (!exclude.is_empty()).then_some(exclude);
+
+        let (ccr, reg_state) = self
+            .webauthn
+            .start_passkey_registration(user_unique_id, user_name, user_display_name, exclude)
+            .map_err(|e| AuthError::WebAuthn(e.to_string()))?;
+
+        let id = random_hex(16);
+        self.pending_registrations
+            .lock()
+            .expect("challenge store mutex poisoned")
+            .insert(id.clone(), (reg_state, now + CHALLENGE_TTL));
+        Ok((id, ccr))
+    }
+
+    /// Finish a registration ceremony, producing a `Credential` ready to be
+    /// inserted into the store. The challenge is consumed regardless of
+    /// success — a verify failure must not leave the challenge in the map
+    /// for the attacker to try again.
+    pub fn finish_registration(
+        &self,
+        challenge_id: &str,
+        response: &RegisterPublicKeyCredential,
+        now: SystemTime,
+    ) -> Result<Credential> {
+        let (reg_state, expires_at) = self
+            .pending_registrations
+            .lock()
+            .expect("challenge store mutex poisoned")
+            .remove(challenge_id)
+            .ok_or(AuthError::ChallengeNotFound)?;
+        if now >= expires_at {
+            return Err(AuthError::ChallengeNotFound);
+        }
+
+        let passkey = self
+            .webauthn
+            .finish_passkey_registration(response, &reg_state)
+            .map_err(|e| AuthError::WebAuthn(e.to_string()))?;
+
+        let id = encode_credential_id(passkey.cred_id());
+        let material =
+            serde_json::to_vec(&passkey).map_err(|e| AuthError::WebAuthn(e.to_string()))?;
+
+        // webauthn-rs's public `Passkey` API deliberately hides the signature
+        // counter (only `cred_id`, `cred_algorithm`, `get_public_key`, and
+        // `update_credential` are exposed). The authoritative counter lives
+        // inside the serialized `Passkey` blob in `public_key` — webauthn-rs
+        // unpacks it on every `finish_passkey_authentication` and enforces
+        // monotonicity there (clone-detection happens inside the library,
+        // not against our field). Our `Credential.counter` is a display/audit
+        // echo: start at 0 and keep it in sync via
+        // `AuthenticationOutcome.new_counter` on each subsequent login.
+        //
+        // Reaching into `Passkey` via the `danger-credential-internals`
+        // feature was considered and rejected — the feature name is a flag,
+        // and the only win would be echoing a (usually-zero) initial value a
+        // few seconds earlier than the first successful auth would update it.
+        Ok(Credential {
+            id,
+            public_key: material,
+            name: None,
+            counter: 0,
+            created_at: now,
+            setup_token_id: None,
+        })
+    }
+
+    /// Start an authentication ceremony. `credentials` is the server's
+    /// complete set of registered credentials (we iterate them all since
+    /// katulong is single-user and credential count is tiny); webauthn-rs
+    /// builds `allowCredentials` from the embedded passkey payload, which
+    /// already carries the correct transports.
+    ///
+    /// Returns an error if there are no parseable credentials — no point
+    /// issuing a login challenge against nothing.
+    pub fn start_authentication(
+        &self,
+        credentials: &[Credential],
+        now: SystemTime,
+    ) -> Result<(ChallengeId, RequestChallengeResponse)> {
+        let passkeys: Vec<Passkey> = credentials
+            .iter()
+            .filter_map(|c| serde_json::from_slice(&c.public_key).ok())
+            .collect();
+        if passkeys.is_empty() {
+            return Err(AuthError::WebAuthn(
+                "no usable credentials registered".into(),
+            ));
+        }
+
+        let (rcr, auth_state) = self
+            .webauthn
+            .start_passkey_authentication(&passkeys)
+            .map_err(|e| AuthError::WebAuthn(e.to_string()))?;
+
+        let id = random_hex(16);
+        self.pending_authentications
+            .lock()
+            .expect("challenge store mutex poisoned")
+            .insert(id.clone(), (auth_state, now + CHALLENGE_TTL));
+        Ok((id, rcr))
+    }
+
+    /// Finish an authentication ceremony. Caller must persist the returned
+    /// counter update — a signature counter regressing is webauthn-rs's
+    /// signal that the credential has been cloned (or replayed from an
+    /// older interaction) and further use should be refused.
+    pub fn finish_authentication(
+        &self,
+        challenge_id: &str,
+        response: &PublicKeyCredential,
+        now: SystemTime,
+    ) -> Result<AuthenticationOutcome> {
+        let (auth_state, expires_at) = self
+            .pending_authentications
+            .lock()
+            .expect("challenge store mutex poisoned")
+            .remove(challenge_id)
+            .ok_or(AuthError::ChallengeNotFound)?;
+        if now >= expires_at {
+            return Err(AuthError::ChallengeNotFound);
+        }
+
+        let result = self
+            .webauthn
+            .finish_passkey_authentication(response, &auth_state)
+            .map_err(|e| AuthError::WebAuthn(e.to_string()))?;
+
+        Ok(AuthenticationOutcome {
+            credential_id: encode_credential_id(result.cred_id()),
+            new_counter: result.counter(),
+            user_verified: result.user_verified(),
+        })
+    }
+
+    /// Drop challenges whose TTL has elapsed. Cheap to call periodically.
+    pub fn prune_expired_challenges(&self, now: SystemTime) {
+        self.pending_registrations
+            .lock()
+            .expect("challenge store mutex poisoned")
+            .retain(|_, (_, exp)| now < *exp);
+        self.pending_authentications
+            .lock()
+            .expect("challenge store mutex poisoned")
+            .retain(|_, (_, exp)| now < *exp);
+    }
+
+    /// Produce the JSON bytes representing a `Passkey` for a fresh
+    /// `Credential`. Exposed for tests and for internal tooling that needs
+    /// to reconstruct the full passkey from stored material.
+    pub fn passkey_from_credential(cred: &Credential) -> Result<Passkey> {
+        serde_json::from_slice(&cred.public_key).map_err(|e| AuthError::WebAuthn(e.to_string()))
+    }
+}
+
+fn encode_credential_id(cred_id: &CredentialID) -> String {
+    URL_SAFE_NO_PAD.encode(cred_id.as_ref())
+}
+
+fn decode_credential_id(s: &str) -> Result<CredentialID> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(s)
+        .map_err(|e| AuthError::WebAuthn(format!("credential id: {e}")))?;
+    Ok(CredentialID::from(bytes))
+}
+
+fn random_hex(bytes: usize) -> String {
+    let mut buf = vec![0u8; bytes];
+    OsRng.fill_bytes(&mut buf);
+    let mut out = String::with_capacity(bytes * 2);
+    for b in buf {
+        write!(&mut out, "{b:02x}").expect("write to String cannot fail");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ceremony() -> WebAuthnCeremony {
+        WebAuthnCeremony::new(
+            "katulong.test",
+            "katulong",
+            "https://katulong.test",
+        )
+        .expect("ceremony should build with a well-formed origin")
+    }
+
+    // `WebAuthnCeremony` wraps `webauthn_rs::Webauthn`, which doesn't
+    // implement `Debug`, so we can't `#[derive(Debug)]` on the ceremony and
+    // therefore can't use `Result::unwrap_err` on `WebAuthnCeremony::new`'s
+    // return. Pattern-match the error variant directly — same coverage,
+    // doesn't require the Ok type to be printable.
+    #[test]
+    fn new_rejects_bad_origin() {
+        let Err(err) = WebAuthnCeremony::new("katulong.test", "katulong", "not a url") else {
+            panic!("expected WebAuthnCeremony::new to reject a non-URL origin");
+        };
+        assert!(matches!(err, AuthError::WebAuthn(_)));
+    }
+
+    #[test]
+    fn new_rejects_rp_mismatch() {
+        // RP id must be a registrable domain suffix of the origin host.
+        let Err(err) = WebAuthnCeremony::new("other.example", "x", "https://katulong.test")
+        else {
+            panic!("expected WebAuthnCeremony::new to reject an rp_id that doesn't suffix the origin host");
+        };
+        assert!(matches!(err, AuthError::WebAuthn(_)));
+    }
+
+    #[test]
+    fn start_registration_returns_unique_challenge_ids() {
+        let svc = ceremony();
+        let (id1, _) = svc
+            .start_registration(
+                Uuid::new_v4(),
+                "felix",
+                "Felix",
+                &[],
+                SystemTime::UNIX_EPOCH,
+            )
+            .unwrap();
+        let (id2, _) = svc
+            .start_registration(
+                Uuid::new_v4(),
+                "felix",
+                "Felix",
+                &[],
+                SystemTime::UNIX_EPOCH,
+            )
+            .unwrap();
+        assert_ne!(id1, id2);
+        assert_eq!(id1.len(), 32);
+    }
+
+    #[test]
+    fn finish_registration_rejects_unknown_challenge() {
+        let svc = ceremony();
+        let fake = fake_register_response();
+        let err = svc
+            .finish_registration("nope", &fake, SystemTime::UNIX_EPOCH)
+            .unwrap_err();
+        assert!(matches!(err, AuthError::ChallengeNotFound));
+    }
+
+    #[test]
+    fn finish_registration_rejects_expired_challenge() {
+        let svc = ceremony();
+        let start = SystemTime::UNIX_EPOCH;
+        let (id, _) = svc
+            .start_registration(Uuid::new_v4(), "u", "U", &[], start)
+            .unwrap();
+        let fake = fake_register_response();
+        let later = start + CHALLENGE_TTL + Duration::from_secs(1);
+        let err = svc.finish_registration(&id, &fake, later).unwrap_err();
+        assert!(matches!(err, AuthError::ChallengeNotFound));
+    }
+
+    #[test]
+    fn finish_registration_consumes_challenge_on_failure() {
+        // A bogus response must still burn the challenge — otherwise an
+        // attacker could keep trying against the same server-side state.
+        let svc = ceremony();
+        let start = SystemTime::UNIX_EPOCH;
+        let (id, _) = svc
+            .start_registration(Uuid::new_v4(), "u", "U", &[], start)
+            .unwrap();
+        let fake = fake_register_response();
+        let _ = svc.finish_registration(&id, &fake, start);
+        // Second attempt finds no state even with the same id.
+        let err = svc.finish_registration(&id, &fake, start).unwrap_err();
+        assert!(matches!(err, AuthError::ChallengeNotFound));
+    }
+
+    #[test]
+    fn start_authentication_rejects_empty_credential_set() {
+        let svc = ceremony();
+        let err = svc.start_authentication(&[], SystemTime::UNIX_EPOCH).unwrap_err();
+        assert!(matches!(err, AuthError::WebAuthn(_)));
+    }
+
+    #[test]
+    fn start_authentication_filters_malformed_credentials() {
+        // A stored row with non-JSON material must not poison the ceremony —
+        // it just gets silently dropped from the allowCredentials list.
+        // With no other credentials, that reduces to the empty-set error.
+        let svc = ceremony();
+        let bad = Credential {
+            id: "cred-bad".into(),
+            public_key: b"not-json".to_vec(),
+            name: None,
+            counter: 0,
+            created_at: SystemTime::UNIX_EPOCH,
+            setup_token_id: None,
+        };
+        let err = svc
+            .start_authentication(std::slice::from_ref(&bad), SystemTime::UNIX_EPOCH)
+            .unwrap_err();
+        // Empty after filter → "no usable credentials".
+        assert!(matches!(err, AuthError::WebAuthn(_)));
+    }
+
+    #[test]
+    fn prune_expired_challenges_removes_stale_entries() {
+        let svc = ceremony();
+        let start = SystemTime::UNIX_EPOCH;
+        let (_, _) = svc
+            .start_registration(Uuid::new_v4(), "u", "U", &[], start)
+            .unwrap();
+        assert_eq!(svc.pending_registrations.lock().unwrap().len(), 1);
+        svc.prune_expired_challenges(start + CHALLENGE_TTL + Duration::from_secs(1));
+        assert_eq!(svc.pending_registrations.lock().unwrap().len(), 0);
+    }
+
+    fn fake_register_response() -> RegisterPublicKeyCredential {
+        // Syntactically minimal, cryptographically invalid — enough to
+        // exercise the challenge lifecycle without running real crypto.
+        serde_json::from_str(
+            r#"{
+                "id": "AAAA",
+                "rawId": "AAAA",
+                "response": {
+                    "clientDataJSON": "",
+                    "attestationObject": ""
+                },
+                "type": "public-key",
+                "extensions": {}
+            }"#,
+        )
+        .expect("fake response should parse")
+    }
+}

--- a/crates/auth/src/webauthn.rs
+++ b/crates/auth/src/webauthn.rs
@@ -82,6 +82,12 @@ pub type ChallengeId = String;
 /// rewritten (e.g., counterless synced passkeys with identical backup
 /// state) — this is the `Passkey::update_credential` returning
 /// `Some(false)` case, not an error.
+///
+/// `#[must_use]` applies to the whole struct: forgetting to inspect
+/// `updated_credential` silently reopens the clone-detection gap this
+/// slice was built to close, so the compiler should warn if the whole
+/// value is dropped without a match.
+#[must_use = "updated_credential must be persisted via AuthStore or webauthn-rs clone-detection is inert"]
 #[derive(Debug, Clone)]
 pub struct VerifiedAuthentication {
     pub credential_id: String,
@@ -201,7 +207,7 @@ impl WebAuthnService {
         // monotonicity there (clone-detection happens inside the library,
         // not against our field). Our `Credential.counter` is a display/audit
         // echo: start at 0 and keep it in sync via
-        // `AuthenticationOutcome.new_counter` on each subsequent login.
+        // `VerifiedAuthentication.new_counter` on each subsequent login.
         //
         // Reaching into `Passkey` via the `danger-credential-internals`
         // feature was considered and rejected — the feature name is a flag,
@@ -296,17 +302,22 @@ impl WebAuthnService {
         let new_counter = result.counter();
         let user_verified = result.user_verified();
 
-        // Find the matching stored credential so we can advance its
-        // Passkey blob's internal counter. Not finding it would be surprising
-        // — `finish_passkey_authentication` only succeeds against a cred_id
-        // we included in the `auth_state` at start — but we handle it
-        // defensively rather than panicking, since a concurrent delete
-        // between start and finish is theoretically possible.
-        let updated_credential = credentials
+        // The stored credential must still exist for the assertion to be
+        // meaningful: `start_authentication` captured it in `auth_state`, and
+        // an admin revocation during the 5-minute challenge window (or any
+        // other deletion) means the passkey has been explicitly disallowed.
+        // Letting the ceremony succeed anyway would defeat revocation — the
+        // caller would mint a session against a credential the admin
+        // already pulled. Fail closed.
+        let cred = credentials
             .iter()
             .find(|c| c.id == credential_id)
-            .and_then(|cred| apply_auth_result(cred, &result).transpose())
-            .transpose()?;
+            .ok_or_else(|| {
+                AuthError::WebAuthn(
+                    "credential revoked or missing after successful ceremony".into(),
+                )
+            })?;
+        let updated_credential = apply_auth_result(cred, &result)?;
 
         Ok(VerifiedAuthentication {
             credential_id,
@@ -341,7 +352,10 @@ impl WebAuthnService {
 /// skip the write. `Some(updated)` means the `Passkey` advanced and the
 /// caller must upsert — failing to persist leaves clone-detection stuck
 /// at the previous baseline.
-fn apply_auth_result(cred: &Credential, result: &AuthenticationResult) -> Result<Option<Credential>> {
+fn apply_auth_result(
+    cred: &Credential,
+    result: &AuthenticationResult,
+) -> Result<Option<Credential>> {
     let mut passkey = cred.to_passkey()?;
     match passkey.update_credential(result) {
         Some(true) => {
@@ -353,12 +367,19 @@ fn apply_auth_result(cred: &Credential, result: &AuthenticationResult) -> Result
                 ..cred.clone()
             }))
         }
-        // `Some(false)` — cred id matched but nothing to update.
-        // `None` — cred id didn't match, which would mean webauthn-rs
-        // verified against one passkey but we're looking up a different
-        // credential; treat as "nothing to persist on THIS record" so we
-        // don't write a same-bytes blob on an unrelated credential.
-        Some(false) | None => Ok(None),
+        // Cred id matched, nothing to update — counterless synced passkey
+        // with identical backup state. Safe no-op.
+        Some(false) => Ok(None),
+        // Cred id inside the blob doesn't match the result's cred id.
+        // The caller already looked up `cred` by the result's encoded
+        // cred id, so this means the stored blob disagrees with its
+        // own row — a data-integrity corruption. Fail loudly rather
+        // than silently skipping the counter update, because collapsing
+        // this into `Ok(None)` would leave clone-detection permanently
+        // inert for that credential with no operator-visible signal.
+        None => Err(AuthError::WebAuthn(
+            "credential blob cred_id mismatch; refusing to skip counter update".into(),
+        )),
     }
 }
 


### PR DESCRIPTION
## Summary

Port the passkey ceremony layer to Rust on top of `webauthn-rs` 0.5.

- `crates/auth/src/webauthn.rs` — `WebAuthnCeremony` struct owns the in-memory challenge store between `start_*` and `finish_*`; 5-minute TTL, single-use (entry removed before verify so a replayed response fails by missing state rather than by re-verifying against a resident challenge).
- RP id and origin come from operator configuration at startup — never from request headers. Deliberate deviation from Node (`21045b2` trusted `X-Forwarded-Proto` as a tunnel convenience); this port refuses on principle because spoofing that header would let an attacker on the tunnel bend origin matching.
- `Credential.counter` kept as an audit echo (starts at 0, updated from `AuthenticationOutcome.new_counter` on each login). webauthn-rs's public `Passkey` API doesn't expose the signature counter — the authoritative counter lives inside the serialized blob in `public_key` and webauthn-rs runs the monotonicity check there. `danger-credential-internals` was considered and rejected (feature name is a flag for a reason).
- Malformed-credential tolerance: `start_registration` silently drops non-decodable ids from `excludeCredentials` and `start_authentication` filters non-parseable stored passkeys. One bad row shouldn't lock out the whole instance (Node scar: `2d73b6c`).

## Changes

- `crates/auth/Cargo.toml` — add `webauthn-rs 0.5` (feature `danger-allow-state-serialisation` so we can cache ceremony state in the in-memory map), `url`, `uuid`, `base64`.
- `crates/auth/src/error.rs` — two new variants: `WebAuthn(String)` and `ChallengeNotFound`.
- `crates/auth/src/lib.rs` — export the new module.
- `crates/auth/src/webauthn.rs` — new file, ceremony struct + challenge store + 9 tests.

## Test plan

- [x] `cargo test -p katulong-auth` passes (41 tests, slice 1+2+3)
- [x] `cargo clippy -p katulong-auth --all-targets -- -D warnings` clean
- [ ] Wire into `AuthStore` and an HTTP surface — reserved for a later slice

## Out of scope

This slice is the standalone ceremony module only. Persistence (store integration), HTTP handlers, and session minting after successful auth land in subsequent slices.