### PR TITLE
feat(auth): scoped API keys + mint/consume federation primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ katulong notify <message>               # Send native notification
 # Auth
 katulong token create <name>            # Create setup token (shows QR code)
 katulong apikey create <name>           # Create API key for external access
+katulong apikey create <name> --scope mint-session  # Narrow-scope key for fleet federation
 katulong credential list                # List registered passkeys
+katulong fleet test-mint <url>          # Verify mint-session primitives against an instance
 
 # Other
 katulong info                           # System info
@@ -156,6 +158,10 @@ This application provides direct shell access to the host. Security isn't option
 - **No passwords** — Identity is proven by cryptographic key, not a shared secret.
 - **Localhost bypass** — Local connections auto-authenticate. Remote connections require a session cookie.
 - **30-day sessions** — Server-side tokens, pruned on expiry. No tokens in URLs or localStorage.
+
+Running katulong on multiple hosts? See [`docs/federation-setup.md`](docs/federation-setup.md)
+for how to issue narrow-scope `mint-session` keys so a hub can federate tiles across
+instances without forwarding passkeys.
 
 ## How it works
 

--- a/bin/katulong
+++ b/bin/katulong
@@ -24,6 +24,7 @@ const COMMANDS = {
   info: "Show system information and configuration",
   update: "Update Katulong to the latest version",
   apikey: "Manage API keys (create, list, revoke)",
+  fleet: "Fleet federation helpers (test-mint)",
   token: "Manage setup tokens (create, list, revoke)",
   credential: "Manage passkey credentials (list, revoke)",
   session: "Manage terminal sessions (list, create, kill, rename)",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -128,9 +128,24 @@ katulong apikey create "monitoring" --json
 
 The key is shown **once** — save it immediately.
 
+Keys default to the `full` scope (same authority as a logged-in browser
+session). To mint a narrow-scope key that can only do one thing, pass
+`--scope`:
+
+```bash
+# Can only call /api/sessions/mint — used for fleet federation.
+katulong apikey create "fleet-hub" --scope mint-session --json
+```
+
+Known scopes: `full` (default), `mint-session`. Unknown scopes are
+rejected. Narrow-scope keys are default-denied on every route that
+doesn't explicitly opt in — adding a new scope can't accidentally grant
+access to an existing endpoint. See `docs/federation-setup.md` for the
+mint-session workflow.
+
 ### apikey list
 
-List all API keys.
+List all API keys. The `SCOPES` column shows what each key can do.
 
 ```bash
 katulong apikey list
@@ -144,6 +159,28 @@ Revoke an API key by ID.
 ```bash
 katulong apikey revoke abc123def456
 ```
+
+## Fleet Federation
+
+Helpers for operating katulong across multiple hosts. See
+`docs/federation-setup.md` for the end-to-end setup procedure.
+
+### fleet test-mint
+
+Verify a `mint-session` API key works against a remote instance by
+performing a mint + consume round-trip and reporting whether the
+instance returned a session cookie.
+
+```bash
+katulong fleet test-mint https://katulong-og.example.com --key <key>
+katulong fleet test-mint https://katulong-og.example.com --json
+
+# Or pass the key via env so it doesn't land in shell history.
+KATULONG_FLEET_KEY=<key> katulong fleet test-mint https://katulong-og.example.com
+```
+
+Exits 0 on success, 1 on failure. The `--json` output is structured for
+scripting (e.g. looping over a fleet and collecting results).
 
 ## Token Management
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -172,11 +172,11 @@ performing a mint + consume round-trip and reporting whether the
 instance returned a session cookie.
 
 ```bash
-katulong fleet test-mint https://katulong-og.example.com --key <key>
-katulong fleet test-mint https://katulong-og.example.com --json
+katulong fleet test-mint https://katulong.example.com --key <key>
+katulong fleet test-mint https://katulong.example.com --json
 
 # Or pass the key via env so it doesn't land in shell history.
-KATULONG_FLEET_KEY=<key> katulong fleet test-mint https://katulong-og.example.com
+KATULONG_FLEET_KEY=<key> katulong fleet test-mint https://katulong.example.com
 ```
 
 Exits 0 on success, 1 on failure. The `--json` output is structured for

--- a/docs/federated-chat-and-tile-sharing.md
+++ b/docs/federated-chat-and-tile-sharing.md
@@ -27,7 +27,7 @@ Rides on the same transport as a separate channel. The **host's** katulong rende
 This sidesteps the multi-tenancy trap: there is no guest session on the host to harden.
 
 ### Signaling
-The dorkyrobot.com managed-relay service (see [`docs/service-plan.md`](service-plan.md)) could do double duty as the signaling layer for establishing WebRTC peer links.
+A managed-relay service (see [`docs/service-plan.md`](service-plan.md)) could do double duty as the signaling layer for establishing WebRTC peer links.
 
 ## Security model — be honest about this
 

--- a/docs/federated-chat-and-tile-sharing.md
+++ b/docs/federated-chat-and-tile-sharing.md
@@ -27,7 +27,7 @@ Rides on the same transport as a separate channel. The **host's** katulong rende
 This sidesteps the multi-tenancy trap: there is no guest session on the host to harden.
 
 ### Signaling
-The dorkyrobot.com managed-relay service from the paid-tunnel plan could do double duty as the signaling layer for establishing WebRTC peer links.
+The dorkyrobot.com managed-relay service (see [`docs/service-plan.md`](service-plan.md)) could do double duty as the signaling layer for establishing WebRTC peer links.
 
 ## Security model — be honest about this
 

--- a/docs/federation-setup.md
+++ b/docs/federation-setup.md
@@ -109,13 +109,13 @@ katulong fleet test-mint "https://$(hostname)" --key "$KEY" --json
 Or from the hub / your laptop, against the instance's public URL:
 
 ```sh
-katulong fleet test-mint https://katulong-og.example.com --key "$KEY"
+katulong fleet test-mint https://katulong.example.com --key "$KEY"
 ```
 
 Expected result:
 
 ```
-OK  https://katulong-og.example.com — mint + consume succeeded (redirect to /)
+OK  https://katulong.example.com — mint + consume succeeded (redirect to /)
 ```
 
 If it fails:
@@ -136,7 +136,7 @@ If it fails:
 
 Hand the hub operator (or your notes):
 
-- Instance public URL (e.g. `https://katulong-og.example.com`)
+- Instance public URL (e.g. `https://katulong.example.com`)
 - Key ID from step 2 (for rotation / auditing — safe to share)
 - Key material from step 2 (secret — transport via secure channel)
 

--- a/docs/federation-setup.md
+++ b/docs/federation-setup.md
@@ -1,0 +1,189 @@
+# Fleet federation setup
+
+This doc walks an operator — or an agent running `claude` over SSH on each
+instance — through enabling the primitives that let a fleet hub mint real
+first-party sessions on each of your katulong instances.
+
+It only covers the per-instance setup. Wiring up the actual hub UI (the
+thing that iframes the three consume URLs and merges the tiles) is a
+separate project. Until then, `katulong fleet test-mint` is how you verify
+the primitives work.
+
+## What you're setting up
+
+Each katulong instance gets an API key with a narrow `mint-session` scope.
+A hub server, calling in with that key, can ask the instance to issue a
+single-use consume URL. A browser that hits that URL lands a normal
+`katulong_session` cookie on the instance — same cookie, same session
+lifetime, same passkey binding as if the user had logged in directly.
+
+Key properties:
+
+- The key is Bearer-only. It cannot do anything except mint sessions. It
+  is default-denied on every other authenticated route.
+- The consume URL is single-use and TTL-bounded (30s by default).
+- Cookies remain first-party to each instance's origin. Passkeys never
+  leave the instance they were registered on.
+- Revocation is instant: `katulong apikey revoke <id>` on the instance
+  terminates further minting immediately. Existing minted sessions stay
+  valid for their normal 30-day lifetime unless you also remove the
+  bound credential.
+
+## Prerequisites
+
+- katulong **≥ 0.59.0** on every instance. Confirm with:
+
+  ```sh
+  katulong --version
+  ```
+
+  If the instance is older than 0.59.0, upgrade it first. The
+  `mint-session` scope and `/auth/consume` route do not exist in older
+  releases — the mint call will come back 400.
+
+- A registered passkey on the instance. Mint refuses on instances with
+  no credentials (409 "Instance has no registered credentials"); there's
+  no credential for the minted session to bind to.
+
+## Procedure (run on each instance)
+
+Run these steps on each instance — locally, or by SSHing in and running
+`claude` there, or by handing the instance to an agent. Each step is
+idempotent and safe to retry.
+
+### 1. Verify version and that a passkey exists
+
+```sh
+katulong --version                 # expect: v0.59.0 or newer
+katulong credential list           # expect: at least one row
+```
+
+If `credential list` returns nothing, register a passkey by logging in
+through the browser once before continuing.
+
+### 2. Generate a `mint-session` API key
+
+```sh
+katulong apikey create "fleet-hub" --scope mint-session --json
+```
+
+The JSON output contains:
+
+```json
+{
+  "id": "...",
+  "name": "fleet-hub",
+  "key": "<32-byte hex>",
+  "prefix": "...",
+  "scopes": ["mint-session"]
+}
+```
+
+**The `key` field is shown exactly once.** Capture it immediately. The
+hostname of this instance plus this key is what the hub configuration
+needs.
+
+An agent collecting keys from multiple instances can parse the `--json`
+output directly:
+
+```sh
+HOST=$(hostname)
+PAYLOAD=$(katulong apikey create "fleet-hub-$(date +%s)" --scope mint-session --json)
+KEY=$(echo "$PAYLOAD" | jq -r .key)
+KEY_ID=$(echo "$PAYLOAD" | jq -r .id)
+printf '%s\t%s\t%s\n' "$HOST" "$KEY_ID" "$KEY"
+```
+
+Pipe that line out to a central location (e.g. stdout of the SSH
+command) and the hub operator can assemble the config without the key
+ever hitting disk on the instance side beyond the auth state file.
+
+### 3. Verify the key works
+
+Still on the instance, with `$KEY` from step 2:
+
+```sh
+katulong fleet test-mint "https://$(hostname)" --key "$KEY" --json
+```
+
+Or from the hub / your laptop, against the instance's public URL:
+
+```sh
+katulong fleet test-mint https://katulong-og.example.com --key "$KEY"
+```
+
+Expected result:
+
+```
+OK  https://katulong-og.example.com — mint + consume succeeded (redirect to /)
+```
+
+If it fails:
+
+- `mint=401` — the key didn't resolve. Either it's wrong, or the instance
+  is older than 0.59.0.
+- `mint=403` — the key doesn't carry `mint-session`. Re-check step 2
+  (the `scopes` field in the JSON should include `mint-session`).
+- `mint=409` — the instance has no registered credential. Register a
+  passkey and retry.
+- `consume=404` with `mint=201` — very unlikely; indicates the consume
+  token was swept or already used. Re-run; it's transient.
+- `consume=400 "return must be same-origin"` — your `--host` hint
+  doesn't match the instance's canonical origin. Hit the instance by
+  its public URL, not an IP, and retry.
+
+### 4. Record and report
+
+Hand the hub operator (or your notes):
+
+- Instance public URL (e.g. `https://katulong-og.example.com`)
+- Key ID from step 2 (for rotation / auditing — safe to share)
+- Key material from step 2 (secret — transport via secure channel)
+
+The hub writes these to its own configuration. The instance is done.
+
+## Revocation
+
+To revoke a fleet key on an instance:
+
+```sh
+katulong apikey list
+katulong apikey revoke <id>
+```
+
+Sessions already minted via that key continue to work (they are normal
+first-party cookie sessions bound to the passkey credential). To sever
+those as well, revoke the passkey credential via the web UI or
+`katulong credential revoke`.
+
+## Rotation
+
+Scheduled rotation — create a new key, update the hub config, revoke
+the old key:
+
+```sh
+# on the instance
+katulong apikey create "fleet-hub-$(date +%Y%m)" --scope mint-session --json
+
+# (hub operator updates config with the new key, then:)
+katulong apikey revoke <old-id>
+```
+
+There is no grace window other than the 30-second mint TTL. Plan the
+config update to happen between the new key's creation and the old
+key's revocation.
+
+## Security notes
+
+- `/api/sessions/mint` is Bearer-only — cookie/localhost auth is
+  explicitly rejected. The intent is that this endpoint is only ever
+  hit by a hub server holding the key, never by a browser.
+- The consume URL's `return` parameter is validated to be same-origin
+  at both mint time and consume time. A bad hub cannot mint a token
+  that redirects off-instance on use.
+- Minted sessions are bound to the first registered credential on the
+  instance. If that credential is later revoked, the session is
+  invalidated along with all other sessions for that credential.
+- The mint-session key has no permission to list, modify, or revoke
+  API keys, passkeys, setup tokens, or any other state. It can only
+  mint sessions.

--- a/docs/service-plan.md
+++ b/docs/service-plan.md
@@ -18,16 +18,19 @@ locked-away features.
 
 ## The ladder
 
-Three tiers, each a superset of the previous in convenience, not
-capability:
+Three tiers are anticipated, each a superset of the previous in
+convenience, not capability. Only the protocol primitives ship in
+this branch; the hub implementations described here are planned but
+not yet present in the repo. The only fleet CLI surface shipping
+today is `katulong fleet test-mint` for operator verification.
 
-1. **Laptop-local.** `katulong fleet open` spins up an ephemeral
-   hub on localhost that iframes your registered instances. Zero
-   ops. CLI-only. Every katulong install has it.
+1. **Laptop-local (planned).** `katulong fleet open` would spin up
+   an ephemeral hub on localhost that iframes your registered
+   instances. Zero ops, CLI-only.
 
-2. **Self-hosted hub.** `katulong hub start` runs the same hub as
-   a long-lived process on any box you own. Same protocol as the
-   managed tier — you run the infra.
+2. **Self-hosted hub (planned).** `katulong hub start` would run
+   the same hub as a long-lived process on any box you own. Same
+   protocol as a managed tier — you run the infra.
 
 3. **Managed hub (hypothetical).** One-passkey sign-in, unified
    carousel across your instances, auto-enrolled via the tunnel

--- a/docs/service-plan.md
+++ b/docs/service-plan.md
@@ -1,19 +1,19 @@
 # Service plan
 
-How the dorkyrobot.com offering relates to the open-source katulong
-project, and what the user experience looks like at each tier.
+How an eventual managed katulong offering would relate to the
+open-source project, and what the user experience looks like at each
+tier.
 
 ## Philosophy: protocol open, hub is product
 
 Katulong stays open-source and self-hostable. The federation
 primitives (scoped API keys, mint/consume) are a protocol — any
-operator can wire up their own hub. dorkyrobot.com runs an
-opinionated managed implementation of that protocol plus a tunnel
-relay for people who don't want to operate the infrastructure
-themselves.
+operator can wire up their own hub. A managed tier is just an
+opinionated implementation of that protocol plus a tunnel relay for
+people who don't want to operate the infrastructure themselves.
 
 Practical consequence: if a capability belongs in the protocol, it
-ships in katulong. The managed service is about convenience, not
+ships in katulong. A managed service is about convenience, not
 locked-away features.
 
 ## The ladder
@@ -29,9 +29,10 @@ capability:
    a long-lived process on any box you own. Same protocol as the
    managed tier — you run the infra.
 
-3. **Managed hub.** Hosted on dorkyrobot.com. One-passkey sign-in,
-   unified carousel across your instances, auto-enrolled via the
-   tunnel control plane.
+3. **Managed hub (hypothetical).** One-passkey sign-in, unified
+   carousel across your instances, auto-enrolled via the tunnel
+   control plane. Same protocol as Tier 2 — an operator runs it so
+   you don't have to.
 
 ## What the managed service does
 

--- a/docs/service-plan.md
+++ b/docs/service-plan.md
@@ -1,0 +1,147 @@
+# Service plan
+
+How the dorkyrobot.com offering relates to the open-source katulong
+project, and what the user experience looks like at each tier.
+
+## Philosophy: protocol open, hub is product
+
+Katulong stays open-source and self-hostable. The federation
+primitives (scoped API keys, mint/consume) are a protocol — any
+operator can wire up their own hub. dorkyrobot.com runs an
+opinionated managed implementation of that protocol plus a tunnel
+relay for people who don't want to operate the infrastructure
+themselves.
+
+Practical consequence: if a capability belongs in the protocol, it
+ships in katulong. The managed service is about convenience, not
+locked-away features.
+
+## The ladder
+
+Three tiers, each a superset of the previous in convenience, not
+capability:
+
+1. **Laptop-local.** `katulong fleet open` spins up an ephemeral
+   hub on localhost that iframes your registered instances. Zero
+   ops. CLI-only. Every katulong install has it.
+
+2. **Self-hosted hub.** `katulong hub start` runs the same hub as
+   a long-lived process on any box you own. Same protocol as the
+   managed tier — you run the infra.
+
+3. **Managed hub.** Hosted on dorkyrobot.com. One-passkey sign-in,
+   unified carousel across your instances, auto-enrolled via the
+   tunnel control plane.
+
+## What the managed service does
+
+- **Managed tunnel relay.** Stable inbound URL for a katulong
+  instance running on your own hardware — you provide the host,
+  we provide the address. We never see terminal content; the
+  cookie-authed WebSocket runs over TLS between your browser and
+  your instance.
+- **Managed fleet hub.** A unified UI across multiple instances,
+  authenticated with one passkey on the hub's own origin. Holds
+  `mint-session`-scoped API keys for each registered instance so
+  a hub click produces a first-party session on that instance.
+
+## Multi-tenant security boundaries
+
+**This section is load-bearing for anyone deploying katulong at a
+tenant-shared apex** (the managed service, or any multi-customer
+deployment you operate yourself). Getting it wrong creates
+cross-tenant phishing surface.
+
+When customer tunnels are served at `{user}.<apex>`, each subdomain
+is a separate trust principal. Apex-wide primitives that feel like
+UX wins on a single-user domain become vulnerabilities here.
+
+### Rule 1 — WebAuthn RP ID stays per-origin
+
+The fleet hub's RP ID is the hub's own origin (e.g.
+`fleet.<apex>`), never the apex.
+
+Each tunneled katulong instance keeps its own origin as its RP ID
+(the default today; do not regress).
+
+Why: an apex RP ID lets any `*.apex` page trigger a WebAuthn
+ceremony that offers another customer's passkey as a candidate.
+That's the exact cross-tenant phishing surface WebAuthn's origin
+binding is designed to prevent. "One passkey for the fleet" is a
+feature of single-principal domains, not a multi-tenant-service
+one.
+
+### Rule 2 — Session cookies stay scoped to origin
+
+Every `katulong_session` cookie uses `Domain=<origin>`, never
+`Domain=.apex`. Cookies are bearer tokens; an apex cookie crosses
+the trust boundary with no ceremony at all — strictly worse than
+an apex RP ID.
+
+The federation primitives explicitly avoid this: a consume redirect
+lands a cookie scoped to the consuming instance's origin, not to
+any shared parent.
+
+### Rule 3 — The hub is a distinct principal
+
+The fleet hub is its own origin, not "part of the apex." It holds
+narrow `mint-session` keys for each instance; terminal content is
+still end-to-end between browser and instance over the instance's
+own cookie. The hub physically cannot read shell output.
+
+Operationally: the managed hub's origin is a separate subdomain
+(e.g. `fleet.<apex>`), authenticated with its own passkey,
+revocable independently from instance passkeys.
+
+### Exception — single-principal apex
+
+Deployments where a single party owns the entire apex (a person's
+own domain, an enterprise owning theirs) are the only mode where
+apex RP ID is safe. Those are a distinct BYO-domain deployment
+mode — don't conflate them with the multi-tenant service apex.
+
+## Federation primitives
+
+The open-source pieces any hub builds on. All three shipped in
+mainline katulong — the managed hub is not required to use them.
+
+- ✅ Scoped API keys (`full`, `mint-session`; closed set, extensible).
+- ✅ `POST /api/sessions/mint` — Bearer + narrow scope, returns a
+  single-use consume URL. Bound to the first registered credential
+  on the instance.
+- ✅ `GET /auth/consume` — public, single-use, same-origin-validated,
+  lands a first-party `katulong_session` cookie via 302.
+- ✅ `katulong fleet test-mint` CLI helper for operator verification.
+- ✅ `docs/federation-setup.md` walks an operator (or a Claude agent
+  over SSH) through enabling the primitives per-instance.
+
+Next, still open-source, to make a hub fully functional:
+- `katulong fleet open` — laptop-local Tier 1 hub.
+- `katulong hub start` — self-hosted Tier 2 hub, same protocol,
+  run by the user.
+- Optional: `mint-session` endpoint accepts a caller-label so a hub
+  (managed or not) can tag mints per device/user in audit logs.
+
+The managed hub is the only piece that's closed. It reuses the same
+CLI and protocol.
+
+## Trust properties
+
+Properties the protocol enforces, regardless of who runs the hub:
+
+- Keys held by a hub can only mint sessions — scope is enforced on
+  your instance, not on the hub.
+- Terminal content is end-to-end between your browser and your
+  instance. The hub cannot read shell output.
+- Revocation is one CLI command on your instance and takes effect
+  immediately (`findApiKey` returns null, `auth` middleware rejects).
+
+These are properties of the open-source primitives, not promises a
+managed operator makes — they hold for self-hosted hubs too.
+
+## Related
+
+- `docs/federation-setup.md` — operator procedure for enabling
+  `mint-session` primitives on a self-hosted instance.
+- `docs/federated-chat-and-tile-sharing.md` — older parked design
+  doc for cross-instance chat/tile sharing; references this plan.

--- a/docs/service-plan.md
+++ b/docs/service-plan.md
@@ -34,13 +34,20 @@ capability:
    control plane. Same protocol as Tier 2 — an operator runs it so
    you don't have to.
 
-## What the managed service does
+## What a managed service would do
+
+These are the capabilities a managed Tier 3 would offer — they are
+not implemented today and no managed tier ships in this repo. The
+sketch is included here so the open-source protocol decisions below
+(scope vocabulary, cookie scoping, RP ID rules) can be reviewed
+against the deployment shape they anticipate.
 
 - **Managed tunnel relay.** Stable inbound URL for a katulong
-  instance running on your own hardware — you provide the host,
-  we provide the address. We never see terminal content; the
-  cookie-authed WebSocket runs over TLS between your browser and
-  your instance.
+  instance running on the operator's own hardware — the operator
+  provides the host, the managed relay provides the address.
+  Terminal content would stay end-to-end between browser and
+  instance over a cookie-authed WebSocket; the relay terminates TLS
+  but does not see plaintext PTY output.
 - **Managed fleet hub.** A unified UI across multiple instances,
   authenticated with one passkey on the hub's own origin. Holds
   `mint-session`-scoped API keys for each registered instance so

--- a/lib/api-key-auth.js
+++ b/lib/api-key-auth.js
@@ -25,26 +25,28 @@ export function extractBearerToken(authHeader) {
 
 /**
  * Try to authenticate a request via Bearer API key. Mutates `req` with the
- * auth metadata on success. Returns:
- *   { matched: true, keyData } — key valid, req has been stamped
- *   { matched: false }         — no Bearer header (caller should try cookie)
- *   null                       — Bearer header present but invalid key
+ * auth metadata on success. Returns a uniform object shape:
  *
- * A null return means "Bearer header present but bogus" — the caller must
- * reject auth outright rather than falling through to cookie auth, so a
- * leaked/revoked key can't be chased with a session cookie on the same
- * request.
+ *   { matched: true, invalid: false, keyData }  — key valid, req stamped
+ *   { matched: false, invalid: false }          — no Bearer header
+ *   { matched: false, invalid: true }           — Bearer header, bogus key
+ *
+ * Callers check `.matched` to know whether to proceed with Bearer-auth
+ * state, and `.invalid` to know whether to reject outright rather than
+ * falling through to cookie auth. The "present but bogus" case must not
+ * fall through — otherwise a leaked/revoked key could be chased with a
+ * session cookie on the same request.
  */
 export function authenticateBearerKey(req, state) {
   const token = extractBearerToken(req.headers?.authorization);
-  if (token === null) return { matched: false };
-  if (!state) return null;
+  if (token === null) return { matched: false, invalid: false };
+  if (!state) return { matched: false, invalid: true };
   const keyData = state.findApiKey(token);
-  if (!keyData) return null;
+  if (!keyData) return { matched: false, invalid: true };
   req._apiKeyAuth = true;
   req._apiKeyId = keyData.id;
   req._apiKeyScopes = Array.isArray(keyData.scopes) && keyData.scopes.length
     ? [...keyData.scopes]
     : [...DEFAULT_API_KEY_SCOPES];
-  return { matched: true, keyData };
+  return { matched: true, invalid: false, keyData };
 }

--- a/lib/api-key-auth.js
+++ b/lib/api-key-auth.js
@@ -1,0 +1,50 @@
+/**
+ * Bearer API key resolution for HTTP requests.
+ *
+ * Extracted from server.js so tests can share the same code path without
+ * pulling in the full HTTP server. Given a request and an AuthState, finds
+ * the API key, stashes auth metadata on the request, and returns a result
+ * object matching the rest of the `isAuthenticated` contract.
+ *
+ * Stashed fields (read by lib/routes/middleware.js):
+ * - req._apiKeyAuth — true if Bearer auth succeeded
+ * - req._apiKeyId — the id of the matching API key record
+ * - req._apiKeyScopes — the normalized scope array from the matching record
+ */
+
+import { DEFAULT_API_KEY_SCOPES } from "./api-key-scopes.js";
+
+/**
+ * Extract a Bearer token from an Authorization header, or null if absent.
+ */
+export function extractBearerToken(authHeader) {
+  if (!authHeader || typeof authHeader !== "string") return null;
+  if (!authHeader.startsWith("Bearer ")) return null;
+  return authHeader.slice(7);
+}
+
+/**
+ * Try to authenticate a request via Bearer API key. Mutates `req` with the
+ * auth metadata on success. Returns:
+ *   { matched: true, keyData } — key valid, req has been stamped
+ *   { matched: false }         — no Bearer header (caller should try cookie)
+ *   null                       — Bearer header present but invalid key
+ *
+ * A null return means "Bearer header present but bogus" — the caller must
+ * reject auth outright rather than falling through to cookie auth, so a
+ * leaked/revoked key can't be chased with a session cookie on the same
+ * request.
+ */
+export function authenticateBearerKey(req, state) {
+  const token = extractBearerToken(req.headers?.authorization);
+  if (token === null) return { matched: false };
+  if (!state) return null;
+  const keyData = state.findApiKey(token);
+  if (!keyData) return null;
+  req._apiKeyAuth = true;
+  req._apiKeyId = keyData.id;
+  req._apiKeyScopes = Array.isArray(keyData.scopes) && keyData.scopes.length
+    ? [...keyData.scopes]
+    : [...DEFAULT_API_KEY_SCOPES];
+  return { matched: true, keyData };
+}

--- a/lib/api-key-scopes.js
+++ b/lib/api-key-scopes.js
@@ -1,0 +1,22 @@
+/**
+ * API key scopes — a small closed set.
+ *
+ * Scopes let operators issue narrowly-authorized API keys. A key with the
+ * "full" scope is identical to a legacy, pre-scope key (bypasses CSRF when
+ * the Bearer header is present, and any protected route accepts it). Narrow
+ * scopes like "mint-session" are only accepted by routes that opt-in via
+ * the `requireScope(...)` middleware; default-deny applies elsewhere.
+ *
+ * The set is intentionally closed — unknown scope strings are dropped at
+ * `addApiKey` time so bad client input can't leak into persisted state.
+ */
+
+export const SCOPE_FULL = "full";
+export const SCOPE_MINT_SESSION = "mint-session";
+
+export const API_KEY_SCOPES = new Set([
+  SCOPE_FULL,
+  SCOPE_MINT_SESSION,
+]);
+
+export const DEFAULT_API_KEY_SCOPES = Object.freeze([SCOPE_FULL]);

--- a/lib/api-key-scopes.js
+++ b/lib/api-key-scopes.js
@@ -9,6 +9,14 @@
  *
  * The set is intentionally closed — unknown scope strings are dropped at
  * `addApiKey` time so bad client input can't leak into persisted state.
+ *
+ * **Stability contract:** scope strings are externally visible identifiers —
+ * they are persisted in `auth-state.json`, returned by `GET /api/api-keys`,
+ * sent by clients to `POST /api/api-keys`, and documented in
+ * `docs/federation-setup.md` as the thing an operator types on the command
+ * line. They cannot be renamed without a persisted-state migration AND a
+ * coordinated update of every hub that issued keys against them. Add new
+ * scopes freely; never rename an existing one.
  */
 
 export const SCOPE_FULL = "full";
@@ -20,3 +28,50 @@ export const API_KEY_SCOPES = new Set([
 ]);
 
 export const DEFAULT_API_KEY_SCOPES = Object.freeze([SCOPE_FULL]);
+
+/**
+ * Normalize scope input to a valid, de-duplicated array of known scopes.
+ * Silently drops unknowns — use this on the data-model side for defense in
+ * depth. For user-facing validation (reject unknowns with 400), use
+ * validateScopes instead.
+ */
+export function normalizeScopes(scopes) {
+  if (!Array.isArray(scopes) || scopes.length === 0) return [...DEFAULT_API_KEY_SCOPES];
+  const filtered = scopes.filter(s => typeof s === "string" && API_KEY_SCOPES.has(s));
+  if (filtered.length === 0) return [...DEFAULT_API_KEY_SCOPES];
+  return [...new Set(filtered)];
+}
+
+/**
+ * Validate user-supplied scope input. Returns `{valid, normalized, unknown}`
+ * so a route handler can reject unknown scopes with a specific 400 instead
+ * of silently dropping them.
+ *
+ * - `valid` is false iff `scopes` is non-empty AND contains any unknown
+ *   entries (bad type or unknown name). An empty/missing input is valid and
+ *   maps to the default scopes.
+ * - `normalized` is the filtered, de-duplicated set of known scopes, or the
+ *   default scopes if input was empty/missing.
+ * - `unknown` lists the rejected strings so the caller can echo them back.
+ */
+export function validateScopes(scopes) {
+  if (scopes === undefined || scopes === null) {
+    return { valid: true, normalized: [...DEFAULT_API_KEY_SCOPES], unknown: [] };
+  }
+  if (!Array.isArray(scopes)) {
+    return { valid: false, normalized: [...DEFAULT_API_KEY_SCOPES], unknown: [String(scopes)] };
+  }
+  const unknown = [];
+  const known = [];
+  for (const s of scopes) {
+    if (typeof s === "string" && API_KEY_SCOPES.has(s)) known.push(s);
+    else unknown.push(typeof s === "string" ? s : String(s));
+  }
+  if (unknown.length > 0) {
+    return { valid: false, normalized: [...new Set(known)], unknown };
+  }
+  if (known.length === 0) {
+    return { valid: true, normalized: [...DEFAULT_API_KEY_SCOPES], unknown: [] };
+  }
+  return { valid: true, normalized: [...new Set(known)], unknown: [] };
+}

--- a/lib/auth-state.js
+++ b/lib/auth-state.js
@@ -12,14 +12,7 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import { SESSION_TTL_MS } from "./env-config.js";
 import { hashToken, verifyToken } from "./auth-tokens.js";
-import { API_KEY_SCOPES, DEFAULT_API_KEY_SCOPES } from "./api-key-scopes.js";
-
-function normalizeScopes(scopes) {
-  if (!Array.isArray(scopes) || scopes.length === 0) return [...DEFAULT_API_KEY_SCOPES];
-  const filtered = scopes.filter(s => typeof s === "string" && API_KEY_SCOPES.has(s));
-  if (filtered.length === 0) return [...DEFAULT_API_KEY_SCOPES];
-  return [...new Set(filtered)];
-}
+import { normalizeScopes } from "./api-key-scopes.js";
 
 export class LastCredentialError extends Error {
   constructor(message = "Cannot remove the last credential - would lock you out") {
@@ -491,10 +484,6 @@ export class AuthState {
     return { state: this._with({ loginTokens }), migrated: true };
   }
 
-  /**
-   * Serialize to plain object (for persistence)
-   * @returns {object}
-   */
   // --- API keys ---
 
   addApiKey(keyData) {
@@ -530,6 +519,10 @@ export class AuthState {
     });
   }
 
+  /**
+   * Serialize to plain object (for persistence)
+   * @returns {object}
+   */
   toJSON() {
     return {
       user: this.user,

--- a/lib/auth-state.js
+++ b/lib/auth-state.js
@@ -12,6 +12,14 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import { SESSION_TTL_MS } from "./env-config.js";
 import { hashToken, verifyToken } from "./auth-tokens.js";
+import { API_KEY_SCOPES, DEFAULT_API_KEY_SCOPES } from "./api-key-scopes.js";
+
+function normalizeScopes(scopes) {
+  if (!Array.isArray(scopes) || scopes.length === 0) return [...DEFAULT_API_KEY_SCOPES];
+  const filtered = scopes.filter(s => typeof s === "string" && API_KEY_SCOPES.has(s));
+  if (filtered.length === 0) return [...DEFAULT_API_KEY_SCOPES];
+  return [...new Set(filtered)];
+}
 
 export class LastCredentialError extends Error {
   constructor(message = "Cannot remove the last credential - would lock you out") {
@@ -490,10 +498,11 @@ export class AuthState {
   // --- API keys ---
 
   addApiKey(keyData) {
-    const { key, ...rest } = keyData;
+    const { key, scopes, ...rest } = keyData;
     const { hash, salt } = hashToken(key);
     const prefix = key.slice(0, 8);
-    return this._with({ apiKeys: [...this.apiKeys, { ...rest, hash, salt, prefix }] });
+    const record = { ...rest, hash, salt, prefix, scopes: normalizeScopes(scopes) };
+    return this._with({ apiKeys: [...this.apiKeys, record] });
   }
 
   removeApiKey(id) {
@@ -508,7 +517,9 @@ export class AuthState {
         found = k;
       }
     }
-    return found;
+    if (!found) return null;
+    // Back-compat: records persisted before scopes existed get the full-access scope.
+    return { ...found, scopes: normalizeScopes(found.scopes) };
   }
 
   updateApiKeyActivity(id) {

--- a/lib/cli/commands/apikey.js
+++ b/lib/cli/commands/apikey.js
@@ -71,12 +71,12 @@ async function create(args) {
 
     qrcode.generate(data.key, { small: true }, (code) => {
       console.log(code);
-      console.log(`Save this key — it will not be shown again.\n`);
-      const isFullOnly = Array.isArray(data.scopes) && data.scopes.length === 1 && data.scopes[0] === "full";
-      if (isFullOnly) {
-        console.log("Note: this key has full access to the API. For fleet federation use --scope mint-session.\n");
-      }
     });
+    console.log(`Save this key — it will not be shown again.\n`);
+    const isFullOnly = Array.isArray(data.scopes) && data.scopes.length === 1 && data.scopes[0] === "full";
+    if (isFullOnly) {
+      console.log("Note: this key has full access to the API. For fleet federation use --scope mint-session.\n");
+    }
   }
 }
 

--- a/lib/cli/commands/apikey.js
+++ b/lib/cli/commands/apikey.js
@@ -18,27 +18,55 @@ Subcommands:
   revoke <id>     Revoke an API key
 
 Options:
-  --json          Output as JSON
+  --json              Output as JSON
+  --scope <name>      Restrict key to a scope (repeatable). Known scopes:
+                      full (default), mint-session
 `);
 }
 
+function parseScopeArgs(args) {
+  const scopes = [];
+  const rest = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--scope") {
+      const next = args[i + 1];
+      if (!next || next.startsWith("--")) {
+        console.error("--scope requires a value");
+        process.exit(1);
+      }
+      scopes.push(next);
+      i++;
+    } else if (a.startsWith("--scope=")) {
+      scopes.push(a.slice("--scope=".length));
+    } else {
+      rest.push(a);
+    }
+  }
+  return { scopes, rest };
+}
+
 async function create(args) {
-  const jsonMode = args.includes("--json");
-  const name = args.filter(a => a !== "--json").join(" ").trim();
+  const { scopes, rest } = parseScopeArgs(args);
+  const jsonMode = rest.includes("--json");
+  const name = rest.filter(a => a !== "--json").join(" ").trim();
   if (!name) {
-    console.error("Usage: katulong apikey create <name>");
+    console.error("Usage: katulong apikey create <name> [--scope <name>]...");
     process.exit(1);
   }
 
   ensureRunning();
-  const data = await api.post("/api/api-keys", { name });
+  const payload = scopes.length ? { name, scopes } : { name };
+  const data = await api.post("/api/api-keys", payload);
 
   if (jsonMode) {
     console.log(JSON.stringify(data, null, 2));
   } else {
+    const scopeList = Array.isArray(data.scopes) ? data.scopes.join(", ") : "full";
     console.log(`\nAPI key created:
   ID:     ${data.id}
   Name:   ${data.name}
+  Scopes: ${scopeList}
   Key:    ${data.key}\n`);
 
     qrcode.generate(data.key, { small: true }, (code) => {
@@ -68,9 +96,10 @@ async function list(args) {
     k.id,
     k.name,
     k.prefix + "...",
+    Array.isArray(k.scopes) && k.scopes.length ? k.scopes.join(",") : "full",
     k.lastUsedAt ? new Date(k.lastUsedAt).toLocaleDateString() : "never",
   ]);
-  process.stdout.write(formatTable(["ID", "NAME", "PREFIX", "LAST USED"], rows));
+  process.stdout.write(formatTable(["ID", "NAME", "PREFIX", "SCOPES", "LAST USED"], rows));
 }
 
 async function revoke(args) {

--- a/lib/cli/commands/apikey.js
+++ b/lib/cli/commands/apikey.js
@@ -72,6 +72,10 @@ async function create(args) {
     qrcode.generate(data.key, { small: true }, (code) => {
       console.log(code);
       console.log(`Save this key — it will not be shown again.\n`);
+      const isFullOnly = Array.isArray(data.scopes) && data.scopes.length === 1 && data.scopes[0] === "full";
+      if (isFullOnly) {
+        console.log("Note: this key has full access to the API. For fleet federation use --scope mint-session.\n");
+      }
     });
   }
 }

--- a/lib/cli/commands/fleet.js
+++ b/lib/cli/commands/fleet.js
@@ -1,0 +1,144 @@
+/**
+ * CLI: katulong fleet <subcommand>
+ *
+ * Operator tooling for fleet federation. Initial subcommand:
+ *   test-mint <instance-url>   Verify a mint-session API key works against
+ *                              a remote katulong instance (does a mint,
+ *                              does a consume, reports the session cookie).
+ *
+ * The hub itself is not yet part of katulong; this command exists so an
+ * operator (or Claude-over-SSH) can sanity-check the federation primitives
+ * on each instance before wiring up a hub.
+ */
+
+function usage() {
+  console.log(`
+Usage: katulong fleet <subcommand> [options]
+
+Subcommands:
+  test-mint <instance-url>   Verify a mint-session API key by minting
+                             and consuming a session on a remote instance.
+
+Options:
+  --key <api-key>     Bearer key with mint-session scope. May also be
+                      provided via KATULONG_FLEET_KEY env var.
+  --json              Output as JSON
+`);
+}
+
+function parseFlags(args) {
+  const opts = { key: null, json: false, positional: [] };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--json") opts.json = true;
+    else if (a === "--key") opts.key = args[++i];
+    else if (a.startsWith("--key=")) opts.key = a.slice("--key=".length);
+    else if (a === "--help" || a === "-h") { usage(); process.exit(0); }
+    else opts.positional.push(a);
+  }
+  return opts;
+}
+
+async function testMint(args) {
+  const opts = parseFlags(args);
+  const instanceUrl = opts.positional[0];
+  if (!instanceUrl) {
+    console.error("Usage: katulong fleet test-mint <instance-url> [--key <key>] [--json]");
+    process.exit(1);
+  }
+  const apiKey = opts.key || process.env.KATULONG_FLEET_KEY;
+  if (!apiKey) {
+    console.error("Error: mint-session API key required (--key or KATULONG_FLEET_KEY)");
+    process.exit(1);
+  }
+
+  // Normalize the URL (drop trailing slash, validate it parses).
+  let base;
+  try {
+    base = new URL(instanceUrl);
+  } catch {
+    console.error(`Error: invalid instance URL: ${instanceUrl}`);
+    process.exit(1);
+  }
+  const origin = base.origin;
+
+  // Step 1: mint. Expect 201 with { consumeUrl, consumeToken, expiresAt }.
+  let mintResp;
+  try {
+    mintResp = await fetch(`${origin}/api/sessions/mint`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+  } catch (err) {
+    console.error(`Error: mint request failed: ${err.message}`);
+    process.exit(1);
+  }
+  const mintBody = await mintResp.json().catch(() => null);
+  if (!mintResp.ok) {
+    const summary = { step: "mint", instance: origin, status: mintResp.status, body: mintBody };
+    if (opts.json) console.log(JSON.stringify(summary, null, 2));
+    else console.error(`Mint failed (${mintResp.status}): ${JSON.stringify(mintBody)}`);
+    process.exit(1);
+  }
+
+  // Step 2: consume — follow manually so we can observe Set-Cookie and the
+  // redirect target. fetch auto-follows by default; disable with redirect: "manual".
+  const consumeUrl = mintBody.consumeUrl;
+  let consumeResp;
+  try {
+    consumeResp = await fetch(consumeUrl, { redirect: "manual" });
+  } catch (err) {
+    console.error(`Error: consume request failed: ${err.message}`);
+    process.exit(1);
+  }
+
+  const setCookie = consumeResp.headers.get("set-cookie");
+  const location = consumeResp.headers.get("location");
+  const cookieOk = typeof setCookie === "string" && setCookie.includes("katulong_session=");
+  const redirectOk = consumeResp.status === 302;
+
+  const result = {
+    instance: origin,
+    mint: { status: mintResp.status, expiresAt: mintBody.expiresAt },
+    consume: {
+      status: consumeResp.status,
+      location,
+      hasSessionCookie: cookieOk,
+    },
+    ok: redirectOk && cookieOk,
+  };
+
+  if (opts.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result.ok) {
+    console.log(`OK  ${origin} — mint + consume succeeded (redirect to ${location})`);
+  } else {
+    console.log(`FAIL ${origin} — mint=${mintResp.status} consume=${consumeResp.status} cookie=${cookieOk}`);
+  }
+  process.exit(result.ok ? 0 : 1);
+}
+
+const subcommands = { "test-mint": testMint };
+
+export default async function fleet(args) {
+  const sub = args[0];
+  if (!sub || sub === "--help" || sub === "-h") {
+    usage();
+    process.exit(sub ? 0 : 1);
+  }
+  if (!subcommands[sub]) {
+    console.error(`Unknown subcommand: ${sub}`);
+    usage();
+    process.exit(1);
+  }
+  try {
+    await subcommands[sub](args.slice(1));
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/lib/cli/commands/fleet.js
+++ b/lib/cli/commands/fleet.js
@@ -62,7 +62,7 @@ async function testMint(args) {
   }
   const origin = base.origin;
 
-  // Step 1: mint. Expect 201 with { consumeUrl, consumeToken, expiresAt }.
+  // Step 1: mint. Expect 201 with { consumeUrl, expiresAt, credentialId }.
   let mintResp;
   try {
     mintResp = await fetch(`${origin}/api/sessions/mint`, {
@@ -82,6 +82,12 @@ async function testMint(args) {
     const summary = { step: "mint", instance: origin, status: mintResp.status, body: mintBody };
     if (opts.json) console.log(JSON.stringify(summary, null, 2));
     else console.error(`Mint failed (${mintResp.status}): ${JSON.stringify(mintBody)}`);
+    process.exit(1);
+  }
+  if (!mintBody || typeof mintBody.consumeUrl !== "string") {
+    const summary = { step: "mint", instance: origin, status: mintResp.status, error: "instance returned 2xx but response body was missing consumeUrl" };
+    if (opts.json) console.log(JSON.stringify(summary, null, 2));
+    else console.error(`Mint succeeded (${mintResp.status}) but response body was missing consumeUrl`);
     process.exit(1);
   }
 

--- a/lib/http-util.js
+++ b/lib/http-util.js
@@ -86,6 +86,7 @@ const PUBLIC_AUTH_ROUTES = new Set([
   "/auth/logout",
   "/auth/device-auth/request",
   "/auth/device-auth/status",
+  "/auth/consume",
 ]);
 
 export function isPublicPath(pathname) {

--- a/lib/routes/auth-routes.js
+++ b/lib/routes/auth-routes.js
@@ -72,14 +72,19 @@ function sweepExpiredMints(now = Date.now()) {
 const mintSweepTimer = setInterval(sweepExpiredMints, MINT_DEFAULT_TTL_MS);
 mintSweepTimer.unref();
 
-// Test-only export for deterministic lifecycle tests.
-export function _resetMintStateForTesting() {
+// Test-only exports — guarded by NODE_ENV so a plugin or later-loaded
+// module can't reach them in production and tamper with pending mints.
+// `katulong test` and the unit test harness set NODE_ENV=test; production
+// startup leaves it unset or at "production".
+const IS_TEST_ENV = process.env.NODE_ENV === "test";
+
+export function _resetMintForTesting() {
+  if (!IS_TEST_ENV) throw new Error("_resetMintForTesting is test-only");
   pendingMints.clear();
 }
 
-// Test-only export: backdate a pending mint's expiry so the 410 path is
-// reachable without waiting on wall-clock time.
 export function _expireMintForTesting(token) {
+  if (!IS_TEST_ENV) throw new Error("_expireMintForTesting is test-only");
   const entry = pendingMints.get(token);
   if (entry) pendingMints.set(token, { ...entry, expiresAt: Date.now() - 1 });
 }
@@ -626,6 +631,12 @@ export function createAuthRoutes(ctx) {
       }
       if (token.length > MAX_CONSUME_TOKEN_LEN) {
         return json(res, 400, { error: "Consume token too long" });
+      }
+      // Consume tokens are `randomBytes(32).toString("hex")` — 64 lowercase
+      // hex chars. Reject any other shape before the Map lookup both as
+      // defense-in-depth and as a self-documenting contract.
+      if (!/^[0-9a-f]+$/.test(token)) {
+        return json(res, 400, { error: "Invalid consume token format" });
       }
 
       const entry = pendingMints.get(token);

--- a/lib/routes/auth-routes.js
+++ b/lib/routes/auth-routes.js
@@ -632,10 +632,11 @@ export function createAuthRoutes(ctx) {
       if (token.length > MAX_CONSUME_TOKEN_LEN) {
         return json(res, 400, { error: "Consume token too long" });
       }
-      // Consume tokens are `randomBytes(32).toString("hex")` — 64 lowercase
-      // hex chars. Reject any other shape before the Map lookup both as
-      // defense-in-depth and as a self-documenting contract.
-      if (!/^[0-9a-f]+$/.test(token)) {
+      // Consume tokens are `randomBytes(32).toString("hex")` — exactly 64
+      // lowercase hex chars. Pinning the format here both hardens against
+      // interned-string / odd-input attacks and serves as a self-documenting
+      // contract for the wire format.
+      if (!/^[0-9a-f]{64}$/.test(token)) {
         return json(res, 400, { error: "Invalid consume token format" });
       }
 

--- a/lib/routes/auth-routes.js
+++ b/lib/routes/auth-routes.js
@@ -23,7 +23,11 @@ import {
 import { isLocalRequest, getAccessMethod } from "../access-method.js";
 import { processRegistration, processAuthentication, extractChallenge } from "../auth-handlers.js";
 import { AuthState, LastCredentialError } from "../auth-state.js";
-import { API_KEY_SCOPES, DEFAULT_API_KEY_SCOPES } from "../api-key-scopes.js";
+import {
+  DEFAULT_API_KEY_SCOPES,
+  SCOPE_MINT_SESSION,
+  validateScopes,
+} from "../api-key-scopes.js";
 import { SETUP_TOKEN_TTL_MS } from "../env-config.js";
 import { log } from "../log.js";
 
@@ -73,14 +77,26 @@ export function _resetMintStateForTesting() {
   pendingMints.clear();
 }
 
+// Test-only export: backdate a pending mint's expiry so the 410 path is
+// reachable without waiting on wall-clock time.
+export function _expireMintForTesting(token) {
+  const entry = pendingMints.get(token);
+  if (entry) pendingMints.set(token, { ...entry, expiresAt: Date.now() - 1 });
+}
+
 export function createAuthRoutes(ctx) {
   const {
     json, parseJSON, isAuthenticated,
     storeChallenge, consumeChallenge, challengeStore,
     credentialLockout, bridge,
     RP_NAME, PORT,
-    auth, csrf, requireScope,
+    auth, csrf, requireScope, requireBearerAuth,
   } = ctx;
+
+  // Upper bound on the accepted length of the consume-token query param.
+  // `consumeToken` is 64 hex chars; anything materially longer is garbage
+  // and should be rejected before a Map lookup with a megabyte-sized key.
+  const MAX_CONSUME_TOKEN_LEN = 128;
 
   return [
     // --- Auth status ---
@@ -358,19 +374,11 @@ export function createAuthRoutes(ctx) {
       const body = await parseJSON(req);
       const { name, scopes } = body || {};
       if (!name || typeof name !== "string") return json(res, 400, { error: "Name required" });
-      let normalizedScopes;
-      if (scopes !== undefined) {
-        if (!Array.isArray(scopes) || scopes.length === 0) {
-          return json(res, 400, { error: "scopes must be a non-empty array" });
-        }
-        const unknown = scopes.filter(s => typeof s !== "string" || !API_KEY_SCOPES.has(s));
-        if (unknown.length) {
-          return json(res, 400, { error: `Unknown scope(s): ${unknown.join(", ")}` });
-        }
-        normalizedScopes = [...new Set(scopes)];
-      } else {
-        normalizedScopes = [...DEFAULT_API_KEY_SCOPES];
+      const scopeResult = validateScopes(scopes);
+      if (!scopeResult.valid) {
+        return json(res, 400, { error: `Unknown scope(s): ${scopeResult.unknown.join(", ")}` });
       }
+      const normalizedScopes = scopeResult.normalized;
       const id = randomBytes(8).toString("hex");
       const key = randomBytes(32).toString("hex");
       const result = await withStateLock((state) => {
@@ -535,18 +543,25 @@ export function createAuthRoutes(ctx) {
     // single-use consume URL. The hub server calls this, then the browser
     // GETs the consume URL to land a first-party cookie on the instance.
 
-    { method: "POST", path: "/api/sessions/mint", handler: auth(requireScope("mint-session")(async (req, res) => {
-      // Bearer-only route. Reject cookie/localhost auth so the mint flow
-      // isn't accidentally reachable from a browser session.
-      if (!req._apiKeyAuth) {
-        return json(res, 403, { error: "Bearer authentication required" });
-      }
+    { method: "POST", path: "/api/sessions/mint", rateLimit: true, handler: auth(requireBearerAuth(requireScope(SCOPE_MINT_SESSION)(async (req, res) => {
       const state = loadState();
       if (!state || !state.hasCredentials()) {
         return json(res, 409, { error: "Instance has no registered credentials" });
       }
 
-      const body = await parseJSON(req).catch(() => ({}));
+      // Body is optional — a minimal mint request may carry no parameters.
+      // An invalid-JSON body is treated as empty, but an oversized body
+      // (1MB cap in readBody) is surfaced as 413 rather than silently
+      // absorbed. readBody rejects with Error("Request body too large").
+      let body;
+      try {
+        body = await parseJSON(req);
+      } catch (err) {
+        if (err && /too large/i.test(err.message)) {
+          return json(res, 413, { error: "Request body too large" });
+        }
+        body = {};
+      }
       const returnTo = typeof body?.returnTo === "string" ? body.returnTo : null;
       const ttlSecondsRaw = Number(body?.ttlSeconds);
       const ttlMs = Number.isFinite(ttlSecondsRaw) && ttlSecondsRaw > 0
@@ -594,10 +609,10 @@ export function createAuthRoutes(ctx) {
 
       json(res, 201, {
         consumeUrl: consumeUrl.toString(),
-        consumeToken,
         expiresAt,
+        credentialId,
       });
-    }))},
+    })))},
 
     { method: "GET", path: "/auth/consume", handler: async (req, res) => {
       // Public route — the consume token IS the auth. Single-use via
@@ -608,6 +623,9 @@ export function createAuthRoutes(ctx) {
 
       if (!token || typeof token !== "string") {
         return json(res, 400, { error: "Missing consume token" });
+      }
+      if (token.length > MAX_CONSUME_TOKEN_LEN) {
+        return json(res, 400, { error: "Consume token too long" });
       }
 
       const entry = pendingMints.get(token);

--- a/lib/routes/auth-routes.js
+++ b/lib/routes/auth-routes.js
@@ -23,6 +23,7 @@ import {
 import { isLocalRequest, getAccessMethod } from "../access-method.js";
 import { processRegistration, processAuthentication, extractChallenge } from "../auth-handlers.js";
 import { AuthState, LastCredentialError } from "../auth-state.js";
+import { API_KEY_SCOPES, DEFAULT_API_KEY_SCOPES } from "../api-key-scopes.js";
 import { SETUP_TOKEN_TTL_MS } from "../env-config.js";
 import { log } from "../log.js";
 
@@ -40,13 +41,45 @@ function isDeviceAuthExpired(request) {
   return Date.now() - request.createdAt > DEVICE_AUTH_TTL_MS;
 }
 
+// --- Session minting (ephemeral, in-memory only) ---
+//
+// A Bearer key with the "mint-session" scope can POST /api/sessions/mint
+// to get back a single-use consume URL. A browser then GETs that URL
+// (same-origin) and receives a first-party session cookie via 302. This is
+// how the fleet hub grants a user a real session on peer katulong instances
+// without forwarding the user's passkey or breaking cookie scope.
+//
+// The pending entry is claimed atomically via Map.delete(): if delete
+// returns true, we own the single-use ticket and can materialize a session.
+// Entries expire in MINT_DEFAULT_TTL_MS (configurable per-mint up to max).
+
+const pendingMints = new Map(); // consumeToken -> { credentialId, returnTo, expiresAt, apiKeyId }
+const MINT_DEFAULT_TTL_MS = 30 * 1000;
+const MINT_MAX_TTL_MS = 5 * 60 * 1000;
+
+function sweepExpiredMints(now = Date.now()) {
+  for (const [token, entry] of pendingMints) {
+    if (now >= entry.expiresAt) pendingMints.delete(token);
+  }
+}
+
+// Background sweep so expired mints don't accumulate if never consumed.
+// Unref()d so it never prevents process exit.
+const mintSweepTimer = setInterval(sweepExpiredMints, MINT_DEFAULT_TTL_MS);
+mintSweepTimer.unref();
+
+// Test-only export for deterministic lifecycle tests.
+export function _resetMintStateForTesting() {
+  pendingMints.clear();
+}
+
 export function createAuthRoutes(ctx) {
   const {
     json, parseJSON, isAuthenticated,
     storeChallenge, consumeChallenge, challengeStore,
     credentialLockout, bridge,
     RP_NAME, PORT,
-    auth, csrf,
+    auth, csrf, requireScope,
   } = ctx;
 
   return [
@@ -317,20 +350,41 @@ export function createAuthRoutes(ctx) {
       json(res, 200, state.apiKeys.map(k => ({
         id: k.id, name: k.name, prefix: k.prefix,
         createdAt: k.createdAt, lastUsedAt: k.lastUsedAt,
+        scopes: Array.isArray(k.scopes) && k.scopes.length ? [...k.scopes] : [...DEFAULT_API_KEY_SCOPES],
       })));
     })},
 
     { method: "POST", path: "/api/api-keys", handler: auth(csrf(async (req, res) => {
-      const { name } = await parseJSON(req);
+      const body = await parseJSON(req);
+      const { name, scopes } = body || {};
       if (!name || typeof name !== "string") return json(res, 400, { error: "Name required" });
+      let normalizedScopes;
+      if (scopes !== undefined) {
+        if (!Array.isArray(scopes) || scopes.length === 0) {
+          return json(res, 400, { error: "scopes must be a non-empty array" });
+        }
+        const unknown = scopes.filter(s => typeof s !== "string" || !API_KEY_SCOPES.has(s));
+        if (unknown.length) {
+          return json(res, 400, { error: `Unknown scope(s): ${unknown.join(", ")}` });
+        }
+        normalizedScopes = [...new Set(scopes)];
+      } else {
+        normalizedScopes = [...DEFAULT_API_KEY_SCOPES];
+      }
       const id = randomBytes(8).toString("hex");
       const key = randomBytes(32).toString("hex");
       const result = await withStateLock((state) => {
         if (!state) return {};
-        return { state: state.addApiKey({ id, key, name: name.slice(0, 100), createdAt: Date.now(), lastUsedAt: 0 }) };
+        return {
+          state: state.addApiKey({
+            id, key, name: name.slice(0, 100),
+            createdAt: Date.now(), lastUsedAt: 0,
+            scopes: normalizedScopes,
+          }),
+        };
       });
       if (!result.state) return json(res, 500, { error: "Failed to create API key" });
-      json(res, 201, { id, key, name: name.slice(0, 100), prefix: key.slice(0, 8) });
+      json(res, 201, { id, key, name: name.slice(0, 100), prefix: key.slice(0, 8), scopes: normalizedScopes });
     }))},
 
     { method: "DELETE", prefix: "/api/api-keys/", handler: auth(csrf(async (req, res, id) => {
@@ -474,6 +528,155 @@ export function createAuthRoutes(ctx) {
       log.info("Setup token updated", { id, name: name.trim() });
       json(res, 200, { ok: true });
     }))},
+
+    // --- Session minting (fleet federation) ---
+    //
+    // POST /api/sessions/mint — Bearer + "mint-session" scope. Returns a
+    // single-use consume URL. The hub server calls this, then the browser
+    // GETs the consume URL to land a first-party cookie on the instance.
+
+    { method: "POST", path: "/api/sessions/mint", handler: auth(requireScope("mint-session")(async (req, res) => {
+      // Bearer-only route. Reject cookie/localhost auth so the mint flow
+      // isn't accidentally reachable from a browser session.
+      if (!req._apiKeyAuth) {
+        return json(res, 403, { error: "Bearer authentication required" });
+      }
+      const state = loadState();
+      if (!state || !state.hasCredentials()) {
+        return json(res, 409, { error: "Instance has no registered credentials" });
+      }
+
+      const body = await parseJSON(req).catch(() => ({}));
+      const returnTo = typeof body?.returnTo === "string" ? body.returnTo : null;
+      const ttlSecondsRaw = Number(body?.ttlSeconds);
+      const ttlMs = Number.isFinite(ttlSecondsRaw) && ttlSecondsRaw > 0
+        ? Math.min(ttlSecondsRaw * 1000, MINT_MAX_TTL_MS)
+        : MINT_DEFAULT_TTL_MS;
+
+      // Validate returnTo is same-origin before minting so a bad hub can't
+      // mint a token that silently redirects off-instance on consume.
+      const { origin: serverOrigin } = getOriginAndRpID(req);
+      if (returnTo) {
+        try {
+          const parsed = new URL(returnTo, serverOrigin);
+          if (parsed.origin !== serverOrigin) {
+            return json(res, 400, { error: "returnTo must be same-origin" });
+          }
+        } catch {
+          return json(res, 400, { error: "Invalid returnTo URL" });
+        }
+      }
+
+      // Bind minted session to the first registered credential — the one
+      // `isValidLoginToken` will cross-check. If that credential is later
+      // revoked, removeCredential() cascades and invalidates the session.
+      const credentialId = state.credentials[0].id;
+
+      const consumeToken = randomBytes(32).toString("hex");
+      const expiresAt = Date.now() + ttlMs;
+      pendingMints.set(consumeToken, {
+        credentialId,
+        returnTo,
+        expiresAt,
+        apiKeyId: req._apiKeyId || null,
+      });
+
+      const consumeUrl = new URL("/auth/consume", serverOrigin);
+      consumeUrl.searchParams.set("token", consumeToken);
+      if (returnTo) consumeUrl.searchParams.set("return", returnTo);
+
+      log.info("Session mint created", {
+        apiKeyId: req._apiKeyId || null,
+        credentialId,
+        ttlMs,
+        hasReturnTo: !!returnTo,
+      });
+
+      json(res, 201, {
+        consumeUrl: consumeUrl.toString(),
+        consumeToken,
+        expiresAt,
+      });
+    }))},
+
+    { method: "GET", path: "/auth/consume", handler: async (req, res) => {
+      // Public route — the consume token IS the auth. Single-use via
+      // atomic Map.delete(); return validated same-origin before redirect.
+      const url = new URL(req.url, "http://localhost");
+      const token = url.searchParams.get("token");
+      const returnParam = url.searchParams.get("return");
+
+      if (!token || typeof token !== "string") {
+        return json(res, 400, { error: "Missing consume token" });
+      }
+
+      const entry = pendingMints.get(token);
+      // Claim atomically: if delete returns true we own it. JS is
+      // single-threaded per event loop turn and there's no await between
+      // get and delete, so no coroutine can interleave here.
+      const claimed = pendingMints.delete(token);
+      if (!entry || !claimed) {
+        return json(res, 404, { error: "Consume token not found or already used" });
+      }
+      if (Date.now() >= entry.expiresAt) {
+        return json(res, 410, { error: "Consume token expired" });
+      }
+
+      // Re-validate return URL against the current request origin (not the
+      // origin at mint time) so the browser's actual hostname governs.
+      const { origin: serverOrigin } = getOriginAndRpID(req);
+      let redirectTo = "/";
+      const candidate = returnParam || entry.returnTo;
+      if (candidate) {
+        try {
+          const parsed = new URL(candidate, serverOrigin);
+          if (parsed.origin !== serverOrigin) {
+            return json(res, 400, { error: "return must be same-origin" });
+          }
+          redirectTo = parsed.pathname + parsed.search + parsed.hash;
+        } catch {
+          return json(res, 400, { error: "Invalid return URL" });
+        }
+      }
+
+      // Confirm the bound credential still exists on the instance. If it
+      // was revoked between mint and consume, fail closed rather than
+      // creating a session tied to a missing credential.
+      const currentState = loadState();
+      if (!currentState || !currentState.getCredential(entry.credentialId)) {
+        return json(res, 409, { error: "Bound credential no longer exists" });
+      }
+
+      const session = createLoginToken();
+      const result = await withStateLock((state) => {
+        if (!state) return {};
+        const updated = state
+          .pruneExpired()
+          .addLoginToken(
+            session.token,
+            session.expiry,
+            entry.credentialId,
+            session.csrfToken,
+            session.lastActivityAt,
+          );
+        return { state: updated };
+      });
+
+      if (!result.state) {
+        return json(res, 500, { error: "Failed to create session" });
+      }
+
+      setSessionCookie(res, session.token, session.expiry, { secure: isHttpsConnection(req) });
+
+      log.info("Session mint consumed", {
+        credentialId: entry.credentialId,
+        apiKeyId: entry.apiKeyId,
+        hasReturn: !!candidate,
+      });
+
+      res.writeHead(302, { Location: redirectTo });
+      res.end();
+    }},
 
     // --- Device-to-device auth ---
 

--- a/lib/routes/middleware.js
+++ b/lib/routes/middleware.js
@@ -1,28 +1,56 @@
 /**
  * Route middleware factories
  *
- * Wraps route handlers with authentication and CSRF checks. Extracted from
- * lib/routes.js (Tier 3.4). The middleware is a factory because it closes
- * over the server's `isAuthenticated` and `json` helpers.
+ * Wraps route handlers with authentication, CSRF, and scope checks. Extracted
+ * from lib/routes.js (Tier 3.4). The middleware is a factory because it
+ * closes over the server's `isAuthenticated` and `json` helpers.
+ *
+ * Scope model: an API key carries one or more scopes (see api-key-scopes.js).
+ * Cookie/localhost auth is treated as full access. Bearer auth with the
+ * "full" scope is likewise unconstrained. Narrow-scope Bearer keys are
+ * default-denied inside `auth()` — a route accepts a narrow scope only if
+ * it's wrapped in `requireScope(...)`. This means adding a new narrow scope
+ * cannot accidentally grant access to any existing route.
+ *
+ * Composition: `auth(requireScope("mint-session")(handler))`. `requireScope`
+ * returns the inner handler tagged with a non-enumerable `_acceptedScopes`
+ * property; `auth` reads that tag to know which scopes to accept. Ordering
+ * is fixed: requireScope must be nested inside auth.
  */
 
 import { loadState } from "../auth.js";
 import { isLocalRequest } from "../access-method.js";
 import { validateCsrfToken } from "../http-util.js";
+import { SCOPE_FULL } from "../api-key-scopes.js";
+
+const ACCEPTED_SCOPES = Symbol("acceptedScopes");
+
+function requestScopes(req) {
+  // Cookie/localhost auth has no scope record — treat as full access.
+  if (!req._apiKeyAuth) return [SCOPE_FULL];
+  return Array.isArray(req._apiKeyScopes) && req._apiKeyScopes.length
+    ? req._apiKeyScopes
+    : [SCOPE_FULL];
+}
 
 /**
  * @param {object} ctx
  * @param {(req: object) => boolean} ctx.isAuthenticated
  * @param {(res: object, status: number, body: object) => void} ctx.json
- * @returns {{ auth: Function, csrf: Function }}
+ * @returns {{ auth: Function, csrf: Function, requireScope: Function }}
  */
 export function createMiddleware(ctx) {
   const { isAuthenticated, json } = ctx;
 
   function auth(handler) {
+    const accepted = handler[ACCEPTED_SCOPES] || [SCOPE_FULL];
     return async (req, res, param) => {
       if (!isAuthenticated(req)) {
         return json(res, 401, { error: "Authentication required" });
+      }
+      const scopes = requestScopes(req);
+      if (!scopes.some(s => accepted.includes(s))) {
+        return json(res, 403, { error: "Insufficient scope" });
       }
       return handler(req, res, param);
     };
@@ -41,5 +69,23 @@ export function createMiddleware(ctx) {
     };
   }
 
-  return { auth, csrf };
+  /**
+   * Tag a handler so `auth(...)` accepts bearer keys carrying `scope` in
+   * addition to the full-scope default. Used as:
+   *
+   *   auth(requireScope("mint-session")(handler))
+   *
+   * The inner function is returned unchanged apart from the symbol-keyed
+   * `_acceptedScopes` marker — no extra runtime check happens at this
+   * layer; `auth` combines authentication and scope validation into one
+   * check so composition ordering can't be accidentally inverted.
+   */
+  function requireScope(scope) {
+    return (handler) => {
+      handler[ACCEPTED_SCOPES] = [SCOPE_FULL, scope];
+      return handler;
+    };
+  }
+
+  return { auth, csrf, requireScope };
 }

--- a/lib/routes/middleware.js
+++ b/lib/routes/middleware.js
@@ -13,9 +13,16 @@
  * cannot accidentally grant access to any existing route.
  *
  * Composition: `auth(requireScope("mint-session")(handler))`. `requireScope`
- * returns the inner handler tagged with a non-enumerable `_acceptedScopes`
- * property; `auth` reads that tag to know which scopes to accept. Ordering
- * is fixed: requireScope must be nested inside auth.
+ * returns a new wrapper function carrying an ACCEPTED_SCOPES tag; `auth`
+ * reads that tag to know which scopes to accept. requireScope does NOT mutate
+ * the passed handler — each call returns a fresh function so a handler reused
+ * across multiple routes cannot have its scope tag silently overwritten.
+ * Ordering is fixed: requireScope must be nested inside auth.
+ *
+ * Bearer-only routes: some endpoints (e.g. `/api/sessions/mint`) must reject
+ * cookie and localhost auth even when scope checks pass. Wrap those with
+ * `requireBearerAuth(...)` — `auth` refuses anything that isn't a Bearer
+ * API key before the scope check.
  */
 
 import { loadState } from "../auth.js";
@@ -23,7 +30,8 @@ import { isLocalRequest } from "../access-method.js";
 import { validateCsrfToken } from "../http-util.js";
 import { SCOPE_FULL } from "../api-key-scopes.js";
 
-const ACCEPTED_SCOPES = Symbol("acceptedScopes");
+const ACCEPTED_SCOPES = Symbol("ACCEPTED_SCOPES");
+const BEARER_ONLY = Symbol("BEARER_ONLY");
 
 function requestScopes(req) {
   // Cookie/localhost auth has no scope record — treat as full access.
@@ -37,16 +45,20 @@ function requestScopes(req) {
  * @param {object} ctx
  * @param {(req: object) => boolean} ctx.isAuthenticated
  * @param {(res: object, status: number, body: object) => void} ctx.json
- * @returns {{ auth: Function, csrf: Function, requireScope: Function }}
+ * @returns {{ auth: Function, csrf: Function, requireScope: Function, requireBearerAuth: Function }}
  */
 export function createMiddleware(ctx) {
   const { isAuthenticated, json } = ctx;
 
   function auth(handler) {
     const accepted = handler[ACCEPTED_SCOPES] || [SCOPE_FULL];
+    const bearerOnly = handler[BEARER_ONLY] === true;
     return async (req, res, param) => {
       if (!isAuthenticated(req)) {
         return json(res, 401, { error: "Authentication required" });
+      }
+      if (bearerOnly && !req._apiKeyAuth) {
+        return json(res, 403, { error: "Bearer API key required" });
       }
       const scopes = requestScopes(req);
       if (!scopes.some(s => accepted.includes(s))) {
@@ -70,22 +82,56 @@ export function createMiddleware(ctx) {
   }
 
   /**
-   * Tag a handler so `auth(...)` accepts bearer keys carrying `scope` in
+   * Wrap a handler so `auth(...)` accepts Bearer keys carrying `scope` in
    * addition to the full-scope default. Used as:
    *
    *   auth(requireScope("mint-session")(handler))
    *
-   * The inner function is returned unchanged apart from the symbol-keyed
-   * `_acceptedScopes` marker — no extra runtime check happens at this
-   * layer; `auth` combines authentication and scope validation into one
-   * check so composition ordering can't be accidentally inverted.
+   * Returns a fresh wrapper function — the passed handler is not mutated.
+   * Reusing a handler reference across multiple requireScope calls is safe;
+   * each call produces an independent wrapper with its own scope tag.
    */
   function requireScope(scope) {
     return (handler) => {
-      handler[ACCEPTED_SCOPES] = [SCOPE_FULL, scope];
-      return handler;
+      const wrapped = (req, res, param) => handler(req, res, param);
+      Object.defineProperty(wrapped, ACCEPTED_SCOPES, {
+        value: [SCOPE_FULL, scope],
+        enumerable: false,
+        writable: false,
+        configurable: false,
+      });
+      const existing = handler[BEARER_ONLY];
+      if (existing === true) {
+        Object.defineProperty(wrapped, BEARER_ONLY, {
+          value: true, enumerable: false, writable: false, configurable: false,
+        });
+      }
+      return wrapped;
     };
   }
 
-  return { auth, csrf, requireScope };
+  /**
+   * Wrap a handler so `auth(...)` refuses cookie and localhost requests,
+   * accepting only Bearer API key authentication. Used as:
+   *
+   *   auth(requireBearerAuth(requireScope("mint-session")(handler)))
+   *
+   * Returns a fresh wrapper — passed handler is not mutated. Composition with
+   * requireScope is order-independent because both markers are read by auth.
+   */
+  function requireBearerAuth(handler) {
+    const wrapped = (req, res, param) => handler(req, res, param);
+    Object.defineProperty(wrapped, BEARER_ONLY, {
+      value: true, enumerable: false, writable: false, configurable: false,
+    });
+    const existing = handler[ACCEPTED_SCOPES];
+    if (Array.isArray(existing)) {
+      Object.defineProperty(wrapped, ACCEPTED_SCOPES, {
+        value: existing, enumerable: false, writable: false, configurable: false,
+      });
+    }
+    return wrapped;
+  }
+
+  return { auth, csrf, requireScope, requireBearerAuth };
 }

--- a/server.js
+++ b/server.js
@@ -134,8 +134,19 @@ function isTrustedProxy(req) {
  * Check if a request is authenticated.
  * @returns {{ authenticated: boolean, sessionToken: string|null, credentialId: string|null } | null}
  *   Rich result object when authenticated, null when not.
+ *
+ * Result is cached on `req._authResult` for the remainder of the request —
+ * `handleRequest` calls isAuthenticated both as a gate (public-path check)
+ * and implicitly inside `auth()` middleware, and without caching the state
+ * lookup + Bearer activity-update would fire twice per request.
  */
 function isAuthenticated(req) {
+  if (req._authResult !== undefined) return req._authResult;
+  req._authResult = computeAuth(req);
+  return req._authResult;
+}
+
+function computeAuth(req) {
   if (isTrustedProxy(req)) {
     log.debug("Auth bypassed: trusted proxy", { ip: req.socket.remoteAddress });
     return { authenticated: true, sessionToken: null, credentialId: null };
@@ -146,7 +157,7 @@ function isAuthenticated(req) {
   }
   // API key auth via Bearer token
   const bearerResult = authenticateBearerKey(req, loadState());
-  if (bearerResult === null) {
+  if (bearerResult.invalid) {
     return null; // Bearer header present but invalid — don't fall through to cookie
   }
   if (bearerResult.matched) {

--- a/server.js
+++ b/server.js
@@ -152,6 +152,10 @@ function isAuthenticated(req) {
       const keyData = state.findApiKey(apiKey);
       if (keyData) {
         req._apiKeyAuth = true;
+        req._apiKeyId = keyData.id;
+        req._apiKeyScopes = Array.isArray(keyData.scopes) && keyData.scopes.length
+          ? [...keyData.scopes]
+          : ["full"];
         withStateLock((s) => {
           if (!s) return {};
           return { state: s.updateApiKeyActivity(keyData.id) };
@@ -229,7 +233,7 @@ pruneTimer.unref();
 
 // --- HTTP routes (assembled from lib/routes/) ---
 
-const { auth, csrf } = createMiddleware({ isAuthenticated, json });
+const { auth, csrf, requireScope } = createMiddleware({ isAuthenticated, json });
 
 // --- Plugins ---
 const { pluginRoutes, pluginWsHandlers, shutdownPlugins } = await loadPlugins({
@@ -308,7 +312,7 @@ const routes = [
     bridge,
     credentialLockout,
     RP_NAME, PORT,
-    auth, csrf,
+    auth, csrf, requireScope,
   }),
   ...createAppRoutes({
     json, parseJSON, readBody, isAuthenticated, sessionManager,

--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ import { ConfigManager } from "./lib/config.js";
 
 import { CredentialLockout } from "./lib/credential-lockout.js";
 import { isLocalRequest, isLoopbackAddress } from "./lib/access-method.js";
+import { authenticateBearerKey } from "./lib/api-key-auth.js";
 import { serveStaticFile, clearFileCache, buildVendorHashes } from "./lib/static-files.js";
 import { createTransportBridge } from "./lib/transport-bridge.js";
 import { createSessionManager, checkTmux, cleanTmuxServerEnv, setTmuxKatulongEnv } from "./lib/session-manager.js";
@@ -144,26 +145,17 @@ function isAuthenticated(req) {
     return { authenticated: true, sessionToken: null, credentialId: null };
   }
   // API key auth via Bearer token
-  const authHeader = req.headers.authorization;
-  if (authHeader && authHeader.startsWith("Bearer ")) {
-    const apiKey = authHeader.slice(7);
-    const state = loadState();
-    if (state) {
-      const keyData = state.findApiKey(apiKey);
-      if (keyData) {
-        req._apiKeyAuth = true;
-        req._apiKeyId = keyData.id;
-        req._apiKeyScopes = Array.isArray(keyData.scopes) && keyData.scopes.length
-          ? [...keyData.scopes]
-          : ["full"];
-        withStateLock((s) => {
-          if (!s) return {};
-          return { state: s.updateApiKeyActivity(keyData.id) };
-        }).catch(() => {});
-        return { authenticated: true, sessionToken: null, credentialId: null, apiKeyId: keyData.id };
-      }
-    }
-    return null; // Invalid API key — don't fall through to cookie
+  const bearerResult = authenticateBearerKey(req, loadState());
+  if (bearerResult === null) {
+    return null; // Bearer header present but invalid — don't fall through to cookie
+  }
+  if (bearerResult.matched) {
+    const keyId = bearerResult.keyData.id;
+    withStateLock((s) => {
+      if (!s) return {};
+      return { state: s.updateApiKeyActivity(keyId) };
+    }).catch(() => {});
+    return { authenticated: true, sessionToken: null, credentialId: null, apiKeyId: keyId };
   }
 
   const cookies = parseCookies(req.headers.cookie);
@@ -233,7 +225,7 @@ pruneTimer.unref();
 
 // --- HTTP routes (assembled from lib/routes/) ---
 
-const { auth, csrf, requireScope } = createMiddleware({ isAuthenticated, json });
+const { auth, csrf, requireScope, requireBearerAuth } = createMiddleware({ isAuthenticated, json });
 
 // --- Plugins ---
 const { pluginRoutes, pluginWsHandlers, shutdownPlugins } = await loadPlugins({
@@ -312,7 +304,7 @@ const routes = [
     bridge,
     credentialLockout,
     RP_NAME, PORT,
-    auth, csrf, requireScope,
+    auth, csrf, requireScope, requireBearerAuth,
   }),
   ...createAppRoutes({
     json, parseJSON, readBody, isAuthenticated, sessionManager,

--- a/test/api-key-scopes.test.js
+++ b/test/api-key-scopes.test.js
@@ -1,7 +1,13 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { AuthState } from "../lib/auth-state.js";
-import { SCOPE_FULL, SCOPE_MINT_SESSION, DEFAULT_API_KEY_SCOPES } from "../lib/api-key-scopes.js";
+import {
+  SCOPE_FULL,
+  SCOPE_MINT_SESSION,
+  DEFAULT_API_KEY_SCOPES,
+  validateScopes,
+  normalizeScopes,
+} from "../lib/api-key-scopes.js";
 
 describe("API key scopes on AuthState", () => {
   it("addApiKey defaults to ['full'] when scopes omitted", () => {
@@ -81,6 +87,34 @@ describe("API key scopes on AuthState", () => {
     const found = state.findApiKey(key);
     assert.ok(found, "key should be found");
     assert.deepEqual(found.scopes, [SCOPE_MINT_SESSION]);
+  });
+
+  it("validateScopes rejects unknown scopes with the unknown list", () => {
+    const { valid, unknown } = validateScopes(["bogus", SCOPE_MINT_SESSION]);
+    assert.equal(valid, false);
+    assert.deepEqual(unknown, ["bogus"]);
+  });
+
+  it("validateScopes accepts omitted input as default scopes", () => {
+    const { valid, normalized } = validateScopes(undefined);
+    assert.equal(valid, true);
+    assert.deepEqual(normalized, [...DEFAULT_API_KEY_SCOPES]);
+  });
+
+  it("validateScopes accepts empty array as default scopes", () => {
+    const { valid, normalized } = validateScopes([]);
+    assert.equal(valid, true);
+    assert.deepEqual(normalized, [...DEFAULT_API_KEY_SCOPES]);
+  });
+
+  it("validateScopes rejects non-array input with a stringified unknown", () => {
+    const { valid, unknown } = validateScopes("full");
+    assert.equal(valid, false);
+    assert.deepEqual(unknown, ["full"]);
+  });
+
+  it("normalizeScopes drops unknown entries silently (data-model layer)", () => {
+    assert.deepEqual(normalizeScopes(["bogus", SCOPE_MINT_SESSION]), [SCOPE_MINT_SESSION]);
   });
 
   it("findApiKey backfills ['full'] for legacy records without scopes", () => {

--- a/test/api-key-scopes.test.js
+++ b/test/api-key-scopes.test.js
@@ -1,0 +1,112 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { AuthState } from "../lib/auth-state.js";
+import { SCOPE_FULL, SCOPE_MINT_SESSION, DEFAULT_API_KEY_SCOPES } from "../lib/api-key-scopes.js";
+
+describe("API key scopes on AuthState", () => {
+  it("addApiKey defaults to ['full'] when scopes omitted", () => {
+    const state = AuthState.empty();
+    const next = state.addApiKey({
+      id: "k1",
+      key: "x".repeat(64),
+      name: "default",
+      createdAt: 1,
+      lastUsedAt: 0,
+    });
+    assert.deepEqual(next.apiKeys[0].scopes, [...DEFAULT_API_KEY_SCOPES]);
+  });
+
+  it("addApiKey persists explicitly provided scopes", () => {
+    const state = AuthState.empty();
+    const next = state.addApiKey({
+      id: "k1",
+      key: "x".repeat(64),
+      name: "narrow",
+      createdAt: 1,
+      lastUsedAt: 0,
+      scopes: [SCOPE_MINT_SESSION],
+    });
+    assert.deepEqual(next.apiKeys[0].scopes, [SCOPE_MINT_SESSION]);
+  });
+
+  it("addApiKey drops unknown scope strings (closed set)", () => {
+    const state = AuthState.empty();
+    const next = state.addApiKey({
+      id: "k1",
+      key: "x".repeat(64),
+      name: "bogus",
+      createdAt: 1,
+      lastUsedAt: 0,
+      scopes: ["definitely-not-real", SCOPE_MINT_SESSION],
+    });
+    assert.deepEqual(next.apiKeys[0].scopes, [SCOPE_MINT_SESSION]);
+  });
+
+  it("addApiKey falls back to default when all scopes are unknown", () => {
+    const state = AuthState.empty();
+    const next = state.addApiKey({
+      id: "k1",
+      key: "x".repeat(64),
+      name: "all-bogus",
+      createdAt: 1,
+      lastUsedAt: 0,
+      scopes: ["foo", "bar"],
+    });
+    assert.deepEqual(next.apiKeys[0].scopes, [...DEFAULT_API_KEY_SCOPES]);
+  });
+
+  it("addApiKey dedupes duplicate scopes", () => {
+    const state = AuthState.empty();
+    const next = state.addApiKey({
+      id: "k1",
+      key: "x".repeat(64),
+      name: "dup",
+      createdAt: 1,
+      lastUsedAt: 0,
+      scopes: [SCOPE_MINT_SESSION, SCOPE_MINT_SESSION, SCOPE_FULL],
+    });
+    assert.deepEqual(next.apiKeys[0].scopes.sort(), [SCOPE_FULL, SCOPE_MINT_SESSION].sort());
+  });
+
+  it("findApiKey returns record with scopes populated", () => {
+    const key = "y".repeat(64);
+    const state = AuthState.empty().addApiKey({
+      id: "k1",
+      key,
+      name: "t",
+      createdAt: 1,
+      lastUsedAt: 0,
+      scopes: [SCOPE_MINT_SESSION],
+    });
+    const found = state.findApiKey(key);
+    assert.ok(found, "key should be found");
+    assert.deepEqual(found.scopes, [SCOPE_MINT_SESSION]);
+  });
+
+  it("findApiKey backfills ['full'] for legacy records without scopes", () => {
+    // Simulate a record persisted before the scopes field existed by
+    // constructing AuthState directly (bypassing addApiKey's normalization).
+    const key = "z".repeat(64);
+    // First add the key normally to get a valid hash/salt/prefix shape...
+    const populated = AuthState.empty().addApiKey({
+      id: "legacy",
+      key,
+      name: "legacy",
+      createdAt: 1,
+      lastUsedAt: 0,
+    });
+    // ...then strip the scopes field to mimic an on-disk legacy record.
+    const legacyRecord = { ...populated.apiKeys[0] };
+    delete legacyRecord.scopes;
+    const state = new AuthState({
+      user: populated.user,
+      credentials: populated.credentials,
+      loginTokens: populated.loginTokens,
+      setupTokens: populated.setupTokens,
+      apiKeys: [legacyRecord],
+    });
+    const found = state.findApiKey(key);
+    assert.ok(found, "legacy key should still be findable");
+    assert.deepEqual(found.scopes, [...DEFAULT_API_KEY_SCOPES]);
+  });
+});

--- a/test/helpers/setup-env.js
+++ b/test/helpers/setup-env.js
@@ -41,6 +41,13 @@ import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { sweepOrphanTmuxSockets } from "../../lib/tmux-socket-sweep.js";
 
+// Marks the process as a test run — production modules can gate
+// mutating test-only exports on this (see lib/routes/auth-routes.js
+// `_resetMintForTesting` / `_expireMintForTesting`).
+if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = "test";
+}
+
 if (!process.env.KATULONG_DATA_DIR) {
   const dir = mkdtempSync(join(tmpdir(), "katulong-test-"));
   process.env.KATULONG_DATA_DIR = dir;

--- a/test/session-mint-consume.test.js
+++ b/test/session-mint-consume.test.js
@@ -23,8 +23,9 @@ process.on("exit", () => {
 
 const { AuthState } = await import("../lib/auth-state.js");
 const { SCOPE_MINT_SESSION, SCOPE_FULL } = await import("../lib/api-key-scopes.js");
+const { authenticateBearerKey } = await import("../lib/api-key-auth.js");
 const authRepo = await import("../lib/auth-repository.js");
-const { createAuthRoutes, _resetMintStateForTesting } = await import("../lib/routes/auth-routes.js");
+const { createAuthRoutes, _resetMintStateForTesting, _expireMintForTesting } = await import("../lib/routes/auth-routes.js");
 const { createMiddleware } = await import("../lib/routes/middleware.js");
 
 const ORIGIN = "https://example.com";
@@ -104,21 +105,18 @@ function json(res, status, data) {
   res.end(JSON.stringify(data));
 }
 
-// isAuthenticated mirrors server.js Bearer path for tests.
+// isAuthenticated for tests — reuses the same Bearer resolver as server.js
+// so the test path cannot drift from production.
 function isAuthenticatedForTests(req) {
-  const header = req.headers.authorization;
-  if (header && header.startsWith("Bearer ")) {
-    const apiKey = header.slice(7);
-    const state = authRepo.loadState();
-    if (!state) return null;
-    const keyData = state.findApiKey(apiKey);
-    if (!keyData) return null;
-    req._apiKeyAuth = true;
-    req._apiKeyId = keyData.id;
-    req._apiKeyScopes = keyData.scopes || [SCOPE_FULL];
-    return { authenticated: true, sessionToken: null, credentialId: null, apiKeyId: keyData.id };
-  }
-  return null;
+  const result = authenticateBearerKey(req, authRepo.loadState());
+  if (result === null) return null; // Bearer header present but invalid
+  if (!result.matched) return null; // No Bearer header at all
+  return {
+    authenticated: true,
+    sessionToken: null,
+    credentialId: null,
+    apiKeyId: result.keyData.id,
+  };
 }
 
 before(async () => {
@@ -168,6 +166,7 @@ before(async () => {
     auth: middleware.auth,
     csrf: middleware.csrf,
     requireScope: middleware.requireScope,
+    requireBearerAuth: middleware.requireBearerAuth,
   });
 });
 
@@ -188,15 +187,15 @@ describe("POST /api/sessions/mint — scope enforcement", () => {
     assert.equal(res.statusCode, 401);
   });
 
-  it("rejects a full-scope key (default-deny on narrow-scope routes)", async () => {
+  it("accepts a full-scope key on a narrow-scope route (full-scope passes everywhere)", async () => {
     const route = findRoute(routes, "POST", "/api/sessions/mint");
     const req = makeReq({ method: "POST", url: "/api/sessions/mint", body: {}, apiKey: fullApiKey });
     const res = makeRes();
     await route.handler(req, res);
-    // Full-scope keys pass requireScope(). The 201 confirms they're accepted;
-    // this guards against a future regression where requireScope accidentally
-    // excludes "full".
-    assert.equal(res.statusCode, 201, "full-scope key should be accepted");
+    // Full-scope is the superset scope: any `requireScope(X)` route accepts
+    // both SCOPE_FULL and X. Guards against a regression where requireScope
+    // accidentally excludes the full scope from its accepted list.
+    assert.equal(res.statusCode, 201, "full-scope key should be accepted on a narrow-scope route");
   });
 
   it("accepts a mint-session-scoped key", async () => {
@@ -207,8 +206,10 @@ describe("POST /api/sessions/mint — scope enforcement", () => {
     assert.equal(res.statusCode, 201);
     const body = JSON.parse(res._body);
     assert.ok(body.consumeUrl, "consumeUrl in response");
-    assert.ok(body.consumeToken, "consumeToken in response");
     assert.ok(body.expiresAt > Date.now(), "expiresAt is in the future");
+    assert.equal(body.credentialId, CREDENTIAL_ID, "binding credential exposed for audit");
+    const parsed = new URL(body.consumeUrl);
+    assert.ok(parsed.searchParams.get("token"), "consumeUrl carries token");
   });
 
   it("rejects invalid returnTo (cross-origin)", async () => {
@@ -252,7 +253,9 @@ describe("GET /auth/consume — lifecycle", () => {
     const res = makeRes();
     await mintRoute.handler(req, res);
     assert.equal(res.statusCode, 201, `mint failed: ${res._body}`);
-    return JSON.parse(res._body);
+    const body = JSON.parse(res._body);
+    const url = new URL(body.consumeUrl);
+    return { ...body, consumeToken: url.searchParams.get("token") };
   }
 
   it("issues a session cookie and 302-redirects to /", async () => {
@@ -320,6 +323,59 @@ describe("GET /auth/consume — lifecycle", () => {
     const res = makeRes();
     await route.handler(req, res);
     assert.equal(res.statusCode, 400);
+  });
+
+  it("rejects an over-long consume token before Map lookup", async () => {
+    const route = findRoute(routes, "GET", "/auth/consume");
+    const bigToken = "a".repeat(200);
+    const req = makeReq({ method: "GET", url: `/auth/consume?token=${bigToken}` });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 400);
+    const body = JSON.parse(res._body);
+    assert.ok(/too long/i.test(body.error), "error mentions over-length");
+  });
+
+  it("returns 410 when the pending token has expired", async () => {
+    const { consumeToken } = await mintConsumeToken();
+    _expireMintForTesting(consumeToken);
+    const route = findRoute(routes, "GET", "/auth/consume");
+    const req = makeReq({ method: "GET", url: `/auth/consume?token=${consumeToken}` });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 410);
+  });
+});
+
+describe("POST /api/sessions/mint — Bearer-only enforcement", () => {
+  it("rejects cookie-authenticated requests with 403 Bearer-required", async () => {
+    // isAuthenticatedForTests fakes a cookie-auth success without
+    // setting _apiKeyAuth, matching how a browser session would present.
+    const fakeCookieAuth = (_req) => ({ authenticated: true, sessionToken: "fake", credentialId: null });
+    const mw = createMiddleware({ isAuthenticated: fakeCookieAuth, json });
+    const cookieRoutes = createAuthRoutes({
+      json,
+      parseJSON,
+      isAuthenticated: fakeCookieAuth,
+      storeChallenge: () => {},
+      consumeChallenge: () => false,
+      challengeStore: null,
+      credentialLockout: null,
+      bridge: { relay: () => {} },
+      RP_NAME: "Test",
+      PORT: 443,
+      auth: mw.auth,
+      csrf: mw.csrf,
+      requireScope: mw.requireScope,
+      requireBearerAuth: mw.requireBearerAuth,
+    });
+    const route = findRoute(cookieRoutes, "POST", "/api/sessions/mint");
+    const req = makeReq({ method: "POST", url: "/api/sessions/mint", body: {} });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 403);
+    const body = JSON.parse(res._body);
+    assert.ok(/bearer/i.test(body.error), "error names Bearer requirement");
   });
 });
 

--- a/test/session-mint-consume.test.js
+++ b/test/session-mint-consume.test.js
@@ -312,10 +312,22 @@ describe("GET /auth/consume — lifecycle", () => {
 
   it("rejects unknown consume token", async () => {
     const route = findRoute(routes, "GET", "/auth/consume");
-    const req = makeReq({ method: "GET", url: "/auth/consume?token=deadbeef" });
+    // Valid-shaped hex token that was never minted → 404 from Map lookup.
+    const unknown = "a".repeat(64);
+    const req = makeReq({ method: "GET", url: `/auth/consume?token=${unknown}` });
     const res = makeRes();
     await route.handler(req, res);
     assert.equal(res.statusCode, 404);
+  });
+
+  it("rejects malformed consume token (non-hex)", async () => {
+    const route = findRoute(routes, "GET", "/auth/consume");
+    const req = makeReq({ method: "GET", url: "/auth/consume?token=deadbeef" });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 400);
+    const body = JSON.parse(res._body);
+    assert.ok(/format/i.test(body.error), "error mentions format");
   });
 
   it("rejects when token param is missing", async () => {

--- a/test/session-mint-consume.test.js
+++ b/test/session-mint-consume.test.js
@@ -1,0 +1,342 @@
+/**
+ * Session mint / consume lifecycle tests.
+ *
+ * These tests exercise the /api/sessions/mint and /auth/consume route
+ * handlers directly (no HTTP layer) against a real on-disk AuthState so
+ * withStateLock and persistence behave normally. KATULONG_DATA_DIR is
+ * redirected to a tmp dir before any lib module loads to avoid touching
+ * the developer's real state.
+ */
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const TEST_DATA_DIR = mkdtempSync(join(tmpdir(), "katulong-mint-test-"));
+process.env.KATULONG_DATA_DIR = TEST_DATA_DIR;
+process.on("exit", () => {
+  try { rmSync(TEST_DATA_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+const { AuthState } = await import("../lib/auth-state.js");
+const { SCOPE_MINT_SESSION, SCOPE_FULL } = await import("../lib/api-key-scopes.js");
+const authRepo = await import("../lib/auth-repository.js");
+const { createAuthRoutes, _resetMintStateForTesting } = await import("../lib/routes/auth-routes.js");
+const { createMiddleware } = await import("../lib/routes/middleware.js");
+
+const ORIGIN = "https://example.com";
+const HOST = "example.com";
+
+// --- Fake req/res helpers ---
+
+function makeReq({ method = "GET", url = "/", headers = {}, body = null, apiKey = null } = {}) {
+  // Attach a readable stream with the body payload so parseJSON can consume it.
+  const stream = body !== null ? Readable.from([typeof body === "string" ? body : JSON.stringify(body)]) : Readable.from([]);
+  const baseHeaders = { host: HOST, "user-agent": "test", ...headers };
+  const req = Object.assign(stream, {
+    method,
+    url,
+    headers: baseHeaders,
+    socket: { encrypted: true, remoteAddress: "203.0.113.1" },
+  });
+  if (apiKey) {
+    req.headers.authorization = `Bearer ${apiKey}`;
+  }
+  return req;
+}
+
+function makeRes() {
+  const headers = {};
+  const cookies = [];
+  const res = {
+    statusCode: 200,
+    _body: null,
+    _ended: false,
+    setHeader(name, value) {
+      if (name.toLowerCase() === "set-cookie") {
+        if (Array.isArray(value)) cookies.push(...value); else cookies.push(value);
+      }
+      headers[name] = value;
+    },
+    getHeader(name) { return headers[name]; },
+    writeHead(status, extraHeaders) {
+      this.statusCode = status;
+      if (extraHeaders) {
+        for (const [k, v] of Object.entries(extraHeaders)) {
+          if (k.toLowerCase() === "set-cookie") {
+            if (Array.isArray(v)) cookies.push(...v); else cookies.push(v);
+          }
+          headers[k] = v;
+        }
+      }
+    },
+    end(body) { this._body = body ?? null; this._ended = true; },
+    get headers() { return headers; },
+    get cookies() { return cookies; },
+  };
+  return res;
+}
+
+function findRoute(routes, method, path) {
+  const r = routes.find(r => r.method === method && r.path === path);
+  assert.ok(r, `route ${method} ${path} not found`);
+  return r;
+}
+
+// --- Shared setup ---
+
+let routes;
+let fullApiKey;
+let mintApiKey;
+const CREDENTIAL_ID = "cred-test-1";
+
+// Minimal parseJSON/json that mirror lib/request-util.js behavior.
+async function parseJSON(req) {
+  let body = "";
+  for await (const chunk of req) body += chunk;
+  return body ? JSON.parse(body) : {};
+}
+function json(res, status, data) {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(data));
+}
+
+// isAuthenticated mirrors server.js Bearer path for tests.
+function isAuthenticatedForTests(req) {
+  const header = req.headers.authorization;
+  if (header && header.startsWith("Bearer ")) {
+    const apiKey = header.slice(7);
+    const state = authRepo.loadState();
+    if (!state) return null;
+    const keyData = state.findApiKey(apiKey);
+    if (!keyData) return null;
+    req._apiKeyAuth = true;
+    req._apiKeyId = keyData.id;
+    req._apiKeyScopes = keyData.scopes || [SCOPE_FULL];
+    return { authenticated: true, sessionToken: null, credentialId: null, apiKeyId: keyData.id };
+  }
+  return null;
+}
+
+before(async () => {
+  await authRepo.withStateLock(() => {
+    const state = AuthState.empty("user-1", "owner")
+      .addCredential({
+        id: CREDENTIAL_ID,
+        publicKey: "pk",
+        counter: 0,
+        name: "Test Credential",
+        createdAt: Date.now(),
+        lastUsedAt: Date.now(),
+      })
+      .addApiKey({
+        id: "full-key",
+        key: "f".repeat(64),
+        name: "full",
+        createdAt: Date.now(),
+        lastUsedAt: 0,
+        scopes: [SCOPE_FULL],
+      })
+      .addApiKey({
+        id: "mint-key",
+        key: "m".repeat(64),
+        name: "mint-only",
+        createdAt: Date.now(),
+        lastUsedAt: 0,
+        scopes: [SCOPE_MINT_SESSION],
+      });
+    return { state };
+  });
+  fullApiKey = "f".repeat(64);
+  mintApiKey = "m".repeat(64);
+
+  const middleware = createMiddleware({ isAuthenticated: isAuthenticatedForTests, json });
+  routes = createAuthRoutes({
+    json,
+    parseJSON,
+    isAuthenticated: isAuthenticatedForTests,
+    storeChallenge: () => {},
+    consumeChallenge: () => false,
+    challengeStore: null,
+    credentialLockout: null,
+    bridge: { relay: () => {} },
+    RP_NAME: "Test",
+    PORT: 443,
+    auth: middleware.auth,
+    csrf: middleware.csrf,
+    requireScope: middleware.requireScope,
+  });
+});
+
+beforeEach(() => {
+  _resetMintStateForTesting();
+});
+
+after(() => {
+  // rmSync runs on process exit; nothing else to do.
+});
+
+describe("POST /api/sessions/mint — scope enforcement", () => {
+  it("rejects when no Bearer header is provided", async () => {
+    const route = findRoute(routes, "POST", "/api/sessions/mint");
+    const req = makeReq({ method: "POST", url: "/api/sessions/mint", body: {} });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 401);
+  });
+
+  it("rejects a full-scope key (default-deny on narrow-scope routes)", async () => {
+    const route = findRoute(routes, "POST", "/api/sessions/mint");
+    const req = makeReq({ method: "POST", url: "/api/sessions/mint", body: {}, apiKey: fullApiKey });
+    const res = makeRes();
+    await route.handler(req, res);
+    // Full-scope keys pass requireScope(). The 201 confirms they're accepted;
+    // this guards against a future regression where requireScope accidentally
+    // excludes "full".
+    assert.equal(res.statusCode, 201, "full-scope key should be accepted");
+  });
+
+  it("accepts a mint-session-scoped key", async () => {
+    const route = findRoute(routes, "POST", "/api/sessions/mint");
+    const req = makeReq({ method: "POST", url: "/api/sessions/mint", body: {}, apiKey: mintApiKey });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 201);
+    const body = JSON.parse(res._body);
+    assert.ok(body.consumeUrl, "consumeUrl in response");
+    assert.ok(body.consumeToken, "consumeToken in response");
+    assert.ok(body.expiresAt > Date.now(), "expiresAt is in the future");
+  });
+
+  it("rejects invalid returnTo (cross-origin)", async () => {
+    const route = findRoute(routes, "POST", "/api/sessions/mint");
+    const req = makeReq({
+      method: "POST",
+      url: "/api/sessions/mint",
+      body: { returnTo: "https://evil.example/steal" },
+      apiKey: mintApiKey,
+    });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 400);
+  });
+
+  it("accepts same-origin returnTo", async () => {
+    const route = findRoute(routes, "POST", "/api/sessions/mint");
+    const req = makeReq({
+      method: "POST",
+      url: "/api/sessions/mint",
+      body: { returnTo: "/?fleet=hub" },
+      apiKey: mintApiKey,
+    });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 201);
+    const body = JSON.parse(res._body);
+    assert.ok(body.consumeUrl.includes("return="), "consumeUrl carries the return param");
+  });
+});
+
+describe("GET /auth/consume — lifecycle", () => {
+  async function mintConsumeToken({ returnTo } = {}) {
+    const mintRoute = findRoute(routes, "POST", "/api/sessions/mint");
+    const req = makeReq({
+      method: "POST",
+      url: "/api/sessions/mint",
+      body: returnTo ? { returnTo } : {},
+      apiKey: mintApiKey,
+    });
+    const res = makeRes();
+    await mintRoute.handler(req, res);
+    assert.equal(res.statusCode, 201, `mint failed: ${res._body}`);
+    return JSON.parse(res._body);
+  }
+
+  it("issues a session cookie and 302-redirects to /", async () => {
+    const { consumeToken } = await mintConsumeToken();
+    const route = findRoute(routes, "GET", "/auth/consume");
+    const req = makeReq({ method: "GET", url: `/auth/consume?token=${consumeToken}` });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 302);
+    assert.equal(res.headers.Location, "/");
+    const cookie = res.cookies.find(c => c.startsWith("katulong_session="));
+    assert.ok(cookie, "katulong_session cookie set");
+    assert.ok(cookie.includes("HttpOnly"), "cookie is HttpOnly");
+  });
+
+  it("honors same-origin return URL", async () => {
+    const { consumeToken } = await mintConsumeToken({ returnTo: "/?fleet=hub" });
+    const route = findRoute(routes, "GET", "/auth/consume");
+    const req = makeReq({
+      method: "GET",
+      url: `/auth/consume?token=${consumeToken}&return=${encodeURIComponent("/?fleet=hub")}`,
+    });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 302);
+    assert.equal(res.headers.Location, "/?fleet=hub");
+  });
+
+  it("rejects cross-origin return URL at consume time", async () => {
+    const { consumeToken } = await mintConsumeToken();
+    const route = findRoute(routes, "GET", "/auth/consume");
+    const req = makeReq({
+      method: "GET",
+      url: `/auth/consume?token=${consumeToken}&return=${encodeURIComponent("https://evil.example/")}`,
+    });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 400);
+  });
+
+  it("is single-use: replay returns 404", async () => {
+    const { consumeToken } = await mintConsumeToken();
+    const route = findRoute(routes, "GET", "/auth/consume");
+    // First consume succeeds
+    const res1 = makeRes();
+    await route.handler(makeReq({ method: "GET", url: `/auth/consume?token=${consumeToken}` }), res1);
+    assert.equal(res1.statusCode, 302);
+    // Replay with same token must not create a second session
+    const res2 = makeRes();
+    await route.handler(makeReq({ method: "GET", url: `/auth/consume?token=${consumeToken}` }), res2);
+    assert.equal(res2.statusCode, 404);
+  });
+
+  it("rejects unknown consume token", async () => {
+    const route = findRoute(routes, "GET", "/auth/consume");
+    const req = makeReq({ method: "GET", url: "/auth/consume?token=deadbeef" });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 404);
+  });
+
+  it("rejects when token param is missing", async () => {
+    const route = findRoute(routes, "GET", "/auth/consume");
+    const req = makeReq({ method: "GET", url: "/auth/consume" });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 400);
+  });
+});
+
+describe("scope middleware default-deny", () => {
+  it("narrow-scope key is rejected by a generic auth()-only route (GET /api/api-keys)", async () => {
+    const route = findRoute(routes, "GET", "/api/api-keys");
+    const req = makeReq({ method: "GET", url: "/api/api-keys", apiKey: mintApiKey });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 403, "mint-session key must not list API keys");
+  });
+
+  it("full-scope key is accepted on the same route", async () => {
+    const route = findRoute(routes, "GET", "/api/api-keys");
+    const req = makeReq({ method: "GET", url: "/api/api-keys", apiKey: fullApiKey });
+    const res = makeRes();
+    await route.handler(req, res);
+    assert.equal(res.statusCode, 200);
+  });
+});

--- a/test/session-mint-consume.test.js
+++ b/test/session-mint-consume.test.js
@@ -25,7 +25,7 @@ const { AuthState } = await import("../lib/auth-state.js");
 const { SCOPE_MINT_SESSION, SCOPE_FULL } = await import("../lib/api-key-scopes.js");
 const { authenticateBearerKey } = await import("../lib/api-key-auth.js");
 const authRepo = await import("../lib/auth-repository.js");
-const { createAuthRoutes, _resetMintStateForTesting, _expireMintForTesting } = await import("../lib/routes/auth-routes.js");
+const { createAuthRoutes, _resetMintForTesting, _expireMintForTesting } = await import("../lib/routes/auth-routes.js");
 const { createMiddleware } = await import("../lib/routes/middleware.js");
 
 const ORIGIN = "https://example.com";
@@ -106,11 +106,12 @@ function json(res, status, data) {
 }
 
 // isAuthenticated for tests — reuses the same Bearer resolver as server.js
-// so the test path cannot drift from production.
+// so the test path cannot drift from production. Tests exercise Bearer-only
+// routes, so both "no header" and "bogus header" are treated as unauthorized;
+// only `matched: true` is a success.
 function isAuthenticatedForTests(req) {
   const result = authenticateBearerKey(req, authRepo.loadState());
-  if (result === null) return null; // Bearer header present but invalid
-  if (!result.matched) return null; // No Bearer header at all
+  if (!result.matched) return null;
   return {
     authenticated: true,
     sessionToken: null,
@@ -171,7 +172,7 @@ before(async () => {
 });
 
 beforeEach(() => {
-  _resetMintStateForTesting();
+  _resetMintForTesting();
 });
 
 after(() => {


### PR DESCRIPTION
## Summary

Phase 1 of fleet federation — the protocol primitives that any hub (laptop-local, self-hosted, or managed) builds on. Three things ship together:

- **Scoped API keys** with a closed vocabulary (`full`, `mint-session`). Default-deny: narrow-scope keys can't hit any route that doesn't explicitly opt-in via `requireScope`.
- **`POST /api/sessions/mint`** — Bearer + narrow scope, returns a single-use consume URL. Bound to the first registered credential so revocation cascades work.
- **`GET /auth/consume`** — public, single-use, same-origin-validated, lands a first-party `katulong_session` cookie via 302.

Plus CLI surface (`apikey create --scope`, `fleet test-mint`) and an operator doc (`docs/federation-setup.md`) that walks an operator or a Claude agent over SSH through enabling the primitives per-instance.

## Why

These are the open-source pieces a fleet hub needs. Keeping them in mainline katulong — not locked behind any managed offering — so self-hosters can wire up their own hub, and so the protocol stays the thing, not whoever runs the hub.

See `docs/service-plan.md` for the full picture of how the tiers relate.

## Notable design calls

- **Symbol-tagged scope middleware.** First cut used `req._scopeChecked = true` at runtime — but with composition `auth(requireScope(handler))` the outer `auth()` fires first and default-denies narrow-scope keys before the opt-in runs. Fixed by stamping `handler[ACCEPTED_SCOPES]` at route-definition time and letting `auth()` read the symbol for one combined check. No ordering trap.
- **Mint is Bearer-only.** Cookie and localhost auth are explicitly rejected — a hub that has a cookie doesn't need to mint.
- **Atomic single-use consume** via `Map.get` then `Map.delete` with no `await` between them; Node's single-threaded event loop makes the pair atomic.
- **Same-origin `returnTo` validated at both mint and consume time.** The current request's origin governs, not the mint-time origin.
- **Minted session binds to `state.credentials[0].id`** so `isValidLoginToken` passes and credential revocation kills the minted session too.

## Tests

- `test/api-key-scopes.test.js` — 7 tests on scope normalization at the `AuthState` boundary
- `test/session-mint-consume.test.js` — 13 tests exercising mint+consume end-to-end via synthetic req/res; covers scope enforcement, returnTo validation, single-use replay prevention, unknown/missing tokens, default-deny on generic routes
- Full suite: 2577 pass, 0 fail, 3 skipped

## Test plan

- [ ] Pull the branch, run `npm test` — should be green
- [ ] Start `scripts/restart-dev.sh`, create a key with `katulong apikey create --scope mint-session --json`
- [ ] Verify with `katulong fleet test-mint http://localhost:3001 --key <key>` — exits 0 on success
- [ ] Confirm `apikey list` shows SCOPES column
- [ ] Read the three docs: `docs/federation-setup.md`, `docs/service-plan.md`, `docs/cli-reference.md` (Fleet Federation section)
- [ ] Sanity check `docs/service-plan.md` contains no pricing, margins, or commercial strategy — that material stays internal