### PR TITLE
rewrite(server): slice 5 — first-device registration + login routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,7 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,6 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,7 @@ dependencies = [
  "scrypt",
  "serde",
  "serde_json",
+ "sha2",
  "subtle",
  "tempfile",
  "thiserror",

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -28,3 +28,4 @@ webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation"]
 url = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 base64 = "0.22"
+sha2 = { version = "0.10", default-features = false }

--- a/crates/auth/src/error.rs
+++ b/crates/auth/src/error.rs
@@ -54,6 +54,16 @@ pub enum AuthError {
     /// shortly" from "something is permanently broken."
     #[error("too many pending challenges")]
     TooManyPendingChallenges,
+
+    /// A state-level invariant was violated while inside an
+    /// `AuthStore::transact` closure — the check that gates the
+    /// transition saw a state that wouldn't permit it. Raised
+    /// specifically to make the TOCTOU-safe pattern usable: a handler
+    /// can do a fast-fail guard outside the mutex AND re-check the same
+    /// invariant inside the closure, with the inner check's error
+    /// routing to the same HTTP `Conflict` shape as the outer one.
+    #[error("state conflict: {0}")]
+    StateConflict(&'static str),
 }
 
 impl AuthError {

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -28,4 +28,16 @@ pub use state::AuthState;
 pub use store::AuthStore;
 pub use webauthn::{ChallengeId, VerifiedAuthentication, WebAuthnService};
 
+/// Re-export the webauthn-rs wire types the server crate needs to shape
+/// its HTTP request/response bodies. Keeping these behind the auth
+/// crate's facade means the server crate doesn't grow a direct
+/// dependency on `webauthn-rs` — if we ever swap the underlying library,
+/// the surface that changes is this file, not every handler.
+pub mod webauthn_wire {
+    pub use webauthn_rs::prelude::{
+        CreationChallengeResponse, PublicKeyCredential, RegisterPublicKeyCredential,
+        RequestChallengeResponse,
+    };
+}
+
 pub type Result<T> = std::result::Result<T, AuthError>;

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -26,7 +26,7 @@ pub use session::{Session, SESSION_TTL};
 pub use setup_token::{PlaintextToken, SetupToken};
 pub use state::AuthState;
 pub use store::AuthStore;
-pub use webauthn::{ChallengeId, VerifiedAuthentication, WebAuthnService};
+pub use webauthn::{fresh_user_handle, ChallengeId, VerifiedAuthentication, WebAuthnService};
 
 /// Re-export the webauthn-rs wire types the server crate needs to shape
 /// its HTTP request/response bodies. Keeping these behind the auth

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -22,11 +22,11 @@ mod webauthn;
 
 pub use credential::Credential;
 pub use error::AuthError;
-pub use session::{Session, SESSION_TTL};
+pub use session::{Session, SessionTokenPlaintext, SESSION_TTL};
 pub use setup_token::{PlaintextToken, SetupToken};
 pub use state::AuthState;
 pub use store::AuthStore;
-pub use webauthn::{fresh_user_handle, ChallengeId, VerifiedAuthentication, WebAuthnService};
+pub use webauthn::{ChallengeId, VerifiedAuthentication, WebAuthnService};
 
 /// Re-export the webauthn-rs wire types the server crate needs to shape
 /// its HTTP request/response bodies. Keeping these behind the auth
@@ -35,8 +35,8 @@ pub use webauthn::{fresh_user_handle, ChallengeId, VerifiedAuthentication, WebAu
 /// the surface that changes is this file, not every handler.
 pub mod webauthn_wire {
     pub use webauthn_rs::prelude::{
-        CreationChallengeResponse, PublicKeyCredential, RegisterPublicKeyCredential,
-        RequestChallengeResponse,
+        AuthenticationResult, CreationChallengeResponse, PublicKeyCredential,
+        RegisterPublicKeyCredential, RequestChallengeResponse,
     };
 }
 

--- a/crates/auth/src/session.rs
+++ b/crates/auth/src/session.rs
@@ -1,5 +1,7 @@
 use crate::random::random_hex;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
 use std::time::{Duration, SystemTime};
 
 /// Default session lifetime: 30 days.
@@ -10,7 +12,24 @@ use std::time::{Duration, SystemTime};
 /// constant elsewhere).
 pub const SESSION_TTL: Duration = Duration::from_secs(60 * 60 * 24 * 30);
 
+/// The plaintext session-token string that goes to the client as a
+/// cookie value. Produced once by `Session::mint` alongside the record
+/// that gets persisted; after mint the server only ever compares hashes
+/// against this value (see `AuthState::find_session`).
+pub type SessionTokenPlaintext = String;
+
 /// A browser session bound to a credential.
+///
+/// The `token_hash` field stores SHA-256 of the plaintext session token,
+/// hex-encoded. The plaintext is delivered to the client once — by
+/// `Session::mint`'s return tuple — and never stored on disk. On every
+/// subsequent request the server hashes the candidate cookie value and
+/// constant-time compares against `token_hash`. Consequence: a stolen
+/// auth-state file exposes only hashes, not replay-usable cookies. The
+/// entropy of the plaintext (256 bits from CSPRNG) already makes
+/// brute-force impossible, so SHA-256 (fast, deterministic) is the
+/// right primitive — scrypt-level work factor would be overkill and
+/// make every request slower for no gain.
 ///
 /// Carries a CSRF token and an activity timestamp to support the 30-day
 /// sliding-expiry model from the Node version (commit `a242051`): fixed
@@ -19,7 +38,9 @@ pub const SESSION_TTL: Duration = Duration::from_secs(60 * 60 * 24 * 30);
 /// has been genuinely active.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Session {
-    pub token: String,
+    /// SHA-256 of the plaintext token, hex-encoded (64 chars). See
+    /// struct docs for the rationale. Never equal to the plaintext.
+    pub token_hash: String,
     pub credential_id: String,
     pub csrf_token: String,
     #[serde(with = "crate::state::systime")]
@@ -31,28 +52,51 @@ pub struct Session {
 }
 
 impl Session {
-    /// Mint a fresh session for `credential_id`, expiring `ttl` after `now`.
+    /// Mint a fresh session for `credential_id`, expiring `ttl` after
+    /// `now`. Returns `(plaintext_token, session)`:
+    /// - The plaintext is 32 random bytes from the OS CSPRNG, hex-encoded
+    ///   (64 ASCII chars, 256 bits of entropy). Send this to the client
+    ///   via the session cookie and DO NOT store it anywhere server-side.
+    /// - The `Session` value carries `token_hash` (SHA-256 of the
+    ///   plaintext), the CSRF token, and timestamps — this is what
+    ///   lands on disk.
     ///
-    /// Both the session token and the paired CSRF token are 32 random bytes
-    /// from the OS CSPRNG, encoded as lowercase hex (64 ASCII chars each).
-    /// That's 256 bits of entropy per token — comfortably past brute-force
-    /// at any realistic rate, and the hex encoding stays transparent when it
-    /// lands in cookies, forms, or logs.
-    ///
-    /// The caller is still responsible for persisting the result via
-    /// `AuthStore::transact(|s| Ok((s.upsert_session(session.clone()),
-    /// session)))` before sending the cookie. Minting without persisting
-    /// would produce a token the server can't later recognise.
-    pub fn mint(credential_id: impl Into<String>, now: SystemTime, ttl: Duration) -> Self {
-        Self {
-            token: random_hex(32),
+    /// The caller is still responsible for persisting the returned
+    /// `Session` via `AuthStore::transact(|s| Ok((s.upsert_session(
+    /// session.clone()), session)))` before sending the cookie. Minting
+    /// without persisting would produce a hash the server can't later
+    /// match.
+    pub fn mint(
+        credential_id: impl Into<String>,
+        now: SystemTime,
+        ttl: Duration,
+    ) -> (SessionTokenPlaintext, Self) {
+        let plaintext = random_hex(32);
+        let session = Self {
+            token_hash: hash_session_token(&plaintext),
             credential_id: credential_id.into(),
             csrf_token: random_hex(32),
             created_at: now,
             expires_at: now + ttl,
             last_activity_at: now,
-        }
+        };
+        (plaintext, session)
     }
+}
+
+/// SHA-256 hash of a plaintext session token, hex-encoded. 64 chars.
+///
+/// Used both at mint time (`Session::mint`) and at lookup time
+/// (`AuthState::find_session`). Keeping it as a crate-private helper
+/// means "how do we hash a session token?" has exactly one answer
+/// visible from both mint and verify paths.
+pub(crate) fn hash_session_token(plaintext: &str) -> String {
+    let digest = Sha256::new().chain_update(plaintext.as_bytes()).finalize();
+    let mut out = String::with_capacity(64);
+    for b in digest.iter() {
+        write!(&mut out, "{b:02x}").expect("write to String cannot fail");
+    }
+    out
 }
 
 #[cfg(test)]
@@ -61,12 +105,13 @@ mod tests {
 
     #[test]
     fn mint_produces_distinct_tokens_on_each_call() {
-        let a = Session::mint("cred", SystemTime::UNIX_EPOCH, SESSION_TTL);
-        let b = Session::mint("cred", SystemTime::UNIX_EPOCH, SESSION_TTL);
-        assert_ne!(a.token, b.token, "session tokens must be unique");
+        let (a_plain, a) = Session::mint("cred", SystemTime::UNIX_EPOCH, SESSION_TTL);
+        let (b_plain, b) = Session::mint("cred", SystemTime::UNIX_EPOCH, SESSION_TTL);
+        assert_ne!(a_plain, b_plain, "plaintext tokens must be unique");
+        assert_ne!(a.token_hash, b.token_hash, "hashes must differ too");
         assert_ne!(a.csrf_token, b.csrf_token, "csrf tokens must be unique");
         assert_ne!(
-            a.token, a.csrf_token,
+            a_plain, a.csrf_token,
             "session and csrf tokens must be drawn independently"
         );
     }
@@ -74,19 +119,44 @@ mod tests {
     #[test]
     fn mint_sets_expiry_from_ttl() {
         let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
-        let s = Session::mint("cred", now, Duration::from_secs(3600));
+        let (_, s) = Session::mint("cred", now, Duration::from_secs(3600));
         assert_eq!(s.created_at, now);
         assert_eq!(s.expires_at, now + Duration::from_secs(3600));
         assert_eq!(s.last_activity_at, now);
     }
 
     #[test]
-    fn token_shape_is_64_hex_chars() {
-        let s = Session::mint("cred", SystemTime::UNIX_EPOCH, SESSION_TTL);
-        assert_eq!(s.token.len(), 64, "32 bytes hex-encoded → 64 chars");
+    fn plaintext_shape_is_64_hex_chars() {
+        let (plaintext, _) = Session::mint("cred", SystemTime::UNIX_EPOCH, SESSION_TTL);
+        assert_eq!(plaintext.len(), 64, "32 bytes hex-encoded → 64 chars");
         assert!(
-            s.token.chars().all(|c| c.is_ascii_hexdigit()),
+            plaintext.chars().all(|c| c.is_ascii_hexdigit()),
             "token must be hex only"
         );
+    }
+
+    #[test]
+    fn stored_hash_is_not_plaintext() {
+        // Paranoid: verify we never accidentally store the plaintext
+        // in the hash field.
+        let (plaintext, s) = Session::mint("cred", SystemTime::UNIX_EPOCH, SESSION_TTL);
+        assert_ne!(
+            plaintext, s.token_hash,
+            "storing the plaintext defeats the hash"
+        );
+        assert_eq!(
+            hash_session_token(&plaintext),
+            s.token_hash,
+            "the stored hash must be SHA-256 of the returned plaintext"
+        );
+    }
+
+    #[test]
+    fn hash_is_deterministic() {
+        let h1 = hash_session_token("abc");
+        let h2 = hash_session_token("abc");
+        assert_eq!(h1, h2);
+        assert_ne!(h1, hash_session_token("abd"));
+        assert_eq!(h1.len(), 64);
     }
 }

--- a/crates/auth/src/state.rs
+++ b/crates/auth/src/state.rs
@@ -1,7 +1,9 @@
+use crate::session::hash_session_token;
 use crate::{Credential, Session, SetupToken};
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
 use subtle::ConstantTimeEq;
+use uuid::Uuid;
 
 /// Constant-time string equality. Used for every session-token comparison
 /// in this module — reads *and* writes — so byte-wise comparison timing
@@ -29,6 +31,21 @@ fn ct_eq_str(a: &str, b: &str) -> bool {
 pub struct AuthState {
     #[serde(default = "current_schema_version")]
     pub schema_version: u32,
+    /// Stable per-user WebAuthn user handle. `None` on a fresh install;
+    /// set on first-device registration and reused for every subsequent
+    /// device so the authenticator treats them as credentials for the
+    /// same user account. Generated on demand via
+    /// `AuthState::user_handle_or_init`.
+    ///
+    /// WebAuthn requires the user handle to be stable across
+    /// registrations for the same logical user — otherwise a
+    /// roaming passkey manager would treat each device pairing as a
+    /// fresh user and some clients show multiple entries. The previous
+    /// shape minted a new UUID per `register_start` call, which was
+    /// fine for single-device installs but would have produced visible
+    /// orphan entries once slice 6's pairing flow lands.
+    #[serde(default)]
+    pub user_handle: Option<Uuid>,
     #[serde(default)]
     pub credentials: Vec<Credential>,
     #[serde(default)]
@@ -47,6 +64,7 @@ impl Default for AuthState {
     fn default() -> Self {
         Self {
             schema_version: SCHEMA_VERSION,
+            user_handle: None,
             credentials: Vec::new(),
             sessions: Vec::new(),
             setup_tokens: Vec::new(),
@@ -65,14 +83,23 @@ impl AuthState {
         self.credentials.iter().find(|c| c.id == id)
     }
 
-    pub fn find_session(&self, token: &str) -> Option<&Session> {
-        self.sessions.iter().find(|s| ct_eq_str(&s.token, token))
+    /// Look up a session by its plaintext token. Hashes the candidate
+    /// and constant-time compares against each stored `token_hash`.
+    /// `token` is the cookie value as received from the client — never
+    /// a stored hash. See `crate::session::hash_session_token` for the
+    /// single source of truth on the hashing.
+    pub fn find_session(&self, plaintext_token: &str) -> Option<&Session> {
+        let candidate = hash_session_token(plaintext_token);
+        self.sessions
+            .iter()
+            .find(|s| ct_eq_str(&s.token_hash, &candidate))
     }
 
     /// `find_session` plus an expiry check. Returns `None` if the session is
     /// missing or has already expired at `now`.
-    pub fn valid_session(&self, token: &str, now: SystemTime) -> Option<&Session> {
-        self.find_session(token).filter(|s| now < s.expires_at)
+    pub fn valid_session(&self, plaintext_token: &str, now: SystemTime) -> Option<&Session> {
+        self.find_session(plaintext_token)
+            .filter(|s| now < s.expires_at)
     }
 
     pub fn find_setup_token(&self, id: &str) -> Option<&SetupToken> {
@@ -114,6 +141,31 @@ impl AuthState {
 
     // ---------- Pure transitions ----------
 
+    /// Return the stable user handle, minting a fresh one if this
+    /// state hasn't seen a registration yet. Returns `(handle, state)`
+    /// — callers inside `AuthStore::transact` substitute the returned
+    /// `state` in the transition chain.
+    ///
+    /// Idempotent: calling on a state that already has a handle
+    /// returns the existing value and an unchanged state clone. The
+    /// handle is generated via the OS CSPRNG (through `Uuid::new_v4`);
+    /// 122 bits of entropy is comfortably past any collision concern.
+    pub fn user_handle_or_init(&self) -> (Uuid, Self) {
+        match self.user_handle {
+            Some(u) => (u, self.clone()),
+            None => {
+                let fresh = Uuid::new_v4();
+                (
+                    fresh,
+                    Self {
+                        user_handle: Some(fresh),
+                        ..self.clone()
+                    },
+                )
+            }
+        }
+    }
+
     /// Add or replace a credential by id.
     pub fn upsert_credential(&self, cred: Credential) -> Self {
         let mut credentials: Vec<Credential> = self
@@ -150,10 +202,12 @@ impl AuthState {
         }
     }
 
-    /// Add or replace a session by token (upsert — mirrors `upsert_credential`).
+    /// Add or replace a session by its stored hash (upsert — mirrors
+    /// `upsert_credential`). The `Session` argument already carries
+    /// `token_hash`; dedup works on that value.
     pub fn upsert_session(&self, session: Session) -> Self {
         let mut sessions = self.sessions.clone();
-        sessions.retain(|s| !ct_eq_str(&s.token, &session.token));
+        sessions.retain(|s| !ct_eq_str(&s.token_hash, &session.token_hash));
         sessions.push(session);
         Self {
             sessions,
@@ -161,12 +215,16 @@ impl AuthState {
         }
     }
 
-    pub fn remove_session(&self, token: &str) -> Self {
+    /// Remove a session identified by its plaintext token value (e.g.
+    /// the cookie the client presented). Hashes the candidate before
+    /// comparing so the stored state never has to hold the plaintext.
+    pub fn remove_session(&self, plaintext_token: &str) -> Self {
+        let target = hash_session_token(plaintext_token);
         Self {
             sessions: self
                 .sessions
                 .iter()
-                .filter(|s| !ct_eq_str(&s.token, token))
+                .filter(|s| !ct_eq_str(&s.token_hash, &target))
                 .cloned()
                 .collect(),
             ..self.clone()
@@ -191,13 +249,14 @@ impl AuthState {
     /// Sliding-expiry policy (when to also bump `expires_at`) lives with the
     /// caller; this transition only records the observation so tests stay
     /// straightforward and policy is free to evolve.
-    pub fn touch_session(&self, token: &str, now: SystemTime) -> Self {
+    pub fn touch_session(&self, plaintext_token: &str, now: SystemTime) -> Self {
+        let target = hash_session_token(plaintext_token);
         Self {
             sessions: self
                 .sessions
                 .iter()
                 .map(|s| {
-                    if ct_eq_str(&s.token, token) {
+                    if ct_eq_str(&s.token_hash, &target) {
                         Session {
                             last_activity_at: now,
                             ..s.clone()
@@ -212,13 +271,14 @@ impl AuthState {
     }
 
     /// Extend a session's expiry. No-op if the token isn't found.
-    pub fn renew_session(&self, token: &str, new_expires_at: SystemTime) -> Self {
+    pub fn renew_session(&self, plaintext_token: &str, new_expires_at: SystemTime) -> Self {
+        let target = hash_session_token(plaintext_token);
         Self {
             sessions: self
                 .sessions
                 .iter()
                 .map(|s| {
-                    if ct_eq_str(&s.token, token) {
+                    if ct_eq_str(&s.token_hash, &target) {
                         Session {
                             expires_at: new_expires_at,
                             ..s.clone()
@@ -392,9 +452,13 @@ mod tests {
         }
     }
 
-    fn sess(token: &str, cred_id: &str, expires_ms: u64) -> Session {
+    /// Build a test `Session` whose `token_hash` is SHA-256 of
+    /// `plaintext_token`. Tests that look up via `find_session` /
+    /// `remove_session` / `touch_session` pass the same `plaintext_token`
+    /// and the hashing round-trip works.
+    fn sess(plaintext_token: &str, cred_id: &str, expires_ms: u64) -> Session {
         Session {
-            token: token.into(),
+            token_hash: hash_session_token(plaintext_token),
             credential_id: cred_id.into(),
             csrf_token: "csrf".into(),
             created_at: epoch_plus(0),

--- a/crates/auth/src/store.rs
+++ b/crates/auth/src/store.rs
@@ -151,9 +151,9 @@ mod tests {
         }
     }
 
-    fn sess(token: &str, cred_id: &str) -> Session {
+    fn sess(plaintext_token: &str, cred_id: &str) -> Session {
         Session {
-            token: token.into(),
+            token_hash: crate::session::hash_session_token(plaintext_token),
             credential_id: cred_id.into(),
             csrf_token: "csrf".into(),
             created_at: SystemTime::UNIX_EPOCH,

--- a/crates/auth/src/webauthn.rs
+++ b/crates/auth/src/webauthn.rs
@@ -111,6 +111,20 @@ pub struct WebAuthnService {
     pending_authentications: Mutex<HashMap<ChallengeId, (PasskeyAuthentication, SystemTime)>>,
 }
 
+/// Mint a fresh WebAuthn user handle.
+///
+/// Separated from `WebAuthnService::start_registration` so the caller
+/// can reuse a stable handle across subsequent-device registrations
+/// (slice 6) without forcing a new one per call. For slice 5 the
+/// first-device path is the only caller and a brand-new UUID is fine.
+///
+/// Owned by the auth crate so the server crate doesn't need a direct
+/// `uuid` dep — the concept "what is a user handle" lives with the
+/// ceremony that consumes it.
+pub fn fresh_user_handle() -> Uuid {
+    Uuid::new_v4()
+}
+
 impl WebAuthnService {
     /// Build a service bound to a specific RP ID + origin. `rp_name` is the
     /// human-readable string that shows up in the browser's passkey dialogue.

--- a/crates/auth/src/webauthn.rs
+++ b/crates/auth/src/webauthn.rs
@@ -70,30 +70,29 @@ pub type ChallengeId = String;
 
 /// Materialised outcome of `finish_authentication`.
 ///
-/// `updated_credential` carries the `Passkey` blob rewritten with the
-/// counter/backup-state update produced by the authenticator. The caller
-/// MUST persist it via `AuthStore::transact(|s| Ok((s.upsert_credential(
-/// updated), ())))` before minting a session — without that write, the
-/// stored `public_key` blob's counter baseline never advances, and
-/// webauthn-rs's clone-detection monotonicity check (which compares
-/// incoming counters against the baseline INSIDE the stored blob) is
-/// silently inert for every subsequent login. `None` means the
-/// authenticator reported no change and the blob does not need to be
-/// rewritten (e.g., counterless synced passkeys with identical backup
-/// state) — this is the `Passkey::update_credential` returning
-/// `Some(false)` case, not an error.
+/// Carries the raw `AuthenticationResult` from webauthn-rs so the
+/// caller can apply it to the *live* `Credential` under
+/// `AuthStore::transact` — the previous shape pre-computed
+/// `updated_credential` from the caller's snapshot, which under
+/// concurrent double-submit could regress the counter baseline by
+/// writing back a pre-update blob. Now the caller does
+/// `cred.apply_authentication(&verified.result)?` INSIDE the transact
+/// closure, where `cred` is fetched from the live `&AuthState` under
+/// the mutex. That closes the race structurally.
 ///
-/// `#[must_use]` applies to the whole struct: forgetting to inspect
-/// `updated_credential` silently reopens the clone-detection gap this
-/// slice was built to close, so the compiler should warn if the whole
-/// value is dropped without a match.
-#[must_use = "updated_credential must be persisted via AuthStore or webauthn-rs clone-detection is inert"]
+/// `#[must_use]` applies to the whole struct: forgetting to invoke
+/// `apply_authentication` silently reopens the clone-detection gap.
+#[must_use = "result must be applied to the stored credential via Credential::apply_authentication within AuthStore::transact — otherwise webauthn-rs clone-detection is inert"]
 #[derive(Debug, Clone)]
 pub struct VerifiedAuthentication {
     pub credential_id: String,
     pub new_counter: u32,
     pub user_verified: bool,
-    pub updated_credential: Option<Credential>,
+    /// The raw webauthn-rs authentication assertion. Apply to the
+    /// stored credential via `Credential::apply_authentication` under
+    /// `AuthStore::transact` to persist the counter/backup-state
+    /// update.
+    pub result: AuthenticationResult,
 }
 
 /// Long-lived WebAuthn ceremony coordinator.
@@ -109,20 +108,6 @@ pub struct WebAuthnService {
     webauthn: Webauthn,
     pending_registrations: Mutex<HashMap<ChallengeId, (PasskeyRegistration, SystemTime)>>,
     pending_authentications: Mutex<HashMap<ChallengeId, (PasskeyAuthentication, SystemTime)>>,
-}
-
-/// Mint a fresh WebAuthn user handle.
-///
-/// Separated from `WebAuthnService::start_registration` so the caller
-/// can reuse a stable handle across subsequent-device registrations
-/// (slice 6) without forcing a new one per call. For slice 5 the
-/// first-device path is the only caller and a brand-new UUID is fine.
-///
-/// Owned by the auth crate so the server crate doesn't need a direct
-/// `uuid` dep — the concept "what is a user handle" lives with the
-/// ceremony that consumes it.
-pub fn fresh_user_handle() -> Uuid {
-    Uuid::new_v4()
 }
 
 impl WebAuthnService {
@@ -278,23 +263,27 @@ impl WebAuthnService {
 
     /// Finish an authentication ceremony.
     ///
-    /// Takes the caller's current credential set so we can look up the
-    /// stored `Passkey` by its cred-id, apply the counter/backup-state
-    /// update from the authenticator's assertion, and hand the refreshed
-    /// `Credential` back for the caller to persist. Without this refresh,
-    /// webauthn-rs's clone-detection baseline (stored inside the serialized
-    /// `Passkey` blob) never advances and monotonicity enforcement is
-    /// inert on every login after the first — a cloned authenticator could
-    /// then replay indefinitely.
+    /// Returns the raw `AuthenticationResult` inside
+    /// `VerifiedAuthentication.result` — the caller must apply it to
+    /// the *live* stored credential inside `AuthStore::transact` via
+    /// `Credential::apply_authentication`. That re-read-under-mutex is
+    /// what closes the counter-regression window: under concurrent
+    /// double-submit, two finish calls would otherwise both compute
+    /// `updated_credential` from their own pre-transact snapshots and
+    /// the second write would overwrite the first's counter advance.
     ///
-    /// `updated_credential` is `None` when `Passkey::update_credential`
-    /// reports no change (counterless synced passkeys with matching backup
-    /// state are the common case) — the caller can then skip the write.
+    /// Revocation during the challenge window is also checked at the
+    /// caller: if the credential has been deleted by the time
+    /// `transact` runs, the transact closure returns
+    /// `AuthError::StateConflict`. This function deliberately does NOT
+    /// look up the credential from a snapshot — the snapshot could be
+    /// stale by the time the caller runs transact, and doing the check
+    /// twice (here and in the closure) would introduce the same TOCTOU
+    /// pattern the reshape was meant to close.
     pub fn finish_authentication(
         &self,
         challenge_id: &str,
         response: &PublicKeyCredential,
-        credentials: &[Credential],
         now: SystemTime,
     ) -> Result<VerifiedAuthentication> {
         let (auth_state, expires_at) = self
@@ -312,32 +301,11 @@ impl WebAuthnService {
             .finish_passkey_authentication(response, &auth_state)
             .map_err(|e| AuthError::WebAuthn(e.to_string()))?;
 
-        let credential_id = encode_credential_id(result.cred_id());
-        let new_counter = result.counter();
-        let user_verified = result.user_verified();
-
-        // The stored credential must still exist for the assertion to be
-        // meaningful: `start_authentication` captured it in `auth_state`, and
-        // an admin revocation during the 5-minute challenge window (or any
-        // other deletion) means the passkey has been explicitly disallowed.
-        // Letting the ceremony succeed anyway would defeat revocation — the
-        // caller would mint a session against a credential the admin
-        // already pulled. Fail closed.
-        let cred = credentials
-            .iter()
-            .find(|c| c.id == credential_id)
-            .ok_or_else(|| {
-                AuthError::WebAuthn(
-                    "credential revoked or missing after successful ceremony".into(),
-                )
-            })?;
-        let updated_credential = apply_auth_result(cred, &result)?;
-
         Ok(VerifiedAuthentication {
-            credential_id,
-            new_counter,
-            user_verified,
-            updated_credential,
+            credential_id: encode_credential_id(result.cred_id()),
+            new_counter: result.counter(),
+            user_verified: result.user_verified(),
+            result,
         })
     }
 
@@ -358,44 +326,6 @@ impl WebAuthnService {
     }
 }
 
-/// Apply a WebAuthn authentication assertion to the stored `Passkey`
-/// blob and return the resulting `Credential` if anything changed.
-///
-/// `None` means the authenticator reported no counter / backup-state
-/// delta (common for counterless synced passkeys), so the caller should
-/// skip the write. `Some(updated)` means the `Passkey` advanced and the
-/// caller must upsert — failing to persist leaves clone-detection stuck
-/// at the previous baseline.
-fn apply_auth_result(
-    cred: &Credential,
-    result: &AuthenticationResult,
-) -> Result<Option<Credential>> {
-    let mut passkey = cred.to_passkey()?;
-    match passkey.update_credential(result) {
-        Some(true) => {
-            let material =
-                serde_json::to_vec(&passkey).map_err(|e| AuthError::WebAuthn(e.to_string()))?;
-            Ok(Some(Credential {
-                public_key: material,
-                counter: result.counter(),
-                ..cred.clone()
-            }))
-        }
-        // Cred id matched, nothing to update — counterless synced passkey
-        // with identical backup state. Safe no-op.
-        Some(false) => Ok(None),
-        // Cred id inside the blob doesn't match the result's cred id.
-        // The caller already looked up `cred` by the result's encoded
-        // cred id, so this means the stored blob disagrees with its
-        // own row — a data-integrity corruption. Fail loudly rather
-        // than silently skipping the counter update, because collapsing
-        // this into `Ok(None)` would leave clone-detection permanently
-        // inert for that credential with no operator-visible signal.
-        None => Err(AuthError::WebAuthn(
-            "credential blob cred_id mismatch; refusing to skip counter update".into(),
-        )),
-    }
-}
 
 /// Insert `(value, expires_at)` at `id`, first pruning expired entries
 /// and then refusing if the map is still at `MAX_PENDING_CHALLENGES`.
@@ -426,6 +356,44 @@ impl Credential {
     /// to hold the service to read its own blob.
     pub fn to_passkey(&self) -> Result<Passkey> {
         serde_json::from_slice(&self.public_key).map_err(|e| AuthError::WebAuthn(e.to_string()))
+    }
+
+    /// Apply a webauthn-rs `AuthenticationResult` to this credential,
+    /// returning `Some(updated)` if the blob changed (caller must
+    /// persist) or `None` if nothing changed (caller can skip the write).
+    ///
+    /// Designed to be called from inside an `AuthStore::transact`
+    /// closure with a credential fetched from the live state — that's
+    /// the TOCTOU-safe path. Calling against a stale snapshot and then
+    /// writing the result back risks regressing the counter under
+    /// concurrent double-submit.
+    ///
+    /// Returns `Err(AuthError::WebAuthn(...))` when the result's
+    /// cred-id doesn't match the credential's blob — that's a
+    /// storage-corruption signal (the row's `id` disagrees with the
+    /// cred-id baked into its serialized `Passkey`). Collapsing it
+    /// into `Ok(None)` would leave clone-detection permanently inert
+    /// for that credential with no operator-visible signal.
+    pub fn apply_authentication(
+        &self,
+        result: &AuthenticationResult,
+    ) -> Result<Option<Credential>> {
+        let mut passkey = self.to_passkey()?;
+        match passkey.update_credential(result) {
+            Some(true) => {
+                let material = serde_json::to_vec(&passkey)
+                    .map_err(|e| AuthError::WebAuthn(e.to_string()))?;
+                Ok(Some(Credential {
+                    public_key: material,
+                    counter: result.counter(),
+                    ..self.clone()
+                }))
+            }
+            Some(false) => Ok(None),
+            None => Err(AuthError::WebAuthn(
+                "credential blob cred_id mismatch; refusing to skip counter update".into(),
+            )),
+        }
     }
 }
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -21,7 +21,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -20,6 +20,7 @@
 
 use crate::access::AccessMethod;
 use crate::api::error::ApiError;
+use crate::api::extract::JsonBody;
 use crate::auth_middleware::Authenticated;
 use crate::cookie::build_set_cookie;
 use crate::state::AppState;
@@ -34,7 +35,7 @@ use katulong_auth::webauthn_wire::{
     CreationChallengeResponse, PublicKeyCredential, RegisterPublicKeyCredential,
     RequestChallengeResponse,
 };
-use katulong_auth::{fresh_user_handle, AuthError, ChallengeId, Session, SESSION_TTL};
+use katulong_auth::{AuthError, ChallengeId, Session, SESSION_TTL};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::time::SystemTime;
@@ -154,31 +155,47 @@ async fn register_start(
     let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
     let access = AccessMethod::classify(peer, host);
     if !matches!(access, AccessMethod::Localhost) {
-        return Err(ApiError::Forbidden(
-            "first-device registration must originate from localhost",
-        ));
+        // Generic "forbidden" — the descriptive variant would confirm
+        // to a remote scanner that this is a katulong instance with a
+        // first-device registration path gated on localhost. Operators
+        // needing detail can read the server log.
+        tracing::warn!("rejecting remote request to first-device registration");
+        return Err(ApiError::Forbidden("forbidden"));
     }
 
-    // Single snapshot for this handler: we use it both for the
-    // "no credentials yet" check and for the `excludeCredentials`
-    // argument. The authoritative re-check happens inside
-    // `register_finish`'s transact closure; this path is the
-    // fast-fail so the user doesn't do a whole biometric prompt only
-    // to be told "already initialised" at the end.
-    let snap = state.auth_store.snapshot().await;
-    if !snap.credentials.is_empty() {
-        return Err(ApiError::Conflict(
-            "instance already initialised; additional devices must pair via setup token",
-        ));
-    }
+    // Get-or-init the stable user handle AND enforce the "no
+    // credentials yet" invariant atomically. `user_handle_or_init`
+    // returns the existing handle on a fresh call for the same
+    // install (idempotent) or mints a fresh one on first use. Doing
+    // this inside `transact` means the handle persists before the
+    // ceremony runs, so `register_finish`'s transact closure reads
+    // the same value even if a second device later pairs in.
+    //
+    // This is the authoritative `credentials.is_empty()` check — the
+    // same re-check appears in `register_finish`'s transact closure
+    // to close the TOCTOU window between start and finish.
+    let (user_handle, credentials) = state
+        .auth_store
+        .transact(|s| {
+            if !s.credentials.is_empty() {
+                return Err(AuthError::StateConflict(
+                    "instance already initialised; additional devices must pair via setup token",
+                ));
+            }
+            let (uh, next) = s.user_handle_or_init();
+            let creds = next.credentials.clone();
+            Ok((next, (uh, creds)))
+        })
+        .await
+        .map_err(ApiError::from)?;
 
     let (id, ccr) = state
         .webauthn
         .start_registration(
-            fresh_user_handle(),
+            user_handle,
             "katulong",
             "Katulong",
-            &snap.credentials,
+            &credentials,
             SystemTime::now(),
         )
         .map_err(ApiError::from)?;
@@ -201,14 +218,17 @@ async fn register_finish(
     State(state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
-    Json(body): Json<RegisterFinishRequest>,
+    JsonBody(body): JsonBody<RegisterFinishRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
     let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
     let access = AccessMethod::classify(peer, host);
     if !matches!(access, AccessMethod::Localhost) {
-        return Err(ApiError::Forbidden(
-            "first-device registration must originate from localhost",
-        ));
+        // Generic "forbidden" — the descriptive variant would confirm
+        // to a remote scanner that this is a katulong instance with a
+        // first-device registration path gated on localhost. Operators
+        // needing detail can read the server log.
+        tracing::warn!("rejecting remote request to first-device registration");
+        return Err(ApiError::Forbidden("forbidden"));
     }
 
     let now = SystemTime::now();
@@ -233,7 +253,7 @@ async fn register_finish(
     // finisher will see state already containing the first winner's
     // credential and bail out with StateConflict (→ 409).
     let credential_clone = credential.clone();
-    let session = state
+    let (plaintext_token, minted_session) = state
         .auth_store
         .transact(move |s| {
             if !s.credentials.is_empty() {
@@ -241,11 +261,11 @@ async fn register_finish(
                     "instance already initialised by a concurrent registration",
                 ));
             }
-            let session = Session::mint(credential_clone.id.clone(), now, SESSION_TTL);
+            let (plaintext, session) = Session::mint(credential_clone.id.clone(), now, SESSION_TTL);
             let next = s
                 .upsert_credential(credential_clone.clone())
                 .upsert_session(session.clone());
-            Ok((next, session))
+            Ok((next, (plaintext, session)))
         })
         .await
         .map_err(ApiError::from)?;
@@ -257,11 +277,11 @@ async fn register_finish(
 
     Ok(session_cookie_response(
         StatusCode::CREATED,
-        &session.token,
+        &plaintext_token,
         state.config.cookie_secure,
         Json(RegisterFinishResponse {
             credential_id: credential.id,
-            csrf_token: session.csrf_token,
+            csrf_token: minted_session.csrf_token,
         }),
     ))
 }
@@ -294,13 +314,12 @@ async fn login_start(
 /// mint a session cookie.
 async fn login_finish(
     State(state): State<AppState>,
-    Json(body): Json<LoginFinishRequest>,
+    JsonBody(body): JsonBody<LoginFinishRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
     let now = SystemTime::now();
-    let snap = state.auth_store.snapshot().await;
     let verified = state
         .webauthn
-        .finish_authentication(&body.challenge_id, &body.response, &snap.credentials, now)
+        .finish_authentication(&body.challenge_id, &body.response, now)
         .inspect_err(|e| {
             tracing::warn!(
                 challenge_id = %body.challenge_id,
@@ -310,30 +329,28 @@ async fn login_finish(
         })
         .map_err(ApiError::from)?;
 
-    // `updated_credential` is `Some` iff the authenticator reported a
-    // counter or backup-state change. Persisting it advances the
-    // monotonicity baseline inside the stored Passkey blob — see
-    // `VerifiedAuthentication` docs for why this MUST happen.
-    //
-    // A theoretical improvement: recompute `updated_credential` from
-    // the live credential inside `transact` rather than from `snap`,
-    // so two simultaneous logins can't regress each other's counter.
-    // Deferred to slice 6 alongside logout/revocation lifecycle work
-    // — the scenario requires two successful concurrent logins with
-    // the same passkey (rare; self-corrects on the next auth) and a
-    // cleaner fix wants `Credential::apply(&AuthenticationResult)`
-    // exposed, which is a bigger refactor than the risk justifies now.
+    // All state reads AND the counter update happen inside `transact`
+    // so there's no window for another login to regress the counter
+    // baseline under concurrent double-submit. Revocation during the
+    // challenge window also fails closed here: if the credential was
+    // deleted between `start_authentication` and this point, the
+    // lookup returns `None` and we surface `StateConflict` (→ 409)
+    // rather than minting a session against a pulled credential.
     let credential_id = verified.credential_id.clone();
-    let session = state
+    let (plaintext_token, minted_session) = state
         .auth_store
         .transact(move |s| {
-            let session = Session::mint(credential_id.clone(), now, SESSION_TTL);
+            let cred = s.find_credential(&credential_id).ok_or(
+                AuthError::StateConflict("credential revoked during authentication ceremony"),
+            )?;
+            let updated = cred.apply_authentication(&verified.result)?;
+            let (plaintext, session) = Session::mint(credential_id.clone(), now, SESSION_TTL);
             let mut next = s.clone();
-            if let Some(updated) = verified.updated_credential.clone() {
-                next = next.upsert_credential(updated);
+            if let Some(updated_cred) = updated {
+                next = next.upsert_credential(updated_cred);
             }
             next = next.upsert_session(session.clone());
-            Ok((next, session))
+            Ok((next, (plaintext, session)))
         })
         .await
         .map_err(ApiError::from)?;
@@ -345,11 +362,11 @@ async fn login_finish(
 
     Ok(session_cookie_response(
         StatusCode::OK,
-        &session.token,
+        &plaintext_token,
         state.config.cookie_secure,
         Json(LoginFinishResponse {
             credential_id: verified.credential_id,
-            csrf_token: session.csrf_token,
+            csrf_token: minted_session.csrf_token,
         }),
     ))
 }

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -101,7 +101,7 @@ async fn status(
 }
 
 #[derive(Debug, Serialize)]
-struct ChallengeStart<T: Serialize> {
+struct ChallengeStartResponse<T: Serialize> {
     challenge_id: ChallengeId,
     options: T,
 }
@@ -150,7 +150,7 @@ async fn register_start(
     State(state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
-) -> Result<Json<ChallengeStart<CreationChallengeResponse>>, ApiError> {
+) -> Result<Json<ChallengeStartResponse<CreationChallengeResponse>>, ApiError> {
     let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
     let access = AccessMethod::classify(peer, host);
     if !matches!(access, AccessMethod::Localhost) {
@@ -182,7 +182,7 @@ async fn register_start(
             SystemTime::now(),
         )
         .map_err(ApiError::from)?;
-    Ok(Json(ChallengeStart {
+    Ok(Json(ChallengeStartResponse {
         challenge_id: id,
         options: ccr,
     }))
@@ -215,6 +215,17 @@ async fn register_finish(
     let credential = state
         .webauthn
         .finish_registration(&body.challenge_id, &body.response, now)
+        .inspect_err(|e| {
+            // Log failed ceremonies at `warn` so brute-force or replay
+            // attempts are visible in operator logs. The challenge id
+            // is safe to log — it's an opaque server-issued handle,
+            // not the attestation response bytes.
+            tracing::warn!(
+                challenge_id = %body.challenge_id,
+                error = %e,
+                "registration ceremony failed"
+            );
+        })
         .map_err(ApiError::from)?;
 
     // The credentials.is_empty() re-check inside the closure is the
@@ -259,7 +270,7 @@ async fn register_finish(
 /// gates who actually passes.
 async fn login_start(
     State(state): State<AppState>,
-) -> Result<Json<ChallengeStart<RequestChallengeResponse>>, ApiError> {
+) -> Result<Json<ChallengeStartResponse<RequestChallengeResponse>>, ApiError> {
     let snap = state.auth_store.snapshot().await;
     if snap.credentials.is_empty() {
         // Fresh-install case. Return an explicit conflict rather than
@@ -273,7 +284,7 @@ async fn login_start(
         .webauthn
         .start_authentication(&snap.credentials, SystemTime::now())
         .map_err(ApiError::from)?;
-    Ok(Json(ChallengeStart {
+    Ok(Json(ChallengeStartResponse {
         challenge_id: id,
         options: rcr,
     }))
@@ -290,6 +301,13 @@ async fn login_finish(
     let verified = state
         .webauthn
         .finish_authentication(&body.challenge_id, &body.response, &snap.credentials, now)
+        .inspect_err(|e| {
+            tracing::warn!(
+                challenge_id = %body.challenge_id,
+                error = %e,
+                "login ceremony failed"
+            );
+        })
         .map_err(ApiError::from)?;
 
     // `updated_credential` is `Some` iff the authenticator reported a

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -1,0 +1,326 @@
+//! Authentication HTTP routes.
+//!
+//! Five endpoints covering the first-device happy path:
+//!
+//! - `GET  /api/auth/status`          — public; surfaces access mode + install state
+//! - `POST /api/auth/register/start`  — localhost-only, no existing credentials
+//! - `POST /api/auth/register/finish` — localhost-only, no existing credentials
+//! - `POST /api/auth/login/start`     — public
+//! - `POST /api/auth/login/finish`    — public; mints session on success
+//!
+//! Logout + setup-token pairing (for adding a second device over a
+//! tunnel) land in slice 6.
+//!
+//! Every successful ceremony writes through `AuthStore::transact` so
+//! the "compute new state, persist atomically, swap in memory" contract
+//! holds. Snapshots are taken exactly once per handler; callers read
+//! from the snapshot and the subsequent `transact` closure re-reads
+//! the (possibly newer) state inside the mutex — cheaper than a
+//! double round-trip and correct under contention.
+
+use crate::access::AccessMethod;
+use crate::api::error::ApiError;
+use crate::cookie::build_set_cookie;
+use crate::state::AppState;
+use axum::{
+    extract::{ConnectInfo, State},
+    http::{header, HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use katulong_auth::webauthn_wire::{
+    CreationChallengeResponse, PublicKeyCredential, RegisterPublicKeyCredential,
+    RequestChallengeResponse,
+};
+use katulong_auth::{ChallengeId, Session, SESSION_TTL};
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use std::time::SystemTime;
+use uuid::Uuid;
+
+pub fn auth_routes() -> Router<AppState> {
+    Router::new()
+        // PUBLIC: reports whether the instance has any credentials and
+        // which access mode this request is coming from; the client
+        // uses this to pick between register/login UI.
+        .route("/api/auth/status", get(status))
+        // PUBLIC (but state-gated): first-device registration. Only
+        // works from localhost AND only when no credentials exist.
+        // Additional-device registration uses the setup-token flow in
+        // slice 6, not this route.
+        .route("/api/auth/register/start", post(register_start))
+        .route("/api/auth/register/finish", post(register_finish))
+        // PUBLIC: anyone can try to log in. The ceremony itself gates
+        // who actually succeeds.
+        .route("/api/auth/login/start", post(login_start))
+        .route("/api/auth/login/finish", post(login_finish))
+}
+
+#[derive(Debug, Serialize)]
+struct AuthStatus {
+    /// `"localhost"` or `"remote"` — the binary access model. No LAN
+    /// tier; see project memory `project_access_model_no_lan`.
+    access_method: &'static str,
+    /// True when at least one credential is registered. A fresh
+    /// install reports `false` and the client routes to the register
+    /// flow.
+    has_credentials: bool,
+    /// True when the current request would pass the `Authenticated`
+    /// extractor — localhost peers are always authenticated; remote
+    /// peers need a valid cookie.
+    authenticated: bool,
+}
+
+async fn status(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Json<AuthStatus> {
+    let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
+    let access = AccessMethod::classify(peer, host);
+    let snap = state.auth_store.snapshot().await;
+    let has_credentials = !snap.credentials.is_empty();
+
+    // Reuse the same cookie-lookup path as the extractor so the
+    // "authenticated" field can't drift from the middleware's answer.
+    let authenticated = match access {
+        AccessMethod::Localhost => true,
+        AccessMethod::Remote => headers
+            .get(header::COOKIE)
+            .and_then(|v| v.to_str().ok())
+            .and_then(crate::cookie::extract_session_token)
+            .and_then(|token| snap.valid_session(&token, SystemTime::now()).cloned())
+            .is_some(),
+    };
+
+    Json(AuthStatus {
+        access_method: match access {
+            AccessMethod::Localhost => "localhost",
+            AccessMethod::Remote => "remote",
+        },
+        has_credentials,
+        authenticated,
+    })
+}
+
+#[derive(Debug, Serialize)]
+struct ChallengeStart<T: Serialize> {
+    challenge_id: ChallengeId,
+    options: T,
+}
+
+#[derive(Debug, Deserialize)]
+struct FinishRegister {
+    challenge_id: ChallengeId,
+    response: RegisterPublicKeyCredential,
+}
+
+#[derive(Debug, Deserialize)]
+struct FinishLogin {
+    challenge_id: ChallengeId,
+    response: PublicKeyCredential,
+}
+
+/// Start a first-device registration ceremony.
+///
+/// First-device is the ONLY registration path this slice supports.
+/// Adding subsequent devices goes through the setup-token flow in
+/// slice 6 (which reuses `WebAuthnService::start_registration` but
+/// gates the state differently).
+///
+/// Two guards:
+/// 1. `access == Localhost` — physical access is required to bootstrap
+///    the first device, since there's nothing to authenticate against
+///    yet. If we let this run from a tunnel, anyone with the URL could
+///    register their own key on a fresh install.
+/// 2. `credentials.is_empty()` — once any device is registered, further
+///    registrations must go through pairing so the existing user can
+///    authorise them.
+async fn register_start(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Result<Json<ChallengeStart<CreationChallengeResponse>>, ApiError> {
+    let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
+    guard_first_device_registration(&state, AccessMethod::classify(peer, host)).await?;
+
+    let snap = state.auth_store.snapshot().await;
+    let (id, ccr) = state
+        .webauthn
+        .start_registration(
+            Uuid::new_v4(),
+            "katulong",
+            "Katulong",
+            &snap.credentials,
+            SystemTime::now(),
+        )
+        .map_err(ApiError::from)?;
+    Ok(Json(ChallengeStart {
+        challenge_id: id,
+        options: ccr,
+    }))
+}
+
+/// Finish the first-device registration, persist the credential, and
+/// mint a session cookie bound to it.
+async fn register_finish(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(body): Json<FinishRegister>,
+) -> Result<impl IntoResponse, ApiError> {
+    let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
+    guard_first_device_registration(&state, AccessMethod::classify(peer, host)).await?;
+
+    let now = SystemTime::now();
+    let credential = state
+        .webauthn
+        .finish_registration(&body.challenge_id, &body.response, now)
+        .map_err(ApiError::from)?;
+
+    // Persist credential + mint session atomically so a crash between
+    // the two writes can't leave a registered credential with no way to
+    // log in. `transact` holds the mutex across the closure.
+    let session = state
+        .auth_store
+        .transact(|s| {
+            let session = Session::mint(credential.id.clone(), now, SESSION_TTL);
+            let next = s
+                .upsert_credential(credential.clone())
+                .upsert_session(session.clone());
+            Ok((next, session))
+        })
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(session_cookie_response(
+        StatusCode::CREATED,
+        &session.token,
+        state.config.cookie_secure,
+        Json(RegisterFinishBody {
+            credential_id: credential.id,
+            csrf_token: session.csrf_token,
+        }),
+    ))
+}
+
+#[derive(Debug, Serialize)]
+struct RegisterFinishBody {
+    credential_id: String,
+    csrf_token: String,
+}
+
+/// Start an authentication ceremony. Public — the ceremony itself
+/// gates who actually passes.
+async fn login_start(
+    State(state): State<AppState>,
+) -> Result<Json<ChallengeStart<RequestChallengeResponse>>, ApiError> {
+    let snap = state.auth_store.snapshot().await;
+    if snap.credentials.is_empty() {
+        // Fresh-install case. Return an explicit conflict rather than
+        // letting webauthn-rs surface "no usable credentials" as a 401;
+        // the client should route to the register flow instead.
+        return Err(ApiError::Conflict(
+            "no credentials registered; first device must register via /api/auth/register/start",
+        ));
+    }
+    let (id, rcr) = state
+        .webauthn
+        .start_authentication(&snap.credentials, SystemTime::now())
+        .map_err(ApiError::from)?;
+    Ok(Json(ChallengeStart {
+        challenge_id: id,
+        options: rcr,
+    }))
+}
+
+/// Finish an authentication ceremony, persist the counter update, and
+/// mint a session cookie.
+async fn login_finish(
+    State(state): State<AppState>,
+    Json(body): Json<FinishLogin>,
+) -> Result<impl IntoResponse, ApiError> {
+    let now = SystemTime::now();
+    let snap = state.auth_store.snapshot().await;
+    let verified = state
+        .webauthn
+        .finish_authentication(&body.challenge_id, &body.response, &snap.credentials, now)
+        .map_err(ApiError::from)?;
+
+    // `updated_credential` is `Some` iff the authenticator reported a
+    // counter or backup-state change. Persisting it advances the
+    // monotonicity baseline inside the stored Passkey blob — see
+    // `VerifiedAuthentication` docs for why this MUST happen.
+    let credential_id = verified.credential_id.clone();
+    let session = state
+        .auth_store
+        .transact(move |s| {
+            let session = Session::mint(credential_id.clone(), now, SESSION_TTL);
+            let mut next = s.clone();
+            if let Some(updated) = verified.updated_credential.clone() {
+                next = next.upsert_credential(updated);
+            }
+            next = next.upsert_session(session.clone());
+            Ok((next, session))
+        })
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(session_cookie_response(
+        StatusCode::OK,
+        &session.token,
+        state.config.cookie_secure,
+        Json(LoginFinishBody {
+            credential_id: verified.credential_id,
+            csrf_token: session.csrf_token,
+        }),
+    ))
+}
+
+#[derive(Debug, Serialize)]
+struct LoginFinishBody {
+    credential_id: String,
+    csrf_token: String,
+}
+
+/// Guard both first-device registration endpoints.
+///
+/// Must be localhost AND must have zero existing credentials.
+/// Returning `Forbidden` (not `Unauthorized`) because the caller is
+/// authenticated-ish via locality; the action is just not permitted in
+/// the current server state. `Conflict` for "already initialised" to
+/// distinguish from "wrong place."
+async fn guard_first_device_registration(
+    state: &AppState,
+    access: AccessMethod,
+) -> Result<(), ApiError> {
+    if !matches!(access, AccessMethod::Localhost) {
+        return Err(ApiError::Forbidden(
+            "first-device registration must originate from localhost",
+        ));
+    }
+    let snap = state.auth_store.snapshot().await;
+    if !snap.credentials.is_empty() {
+        return Err(ApiError::Conflict(
+            "instance already initialised; additional devices must pair via setup token",
+        ));
+    }
+    Ok(())
+}
+
+/// Build a response that attaches a Set-Cookie header carrying a fresh
+/// session, alongside the handler's JSON body.
+fn session_cookie_response<B>(
+    status: StatusCode,
+    token: &str,
+    secure: bool,
+    body: B,
+) -> impl IntoResponse
+where
+    B: IntoResponse,
+{
+    let cookie = build_set_cookie(token, SESSION_TTL.as_secs(), secure);
+    (status, [(header::SET_COOKIE, cookie)], body)
+}
+

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -12,14 +12,15 @@
 //! tunnel) land in slice 6.
 //!
 //! Every successful ceremony writes through `AuthStore::transact` so
-//! the "compute new state, persist atomically, swap in memory" contract
-//! holds. Snapshots are taken exactly once per handler; callers read
-//! from the snapshot and the subsequent `transact` closure re-reads
-//! the (possibly newer) state inside the mutex — cheaper than a
-//! double round-trip and correct under contention.
+//! the "compute new state, persist atomically, swap in memory"
+//! contract holds. Invariants that gate a write (e.g., "first device
+//! only") are checked **inside** the transact closure so the mutex
+//! is the authoritative enforcement point — a pre-flight guard stays
+//! as a fast-fail for the common non-racing case.
 
 use crate::access::AccessMethod;
 use crate::api::error::ApiError;
+use crate::auth_middleware::Authenticated;
 use crate::cookie::build_set_cookie;
 use crate::state::AppState;
 use axum::{
@@ -33,11 +34,10 @@ use katulong_auth::webauthn_wire::{
     CreationChallengeResponse, PublicKeyCredential, RegisterPublicKeyCredential,
     RequestChallengeResponse,
 };
-use katulong_auth::{ChallengeId, Session, SESSION_TTL};
+use katulong_auth::{fresh_user_handle, AuthError, ChallengeId, Session, SESSION_TTL};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::time::SystemTime;
-use uuid::Uuid;
 
 pub fn auth_routes() -> Router<AppState> {
     Router::new()
@@ -57,6 +57,13 @@ pub fn auth_routes() -> Router<AppState> {
         .route("/api/auth/login/finish", post(login_finish))
 }
 
+/// JSON wire format for the status endpoint.
+///
+/// Snake_case on purpose — this is a fresh Rust-only wire format, no
+/// migrated Node clients to stay compatible with. Serde's default
+/// encoding already uses the struct field names so we don't carry a
+/// `rename_all` attribute. Any future interop requirement would land
+/// as an explicit rename.
 #[derive(Debug, Serialize)]
 struct AuthStatus {
     /// `"localhost"` or `"remote"` — the binary access model. No LAN
@@ -67,8 +74,10 @@ struct AuthStatus {
     /// flow.
     has_credentials: bool,
     /// True when the current request would pass the `Authenticated`
-    /// extractor — localhost peers are always authenticated; remote
-    /// peers need a valid cookie.
+    /// extractor. Derived from the same extractor in-process (via
+    /// `Option<Authenticated>`) so the two can't drift — if the
+    /// extractor's acceptance criteria change later, `status` tracks
+    /// automatically.
     authenticated: bool,
 }
 
@@ -76,31 +85,18 @@ async fn status(
     State(state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
+    authed: Option<Authenticated>,
 ) -> Json<AuthStatus> {
     let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
     let access = AccessMethod::classify(peer, host);
     let snap = state.auth_store.snapshot().await;
-    let has_credentials = !snap.credentials.is_empty();
-
-    // Reuse the same cookie-lookup path as the extractor so the
-    // "authenticated" field can't drift from the middleware's answer.
-    let authenticated = match access {
-        AccessMethod::Localhost => true,
-        AccessMethod::Remote => headers
-            .get(header::COOKIE)
-            .and_then(|v| v.to_str().ok())
-            .and_then(crate::cookie::extract_session_token)
-            .and_then(|token| snap.valid_session(&token, SystemTime::now()).cloned())
-            .is_some(),
-    };
-
     Json(AuthStatus {
         access_method: match access {
             AccessMethod::Localhost => "localhost",
             AccessMethod::Remote => "remote",
         },
-        has_credentials,
-        authenticated,
+        has_credentials: !snap.credentials.is_empty(),
+        authenticated: authed.is_some(),
     })
 }
 
@@ -111,15 +107,27 @@ struct ChallengeStart<T: Serialize> {
 }
 
 #[derive(Debug, Deserialize)]
-struct FinishRegister {
+struct RegisterFinishRequest {
     challenge_id: ChallengeId,
     response: RegisterPublicKeyCredential,
 }
 
+#[derive(Debug, Serialize)]
+struct RegisterFinishResponse {
+    credential_id: String,
+    csrf_token: String,
+}
+
 #[derive(Debug, Deserialize)]
-struct FinishLogin {
+struct LoginFinishRequest {
     challenge_id: ChallengeId,
     response: PublicKeyCredential,
+}
+
+#[derive(Debug, Serialize)]
+struct LoginFinishResponse {
+    credential_id: String,
+    csrf_token: String,
 }
 
 /// Start a first-device registration ceremony.
@@ -129,7 +137,8 @@ struct FinishLogin {
 /// slice 6 (which reuses `WebAuthnService::start_registration` but
 /// gates the state differently).
 ///
-/// Two guards:
+/// Two guards — both enforced again inside `register_finish`'s
+/// `transact` closure so a race can't slip past the pre-flight:
 /// 1. `access == Localhost` — physical access is required to bootstrap
 ///    the first device, since there's nothing to authenticate against
 ///    yet. If we let this run from a tunnel, anyone with the URL could
@@ -143,13 +152,30 @@ async fn register_start(
     headers: HeaderMap,
 ) -> Result<Json<ChallengeStart<CreationChallengeResponse>>, ApiError> {
     let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
-    guard_first_device_registration(&state, AccessMethod::classify(peer, host)).await?;
+    let access = AccessMethod::classify(peer, host);
+    if !matches!(access, AccessMethod::Localhost) {
+        return Err(ApiError::Forbidden(
+            "first-device registration must originate from localhost",
+        ));
+    }
 
+    // Single snapshot for this handler: we use it both for the
+    // "no credentials yet" check and for the `excludeCredentials`
+    // argument. The authoritative re-check happens inside
+    // `register_finish`'s transact closure; this path is the
+    // fast-fail so the user doesn't do a whole biometric prompt only
+    // to be told "already initialised" at the end.
     let snap = state.auth_store.snapshot().await;
+    if !snap.credentials.is_empty() {
+        return Err(ApiError::Conflict(
+            "instance already initialised; additional devices must pair via setup token",
+        ));
+    }
+
     let (id, ccr) = state
         .webauthn
         .start_registration(
-            Uuid::new_v4(),
+            fresh_user_handle(),
             "katulong",
             "Katulong",
             &snap.credentials,
@@ -164,14 +190,26 @@ async fn register_start(
 
 /// Finish the first-device registration, persist the credential, and
 /// mint a session cookie bound to it.
+///
+/// The localhost check is outside `transact` (socket state doesn't
+/// change under the mutex). The "no credentials yet" check is INSIDE
+/// `transact` so it evaluates under the same lock that will do the
+/// write — without this, two concurrent finishes could each pass the
+/// pre-flight check on separate snapshots and both end up upserting a
+/// credential on what was supposed to be a single-device install.
 async fn register_finish(
     State(state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
-    Json(body): Json<FinishRegister>,
+    Json(body): Json<RegisterFinishRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
     let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
-    guard_first_device_registration(&state, AccessMethod::classify(peer, host)).await?;
+    let access = AccessMethod::classify(peer, host);
+    if !matches!(access, AccessMethod::Localhost) {
+        return Err(ApiError::Forbidden(
+            "first-device registration must originate from localhost",
+        ));
+    }
 
     let now = SystemTime::now();
     let credential = state
@@ -179,36 +217,42 @@ async fn register_finish(
         .finish_registration(&body.challenge_id, &body.response, now)
         .map_err(ApiError::from)?;
 
-    // Persist credential + mint session atomically so a crash between
-    // the two writes can't leave a registered credential with no way to
-    // log in. `transact` holds the mutex across the closure.
+    // The credentials.is_empty() re-check inside the closure is the
+    // authoritative TOCTOU-safe enforcement — a second concurrent
+    // finisher will see state already containing the first winner's
+    // credential and bail out with StateConflict (→ 409).
+    let credential_clone = credential.clone();
     let session = state
         .auth_store
-        .transact(|s| {
-            let session = Session::mint(credential.id.clone(), now, SESSION_TTL);
+        .transact(move |s| {
+            if !s.credentials.is_empty() {
+                return Err(AuthError::StateConflict(
+                    "instance already initialised by a concurrent registration",
+                ));
+            }
+            let session = Session::mint(credential_clone.id.clone(), now, SESSION_TTL);
             let next = s
-                .upsert_credential(credential.clone())
+                .upsert_credential(credential_clone.clone())
                 .upsert_session(session.clone());
             Ok((next, session))
         })
         .await
         .map_err(ApiError::from)?;
 
+    tracing::info!(
+        credential_id = %credential.id,
+        "registered first device; session minted"
+    );
+
     Ok(session_cookie_response(
         StatusCode::CREATED,
         &session.token,
         state.config.cookie_secure,
-        Json(RegisterFinishBody {
+        Json(RegisterFinishResponse {
             credential_id: credential.id,
             csrf_token: session.csrf_token,
         }),
     ))
-}
-
-#[derive(Debug, Serialize)]
-struct RegisterFinishBody {
-    credential_id: String,
-    csrf_token: String,
 }
 
 /// Start an authentication ceremony. Public — the ceremony itself
@@ -239,7 +283,7 @@ async fn login_start(
 /// mint a session cookie.
 async fn login_finish(
     State(state): State<AppState>,
-    Json(body): Json<FinishLogin>,
+    Json(body): Json<LoginFinishRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
     let now = SystemTime::now();
     let snap = state.auth_store.snapshot().await;
@@ -252,6 +296,15 @@ async fn login_finish(
     // counter or backup-state change. Persisting it advances the
     // monotonicity baseline inside the stored Passkey blob — see
     // `VerifiedAuthentication` docs for why this MUST happen.
+    //
+    // A theoretical improvement: recompute `updated_credential` from
+    // the live credential inside `transact` rather than from `snap`,
+    // so two simultaneous logins can't regress each other's counter.
+    // Deferred to slice 6 alongside logout/revocation lifecycle work
+    // — the scenario requires two successful concurrent logins with
+    // the same passkey (rare; self-corrects on the next auth) and a
+    // cleaner fix wants `Credential::apply(&AuthenticationResult)`
+    // exposed, which is a bigger refactor than the risk justifies now.
     let credential_id = verified.credential_id.clone();
     let session = state
         .auth_store
@@ -267,46 +320,20 @@ async fn login_finish(
         .await
         .map_err(ApiError::from)?;
 
+    tracing::info!(
+        credential_id = %verified.credential_id,
+        "login succeeded; session minted"
+    );
+
     Ok(session_cookie_response(
         StatusCode::OK,
         &session.token,
         state.config.cookie_secure,
-        Json(LoginFinishBody {
+        Json(LoginFinishResponse {
             credential_id: verified.credential_id,
             csrf_token: session.csrf_token,
         }),
     ))
-}
-
-#[derive(Debug, Serialize)]
-struct LoginFinishBody {
-    credential_id: String,
-    csrf_token: String,
-}
-
-/// Guard both first-device registration endpoints.
-///
-/// Must be localhost AND must have zero existing credentials.
-/// Returning `Forbidden` (not `Unauthorized`) because the caller is
-/// authenticated-ish via locality; the action is just not permitted in
-/// the current server state. `Conflict` for "already initialised" to
-/// distinguish from "wrong place."
-async fn guard_first_device_registration(
-    state: &AppState,
-    access: AccessMethod,
-) -> Result<(), ApiError> {
-    if !matches!(access, AccessMethod::Localhost) {
-        return Err(ApiError::Forbidden(
-            "first-device registration must originate from localhost",
-        ));
-    }
-    let snap = state.auth_store.snapshot().await;
-    if !snap.credentials.is_empty() {
-        return Err(ApiError::Conflict(
-            "instance already initialised; additional devices must pair via setup token",
-        ));
-    }
-    Ok(())
 }
 
 /// Build a response that attaches a Set-Cookie header carrying a fresh
@@ -323,4 +350,3 @@ where
     let cookie = build_set_cookie(token, SESSION_TTL.as_secs(), secure);
     (status, [(header::SET_COOKIE, cookie)], body)
 }
-

--- a/crates/server/src/api/error.rs
+++ b/crates/server/src/api/error.rs
@@ -1,0 +1,107 @@
+//! HTTP error shape for API handlers.
+//!
+//! One error type. Every handler returns `Result<Json<T>, ApiError>`
+//! and this module owns the status-code + response-body mapping. The
+//! response body is deliberately terse — a client gets a stable
+//! `code` string and a short human-readable message, never stack
+//! traces or server-side error chains. `AuthError`'s own `Display`
+//! carries operator-facing context (paths, library detail) and is
+//! suitable for server logs only; see the caller-obligation comment
+//! in `crates/auth/src/error.rs`.
+
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use katulong_auth::AuthError;
+use serde_json::json;
+
+/// Every HTTP failure the auth routes can surface.
+///
+/// Variants here are named after the client-facing condition, not the
+/// internal cause — an HTTP consumer should never need to understand
+/// whether the failure was in serde, the mutex, or the filesystem.
+/// Operator-facing detail (if any) is logged via `tracing` at the
+/// `IntoResponse` site.
+#[derive(Debug)]
+pub enum ApiError {
+    /// Caller is not authenticated (or session expired / unknown).
+    Unauthorized,
+    /// Caller is authenticated but not allowed to perform this action.
+    /// Used for "first-device registration from non-localhost" etc.
+    Forbidden(&'static str),
+    /// Request body parse failure, missing field, bad format.
+    BadRequest(&'static str),
+    /// Challenge id in the finish request is unknown or expired.
+    ChallengeNotFound,
+    /// Server is rate-limiting pending ceremonies. Caller should retry.
+    RateLimited,
+    /// Nothing wrong with the request, but the state doesn't permit
+    /// this action yet (e.g., login against a fresh install with no
+    /// credentials).
+    Conflict(&'static str),
+    /// Anything else — mapped to 500. Internal detail goes to logs,
+    /// NOT the response body.
+    Internal(AuthError),
+}
+
+impl ApiError {
+    fn as_pieces(&self) -> (StatusCode, &'static str, String) {
+        match self {
+            Self::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized", "unauthorized".into()),
+            Self::Forbidden(why) => (StatusCode::FORBIDDEN, "forbidden", (*why).into()),
+            Self::BadRequest(why) => (StatusCode::BAD_REQUEST, "bad_request", (*why).into()),
+            Self::ChallengeNotFound => (
+                StatusCode::UNAUTHORIZED,
+                "challenge_not_found",
+                "challenge not found or expired".into(),
+            ),
+            Self::RateLimited => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "rate_limited",
+                "server busy; retry shortly".into(),
+            ),
+            Self::Conflict(why) => (StatusCode::CONFLICT, "conflict", (*why).into()),
+            Self::Internal(_) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal",
+                "internal server error".into(),
+            ),
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let (status, code, message) = self.as_pieces();
+        // Log the full internal detail for operators — never reach the
+        // client. `Display` of `AuthError` carries path + library chain.
+        if let Self::Internal(ref inner) = self {
+            tracing::error!(error = %inner, "api internal error");
+        }
+        let body = Json(json!({
+            "error": { "code": code, "message": message },
+        }));
+        (status, body).into_response()
+    }
+}
+
+impl From<AuthError> for ApiError {
+    /// Best-effort classification of a raw `AuthError` into an HTTP shape.
+    ///
+    /// `ChallengeNotFound` and `TooManyPendingChallenges` have obvious
+    /// HTTP semantics. `WebAuthn(_)` (runtime ceremony failure) maps to
+    /// 401 — the assertion didn't verify, which from the caller's
+    /// perspective looks like "auth failed." Everything else (IO,
+    /// Parse of on-disk state, Hash, WebAuthnConfig — all
+    /// server-internal) becomes 500.
+    fn from(err: AuthError) -> Self {
+        match err {
+            AuthError::ChallengeNotFound => Self::ChallengeNotFound,
+            AuthError::TooManyPendingChallenges => Self::RateLimited,
+            AuthError::WebAuthn(_) => Self::Unauthorized,
+            other => Self::Internal(other),
+        }
+    }
+}

--- a/crates/server/src/api/error.rs
+++ b/crates/server/src/api/error.rs
@@ -41,9 +41,12 @@ pub enum ApiError {
     /// this action yet (e.g., login against a fresh install with no
     /// credentials).
     Conflict(&'static str),
-    /// Anything else — mapped to 500. Internal detail goes to logs,
-    /// NOT the response body.
-    Internal(AuthError),
+    /// Anything else — mapped to 500. Internal detail is logged at the
+    /// `From<AuthError>` conversion site, NOT stored on the variant, so
+    /// no caller can pattern-match this variant and re-render the
+    /// inner chain into user-facing text by accident. A future handler
+    /// seeing `Internal` in a match arm sees only the tag.
+    Internal,
 }
 
 impl ApiError {
@@ -63,7 +66,7 @@ impl ApiError {
                 "server busy; retry shortly".into(),
             ),
             Self::Conflict(why) => (StatusCode::CONFLICT, "conflict", (*why).into()),
-            Self::Internal(_) => (
+            Self::Internal => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal",
                 "internal server error".into(),
@@ -75,11 +78,6 @@ impl ApiError {
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let (status, code, message) = self.as_pieces();
-        // Log the full internal detail for operators — never reach the
-        // client. `Display` of `AuthError` carries path + library chain.
-        if let Self::Internal(ref inner) = self {
-            tracing::error!(error = %inner, "api internal error");
-        }
         let body = Json(json!({
             "error": { "code": code, "message": message },
         }));
@@ -93,15 +91,25 @@ impl From<AuthError> for ApiError {
     /// `ChallengeNotFound` and `TooManyPendingChallenges` have obvious
     /// HTTP semantics. `WebAuthn(_)` (runtime ceremony failure) maps to
     /// 401 — the assertion didn't verify, which from the caller's
-    /// perspective looks like "auth failed." Everything else (IO,
+    /// perspective looks like "auth failed." `StateConflict` maps to
+    /// 409 so a transact-internal invariant check surfaces the same
+    /// shape as the handler's fast-fail guard. Everything else (IO,
     /// Parse of on-disk state, Hash, WebAuthnConfig — all
-    /// server-internal) becomes 500.
+    /// server-internal) becomes 500 AND is logged here; the `Internal`
+    /// variant deliberately carries no data so a future handler can't
+    /// accidentally re-render the chain into a response body.
     fn from(err: AuthError) -> Self {
         match err {
             AuthError::ChallengeNotFound => Self::ChallengeNotFound,
             AuthError::TooManyPendingChallenges => Self::RateLimited,
             AuthError::WebAuthn(_) => Self::Unauthorized,
-            other => Self::Internal(other),
+            AuthError::StateConflict(msg) => Self::Conflict(msg),
+            other => {
+                // Log the full chain for operators; the response body
+                // stays opaque via the unit variant.
+                tracing::error!(error = %other, "api internal error");
+                Self::Internal
+            }
         }
     }
 }

--- a/crates/server/src/api/extract.rs
+++ b/crates/server/src/api/extract.rs
@@ -1,0 +1,52 @@
+//! Custom axum extractors that keep the error envelope stable.
+//!
+//! Axum's default `Json<T>` returns a bespoke 400 when the body fails
+//! to parse, with a body that names the offending field (e.g. `"Failed
+//! to deserialize the JSON body: missing field 'challenge_id'"`). That
+//! leaks request-struct field names to clients and — more importantly
+//! — bypasses the `ApiError` envelope (`{"error": {"code": ..., "message":
+//! ...}}`) that every other failure in this crate renders. `JsonBody<T>`
+//! wraps the same parse logic but routes its rejection through
+//! `ApiError::BadRequest`, so a malformed JSON body looks identical to
+//! any other 400 on the wire.
+
+use crate::api::error::ApiError;
+use axum::{
+    extract::{rejection::JsonRejection, FromRequest, Request},
+    Json,
+};
+use serde::de::DeserializeOwned;
+
+pub struct JsonBody<T>(pub T);
+
+#[axum::async_trait]
+impl<T, S> FromRequest<S> for JsonBody<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        match Json::<T>::from_request(req, state).await {
+            Ok(Json(value)) => Ok(Self(value)),
+            Err(rej) => {
+                // Log the rejection's detail server-side so operators can
+                // diagnose malformed clients; keep the response body generic.
+                tracing::warn!(error = %rej, "malformed request body");
+                Err(match rej {
+                    JsonRejection::JsonDataError(_) => {
+                        ApiError::BadRequest("request body does not match expected shape")
+                    }
+                    JsonRejection::JsonSyntaxError(_) => {
+                        ApiError::BadRequest("request body is not valid JSON")
+                    }
+                    JsonRejection::MissingJsonContentType(_) => {
+                        ApiError::BadRequest("Content-Type must be application/json")
+                    }
+                    _ => ApiError::BadRequest("malformed request body"),
+                })
+            }
+        }
+    }
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -8,3 +8,4 @@
 
 pub mod auth;
 pub mod error;
+pub mod extract;

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -1,0 +1,10 @@
+//! HTTP API surface.
+//!
+//! Routes grouped by domain. Each domain module exposes a
+//! `*_routes() -> Router<AppState>` function that `lib.rs::app()`
+//! merges into the main router. The `error` module owns the HTTP
+//! error shape so handlers return `Result<Json<T>, ApiError>` and
+//! the status-code + body mapping happens in exactly one place.
+
+pub mod auth;
+pub mod error;

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -6,10 +6,12 @@
 //! client.
 
 pub mod access;
+pub mod api;
 pub mod auth_middleware;
 pub mod cookie;
 pub mod state;
 
+use api::auth::auth_routes;
 use auth_middleware::Authenticated;
 use axum::{extract::DefaultBodyLimit, routing::get, Json, Router};
 use katulong_shared::{ServerMessage, PROTOCOL_VERSION};
@@ -54,6 +56,9 @@ pub fn app(state: AppState) -> Router {
         // extraction, store lookup) in a single round-trip.
         // Integration tests target this route.
         .route("/api/me", get(me))
+        // Auth ceremony routes. Each endpoint's public/protected
+        // status is documented on the route line inside the module.
+        .merge(auth_routes())
         .layer(DefaultBodyLimit::max(REQUEST_BODY_LIMIT))
         .with_state(state)
 }

--- a/crates/server/tests/auth_routes.rs
+++ b/crates/server/tests/auth_routes.rs
@@ -8,74 +8,29 @@
 //! - `/api/auth/status` in all four cases (install × access)
 //! - `register_start` guards: non-localhost → 403; fresh localhost → 200
 //!   with a challenge id + options; already-initialised → 409
-//! - `register_finish` guard: non-localhost → 403
-//! - `register_finish` with a localhost peer but bogus challenge id →
-//!   `challenge_not_found` (validates the error pipe, not the crypto)
-//! - `login_start` on a fresh install → 409 (the Conflict branch that
-//!   replaces Node's "empty usable credentials" 401)
-//! - Unknown JSON shape → 400
+//! - `register_finish` guards: non-localhost → 403
+//! - `register_finish` with unknown challenge id → 401
+//!   `challenge_not_found`
+//! - `register_finish` with a real challenge id but cryptographically
+//!   bogus response → 401 `unauthorized` (exercises the crypto-reject
+//!   path through the route handler)
+//! - `login_start` on a fresh install → 409 Conflict
+//! - `login_finish` with unknown challenge id → 401
+//! - `login_finish` with a real challenge id + bogus response → 401
 //!
 //! A separate end-to-end test that drives an actual browser passkey
 //! belongs in the e2e layer (Playwright, slice 8-ish), not here.
 
+mod common;
+
 use axum::{
     body::Body,
-    http::{header, request::Builder as RequestBuilder, Method, Request, StatusCode},
+    http::{header, Method, StatusCode},
 };
-use http_body_util::BodyExt;
-use katulong_auth::{AuthStore, Credential, WebAuthnService};
-use katulong_server::{
-    app,
-    state::{AppState, ServerConfig},
-};
+use common::{body_json, ephemeral_state, json_body, req, stub_credential};
+use katulong_server::app;
 use serde_json::{json, Value};
-use std::net::SocketAddr;
-use std::time::SystemTime;
-use tempfile::TempDir;
 use tower::util::ServiceExt;
-
-fn cfg() -> ServerConfig {
-    ServerConfig {
-        public_origin: "https://katulong.test".into(),
-        rp_id: "katulong.test".into(),
-        rp_name: "Katulong Test".into(),
-        cookie_secure: true,
-    }
-}
-
-async fn ephemeral_state() -> (AppState, TempDir) {
-    let dir = TempDir::new().unwrap();
-    let store = AuthStore::open(dir.path().join("auth.json")).await.unwrap();
-    let webauthn = WebAuthnService::new("katulong.test", "Katulong Test", "https://katulong.test")
-        .unwrap();
-    (AppState::new(store, webauthn, cfg()), dir)
-}
-
-fn seed_credential(id: &str) -> Credential {
-    Credential {
-        id: id.into(),
-        public_key: b"{}".to_vec(),
-        name: None,
-        counter: 0,
-        created_at: SystemTime::UNIX_EPOCH,
-        setup_token_id: None,
-    }
-}
-
-fn req(peer: SocketAddr, host: &str) -> RequestBuilder {
-    Request::builder()
-        .extension(axum::extract::ConnectInfo(peer))
-        .header(header::HOST, host)
-}
-
-fn json_body<T: serde::Serialize>(value: &T) -> Body {
-    Body::from(serde_json::to_vec(value).unwrap())
-}
-
-async fn body_json(resp: axum::response::Response) -> Value {
-    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-    serde_json::from_slice(&bytes).unwrap()
-}
 
 // ---------------- /api/auth/status ----------------
 
@@ -124,7 +79,7 @@ async fn status_after_credential_registered() {
     let (state, _dir) = ephemeral_state().await;
     state
         .auth_store
-        .transact(|s| Ok((s.upsert_credential(seed_credential("c1")), ())))
+        .transact(|s| Ok((s.upsert_credential(stub_credential("c1")), ())))
         .await
         .unwrap();
     let resp = app(state)
@@ -191,7 +146,7 @@ async fn register_start_localhost_after_init_is_conflict() {
     let (state, _dir) = ephemeral_state().await;
     state
         .auth_store
-        .transact(|s| Ok((s.upsert_credential(seed_credential("c1")), ())))
+        .transact(|s| Ok((s.upsert_credential(stub_credential("c1")), ())))
         .await
         .unwrap();
     let resp = app(state)
@@ -257,6 +212,55 @@ async fn register_finish_with_unknown_challenge_id_returns_challenge_not_found()
 }
 
 #[tokio::test]
+async fn register_finish_with_real_challenge_but_bogus_response_returns_401() {
+    // Covers the crypto-rejection path: a challenge was legitimately
+    // issued by `register_start` so it exists in the pending map, but
+    // the response payload is cryptographically garbage. webauthn-rs
+    // must reject, `finish_registration` must return an error, and
+    // the handler must map it to 401 `unauthorized` (not 500, not
+    // `challenge_not_found`).
+    let (state, _dir) = ephemeral_state().await;
+    let router = app(state);
+
+    let start = router
+        .clone()
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::POST)
+                .uri("/api/auth/register/start")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(start.status(), StatusCode::OK);
+    let challenge_id = body_json(start).await["challenge_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let body = json!({
+        "challenge_id": challenge_id,
+        "response": fake_register_response(),
+    });
+    let resp = router
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::POST)
+                .uri("/api/auth/register/finish")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], "unauthorized");
+}
+
+#[tokio::test]
 async fn register_finish_with_bad_json_returns_400() {
     let (state, _dir) = ephemeral_state().await;
     let resp = app(state)
@@ -299,11 +303,9 @@ async fn login_start_on_fresh_install_is_conflict() {
 #[tokio::test]
 async fn login_finish_with_unknown_challenge_id_returns_challenge_not_found() {
     let (state, _dir) = ephemeral_state().await;
-    // Seed a credential so `login_start` wouldn't 409, though we bypass
-    // it and go straight to finish with a bogus id.
     state
         .auth_store
-        .transact(|s| Ok((s.upsert_credential(seed_credential("c1")), ())))
+        .transact(|s| Ok((s.upsert_credential(stub_credential("c1")), ())))
         .await
         .unwrap();
     let body = json!({

--- a/crates/server/tests/auth_routes.rs
+++ b/crates/server/tests/auth_routes.rs
@@ -1,0 +1,356 @@
+//! Integration tests for the auth HTTP routes.
+//!
+//! These cannot exercise a real WebAuthn ceremony without a real
+//! authenticator on the other end — the crypto in `finish_*` requires
+//! a browser-signed assertion, which an in-process test can't produce.
+//! So the tests here cover:
+//!
+//! - `/api/auth/status` in all four cases (install × access)
+//! - `register_start` guards: non-localhost → 403; fresh localhost → 200
+//!   with a challenge id + options; already-initialised → 409
+//! - `register_finish` guard: non-localhost → 403
+//! - `register_finish` with a localhost peer but bogus challenge id →
+//!   `challenge_not_found` (validates the error pipe, not the crypto)
+//! - `login_start` on a fresh install → 409 (the Conflict branch that
+//!   replaces Node's "empty usable credentials" 401)
+//! - Unknown JSON shape → 400
+//!
+//! A separate end-to-end test that drives an actual browser passkey
+//! belongs in the e2e layer (Playwright, slice 8-ish), not here.
+
+use axum::{
+    body::Body,
+    http::{header, request::Builder as RequestBuilder, Method, Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use katulong_auth::{AuthStore, Credential, WebAuthnService};
+use katulong_server::{
+    app,
+    state::{AppState, ServerConfig},
+};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::time::SystemTime;
+use tempfile::TempDir;
+use tower::util::ServiceExt;
+
+fn cfg() -> ServerConfig {
+    ServerConfig {
+        public_origin: "https://katulong.test".into(),
+        rp_id: "katulong.test".into(),
+        rp_name: "Katulong Test".into(),
+        cookie_secure: true,
+    }
+}
+
+async fn ephemeral_state() -> (AppState, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let store = AuthStore::open(dir.path().join("auth.json")).await.unwrap();
+    let webauthn = WebAuthnService::new("katulong.test", "Katulong Test", "https://katulong.test")
+        .unwrap();
+    (AppState::new(store, webauthn, cfg()), dir)
+}
+
+fn seed_credential(id: &str) -> Credential {
+    Credential {
+        id: id.into(),
+        public_key: b"{}".to_vec(),
+        name: None,
+        counter: 0,
+        created_at: SystemTime::UNIX_EPOCH,
+        setup_token_id: None,
+    }
+}
+
+fn req(peer: SocketAddr, host: &str) -> RequestBuilder {
+    Request::builder()
+        .extension(axum::extract::ConnectInfo(peer))
+        .header(header::HOST, host)
+}
+
+fn json_body<T: serde::Serialize>(value: &T) -> Body {
+    Body::from(serde_json::to_vec(value).unwrap())
+}
+
+async fn body_json(resp: axum::response::Response) -> Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+// ---------------- /api/auth/status ----------------
+
+#[tokio::test]
+async fn status_fresh_install_from_localhost() {
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::GET)
+                .uri("/api/auth/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v["access_method"], "localhost");
+    assert_eq!(v["has_credentials"], false);
+    assert_eq!(v["authenticated"], true, "localhost is always authed");
+}
+
+#[tokio::test]
+async fn status_fresh_install_from_remote() {
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::GET)
+                .uri("/api/auth/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v["access_method"], "remote");
+    assert_eq!(v["has_credentials"], false);
+    assert_eq!(v["authenticated"], false, "no cookie + remote = unauthed");
+}
+
+#[tokio::test]
+async fn status_after_credential_registered() {
+    let (state, _dir) = ephemeral_state().await;
+    state
+        .auth_store
+        .transact(|s| Ok((s.upsert_credential(seed_credential("c1")), ())))
+        .await
+        .unwrap();
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::GET)
+                .uri("/api/auth/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let v = body_json(resp).await;
+    assert_eq!(v["has_credentials"], true);
+    assert_eq!(v["authenticated"], false);
+}
+
+// ---------------- /api/auth/register/start ----------------
+
+#[tokio::test]
+async fn register_start_from_remote_is_forbidden() {
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/register/start")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], "forbidden");
+}
+
+#[tokio::test]
+async fn register_start_localhost_fresh_install_returns_challenge() {
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::POST)
+                .uri("/api/auth/register/start")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert!(
+        v["challenge_id"].as_str().is_some_and(|s| s.len() == 32),
+        "challenge_id should be 32 hex chars"
+    );
+    assert!(v["options"].is_object(), "options should be a JSON object");
+}
+
+#[tokio::test]
+async fn register_start_localhost_after_init_is_conflict() {
+    let (state, _dir) = ephemeral_state().await;
+    state
+        .auth_store
+        .transact(|s| Ok((s.upsert_credential(seed_credential("c1")), ())))
+        .await
+        .unwrap();
+    let resp = app(state)
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::POST)
+                .uri("/api/auth/register/start")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], "conflict");
+}
+
+// ---------------- /api/auth/register/finish ----------------
+
+#[tokio::test]
+async fn register_finish_from_remote_is_forbidden() {
+    let (state, _dir) = ephemeral_state().await;
+    let body = json!({
+        "challenge_id": "deadbeef",
+        "response": fake_register_response(),
+    });
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/register/finish")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn register_finish_with_unknown_challenge_id_returns_challenge_not_found() {
+    let (state, _dir) = ephemeral_state().await;
+    let body = json!({
+        "challenge_id": "deadbeef-never-issued",
+        "response": fake_register_response(),
+    });
+    let resp = app(state)
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::POST)
+                .uri("/api/auth/register/finish")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], "challenge_not_found");
+}
+
+#[tokio::test]
+async fn register_finish_with_bad_json_returns_400() {
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::POST)
+                .uri("/api/auth/register/finish")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("not json"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// ---------------- /api/auth/login/start ----------------
+
+#[tokio::test]
+async fn login_start_on_fresh_install_is_conflict() {
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/login/start")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], "conflict");
+}
+
+// ---------------- /api/auth/login/finish ----------------
+
+#[tokio::test]
+async fn login_finish_with_unknown_challenge_id_returns_challenge_not_found() {
+    let (state, _dir) = ephemeral_state().await;
+    // Seed a credential so `login_start` wouldn't 409, though we bypass
+    // it and go straight to finish with a bogus id.
+    state
+        .auth_store
+        .transact(|s| Ok((s.upsert_credential(seed_credential("c1")), ())))
+        .await
+        .unwrap();
+    let body = json!({
+        "challenge_id": "deadbeef",
+        "response": fake_login_response(),
+    });
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/login/finish")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], "challenge_not_found");
+}
+
+// Syntactically minimal WebAuthn response payloads. Not
+// cryptographically valid — they exercise the challenge-lookup path
+// without running real verification. Real crypto validation belongs
+// in the browser-driven e2e tests.
+fn fake_register_response() -> Value {
+    json!({
+        "id": "AAAA",
+        "rawId": "AAAA",
+        "response": {"clientDataJSON": "", "attestationObject": ""},
+        "type": "public-key",
+        "extensions": {}
+    })
+}
+
+fn fake_login_response() -> Value {
+    json!({
+        "id": "AAAA",
+        "rawId": "AAAA",
+        "response": {
+            "clientDataJSON": "",
+            "authenticatorData": "",
+            "signature": "",
+            "userHandle": null
+        },
+        "type": "public-key",
+        "extensions": {}
+    })
+}

--- a/crates/server/tests/auth_smoke.rs
+++ b/crates/server/tests/auth_smoke.rs
@@ -10,61 +10,17 @@
 //! - loopback peer + loopback host returns 200 with "localhost" access
 //! - loopback peer + tunnel host returns 401 (the cloudflared scar)
 
+mod common;
+
 use axum::{
     body::Body,
-    http::{header, request::Builder as RequestBuilder, Method, Request, StatusCode},
+    http::{header, StatusCode},
 };
-use http_body_util::BodyExt;
-use katulong_auth::{AuthStore, Credential, Session, WebAuthnService, SESSION_TTL};
-use katulong_server::{
-    app,
-    state::{AppState, ServerConfig},
-};
-use std::net::SocketAddr;
+use common::{body_json, ephemeral_state, req, stub_credential};
+use katulong_auth::{Session, SESSION_TTL};
+use katulong_server::app;
 use std::time::{Duration, SystemTime};
-use tempfile::TempDir;
 use tower::util::ServiceExt;
-
-fn cfg() -> ServerConfig {
-    ServerConfig {
-        public_origin: "https://katulong.test".into(),
-        rp_id: "katulong.test".into(),
-        rp_name: "Katulong Test".into(),
-        cookie_secure: true,
-    }
-}
-
-async fn ephemeral_state() -> (AppState, TempDir) {
-    let dir = TempDir::new().unwrap();
-    let store = AuthStore::open(dir.path().join("auth.json")).await.unwrap();
-    let webauthn = WebAuthnService::new("katulong.test", "Katulong Test", "https://katulong.test")
-        .unwrap();
-    let state = AppState::new(store, webauthn, cfg());
-    (state, dir)
-}
-
-fn cred(id: &str) -> Credential {
-    Credential {
-        id: id.into(),
-        public_key: b"{}".to_vec(),
-        name: None,
-        counter: 0,
-        created_at: SystemTime::UNIX_EPOCH,
-        setup_token_id: None,
-    }
-}
-
-/// Build a request with its ConnectInfo peer address pre-set via the
-/// extension map so `ConnectInfo::<SocketAddr>::from_request_parts`
-/// finds it. Without this, the extractor panics — `into_make_service_with_connect_info`
-/// is what normally stamps this extension, and we bypass that when
-/// calling the router directly via tower.
-fn req(peer: SocketAddr, host: &str) -> RequestBuilder {
-    Request::builder()
-        .method(Method::GET)
-        .extension(axum::extract::ConnectInfo(peer))
-        .header(header::HOST, host)
-}
 
 #[tokio::test]
 async fn unauthed_remote_request_is_rejected() {
@@ -86,13 +42,11 @@ async fn unauthed_remote_request_is_rejected() {
 async fn remote_request_with_valid_cookie_is_authenticated() {
     let (state, _dir) = ephemeral_state().await;
 
-    // Seed a credential + session directly into the store.
-    let session_token;
-    {
+    let session_token = {
         let store = state.auth_store.clone();
-        let token: String = store
+        store
             .transact(|s| {
-                let credential = cred("c1");
+                let credential = stub_credential("c1");
                 let now = SystemTime::now();
                 let sess = Session::mint("c1", now, SESSION_TTL);
                 let tok = sess.token.clone();
@@ -100,9 +54,8 @@ async fn remote_request_with_valid_cookie_is_authenticated() {
                 Ok((next, tok))
             })
             .await
-            .unwrap();
-        session_token = token;
-    }
+            .unwrap()
+    };
 
     let router = app(state);
     let resp = router
@@ -120,8 +73,7 @@ async fn remote_request_with_valid_cookie_is_authenticated() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
-    let body = resp.into_body().collect().await.unwrap().to_bytes();
-    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let v = body_json(resp).await;
     assert_eq!(v["access"], "remote");
     assert_eq!(v["credential_id"], "c1");
 }
@@ -140,8 +92,7 @@ async fn loopback_peer_plus_loopback_host_bypasses_auth() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
-    let body = resp.into_body().collect().await.unwrap().to_bytes();
-    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let v = body_json(resp).await;
     assert_eq!(v["access"], "localhost");
     assert!(v["credential_id"].is_null());
 }
@@ -175,7 +126,7 @@ async fn expired_session_cookie_is_rejected() {
     let token: String = state
         .auth_store
         .transact(|s| {
-            let credential = cred("c1");
+            let credential = stub_credential("c1");
             // Session created a long time ago and already expired.
             let expired_now = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
             let sess = Session::mint("c1", expired_now, Duration::from_secs(60));

--- a/crates/server/tests/auth_smoke.rs
+++ b/crates/server/tests/auth_smoke.rs
@@ -48,10 +48,9 @@ async fn remote_request_with_valid_cookie_is_authenticated() {
             .transact(|s| {
                 let credential = stub_credential("c1");
                 let now = SystemTime::now();
-                let sess = Session::mint("c1", now, SESSION_TTL);
-                let tok = sess.token.clone();
+                let (plaintext, sess) = Session::mint("c1", now, SESSION_TTL);
                 let next = s.upsert_credential(credential).upsert_session(sess);
-                Ok((next, tok))
+                Ok((next, plaintext))
             })
             .await
             .unwrap()
@@ -129,10 +128,9 @@ async fn expired_session_cookie_is_rejected() {
             let credential = stub_credential("c1");
             // Session created a long time ago and already expired.
             let expired_now = SystemTime::UNIX_EPOCH + Duration::from_secs(1000);
-            let sess = Session::mint("c1", expired_now, Duration::from_secs(60));
-            let tok = sess.token.clone();
+            let (plaintext, sess) = Session::mint("c1", expired_now, Duration::from_secs(60));
             let next = s.upsert_credential(credential).upsert_session(sess);
-            Ok((next, tok))
+            Ok((next, plaintext))
         })
         .await
         .unwrap();

--- a/crates/server/tests/common/mod.rs
+++ b/crates/server/tests/common/mod.rs
@@ -1,0 +1,80 @@
+//! Shared fixtures for integration tests.
+//!
+//! Cargo treats `tests/common/mod.rs` (not `tests/common.rs`) as a
+//! non-test-binary module, so the helpers here can be used from every
+//! `tests/*.rs` file without each being compiled into its own test
+//! binary. Consumers declare `mod common;` at the top of each test
+//! file.
+
+#![allow(dead_code)]
+
+use axum::{
+    body::Body,
+    http::{header, request::Builder as RequestBuilder, Request},
+};
+use http_body_util::BodyExt;
+use katulong_auth::{AuthStore, Credential, WebAuthnService};
+use katulong_server::state::{AppState, ServerConfig};
+use serde_json::Value;
+use std::net::SocketAddr;
+use std::time::SystemTime;
+use tempfile::TempDir;
+
+/// Canonical test config. `cookie_secure = true` matches a remote
+/// deployment; tests that specifically need the plain-http loopback
+/// path construct their own.
+pub fn cfg() -> ServerConfig {
+    ServerConfig {
+        public_origin: "https://katulong.test".into(),
+        rp_id: "katulong.test".into(),
+        rp_name: "Katulong Test".into(),
+        cookie_secure: true,
+    }
+}
+
+/// Fresh `AppState` backed by a tempdir-rooted `AuthStore`. The
+/// `TempDir` is returned alongside so the caller can keep it in scope
+/// for the duration of the test — dropping it early would yank the
+/// on-disk state out from under the store.
+pub async fn ephemeral_state() -> (AppState, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let store = AuthStore::open(dir.path().join("auth.json")).await.unwrap();
+    let webauthn = WebAuthnService::new("katulong.test", "Katulong Test", "https://katulong.test")
+        .unwrap();
+    (AppState::new(store, webauthn, cfg()), dir)
+}
+
+/// A placeholder `Credential` for tests that need to seed auth state
+/// without running a real WebAuthn ceremony. The `public_key` blob is
+/// intentionally non-parseable JSON — any test path that tries to
+/// deserialize it as a `Passkey` must handle that failure explicitly.
+pub fn stub_credential(id: &str) -> Credential {
+    Credential {
+        id: id.into(),
+        public_key: b"{}".to_vec(),
+        name: None,
+        counter: 0,
+        created_at: SystemTime::UNIX_EPOCH,
+        setup_token_id: None,
+    }
+}
+
+/// Build a request with its `ConnectInfo` peer set as an extension so
+/// `ConnectInfo::<SocketAddr>::from_request_parts` can find it. In
+/// production axum's `into_make_service_with_connect_info` stamps
+/// this on the connection-level service, but tower's `oneshot` path
+/// skips that layer, so tests set it manually.
+pub fn req(peer: SocketAddr, host: &str) -> RequestBuilder {
+    Request::builder()
+        .extension(axum::extract::ConnectInfo(peer))
+        .header(header::HOST, host)
+}
+
+pub fn json_body<T: serde::Serialize>(value: &T) -> Body {
+    Body::from(serde_json::to_vec(value).unwrap())
+}
+
+pub async fn body_json(resp: axum::response::Response) -> Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}


### PR DESCRIPTION
## Summary

First-device auth happy path lands on the slice-4 HTTP primitives. Five endpoints:

- \`GET  /api/auth/status\` — public; reports access mode + install state + authentication
- \`POST /api/auth/register/start\` — localhost-only, fresh-install only
- \`POST /api/auth/register/finish\` — same gate; mints session on success
- \`POST /api/auth/login/start\` — public
- \`POST /api/auth/login/finish\` — public; persists counter update + mints session

Logout + setup-token pairing land in slice 6.

## Direction: access model is binary

Node had three tiers (localhost / LAN / internet). LAN was eliminated as a distinct category — the Rust \`AccessMethod\` is \`Localhost | Remote\` only. Status endpoint reports one of those two. No QR+PIN pairing flow. Captured in project memory (\`project_access_model_no_lan.md\`).

## First-device guard

\`/register/{start,finish}\` fail closed on two independent conditions:

- Not localhost → 403 \`forbidden\` (don't let tunnel users bootstrap a key on a fresh install)
- Already-initialised → 409 \`conflict\` (additional devices must go through setup-token pairing)

Order matters: localhost check first, so a tunnel user doesn't learn "instance already set up" via the error code.

## Error plumbing

\`ApiError\` owns the status-code + body mapping in one place. Handlers return \`Result<Json<T>, ApiError>\`. \`Display\` of \`AuthError\` never reaches clients — it carries paths and library chains (per the caller-obligation doc on \`AuthError\`). \`From<AuthError>\` classifies: \`ChallengeNotFound\` → 401, \`TooManyPending\` → 503, runtime \`WebAuthn(_)\` → 401, everything else → 500 with detail in server logs.

## Re-export layer

Server crate avoids a direct \`webauthn-rs\` dep. \`katulong_auth::webauthn_wire\` re-exports the four wire types handlers need. Swapping the underlying library is now a single-file change in the auth crate.

## Test plan

- [x] \`cargo test -p katulong-server\` — 13 unit + 6 smoke + 11 new integration tests (30 total)
- [x] \`cargo clippy -p katulong-server -p katulong-auth --all-targets -- -D warnings\` clean
- [x] Integration coverage: status shape (fresh × localhost, fresh × remote, after-cred × remote), register_start (remote-forbidden, localhost-fresh-200, localhost-after-init-409), register_finish (remote-forbidden, unknown-challenge-401, bad-json-400), login_start (fresh-install-409), login_finish (unknown-challenge-401)
- [ ] Real crypto verification — belongs in browser-driven e2e tests (later slice)

## Deferred

- Logout route (needs \`Authenticated\` extractor + session removal) — slice 6
- Setup-token pairing flow (second-device-via-tunnel) — slice 6
- CSRF token validation on state-changing endpoints — \`csrf_token\` minted and returned but not checked; lands when first handler needs it
- \`authenticatorAttachment: "platform"\` hint on first-device registration — default-omit; revisit if browsers don't pick the platform authenticator