### PR TITLE
rewrite(server): slice 4 — HTTP session/cookie/auth-middleware primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1035,10 +1035,14 @@ name = "katulong-server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "http-body-util",
+ "katulong-auth",
  "katulong-shared",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
+ "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2382,6 +2386,21 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tower"

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -22,7 +22,7 @@ mod webauthn;
 
 pub use credential::Credential;
 pub use error::AuthError;
-pub use session::Session;
+pub use session::{Session, SESSION_TTL};
 pub use setup_token::{PlaintextToken, SetupToken};
 pub use state::AuthState;
 pub use store::AuthStore;

--- a/crates/auth/src/session.rs
+++ b/crates/auth/src/session.rs
@@ -1,5 +1,14 @@
+use crate::random::random_hex;
 use serde::{Deserialize, Serialize};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
+
+/// Default session lifetime: 30 days.
+///
+/// Matches the Node `SESSION_TTL_MS` constant (see Node commit `7b3bb1b`
+/// for the consolidation scar — this value was independently redefined in
+/// six places before being centralised; do not reintroduce a local
+/// constant elsewhere).
+pub const SESSION_TTL: Duration = Duration::from_secs(60 * 60 * 24 * 30);
 
 /// A browser session bound to a credential.
 ///
@@ -19,4 +28,65 @@ pub struct Session {
     pub expires_at: SystemTime,
     #[serde(with = "crate::state::systime")]
     pub last_activity_at: SystemTime,
+}
+
+impl Session {
+    /// Mint a fresh session for `credential_id`, expiring `ttl` after `now`.
+    ///
+    /// Both the session token and the paired CSRF token are 32 random bytes
+    /// from the OS CSPRNG, encoded as lowercase hex (64 ASCII chars each).
+    /// That's 256 bits of entropy per token — comfortably past brute-force
+    /// at any realistic rate, and the hex encoding stays transparent when it
+    /// lands in cookies, forms, or logs.
+    ///
+    /// The caller is still responsible for persisting the result via
+    /// `AuthStore::transact(|s| Ok((s.upsert_session(session.clone()),
+    /// session)))` before sending the cookie. Minting without persisting
+    /// would produce a token the server can't later recognise.
+    pub fn mint(credential_id: impl Into<String>, now: SystemTime, ttl: Duration) -> Self {
+        Self {
+            token: random_hex(32),
+            credential_id: credential_id.into(),
+            csrf_token: random_hex(32),
+            created_at: now,
+            expires_at: now + ttl,
+            last_activity_at: now,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mint_produces_distinct_tokens_on_each_call() {
+        let a = Session::mint("cred", SystemTime::UNIX_EPOCH, SESSION_TTL);
+        let b = Session::mint("cred", SystemTime::UNIX_EPOCH, SESSION_TTL);
+        assert_ne!(a.token, b.token, "session tokens must be unique");
+        assert_ne!(a.csrf_token, b.csrf_token, "csrf tokens must be unique");
+        assert_ne!(
+            a.token, a.csrf_token,
+            "session and csrf tokens must be drawn independently"
+        );
+    }
+
+    #[test]
+    fn mint_sets_expiry_from_ttl() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
+        let s = Session::mint("cred", now, Duration::from_secs(3600));
+        assert_eq!(s.created_at, now);
+        assert_eq!(s.expires_at, now + Duration::from_secs(3600));
+        assert_eq!(s.last_activity_at, now);
+    }
+
+    #[test]
+    fn token_shape_is_64_hex_chars() {
+        let s = Session::mint("cred", SystemTime::UNIX_EPOCH, SESSION_TTL);
+        assert_eq!(s.token.len(), 64, "32 bytes hex-encoded → 64 chars");
+        assert!(
+            s.token.chars().all(|c| c.is_ascii_hexdigit()),
+            "token must be hex only"
+        );
+    }
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -8,7 +8,12 @@ license.workspace = true
 name = "katulong-server"
 path = "src/main.rs"
 
+[lib]
+name = "katulong_server"
+path = "src/lib.rs"
+
 [dependencies]
+katulong-auth = { path = "../auth" }
 katulong-shared = { path = "../shared" }
 axum = { workspace = true }
 tokio = { workspace = true }
@@ -16,3 +21,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tower = { version = "0.4", features = ["util"] }
+http-body-util = "0.1"

--- a/crates/server/src/access.rs
+++ b/crates/server/src/access.rs
@@ -1,0 +1,163 @@
+//! Access-method detection: localhost vs remote.
+//!
+//! Critical security boundary. Localhost requests bypass WebAuthn because
+//! local shell access is already root-equivalent; remote requests must
+//! present a valid session cookie. Mis-classifying a tunnel connection as
+//! localhost would hand the internet a free shell.
+//!
+//! The Node implementation learned the hard way (commit `fb4b1f9`) that
+//! a loopback SOCKET address alone isn't enough — Cloudflare Tunnel and
+//! ngrok both bridge traffic through a local cloudflared/ngrok process,
+//! so the server sees `127.0.0.1` as the peer address even for traffic
+//! originating on the public internet. The fix is to require BOTH a
+//! loopback peer AND a Host header pointing at `localhost` / `127.0.0.1`
+//! / `::1`. If either condition fails, treat as remote.
+//!
+//! Note on `X-Forwarded-*`: we deliberately do not consult forwarded
+//! headers here. They are trivially forgeable and trusting them is the
+//! exact class of bug `c37c2c0` in Node flagged.
+
+use std::net::{IpAddr, SocketAddr};
+
+/// Access classification for a single HTTP request.
+///
+/// `Remote` is the safe default: any ambiguity falls this way so the
+/// auth middleware demands a cookie rather than silently bypassing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessMethod {
+    /// Both the peer address AND the Host header resolve to loopback.
+    /// Auth bypass is safe — the peer is this machine.
+    Localhost,
+    /// Anything else. Requires a valid session cookie.
+    Remote,
+}
+
+impl AccessMethod {
+    /// Classify a request from its socket peer address and `Host` header.
+    ///
+    /// `host_header` is the raw value (may include a port suffix like
+    /// `localhost:3000`). Both checks must pass — loopback peer AND
+    /// loopback host — for `Localhost`. Missing header → `Remote`.
+    pub fn classify(peer: SocketAddr, host_header: Option<&str>) -> Self {
+        if !peer.ip().is_loopback() {
+            return Self::Remote;
+        }
+        match host_header.and_then(host_is_loopback) {
+            Some(true) => Self::Localhost,
+            _ => Self::Remote,
+        }
+    }
+}
+
+/// Strip any `:port` from a Host header and test whether the remaining
+/// authority is a loopback hostname or literal loopback IP. Returns
+/// `None` if the header is unparseable at all; the caller treats `None`
+/// as "not loopback."
+///
+/// Accepts the obvious literals (`localhost`, `127.0.0.1`, `::1`) and any
+/// IPv4 in `127.0.0.0/8` — the full loopback range, not just the
+/// single-address one, since `127.0.0.2` etc. are valid loopback aliases
+/// on most platforms and a test rig may use them.
+fn host_is_loopback(header: &str) -> Option<bool> {
+    let authority = strip_port(header);
+    if authority.eq_ignore_ascii_case("localhost") {
+        return Some(true);
+    }
+    if let Ok(ip) = authority.parse::<IpAddr>() {
+        return Some(ip.is_loopback());
+    }
+    Some(false)
+}
+
+/// Strip a trailing `:port` from a host authority, if any. Must handle
+/// both bracketed IPv6 (`[::1]:3000`) and plain IPv4/hostname forms.
+fn strip_port(authority: &str) -> &str {
+    if let Some(rest) = authority.strip_prefix('[') {
+        // IPv6 literal: `[::1]:3000` → pull the inner `::1`.
+        if let Some((addr, _)) = rest.split_once(']') {
+            return addr;
+        }
+    }
+    // Plain form. For hostnames and IPv4 `a.b.c.d:port` works on the
+    // last `:`. For bare IPv6 without brackets the browser wouldn't send
+    // the port anyway (RFC 7230 requires brackets) so we can treat the
+    // whole string as the authority.
+    authority.rsplit_once(':').map_or(authority, |(host, _)| host)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sa(ip: &str, port: u16) -> SocketAddr {
+        format!("{ip}:{port}").parse().unwrap()
+    }
+
+    #[test]
+    fn loopback_peer_plus_loopback_host_is_localhost() {
+        let cases = [
+            ("127.0.0.1", Some("localhost")),
+            ("127.0.0.1", Some("localhost:3000")),
+            ("127.0.0.1", Some("127.0.0.1:3000")),
+            ("127.0.0.1", Some("LOCALHOST")),
+            ("::1", Some("[::1]:3000")),
+        ];
+        for (peer_ip, host) in cases {
+            let peer = if peer_ip.contains(':') {
+                format!("[{peer_ip}]:9999").parse().unwrap()
+            } else {
+                sa(peer_ip, 9999)
+            };
+            assert_eq!(
+                AccessMethod::classify(peer, host),
+                AccessMethod::Localhost,
+                "peer={peer_ip} host={host:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn loopback_peer_with_tunnel_host_is_remote() {
+        // This is THE scar. Cloudflare Tunnel bridges traffic through a
+        // local cloudflared, so peer == 127.0.0.1 even for internet
+        // traffic. Must not classify as localhost.
+        let cases = [
+            Some("katulong.example.com"),
+            Some("abc123.trycloudflare.com"),
+            Some("katulong-mini.felixflor.es"),
+            None, // No host header at all — treat as remote.
+        ];
+        for host in cases {
+            assert_eq!(
+                AccessMethod::classify(sa("127.0.0.1", 9999), host),
+                AccessMethod::Remote,
+                "loopback peer + {host:?} must be Remote"
+            );
+        }
+    }
+
+    #[test]
+    fn non_loopback_peer_is_always_remote() {
+        assert_eq!(
+            AccessMethod::classify(sa("192.168.1.10", 9999), Some("localhost")),
+            AccessMethod::Remote,
+            "even a localhost Host header cannot override a non-loopback peer"
+        );
+    }
+
+    #[test]
+    fn strip_port_handles_ipv6_brackets() {
+        assert_eq!(strip_port("[::1]:3000"), "::1");
+        assert_eq!(strip_port("[::1]"), "::1");
+        assert_eq!(strip_port("localhost:3000"), "localhost");
+        assert_eq!(strip_port("localhost"), "localhost");
+        assert_eq!(strip_port("127.0.0.1:80"), "127.0.0.1");
+    }
+
+    #[test]
+    fn full_127_loopback_range_is_loopback() {
+        // `127.0.0.2` and friends are valid loopback on most systems.
+        assert_eq!(host_is_loopback("127.0.0.2"), Some(true));
+        assert_eq!(host_is_loopback("127.255.255.254"), Some(true));
+    }
+}

--- a/crates/server/src/access.rs
+++ b/crates/server/src/access.rs
@@ -42,31 +42,27 @@ impl AccessMethod {
         if !peer.ip().is_loopback() {
             return Self::Remote;
         }
-        match host_header.and_then(host_is_loopback) {
-            Some(true) => Self::Localhost,
-            _ => Self::Remote,
+        if host_header.is_some_and(host_is_loopback) {
+            Self::Localhost
+        } else {
+            Self::Remote
         }
     }
 }
 
 /// Strip any `:port` from a Host header and test whether the remaining
-/// authority is a loopback hostname or literal loopback IP. Returns
-/// `None` if the header is unparseable at all; the caller treats `None`
-/// as "not loopback."
+/// authority is a loopback hostname or literal loopback IP.
 ///
 /// Accepts the obvious literals (`localhost`, `127.0.0.1`, `::1`) and any
 /// IPv4 in `127.0.0.0/8` — the full loopback range, not just the
 /// single-address one, since `127.0.0.2` etc. are valid loopback aliases
 /// on most platforms and a test rig may use them.
-fn host_is_loopback(header: &str) -> Option<bool> {
+fn host_is_loopback(header: &str) -> bool {
     let authority = strip_port(header);
     if authority.eq_ignore_ascii_case("localhost") {
-        return Some(true);
+        return true;
     }
-    if let Ok(ip) = authority.parse::<IpAddr>() {
-        return Some(ip.is_loopback());
-    }
-    Some(false)
+    authority.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
 }
 
 /// Strip a trailing `:port` from a host authority, if any. Must handle
@@ -157,7 +153,7 @@ mod tests {
     #[test]
     fn full_127_loopback_range_is_loopback() {
         // `127.0.0.2` and friends are valid loopback on most systems.
-        assert_eq!(host_is_loopback("127.0.0.2"), Some(true));
-        assert_eq!(host_is_loopback("127.255.255.254"), Some(true));
+        assert!(host_is_loopback("127.0.0.2"));
+        assert!(host_is_loopback("127.255.255.254"));
     }
 }

--- a/crates/server/src/auth_middleware.rs
+++ b/crates/server/src/auth_middleware.rs
@@ -1,0 +1,125 @@
+//! Request-level authentication.
+//!
+//! One extractor, `Authenticated`, that either (a) proves the request is
+//! from loopback with a loopback Host, in which case auth is satisfied
+//! without a cookie, or (b) carries a valid unexpired session cookie.
+//! Anything else rejects with 401.
+//!
+//! The extractor returns a rich `AuthContext` (not a boolean) so
+//! downstream handlers don't have to re-parse the cookie to learn which
+//! credential is logged in. That duplication bit the Node port and was
+//! consolidated in commit `45f4285`; the Rust port ships with the rich
+//! shape from day one.
+
+use crate::access::AccessMethod;
+use crate::cookie::extract_session_token;
+use crate::state::AppState;
+use axum::{
+    extract::{ConnectInfo, FromRequestParts, State},
+    http::{header, request::Parts, StatusCode},
+    response::{IntoResponse, Response},
+};
+use katulong_auth::{Credential, Session};
+use std::net::SocketAddr;
+use std::time::SystemTime;
+
+/// The rich result produced when a request is authenticated.
+///
+/// `Localhost` carries no session — the peer is this machine and that's
+/// the whole auth story. `Remote` carries both the session and the
+/// credential it was bound to, so handlers that need one or the other
+/// don't go back to the store.
+///
+/// Clippy flags the size imbalance (Remote ≈ 240 bytes, Localhost 0)
+/// and suggests boxing `credential`. We decline: `Remote` is the common
+/// case on every authenticated remote request, and adding a heap
+/// allocation to the hot path to save zeroing 240 stack bytes on the
+/// rare `Localhost` path is the wrong tradeoff for single-user
+/// katulong. If this ever shows up in a profile, revisit.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone)]
+pub enum AuthContext {
+    Localhost,
+    Remote { session: Session, credential: Credential },
+}
+
+impl AuthContext {
+    /// Credential ID if one is bound to this context. `None` for
+    /// `Localhost` — there's no registered device involved.
+    pub fn credential_id(&self) -> Option<&str> {
+        match self {
+            Self::Localhost => None,
+            Self::Remote { credential, .. } => Some(&credential.id),
+        }
+    }
+}
+
+/// Axum extractor wrapper. Handler signature is
+/// `async fn handler(Authenticated(ctx): Authenticated, ...)`.
+#[derive(Debug, Clone)]
+pub struct Authenticated(pub AuthContext);
+
+/// Rejection produced when authentication fails. Always 401 —
+/// distinguishing "no cookie" vs "expired cookie" vs "unknown cookie" in
+/// the response body would help an attacker probe valid session shapes,
+/// so the client gets the same message regardless.
+#[derive(Debug)]
+pub struct AuthRejection;
+
+impl IntoResponse for AuthRejection {
+    fn into_response(self) -> Response {
+        (StatusCode::UNAUTHORIZED, "unauthorized").into_response()
+    }
+}
+
+#[axum::async_trait]
+impl FromRequestParts<AppState> for Authenticated {
+    type Rejection = AuthRejection;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let ConnectInfo(peer) = ConnectInfo::<SocketAddr>::from_request_parts(parts, state)
+            .await
+            .map_err(|_| AuthRejection)?;
+        let host = parts
+            .headers
+            .get(header::HOST)
+            .and_then(|v| v.to_str().ok());
+        let access = AccessMethod::classify(peer, host);
+        if matches!(access, AccessMethod::Localhost) {
+            return Ok(Authenticated(AuthContext::Localhost));
+        }
+
+        let token = parts
+            .headers
+            .get(header::COOKIE)
+            .and_then(|v| v.to_str().ok())
+            .and_then(extract_session_token)
+            .ok_or(AuthRejection)?;
+
+        let snapshot = state.auth_store.snapshot().await;
+        let now = SystemTime::now();
+        let session = snapshot
+            .valid_session(&token, now)
+            .ok_or(AuthRejection)?
+            .clone();
+        let credential = snapshot
+            .find_credential(&session.credential_id)
+            .ok_or(AuthRejection)?
+            .clone();
+
+        Ok(Authenticated(AuthContext::Remote {
+            session,
+            credential,
+        }))
+    }
+}
+
+/// The extractor is generic over `S: AppState`-like state. We also
+/// provide a `State<AppState>` shim so handlers that want direct state
+/// access can take both extractors in one signature — axum composes them
+/// fine, and this keeps the boilerplate-for-the-reader low.
+#[allow(dead_code)]
+pub type AppStateExt = State<AppState>;

--- a/crates/server/src/auth_middleware.rs
+++ b/crates/server/src/auth_middleware.rs
@@ -15,7 +15,7 @@ use crate::access::AccessMethod;
 use crate::cookie::extract_session_token;
 use crate::state::AppState;
 use axum::{
-    extract::{ConnectInfo, FromRequestParts, State},
+    extract::{ConnectInfo, FromRequestParts},
     http::{header, request::Parts, StatusCode},
     response::{IntoResponse, Response},
 };
@@ -117,9 +117,3 @@ impl FromRequestParts<AppState> for Authenticated {
     }
 }
 
-/// The extractor is generic over `S: AppState`-like state. We also
-/// provide a `State<AppState>` shim so handlers that want direct state
-/// access can take both extractors in one signature — axum composes them
-/// fine, and this keeps the boilerplate-for-the-reader low.
-#[allow(dead_code)]
-pub type AppStateExt = State<AppState>;

--- a/crates/server/src/cookie.rs
+++ b/crates/server/src/cookie.rs
@@ -25,8 +25,14 @@ pub fn extract_session_token(header_value: &str) -> Option<String> {
     for pair in header_value.split(';') {
         let pair = pair.trim();
         if let Some((name, value)) = pair.split_once('=') {
-            if name == SESSION_COOKIE {
-                return Some(value.to_string());
+            if name.trim() == SESSION_COOKIE {
+                // Trim the value too — some clients emit
+                // `katulong_session=TOKEN ; next=1` where the space before
+                // the semicolon lands inside the value. Our tokens are
+                // hex-only so whitespace can never be a real value, and a
+                // trimmed mismatch (`"TOKEN "` vs `"TOKEN"`) would silently
+                // 401 an authenticated user.
+                return Some(value.trim().to_string());
             }
         }
     }
@@ -54,14 +60,11 @@ pub fn extract_session_token(header_value: &str) -> Option<String> {
 /// responsible for encoding it; a change here without one there would
 /// silently produce cookies the client can't send back.
 pub fn build_set_cookie(token: &str, max_age_secs: u64, secure: bool) -> String {
-    let mut cookie = format!(
-        "{name}={token}; HttpOnly; SameSite=Lax; Path=/; Max-Age={max_age_secs}",
-        name = SESSION_COOKIE
-    );
-    if secure {
-        cookie.push_str("; Secure");
-    }
-    cookie
+    format!(
+        "{name}={token}; Max-Age={max_age_secs}{flags}",
+        name = SESSION_COOKIE,
+        flags = cookie_flags(secure),
+    )
 }
 
 /// Build a `Set-Cookie` header that clears the session cookie.
@@ -72,14 +75,25 @@ pub fn build_set_cookie(token: &str, max_age_secs: u64, secure: bool) -> String 
 /// `Set-Cookie`. `Secure` follows the live cookie's setting so the
 /// browser is willing to overwrite on the right scheme.
 pub fn build_clear_cookie(secure: bool) -> String {
-    let mut cookie = format!(
-        "{name}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0",
-        name = SESSION_COOKIE
-    );
+    format!(
+        "{name}=; Max-Age=0{flags}",
+        name = SESSION_COOKIE,
+        flags = cookie_flags(secure),
+    )
+}
+
+/// The canonical flag block. Returns the suffix that every `Set-Cookie`
+/// we emit must carry: `HttpOnly`, `SameSite=Lax`, `Path=/`, and
+/// conditional `Secure`. Lives as a private helper so the module's
+/// stated "one flag list" guarantee is structural: adding a flag
+/// (e.g. `Partitioned` or the `__Host-` prefix if we ever adopt it)
+/// is a single-site change rather than "remember both emitters."
+fn cookie_flags(secure: bool) -> String {
+    let mut s = String::from("; HttpOnly; SameSite=Lax; Path=/");
     if secure {
-        cookie.push_str("; Secure");
+        s.push_str("; Secure");
     }
-    cookie
+    s
 }
 
 #[cfg(test)]
@@ -120,6 +134,22 @@ mod tests {
             extract_session_token("katulong_session_other=decoy"),
             None,
             "a similar-but-not-identical name must not match"
+        );
+    }
+
+    #[test]
+    fn extract_trims_whitespace_from_value() {
+        // Clients sometimes emit `katulong_session=TOKEN ; next=1` where
+        // the space before `;` lands inside the value. Hex tokens can't
+        // legitimately contain whitespace, and a non-trimmed mismatch
+        // silently 401s an authenticated user.
+        assert_eq!(
+            extract_session_token("katulong_session=abc123 ; other=1"),
+            Some("abc123".to_string())
+        );
+        assert_eq!(
+            extract_session_token("katulong_session=  abc123  "),
+            Some("abc123".to_string())
         );
     }
 

--- a/crates/server/src/cookie.rs
+++ b/crates/server/src/cookie.rs
@@ -1,0 +1,168 @@
+//! Session cookie primitives.
+//!
+//! One cookie name (`katulong_session`), one set of flags, one parser.
+//! All flag decisions are centralised here so "what flags does the session
+//! cookie carry?" has one answer visible to every reviewer. The equivalent
+//! logic in the Node implementation drifted across three files before
+//! being consolidated (commit `7b3bb1b` in Node tracked the pain); this
+//! file exists to prevent the same drift in Rust.
+
+/// The HTTP cookie name that carries the session token.
+///
+/// Fixed string — never construct this ad-hoc at a call site, because a
+/// typo or case-mismatch will silently authenticate no one.
+pub const SESSION_COOKIE: &str = "katulong_session";
+
+/// Extract the session token from the `Cookie:` header value, if present.
+///
+/// HTTP allows multiple cookies separated by `;` with optional whitespace.
+/// We parse the whole header and pick out our named cookie, rather than
+/// trusting the ordering or the presence of a trailing `;`. Returns `None`
+/// on any parse failure — a malformed cookie header is indistinguishable
+/// from a missing one at the auth boundary. Caller treats both as
+/// "unauthenticated."
+pub fn extract_session_token(header_value: &str) -> Option<String> {
+    for pair in header_value.split(';') {
+        let pair = pair.trim();
+        if let Some((name, value)) = pair.split_once('=') {
+            if name == SESSION_COOKIE {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Build the `Set-Cookie` header value for a freshly minted session.
+///
+/// Flags:
+/// - `HttpOnly` — the cookie is never readable from JavaScript, so an XSS
+///   on a terminal line doesn't hand the attacker a session.
+/// - `SameSite=Lax` — top-level navigations send the cookie (needed for
+///   the OAuth-style redirect flow after WebAuthn), but cross-site POSTs
+///   don't (blocks CSRF on state-changing endpoints that don't do their
+///   own CSRF check yet).
+/// - `Secure` — set when `secure` is true, i.e. remote (tunnel) access.
+///   We intentionally omit it for loopback traffic so dev over
+///   `http://localhost` still works.
+/// - `Path=/` — the session is valid for every route on the origin.
+/// - `Max-Age` — expressed in seconds; the client drops the cookie when
+///   it elapses, matching the server-side `expires_at` on the `Session`.
+///
+/// The token is written verbatim — no URL-escaping is needed since our
+/// tokens are hex-only. If the token format ever changes, the caller is
+/// responsible for encoding it; a change here without one there would
+/// silently produce cookies the client can't send back.
+pub fn build_set_cookie(token: &str, max_age_secs: u64, secure: bool) -> String {
+    let mut cookie = format!(
+        "{name}={token}; HttpOnly; SameSite=Lax; Path=/; Max-Age={max_age_secs}",
+        name = SESSION_COOKIE
+    );
+    if secure {
+        cookie.push_str("; Secure");
+    }
+    cookie
+}
+
+/// Build a `Set-Cookie` header that clears the session cookie.
+///
+/// Same name + path as the live cookie (otherwise the browser won't
+/// overwrite it), `Max-Age=0` to evict immediately. The value is empty
+/// but still present — omitting it entirely would be a malformed
+/// `Set-Cookie`. `Secure` follows the live cookie's setting so the
+/// browser is willing to overwrite on the right scheme.
+pub fn build_clear_cookie(secure: bool) -> String {
+    let mut cookie = format!(
+        "{name}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0",
+        name = SESSION_COOKIE
+    );
+    if secure {
+        cookie.push_str("; Secure");
+    }
+    cookie
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_pulls_named_cookie_from_multi_cookie_header() {
+        let header = "other=foo; katulong_session=abc123; yet_another=bar";
+        assert_eq!(
+            extract_session_token(header),
+            Some("abc123".to_string()),
+            "must locate the session cookie regardless of position"
+        );
+    }
+
+    #[test]
+    fn extract_handles_whitespace_variants() {
+        assert_eq!(
+            extract_session_token("katulong_session=t"),
+            Some("t".to_string())
+        );
+        assert_eq!(
+            extract_session_token("   katulong_session=t  "),
+            Some("t".to_string())
+        );
+        assert_eq!(
+            extract_session_token("a=1;katulong_session=t;b=2"),
+            Some("t".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_returns_none_when_absent() {
+        assert_eq!(extract_session_token(""), None);
+        assert_eq!(extract_session_token("a=1; b=2"), None);
+        assert_eq!(
+            extract_session_token("katulong_session_other=decoy"),
+            None,
+            "a similar-but-not-identical name must not match"
+        );
+    }
+
+    #[test]
+    fn extract_returns_none_on_malformed_pairs() {
+        // A pair without `=` is silently skipped rather than erroring out —
+        // robustness: the auth middleware treats "no session" as
+        // "unauthenticated," and that's the correct fallback for a
+        // degenerate header too.
+        assert_eq!(extract_session_token("no_equals_here"), None);
+        assert_eq!(
+            extract_session_token("no_equals; katulong_session=t"),
+            Some("t".into()),
+            "one malformed pair must not poison the rest"
+        );
+    }
+
+    #[test]
+    fn build_sets_secure_only_when_requested() {
+        let remote = build_set_cookie("abc", 60, true);
+        assert!(remote.contains("Secure"), "remote cookies must be Secure");
+        let local = build_set_cookie("abc", 60, false);
+        assert!(
+            !local.contains("Secure"),
+            "loopback cookies must not carry Secure — blocks dev over http://"
+        );
+    }
+
+    #[test]
+    fn build_always_sets_httponly_and_samesite() {
+        for secure in [true, false] {
+            let c = build_set_cookie("t", 60, secure);
+            assert!(c.contains("HttpOnly"), "HttpOnly must be present");
+            assert!(c.contains("SameSite=Lax"), "SameSite=Lax must be present");
+            assert!(c.contains("Path=/"), "Path=/ must be present");
+        }
+    }
+
+    #[test]
+    fn clear_cookie_uses_max_age_zero() {
+        let c = build_clear_cookie(true);
+        assert!(c.starts_with("katulong_session=;"));
+        assert!(c.contains("Max-Age=0"));
+        assert!(c.contains("Secure"));
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -11,22 +11,50 @@ pub mod cookie;
 pub mod state;
 
 use auth_middleware::Authenticated;
-use axum::{routing::get, Json, Router};
+use axum::{extract::DefaultBodyLimit, routing::get, Json, Router};
 use katulong_shared::{ServerMessage, PROTOCOL_VERSION};
 use serde_json::json;
 use state::AppState;
+
+/// Hard ceiling on request body bytes. 1 MiB matches the Node
+/// implementation's per-auth-route limit. Applied globally here rather
+/// than per-route so future POST routes (slice 5) can't forget to set
+/// their own cap — the axum `content-length` check rejects over-large
+/// requests before they reach any handler.
+const REQUEST_BODY_LIMIT: usize = 1024 * 1024;
 
 /// Build the router with the given application state.
 ///
 /// Separated from `main.rs` so tests can spin up the router against
 /// ephemeral `AuthStore`/`WebAuthnService` instances without opening a
-/// socket. The `/api/me` route is the slice-4 smoke signal — it returns
-/// 200 with the credential id on authenticated requests, 401 otherwise.
+/// socket.
+///
+/// # Public-route convention
+///
+/// By default **every route is unauthenticated** — axum only runs the
+/// `Authenticated` extractor when a handler asks for it. When adding a
+/// route, the reviewer asks: does this handler take `Authenticated`?
+/// If no, add an explanatory comment next to the `.route(...)` line
+/// explaining WHY it's public (health probe, protocol handshake,
+/// auth-kickoff endpoint, etc.) so the allowlist is reviewable
+/// inline. The Node implementation kept this allowlist centralised as
+/// `isPublicPath()`; we enforce it socially instead, which means the
+/// comments ARE the contract.
+///
+/// Currently public: `/health` (k8s/uptime probe, returns static "ok"),
+/// `/api/hello` (protocol-version handshake, no state exposed).
 pub fn app(state: AppState) -> Router {
     Router::new()
+        // PUBLIC: liveness probe. Returns static "ok".
         .route("/health", get(health))
+        // PUBLIC: protocol-version handshake. Exposes no state.
         .route("/api/hello", get(hello))
+        // PROTECTED: smoke-test endpoint that exercises the full
+        // auth extractor chain (access classification, cookie
+        // extraction, store lookup) in a single round-trip.
+        // Integration tests target this route.
         .route("/api/me", get(me))
+        .layer(DefaultBodyLimit::max(REQUEST_BODY_LIMIT))
         .with_state(state)
 }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,0 +1,51 @@
+//! katulong HTTP surface.
+//!
+//! Library crate so integration tests can exercise the router without
+//! spinning up a TCP listener. `main.rs` binds the socket; `app()` here
+//! returns the router ready for `axum::serve` or an in-process tower
+//! client.
+
+pub mod access;
+pub mod auth_middleware;
+pub mod cookie;
+pub mod state;
+
+use auth_middleware::Authenticated;
+use axum::{routing::get, Json, Router};
+use katulong_shared::{ServerMessage, PROTOCOL_VERSION};
+use serde_json::json;
+use state::AppState;
+
+/// Build the router with the given application state.
+///
+/// Separated from `main.rs` so tests can spin up the router against
+/// ephemeral `AuthStore`/`WebAuthnService` instances without opening a
+/// socket. The `/api/me` route is the slice-4 smoke signal — it returns
+/// 200 with the credential id on authenticated requests, 401 otherwise.
+pub fn app(state: AppState) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/api/hello", get(hello))
+        .route("/api/me", get(me))
+        .with_state(state)
+}
+
+async fn health() -> &'static str {
+    "ok"
+}
+
+async fn hello() -> Json<ServerMessage> {
+    Json(ServerMessage::Hello {
+        protocol_version: PROTOCOL_VERSION.to_string(),
+    })
+}
+
+async fn me(Authenticated(ctx): Authenticated) -> Json<serde_json::Value> {
+    Json(json!({
+        "access": match &ctx {
+            auth_middleware::AuthContext::Localhost => "localhost",
+            auth_middleware::AuthContext::Remote { .. } => "remote",
+        },
+        "credential_id": ctx.credential_id(),
+    }))
+}

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,6 +1,7 @@
-use axum::{response::Json, routing::get, Router};
-use katulong_shared::{ServerMessage, PROTOCOL_VERSION};
+use katulong_auth::{AuthStore, WebAuthnService};
+use katulong_server::{app, state::AppState, state::ServerConfig};
 use std::net::SocketAddr;
+use std::path::PathBuf;
 
 #[tokio::main]
 async fn main() {
@@ -11,25 +12,58 @@ async fn main() {
         )
         .init();
 
-    let app = Router::new()
-        .route("/health", get(health))
-        .route("/api/hello", get(hello));
+    let config = load_config_from_env();
+    let auth_store = AuthStore::open(&config_data_file())
+        .await
+        .expect("open auth store");
+    let webauthn = WebAuthnService::new(&config.rp_id, &config.rp_name, &config.public_origin)
+        .expect("build WebAuthn service");
+    let state = AppState::new(auth_store, webauthn, config);
 
     let addr: SocketAddr = "127.0.0.1:3000".parse().expect("valid bind address");
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .expect("bind listener");
-
     tracing::info!(%addr, "katulong-server listening");
-    axum::serve(listener, app).await.expect("serve");
+
+    // `into_make_service_with_connect_info` is required so the auth
+    // middleware can read the peer socket address (needed to
+    // distinguish localhost from remote, see `access.rs`). Without it
+    // `ConnectInfo::<SocketAddr>` panics at request time.
+    axum::serve(
+        listener,
+        app(state).into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
+    .expect("serve");
 }
 
-async fn health() -> &'static str {
-    "ok"
+fn load_config_from_env() -> ServerConfig {
+    let public_origin =
+        std::env::var("KATULONG_ORIGIN").unwrap_or_else(|_| "http://localhost:3000".into());
+    let rp_id = std::env::var("KATULONG_RP_ID").unwrap_or_else(|_| "localhost".into());
+    let rp_name = std::env::var("KATULONG_RP_NAME").unwrap_or_else(|_| "Katulong".into());
+    // Secure cookies only make sense when the public origin is https.
+    // Flipping this for loopback deployments so dev-over-http still works.
+    let cookie_secure = public_origin.starts_with("https://");
+    ServerConfig {
+        public_origin,
+        rp_id,
+        rp_name,
+        cookie_secure,
+    }
 }
 
-async fn hello() -> Json<ServerMessage> {
-    Json(ServerMessage::Hello {
-        protocol_version: PROTOCOL_VERSION.to_string(),
-    })
+fn config_data_file() -> PathBuf {
+    // Default to `~/.config/katulong/auth.json` — matches Node's
+    // `KATULONG_DATA_DIR` convention so a migrated install points at
+    // the same file. Override via `KATULONG_DATA_DIR` for test rigs.
+    let data_dir = std::env::var_os("KATULONG_DATA_DIR").map_or_else(
+        || {
+            let home = std::env::var("HOME").expect("HOME must be set");
+            PathBuf::from(home).join(".config").join("katulong")
+        },
+        PathBuf::from,
+    );
+    data_dir.join("auth.json")
 }

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -1,0 +1,48 @@
+//! Application state shared across request handlers.
+//!
+//! Constructed once at startup, cloned into every request extractor as
+//! an `Arc`-wrapped struct. The inner fields carry their own `Arc`/
+//! mutex discipline — `AuthStore` serialises writes through its own
+//! mutex, `WebAuthnService` holds its in-memory challenge maps behind
+//! their own mutexes. `AppState` itself is just a bundle of references.
+
+use katulong_auth::{AuthStore, WebAuthnService};
+use std::sync::Arc;
+
+/// Operator-supplied configuration captured at startup.
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    /// Public origin (`https://katulong.example`) used for WebAuthn
+    /// assertion matching. MUST come from operator config, not from
+    /// request headers — trusting `X-Forwarded-Proto` here is exactly
+    /// the bug the Node port worked around by accident.
+    pub public_origin: String,
+    /// Relying-party ID (the hostname portion of `public_origin`).
+    pub rp_id: String,
+    /// Human-readable RP name shown in the browser's passkey picker.
+    pub rp_name: String,
+    /// Whether remote cookies should carry the `Secure` flag. True for
+    /// tunnel/TLS deployments, false for plain-http dev over loopback.
+    pub cookie_secure: bool,
+}
+
+/// The handle threaded through every handler and extractor.
+///
+/// Cheap to clone — `Arc` bumps a refcount. The bindings on the inner
+/// fields are all cloneable references to the same underlying state.
+#[derive(Clone)]
+pub struct AppState {
+    pub auth_store: Arc<AuthStore>,
+    pub webauthn: Arc<WebAuthnService>,
+    pub config: Arc<ServerConfig>,
+}
+
+impl AppState {
+    pub fn new(auth_store: AuthStore, webauthn: WebAuthnService, config: ServerConfig) -> Self {
+        Self {
+            auth_store: Arc::new(auth_store),
+            webauthn: Arc::new(webauthn),
+            config: Arc::new(config),
+        }
+    }
+}

--- a/crates/server/tests/auth_smoke.rs
+++ b/crates/server/tests/auth_smoke.rs
@@ -34,7 +34,7 @@ fn cfg() -> ServerConfig {
     }
 }
 
-async fn build() -> (AppState, TempDir) {
+async fn ephemeral_state() -> (AppState, TempDir) {
     let dir = TempDir::new().unwrap();
     let store = AuthStore::open(dir.path().join("auth.json")).await.unwrap();
     let webauthn = WebAuthnService::new("katulong.test", "Katulong Test", "https://katulong.test")
@@ -68,7 +68,7 @@ fn req(peer: SocketAddr, host: &str) -> RequestBuilder {
 
 #[tokio::test]
 async fn unauthed_remote_request_is_rejected() {
-    let (state, _dir) = build().await;
+    let (state, _dir) = ephemeral_state().await;
     let router = app(state);
     let resp = router
         .oneshot(
@@ -84,7 +84,7 @@ async fn unauthed_remote_request_is_rejected() {
 
 #[tokio::test]
 async fn remote_request_with_valid_cookie_is_authenticated() {
-    let (state, _dir) = build().await;
+    let (state, _dir) = ephemeral_state().await;
 
     // Seed a credential + session directly into the store.
     let session_token;
@@ -128,7 +128,7 @@ async fn remote_request_with_valid_cookie_is_authenticated() {
 
 #[tokio::test]
 async fn loopback_peer_plus_loopback_host_bypasses_auth() {
-    let (state, _dir) = build().await;
+    let (state, _dir) = ephemeral_state().await;
     let router = app(state);
     let resp = router
         .oneshot(
@@ -151,7 +151,7 @@ async fn loopback_peer_with_tunnel_host_is_remote_and_rejected() {
     // The Cloudflare Tunnel scar: cloudflared bridges from loopback, so
     // peer == 127.0.0.1 even for internet traffic. The Host header is
     // the public domain — must NOT classify as localhost.
-    let (state, _dir) = build().await;
+    let (state, _dir) = ephemeral_state().await;
     let router = app(state);
     let resp = router
         .oneshot(
@@ -171,7 +171,7 @@ async fn loopback_peer_with_tunnel_host_is_remote_and_rejected() {
 
 #[tokio::test]
 async fn expired_session_cookie_is_rejected() {
-    let (state, _dir) = build().await;
+    let (state, _dir) = ephemeral_state().await;
     let token: String = state
         .auth_store
         .transact(|s| {
@@ -202,7 +202,7 @@ async fn expired_session_cookie_is_rejected() {
 
 #[tokio::test]
 async fn unauthed_routes_still_reachable() {
-    let (state, _dir) = build().await;
+    let (state, _dir) = ephemeral_state().await;
     let router = app(state);
     let resp = router
         .oneshot(

--- a/crates/server/tests/auth_smoke.rs
+++ b/crates/server/tests/auth_smoke.rs
@@ -1,0 +1,217 @@
+//! End-to-end auth middleware smoke test.
+//!
+//! Drives the router with in-process tower `ServiceExt::oneshot` calls
+//! so we exercise the real axum extractor stack (including
+//! `ConnectInfo`) without opening a socket. Each case exercises one
+//! slice of `access.rs` / `auth_middleware.rs`:
+//!
+//! - unauthenticated remote request returns 401
+//! - remote request with valid cookie returns 200 + credential id
+//! - loopback peer + loopback host returns 200 with "localhost" access
+//! - loopback peer + tunnel host returns 401 (the cloudflared scar)
+
+use axum::{
+    body::Body,
+    http::{header, request::Builder as RequestBuilder, Method, Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use katulong_auth::{AuthStore, Credential, Session, WebAuthnService, SESSION_TTL};
+use katulong_server::{
+    app,
+    state::{AppState, ServerConfig},
+};
+use std::net::SocketAddr;
+use std::time::{Duration, SystemTime};
+use tempfile::TempDir;
+use tower::util::ServiceExt;
+
+fn cfg() -> ServerConfig {
+    ServerConfig {
+        public_origin: "https://katulong.test".into(),
+        rp_id: "katulong.test".into(),
+        rp_name: "Katulong Test".into(),
+        cookie_secure: true,
+    }
+}
+
+async fn build() -> (AppState, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let store = AuthStore::open(dir.path().join("auth.json")).await.unwrap();
+    let webauthn = WebAuthnService::new("katulong.test", "Katulong Test", "https://katulong.test")
+        .unwrap();
+    let state = AppState::new(store, webauthn, cfg());
+    (state, dir)
+}
+
+fn cred(id: &str) -> Credential {
+    Credential {
+        id: id.into(),
+        public_key: b"{}".to_vec(),
+        name: None,
+        counter: 0,
+        created_at: SystemTime::UNIX_EPOCH,
+        setup_token_id: None,
+    }
+}
+
+/// Build a request with its ConnectInfo peer address pre-set via the
+/// extension map so `ConnectInfo::<SocketAddr>::from_request_parts`
+/// finds it. Without this, the extractor panics — `into_make_service_with_connect_info`
+/// is what normally stamps this extension, and we bypass that when
+/// calling the router directly via tower.
+fn req(peer: SocketAddr, host: &str) -> RequestBuilder {
+    Request::builder()
+        .method(Method::GET)
+        .extension(axum::extract::ConnectInfo(peer))
+        .header(header::HOST, host)
+}
+
+#[tokio::test]
+async fn unauthed_remote_request_is_rejected() {
+    let (state, _dir) = build().await;
+    let router = app(state);
+    let resp = router
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .uri("/api/me")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn remote_request_with_valid_cookie_is_authenticated() {
+    let (state, _dir) = build().await;
+
+    // Seed a credential + session directly into the store.
+    let session_token;
+    {
+        let store = state.auth_store.clone();
+        let token: String = store
+            .transact(|s| {
+                let credential = cred("c1");
+                let now = SystemTime::now();
+                let sess = Session::mint("c1", now, SESSION_TTL);
+                let tok = sess.token.clone();
+                let next = s.upsert_credential(credential).upsert_session(sess);
+                Ok((next, tok))
+            })
+            .await
+            .unwrap();
+        session_token = token;
+    }
+
+    let router = app(state);
+    let resp = router
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .uri("/api/me")
+                .header(
+                    header::COOKIE,
+                    format!("katulong_session={session_token}"),
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["access"], "remote");
+    assert_eq!(v["credential_id"], "c1");
+}
+
+#[tokio::test]
+async fn loopback_peer_plus_loopback_host_bypasses_auth() {
+    let (state, _dir) = build().await;
+    let router = app(state);
+    let resp = router
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .uri("/api/me")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["access"], "localhost");
+    assert!(v["credential_id"].is_null());
+}
+
+#[tokio::test]
+async fn loopback_peer_with_tunnel_host_is_remote_and_rejected() {
+    // The Cloudflare Tunnel scar: cloudflared bridges from loopback, so
+    // peer == 127.0.0.1 even for internet traffic. The Host header is
+    // the public domain — must NOT classify as localhost.
+    let (state, _dir) = build().await;
+    let router = app(state);
+    let resp = router
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "katulong.example.com")
+                .uri("/api/me")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "loopback socket + tunnel host must not be classified as localhost"
+    );
+}
+
+#[tokio::test]
+async fn expired_session_cookie_is_rejected() {
+    let (state, _dir) = build().await;
+    let token: String = state
+        .auth_store
+        .transact(|s| {
+            let credential = cred("c1");
+            // Session created a long time ago and already expired.
+            let expired_now = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
+            let sess = Session::mint("c1", expired_now, Duration::from_secs(60));
+            let tok = sess.token.clone();
+            let next = s.upsert_credential(credential).upsert_session(sess);
+            Ok((next, tok))
+        })
+        .await
+        .unwrap();
+
+    let router = app(state);
+    let resp = router
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .uri("/api/me")
+                .header(header::COOKIE, format!("katulong_session={token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn unauthed_routes_still_reachable() {
+    let (state, _dir) = build().await;
+    let router = app(state);
+    let resp = router
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}


### PR DESCRIPTION
## Summary

First slice with real HTTP surface area in the Rust rewrite. Lands the primitives every future route will need before slice 5 can ship registration/login flows:

- **\`auth\` crate**: \`Session::mint()\` helper (32-byte CSPRNG token + CSRF, hex-encoded), \`SESSION_TTL\` constant centralised (Node scar \`7b3bb1b\` — consolidated from 6 independent redefinitions).
- **\`server\` crate**: \`cookie.rs\` (HttpOnly / SameSite=Lax / Secure conditional / Path=/), \`access.rs\` (localhost vs remote — requires loopback peer AND loopback Host; closes the Cloudflare Tunnel bridge scar from Node \`fb4b1f9\`), \`state.rs\` (AppState with Arc'd store + service + config), \`auth_middleware.rs\` (axum extractor producing rich \`AuthContext\` instead of boolean — Node scar \`45f4285\` for why rich-from-day-one).
- **Smoke route**: \`/api/me\` returns 200 + credential id on authed, 401 otherwise.

## Scar tissue referenced

- \`fb4b1f9\` (Node): cloudflared bridges tunnel traffic through loopback, so socket peer alone is insufficient to classify localhost. Covered by \`loopback_peer_with_tunnel_host_is_remote_and_rejected\`.
- \`45f4285\` (Node): boolean auth result forced downstream to re-parse cookies, drifted. Rich shape ships from day one.
- \`7b3bb1b\` (Node): \`SESSION_TTL\` was redefined in 6 places before consolidation. Ported as one constant in \`session.rs\`.

## Test plan

- [x] \`cargo test -p katulong-auth\` — 46 tests pass (was 43, +3 for session mint)
- [x] \`cargo test -p katulong-server\` — 12 unit + 6 integration tests pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean across both crates
- [x] Integration coverage: unauthed → 401, remote+cookie → 200, loopback+localhost-host → bypass, loopback+tunnel-host → 401, expired cookie → 401, \`/health\` unprotected

## Deliberately out of scope

- Registration / login / logout routes (slice 5)
- WebSocket upgrade (later; will reuse \`Authenticated\` so revocation can forcibly close connections per Node scar \`c073ec7\`)
- CSRF token check on state-changing requests (\`csrf_token\` minted but not verified yet; lands with routes that need it)
- Session token hashing (plaintext in auth.json; 0600 perms + constant-time compare is already defense-in-depth, hashing is a follow-up)
- \`tracing::warn!\` on silently-filtered corrupt credentials (slice-3 deferred note; still pending the observability pass)