### PR TITLE
rewrite(server): slice 6 — logout + setup-token management + pair flow + CSRF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,6 +1041,7 @@ dependencies = [
  "katulong-shared",
  "serde",
  "serde_json",
+ "subtle",
  "tempfile",
  "tokio",
  "tower 0.4.13",

--- a/crates/auth/src/webauthn.rs
+++ b/crates/auth/src/webauthn.rs
@@ -309,6 +309,27 @@ impl WebAuthnService {
         })
     }
 
+    /// Finish a pairing ceremony, returning a `Credential` already
+    /// stamped with the setup token that authorised it. The
+    /// bidirectional `setup_token_id` link (Node scar `7742ac3`) is a
+    /// domain invariant of the auth crate — a future caller
+    /// constructing a paired credential without it would break the
+    /// cascade on setup-token revoke. Owning the stamp here means
+    /// HTTP handlers can't forget the link.
+    pub fn finish_paired_registration(
+        &self,
+        challenge_id: &str,
+        response: &RegisterPublicKeyCredential,
+        setup_token_id: String,
+        now: SystemTime,
+    ) -> Result<Credential> {
+        let cred = self.finish_registration(challenge_id, response, now)?;
+        Ok(Credential {
+            setup_token_id: Some(setup_token_id),
+            ..cred
+        })
+    }
+
     /// Drop challenges whose TTL has elapsed. Cheap to call periodically.
     /// The HTTP / server layer is expected to schedule this (e.g. every
     /// minute via `tokio::time::interval`); `start_*` also runs an

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -1,29 +1,34 @@
 //! Authentication HTTP routes.
 //!
-//! Five endpoints covering the first-device happy path:
+//! Eight endpoints covering the full auth surface:
 //!
-//! - `GET  /api/auth/status`          — public; surfaces access mode + install state
-//! - `POST /api/auth/register/start`  — localhost-only, no existing credentials
-//! - `POST /api/auth/register/finish` — localhost-only, no existing credentials
+//! - `GET  /api/auth/status`          — public; access mode + install state + authenticated
+//! - `POST /api/auth/register/start`  — localhost-only, fresh install
+//! - `POST /api/auth/register/finish` — localhost-only, fresh install; mints session
 //! - `POST /api/auth/login/start`     — public
-//! - `POST /api/auth/login/finish`    — public; mints session on success
+//! - `POST /api/auth/login/finish`    — public; updates counter + mints session
+//! - `POST /api/auth/pair/start`      — public, setup-token-gated
+//! - `POST /api/auth/pair/finish`     — public; links credential to token + mints session
+//! - `POST /api/auth/logout`          — auth + CSRF; localhost → 409
 //!
-//! Logout + setup-token pairing (for adding a second device over a
-//! tunnel) land in slice 6.
+//! Setup-token management (list / create / revoke) lives in
+//! `api::tokens`. Those routes share the same `CsrfProtected` pattern
+//! as logout for state-changing verbs.
 //!
 //! Every successful ceremony writes through `AuthStore::transact` so
 //! the "compute new state, persist atomically, swap in memory"
 //! contract holds. Invariants that gate a write (e.g., "first device
-//! only") are checked **inside** the transact closure so the mutex
-//! is the authoritative enforcement point — a pre-flight guard stays
-//! as a fast-fail for the common non-racing case.
+//! only", "setup token still redeemable") are checked **inside** the
+//! transact closure so the mutex is the authoritative enforcement
+//! point — a pre-flight guard stays as a fast-fail for the common
+//! non-racing case.
 
 use crate::access::AccessMethod;
 use crate::api::csrf::CsrfProtected;
 use crate::api::error::ApiError;
 use crate::api::extract::JsonBody;
 use crate::auth_middleware::{AuthContext, Authenticated};
-use crate::cookie::{build_clear_cookie, build_set_cookie, extract_session_token};
+use crate::cookie::{build_clear_cookie, build_set_cookie};
 use crate::state::AppState;
 use axum::{
     extract::{ConnectInfo, State},
@@ -36,7 +41,7 @@ use katulong_auth::webauthn_wire::{
     CreationChallengeResponse, PublicKeyCredential, RegisterPublicKeyCredential,
     RequestChallengeResponse,
 };
-use katulong_auth::{AuthError, ChallengeId, Credential, Session, SESSION_TTL};
+use katulong_auth::{AuthError, ChallengeId, Session, SESSION_TTL};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::time::SystemTime;
@@ -124,20 +129,22 @@ struct RegisterFinishRequest {
     response: RegisterPublicKeyCredential,
 }
 
-#[derive(Debug, Serialize)]
-struct RegisterFinishResponse {
-    credential_id: String,
-    csrf_token: String,
-}
-
 #[derive(Debug, Deserialize)]
 struct LoginFinishRequest {
     challenge_id: ChallengeId,
     response: PublicKeyCredential,
 }
 
+/// Shared response shape for every flow that mints a session on
+/// success — register, login, and pair. All three return the same two
+/// fields (`credential_id` for UI display, `csrf_token` for the
+/// client to echo in the `X-Csrf-Token` header on subsequent
+/// state-changing requests). Keeping them as one type means a future
+/// schema addition (e.g., `session_expires_at`) lands in one place.
+/// Status codes still differ per route (201 on register/pair, 200 on
+/// login), so the distinction is preserved at the call sites.
 #[derive(Debug, Serialize)]
-struct LoginFinishResponse {
+struct AuthFinishResponse {
     credential_id: String,
     csrf_token: String,
 }
@@ -263,7 +270,7 @@ async fn register_finish(
     // authoritative TOCTOU-safe enforcement — a second concurrent
     // finisher will see state already containing the first winner's
     // credential and bail out with StateConflict (→ 409).
-    let credential_clone = credential.clone();
+    let new_credential = credential.clone();
     let (plaintext_token, minted_session) = state
         .auth_store
         .transact(move |s| {
@@ -272,9 +279,9 @@ async fn register_finish(
                     "instance already initialised by a concurrent registration",
                 ));
             }
-            let (plaintext, session) = Session::mint(credential_clone.id.clone(), now, SESSION_TTL);
+            let (plaintext, session) = Session::mint(new_credential.id.clone(), now, SESSION_TTL);
             let next = s
-                .upsert_credential(credential_clone.clone())
+                .upsert_credential(new_credential.clone())
                 .upsert_session(session.clone());
             Ok((next, (plaintext, session)))
         })
@@ -290,7 +297,7 @@ async fn register_finish(
         StatusCode::CREATED,
         &plaintext_token,
         state.config.cookie_secure,
-        Json(RegisterFinishResponse {
+        Json(AuthFinishResponse {
             credential_id: credential.id,
             csrf_token: minted_session.csrf_token,
         }),
@@ -375,7 +382,7 @@ async fn login_finish(
         StatusCode::OK,
         &plaintext_token,
         state.config.cookie_secure,
-        Json(LoginFinishResponse {
+        Json(AuthFinishResponse {
             credential_id: verified.credential_id,
             csrf_token: minted_session.csrf_token,
         }),
@@ -424,12 +431,6 @@ struct PairFinishRequest {
     response: RegisterPublicKeyCredential,
 }
 
-#[derive(Debug, Serialize)]
-struct PairFinishResponse {
-    credential_id: String,
-    csrf_token: String,
-}
-
 /// Validate the plaintext token, start a WebAuthn registration
 /// ceremony, and return the challenge. Public — anyone with a valid
 /// token can pair.
@@ -438,16 +439,49 @@ struct PairFinishResponse {
 /// every token and runs scrypt verify (no short-circuit — the slice-2
 /// comment calls out the timing-channel concern). Only live,
 /// non-consumed tokens pass.
+/// Upper bound on the raw `setup_token` value accepted by
+/// `pair_start`. Legitimate tokens are 64 hex chars (32 bytes from
+/// CSPRNG, hex-encoded); 128 gives headroom. The cap exists to stop
+/// an unauthenticated caller from submitting a megabyte-long string
+/// and forcing `find_redeemable_setup_token` to run scrypt verify
+/// against every stored token with a megabyte input per call — a CPU
+/// amplification DoS vector because pair_start is public.
+const SETUP_TOKEN_MAX_LEN: usize = 128;
+
 async fn pair_start(
     State(state): State<AppState>,
     JsonBody(body): JsonBody<PairStartRequest>,
 ) -> Result<Json<PairStartResponse>, ApiError> {
+    if body.setup_token.len() > SETUP_TOKEN_MAX_LEN {
+        tracing::warn!(
+            length = body.setup_token.len(),
+            "pair_start: setup_token exceeds maximum length"
+        );
+        return Err(ApiError::BadRequest("setup_token exceeds maximum length"));
+    }
+
     let now = SystemTime::now();
-    // Take the snapshot once: we need user_handle + existing
-    // credentials + the matching setup token. All three come from
-    // the same point-in-time view. A concurrent mutation between
-    // here and pair_finish's transact is handled by re-validating
-    // the token inside that closure (below).
+
+    // Ensure the stable user handle is persisted before we hand it
+    // to the WebAuthn ceremony. `user_handle_or_init` is idempotent:
+    // returns the existing value on a live install, mints + persists
+    // a fresh one on the pathological path where tokens somehow
+    // exist without a handle. Running this inside `transact` means
+    // the handle that pair_finish reads back is the SAME value that
+    // was used here, even across concurrent pair_start calls.
+    let user_handle = state
+        .auth_store
+        .transact(|s| {
+            let (uh, next) = s.user_handle_or_init();
+            Ok((next, uh))
+        })
+        .await
+        .map_err(ApiError::from)?;
+
+    // A separate snapshot for token validation + excludeCredentials.
+    // `find_redeemable_setup_token` walks every record with scrypt
+    // verify, so a concurrent mutation doesn't matter — the
+    // authoritative token re-check happens in pair_finish's transact.
     let snap = state.auth_store.snapshot().await;
     let token = snap
         .find_redeemable_setup_token(&body.setup_token, now)
@@ -456,12 +490,6 @@ async fn pair_start(
             ApiError::Unauthorized
         })?;
     let setup_token_id = token.id.clone();
-
-    // Pairing requires an already-initialised instance — otherwise
-    // the first-device path is the right answer. This is mostly a
-    // guard against a pathological deployment that has tokens without
-    // credentials (shouldn't happen but fail-closed anyway).
-    let (user_handle, _) = snap.user_handle_or_init();
 
     let (challenge_id, ccr) = state
         .webauthn
@@ -496,9 +524,18 @@ async fn pair_finish(
     JsonBody(body): JsonBody<PairFinishRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
     let now = SystemTime::now();
+    // The auth crate owns the bidirectional link invariant (credential
+    // ↔ setup token). `finish_paired_registration` returns a
+    // credential already stamped with `setup_token_id` — the handler
+    // never constructs that link by hand.
     let credential = state
         .webauthn
-        .finish_registration(&body.challenge_id, &body.response, now)
+        .finish_paired_registration(
+            &body.challenge_id,
+            &body.response,
+            body.setup_token_id.clone(),
+            now,
+        )
         .inspect_err(|e| {
             tracing::warn!(
                 challenge_id = %body.challenge_id,
@@ -508,13 +545,7 @@ async fn pair_finish(
         })
         .map_err(ApiError::from)?;
 
-    // Stamp the bidirectional link before persisting.
-    let linked_credential = Credential {
-        setup_token_id: Some(body.setup_token_id.clone()),
-        ..credential
-    };
-
-    let cred_clone = linked_credential.clone();
+    let new_credential = credential.clone();
     let setup_token_id = body.setup_token_id.clone();
     let (plaintext_token, minted_session) = state
         .auth_store
@@ -536,10 +567,11 @@ async fn pair_finish(
                 ));
             }
 
-            let (plaintext, session) = Session::mint(cred_clone.id.clone(), now, SESSION_TTL);
+            let (plaintext, session) =
+                Session::mint(new_credential.id.clone(), now, SESSION_TTL);
             let next = s
-                .upsert_credential(cred_clone.clone())
-                .consume_setup_token(&setup_token_id, &cred_clone.id, now)
+                .upsert_credential(new_credential.clone())
+                .consume_setup_token(&setup_token_id, &new_credential.id, now)
                 .upsert_session(session.clone());
             Ok((next, (plaintext, session)))
         })
@@ -547,7 +579,7 @@ async fn pair_finish(
         .map_err(ApiError::from)?;
 
     tracing::info!(
-        credential_id = %linked_credential.id,
+        credential_id = %credential.id,
         setup_token_id = %body.setup_token_id,
         "paired new device; session minted"
     );
@@ -556,8 +588,8 @@ async fn pair_finish(
         StatusCode::CREATED,
         &plaintext_token,
         state.config.cookie_secure,
-        Json(PairFinishResponse {
-            credential_id: linked_credential.id,
+        Json(AuthFinishResponse {
+            credential_id: credential.id,
             csrf_token: minted_session.csrf_token,
         }),
     ))
@@ -567,7 +599,6 @@ async fn pair_finish(
 
 async fn logout(
     State(state): State<AppState>,
-    headers: HeaderMap,
     CsrfProtected(ctx): CsrfProtected,
 ) -> Result<impl IntoResponse, ApiError> {
     // Localhost has no session — nothing to end. Return 409 rather
@@ -577,30 +608,25 @@ async fn logout(
     // localhost callers; a request arriving here from localhost is
     // therefore either a buggy client or a probe. Treating it as a
     // conflict keeps the behaviour observable.
-    if matches!(ctx, AuthContext::Localhost) {
+    let AuthContext::Remote {
+        plaintext_token,
+        credential,
+        ..
+    } = ctx
+    else {
         return Err(ApiError::Conflict("localhost peer has no session to end"));
-    }
-
-    // Pull the cookie's plaintext so we can remove the matching
-    // session from the store. The `Authenticated` extractor already
-    // validated it; we re-read here because the session lookup keys
-    // off the plaintext, not off the already-resolved Session.
-    let cookie_value = headers
-        .get(header::COOKIE)
-        .and_then(|v| v.to_str().ok())
-        .and_then(extract_session_token)
-        .ok_or(ApiError::Unauthorized)?;
+    };
 
     state
         .auth_store
-        .transact(move |s| Ok((s.remove_session(&cookie_value), ())))
+        .transact(move |s| Ok((s.remove_session(&plaintext_token), ())))
         .await
         .map_err(ApiError::from)?;
 
     let clear = build_clear_cookie(state.config.cookie_secure);
-    tracing::info!("logout succeeded; session removed");
-    Ok((
-        StatusCode::NO_CONTENT,
-        [(header::SET_COOKIE, clear)],
-    ))
+    tracing::info!(
+        credential_id = %credential.id,
+        "logout succeeded; session removed"
+    );
+    Ok((StatusCode::NO_CONTENT, [(header::SET_COOKIE, clear)]))
 }

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -19,10 +19,11 @@
 //! as a fast-fail for the common non-racing case.
 
 use crate::access::AccessMethod;
+use crate::api::csrf::CsrfProtected;
 use crate::api::error::ApiError;
 use crate::api::extract::JsonBody;
-use crate::auth_middleware::Authenticated;
-use crate::cookie::build_set_cookie;
+use crate::auth_middleware::{AuthContext, Authenticated};
+use crate::cookie::{build_clear_cookie, build_set_cookie, extract_session_token};
 use crate::state::AppState;
 use axum::{
     extract::{ConnectInfo, State},
@@ -35,7 +36,7 @@ use katulong_auth::webauthn_wire::{
     CreationChallengeResponse, PublicKeyCredential, RegisterPublicKeyCredential,
     RequestChallengeResponse,
 };
-use katulong_auth::{AuthError, ChallengeId, Session, SESSION_TTL};
+use katulong_auth::{AuthError, ChallengeId, Credential, Session, SESSION_TTL};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::time::SystemTime;
@@ -48,14 +49,24 @@ pub fn auth_routes() -> Router<AppState> {
         .route("/api/auth/status", get(status))
         // PUBLIC (but state-gated): first-device registration. Only
         // works from localhost AND only when no credentials exist.
-        // Additional-device registration uses the setup-token flow in
-        // slice 6, not this route.
+        // Additional-device registration uses the pair flow below.
         .route("/api/auth/register/start", post(register_start))
         .route("/api/auth/register/finish", post(register_finish))
         // PUBLIC: anyone can try to log in. The ceremony itself gates
         // who actually succeeds.
         .route("/api/auth/login/start", post(login_start))
         .route("/api/auth/login/finish", post(login_finish))
+        // PUBLIC: pair a new device using a setup token issued by an
+        // authenticated admin. The token value IS the gate — anyone
+        // with a valid plaintext token can pair. Token validity and
+        // single-use semantics are enforced inside `transact`.
+        .route("/api/auth/pair/start", post(pair_start))
+        .route("/api/auth/pair/finish", post(pair_finish))
+        // PROTECTED + CSRF: end the caller's session. Localhost
+        // callers get a 409 — there's no session to end, and the
+        // UI shouldn't offer logout for physical-access peers (Node
+        // scar `23981ca`).
+        .route("/api/auth/logout", post(logout))
 }
 
 /// JSON wire format for the status endpoint.
@@ -384,4 +395,212 @@ where
 {
     let cookie = build_set_cookie(token, SESSION_TTL.as_secs(), secure);
     (status, [(header::SET_COOKIE, cookie)], body)
+}
+
+// ============== pair flow (setup-token-gated registration) ==============
+
+#[derive(Debug, Deserialize)]
+struct PairStartRequest {
+    /// Plaintext setup token value as given to the new device's
+    /// operator. The server hashes and looks it up.
+    setup_token: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PairStartResponse {
+    challenge_id: ChallengeId,
+    /// The setup-token id — opaque to the client, returned so the
+    /// finish call can reference it without re-submitting the
+    /// plaintext value. Defence in depth: keeps the plaintext
+    /// transiting the network once, not twice.
+    setup_token_id: String,
+    options: CreationChallengeResponse,
+}
+
+#[derive(Debug, Deserialize)]
+struct PairFinishRequest {
+    challenge_id: ChallengeId,
+    setup_token_id: String,
+    response: RegisterPublicKeyCredential,
+}
+
+#[derive(Debug, Serialize)]
+struct PairFinishResponse {
+    credential_id: String,
+    csrf_token: String,
+}
+
+/// Validate the plaintext token, start a WebAuthn registration
+/// ceremony, and return the challenge. Public — anyone with a valid
+/// token can pair.
+///
+/// Token validation uses `find_redeemable_setup_token` which walks
+/// every token and runs scrypt verify (no short-circuit — the slice-2
+/// comment calls out the timing-channel concern). Only live,
+/// non-consumed tokens pass.
+async fn pair_start(
+    State(state): State<AppState>,
+    JsonBody(body): JsonBody<PairStartRequest>,
+) -> Result<Json<PairStartResponse>, ApiError> {
+    let now = SystemTime::now();
+    // Take the snapshot once: we need user_handle + existing
+    // credentials + the matching setup token. All three come from
+    // the same point-in-time view. A concurrent mutation between
+    // here and pair_finish's transact is handled by re-validating
+    // the token inside that closure (below).
+    let snap = state.auth_store.snapshot().await;
+    let token = snap
+        .find_redeemable_setup_token(&body.setup_token, now)
+        .ok_or_else(|| {
+            tracing::warn!("pair_start: setup token not redeemable");
+            ApiError::Unauthorized
+        })?;
+    let setup_token_id = token.id.clone();
+
+    // Pairing requires an already-initialised instance — otherwise
+    // the first-device path is the right answer. This is mostly a
+    // guard against a pathological deployment that has tokens without
+    // credentials (shouldn't happen but fail-closed anyway).
+    let (user_handle, _) = snap.user_handle_or_init();
+
+    let (challenge_id, ccr) = state
+        .webauthn
+        .start_registration(
+            user_handle,
+            "katulong",
+            "Katulong",
+            &snap.credentials,
+            now,
+        )
+        .map_err(ApiError::from)?;
+
+    Ok(Json(PairStartResponse {
+        challenge_id,
+        setup_token_id,
+        options: ccr,
+    }))
+}
+
+/// Complete the pair ceremony. Verifies the challenge, verifies the
+/// setup token is STILL redeemable under the mutex (TOCTOU-safe vs a
+/// concurrent revoke between start and finish), consumes the token,
+/// persists the new credential with a bidirectional link to the
+/// token, and mints a session cookie.
+///
+/// The bidirectional link (token ↔ credential, Node scar `7742ac3`)
+/// means that revoking the setup token later also cascades to
+/// removing this device. We set it here so future
+/// `remove_setup_token(id)` calls can follow the link.
+async fn pair_finish(
+    State(state): State<AppState>,
+    JsonBody(body): JsonBody<PairFinishRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let now = SystemTime::now();
+    let credential = state
+        .webauthn
+        .finish_registration(&body.challenge_id, &body.response, now)
+        .inspect_err(|e| {
+            tracing::warn!(
+                challenge_id = %body.challenge_id,
+                error = %e,
+                "pair ceremony failed"
+            );
+        })
+        .map_err(ApiError::from)?;
+
+    // Stamp the bidirectional link before persisting.
+    let linked_credential = Credential {
+        setup_token_id: Some(body.setup_token_id.clone()),
+        ..credential
+    };
+
+    let cred_clone = linked_credential.clone();
+    let setup_token_id = body.setup_token_id.clone();
+    let (plaintext_token, minted_session) = state
+        .auth_store
+        .transact(move |s| {
+            // Re-validate the token under the mutex: a concurrent
+            // revoke between pair_start and pair_finish must NOT
+            // succeed in pairing. `find_setup_token` by id because at
+            // this point we're committing against the specific token
+            // the client referenced; we also require it to still be
+            // redeemable.
+            let Some(token) = s.find_setup_token(&setup_token_id) else {
+                return Err(AuthError::StateConflict(
+                    "setup token revoked during pair ceremony",
+                ));
+            };
+            if !token.is_redeemable(now) {
+                return Err(AuthError::StateConflict(
+                    "setup token no longer redeemable (consumed or expired)",
+                ));
+            }
+
+            let (plaintext, session) = Session::mint(cred_clone.id.clone(), now, SESSION_TTL);
+            let next = s
+                .upsert_credential(cred_clone.clone())
+                .consume_setup_token(&setup_token_id, &cred_clone.id, now)
+                .upsert_session(session.clone());
+            Ok((next, (plaintext, session)))
+        })
+        .await
+        .map_err(ApiError::from)?;
+
+    tracing::info!(
+        credential_id = %linked_credential.id,
+        setup_token_id = %body.setup_token_id,
+        "paired new device; session minted"
+    );
+
+    Ok(session_cookie_response(
+        StatusCode::CREATED,
+        &plaintext_token,
+        state.config.cookie_secure,
+        Json(PairFinishResponse {
+            credential_id: linked_credential.id,
+            csrf_token: minted_session.csrf_token,
+        }),
+    ))
+}
+
+// ============== logout ==============
+
+async fn logout(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    CsrfProtected(ctx): CsrfProtected,
+) -> Result<impl IntoResponse, ApiError> {
+    // Localhost has no session — nothing to end. Return 409 rather
+    // than silently succeeding so the UI can surface "you're
+    // physically present; logout doesn't apply." Node reached the
+    // same conclusion (`23981ca`): the logout button is hidden for
+    // localhost callers; a request arriving here from localhost is
+    // therefore either a buggy client or a probe. Treating it as a
+    // conflict keeps the behaviour observable.
+    if matches!(ctx, AuthContext::Localhost) {
+        return Err(ApiError::Conflict("localhost peer has no session to end"));
+    }
+
+    // Pull the cookie's plaintext so we can remove the matching
+    // session from the store. The `Authenticated` extractor already
+    // validated it; we re-read here because the session lookup keys
+    // off the plaintext, not off the already-resolved Session.
+    let cookie_value = headers
+        .get(header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(extract_session_token)
+        .ok_or(ApiError::Unauthorized)?;
+
+    state
+        .auth_store
+        .transact(move |s| Ok((s.remove_session(&cookie_value), ())))
+        .await
+        .map_err(ApiError::from)?;
+
+    let clear = build_clear_cookie(state.config.cookie_secure);
+    tracing::info!("logout succeeded; session removed");
+    Ok((
+        StatusCode::NO_CONTENT,
+        [(header::SET_COOKIE, clear)],
+    ))
 }

--- a/crates/server/src/api/csrf.rs
+++ b/crates/server/src/api/csrf.rs
@@ -1,0 +1,68 @@
+//! CSRF double-submit verification.
+//!
+//! State-changing routes require the caller to echo the session's
+//! CSRF token in an `X-Csrf-Token` header. The header value is
+//! constant-time compared to `Session.csrf_token` as stored at mint
+//! time. Same-site Lax already blocks most cross-site forgeries from
+//! other origins, but a same-site malicious script could still issue
+//! credentialed POSTs — the CSRF double-submit closes that gap.
+//!
+//! The extractor is scoped to remote sessions: `AuthContext::Localhost`
+//! bypasses the check because there's no session (and therefore no
+//! paired CSRF token to compare against), which is consistent with
+//! localhost's physical-access trust model.
+
+use crate::api::error::ApiError;
+use crate::auth_middleware::{AuthContext, Authenticated};
+use crate::state::AppState;
+use axum::{
+    extract::FromRequestParts,
+    http::{request::Parts, HeaderName},
+};
+use subtle::ConstantTimeEq;
+
+/// Header the client must include on state-changing requests.
+pub const CSRF_HEADER: HeaderName = HeaderName::from_static("x-csrf-token");
+
+/// Successful CSRF validation, carrying the resolved `AuthContext` so
+/// handlers don't need to re-extract `Authenticated`.
+///
+/// Usage: `async fn handler(CsrfProtected(ctx): CsrfProtected, ...)`.
+/// The extractor runs `Authenticated` internally; if auth fails the
+/// request gets 401, if CSRF fails 403 with code `csrf`.
+pub struct CsrfProtected(pub AuthContext);
+
+#[axum::async_trait]
+impl FromRequestParts<AppState> for CsrfProtected {
+    type Rejection = ApiError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let Authenticated(ctx) = Authenticated::from_request_parts(parts, state)
+            .await
+            .map_err(|_| ApiError::Unauthorized)?;
+
+        // Localhost has no session and no CSRF pairing. Physical
+        // access is the trust model; no further check adds security.
+        if matches!(ctx, AuthContext::Localhost) {
+            return Ok(Self(ctx));
+        }
+
+        let header = parts
+            .headers
+            .get(&CSRF_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .ok_or(ApiError::CsrfMissing)?;
+
+        let AuthContext::Remote { ref session, .. } = ctx else {
+            unreachable!("non-Remote variant handled above");
+        };
+        if bool::from(header.as_bytes().ct_eq(session.csrf_token.as_bytes())) {
+            Ok(Self(ctx))
+        } else {
+            Err(ApiError::CsrfMismatch)
+        }
+    }
+}

--- a/crates/server/src/api/error.rs
+++ b/crates/server/src/api/error.rs
@@ -41,6 +41,17 @@ pub enum ApiError {
     /// this action yet (e.g., login against a fresh install with no
     /// credentials).
     Conflict(&'static str),
+    /// State-changing request reached us without an `X-Csrf-Token`
+    /// header. Maps to 403 with code `csrf_missing`. Distinct from
+    /// `CsrfMismatch` so a client can distinguish "never sent" from
+    /// "sent but wrong" — the first is a client-code bug, the second
+    /// is an expired session.
+    CsrfMissing,
+    /// State-changing request reached us with an `X-Csrf-Token` that
+    /// didn't match the session's paired value. Usually indicates a
+    /// stale session (the client has a cookie + csrf from a previous
+    /// login that's been superseded).
+    CsrfMismatch,
     /// Anything else — mapped to 500. Internal detail is logged at the
     /// `From<AuthError>` conversion site, NOT stored on the variant, so
     /// no caller can pattern-match this variant and re-render the
@@ -66,6 +77,16 @@ impl ApiError {
                 "server busy; retry shortly".into(),
             ),
             Self::Conflict(why) => (StatusCode::CONFLICT, "conflict", (*why).into()),
+            Self::CsrfMissing => (
+                StatusCode::FORBIDDEN,
+                "csrf_missing",
+                "missing X-Csrf-Token header".into(),
+            ),
+            Self::CsrfMismatch => (
+                StatusCode::FORBIDDEN,
+                "csrf_mismatch",
+                "X-Csrf-Token does not match session".into(),
+            ),
             Self::Internal => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal",

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -7,5 +7,7 @@
 //! the status-code + body mapping happens in exactly one place.
 
 pub mod auth;
+pub mod csrf;
 pub mod error;
 pub mod extract;
+pub mod tokens;

--- a/crates/server/src/api/tokens.rs
+++ b/crates/server/src/api/tokens.rs
@@ -1,0 +1,178 @@
+//! Setup-token management routes.
+//!
+//! Setup tokens are the remote-device pairing primitive. Admin flow:
+//! the currently-authenticated user mints a token (carrying a short
+//! name for audit) and hands the plaintext to the new device's
+//! operator. The new device posts the plaintext to
+//! `/api/auth/pair/start` + `/finish` (in `auth.rs`), which consumes
+//! the token, registers a credential linked to the token, and mints
+//! a session cookie.
+//!
+//! Three endpoints here:
+//! - `GET    /api/auth/setup-tokens`       — list (auth)
+//! - `POST   /api/auth/setup-tokens`       — create (auth + CSRF)
+//! - `DELETE /api/auth/setup-tokens/:id`   — revoke (auth + CSRF)
+//!
+//! Revocation cascades to the paired device AND its sessions via
+//! `AuthState::remove_setup_token` (Node scar `7742ac3`: bidirectional
+//! link between tokens and credentials was added specifically so
+//! "revoke this token" could also pull its device without a separate
+//! API call).
+
+use crate::api::csrf::CsrfProtected;
+use crate::api::error::ApiError;
+use crate::api::extract::JsonBody;
+use crate::auth_middleware::Authenticated;
+use crate::state::AppState;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{delete, get, post},
+    Json, Router,
+};
+use katulong_auth::{PlaintextToken, SetupToken};
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, SystemTime};
+
+/// Default setup-token lifetime. One hour is long enough for a user
+/// to copy the plaintext, walk to the other device, and paste it in;
+/// short enough that a lost token doesn't sit redeemable overnight.
+/// Not currently overridable at the API level — operator tuning would
+/// go through an env var or config file, not per-token.
+const SETUP_TOKEN_TTL: Duration = Duration::from_secs(60 * 60);
+
+pub fn token_routes() -> Router<AppState> {
+    Router::new()
+        // PROTECTED: list requires auth but not CSRF (GET is safe).
+        .route("/api/auth/setup-tokens", get(list_tokens))
+        // PROTECTED + CSRF: state-changing.
+        .route("/api/auth/setup-tokens", post(create_token))
+        .route("/api/auth/setup-tokens/:id", delete(revoke_token))
+}
+
+#[derive(Debug, Serialize)]
+struct TokenListEntry {
+    id: String,
+    name: Option<String>,
+    /// Unix millis. Clients compute "expires in" locally.
+    expires_at_millis: u128,
+    /// Stable semantic tag:
+    /// - `"live"` — not used, not expired, redeemable by a new device
+    /// - `"used"` — already consumed; linked credential still paired
+    /// - `"expired"` — past TTL, never used
+    status: &'static str,
+    /// When `status == "used"`, the id of the device this token
+    /// created. Populated from the bidirectional link set in
+    /// `AuthState::consume_setup_token` (Node scar `7742ac3`).
+    credential_id: Option<String>,
+}
+
+async fn list_tokens(
+    State(state): State<AppState>,
+    Authenticated(_): Authenticated,
+) -> Result<Json<Vec<TokenListEntry>>, ApiError> {
+    let now = SystemTime::now();
+    let snap = state.auth_store.snapshot().await;
+    let entries: Vec<TokenListEntry> = snap
+        .setup_tokens
+        .iter()
+        .map(|t| TokenListEntry {
+            id: t.id.clone(),
+            name: t.name.clone(),
+            expires_at_millis: t
+                .expires_at
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0),
+            status: if t.is_consumed() {
+                "used"
+            } else if t.is_expired(now) {
+                "expired"
+            } else {
+                "live"
+            },
+            credential_id: t.credential_id.clone(),
+        })
+        .collect();
+    Ok(Json(entries))
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateTokenRequest {
+    /// Optional human-readable tag, shown in the device-management
+    /// UI. Clipped server-side to avoid unbounded storage from a
+    /// malicious caller (who, to be clear, is already authenticated —
+    /// this is defence in depth, not a boundary control).
+    name: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateTokenResponse {
+    id: String,
+    /// Hand this to the user. Once the HTTP response is sent, the
+    /// server holds only the scrypt hash — recovery is impossible.
+    plaintext: PlaintextToken,
+    expires_at_millis: u128,
+}
+
+/// Max length for the human-readable `name` field. Chosen so a
+/// label comfortably holds a device nickname ("Felix iPad") without
+/// giving an authenticated caller a vector to grow the state file.
+const TOKEN_NAME_MAX_LEN: usize = 64;
+
+async fn create_token(
+    State(state): State<AppState>,
+    CsrfProtected(_): CsrfProtected,
+    JsonBody(body): JsonBody<CreateTokenRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let name = body
+        .name
+        .map(|n| n.trim().to_string())
+        .filter(|n| !n.is_empty());
+    if let Some(ref n) = name {
+        if n.chars().count() > TOKEN_NAME_MAX_LEN {
+            return Err(ApiError::BadRequest("name exceeds 64 characters"));
+        }
+    }
+    let now = SystemTime::now();
+    let (plaintext, token) =
+        SetupToken::issue(name, now, SETUP_TOKEN_TTL).map_err(ApiError::from)?;
+    let id = token.id.clone();
+    let expires_at = token.expires_at;
+    state
+        .auth_store
+        .transact(|s| Ok((s.add_setup_token(token.clone()), ())))
+        .await
+        .map_err(ApiError::from)?;
+
+    tracing::info!(token_id = %id, "setup token minted");
+    Ok((
+        StatusCode::CREATED,
+        Json(CreateTokenResponse {
+            id,
+            plaintext,
+            expires_at_millis: expires_at
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0),
+        }),
+    ))
+}
+
+async fn revoke_token(
+    State(state): State<AppState>,
+    CsrfProtected(_): CsrfProtected,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    // `remove_setup_token` is a no-op on unknown ids — we treat that
+    // as idempotent success (204). The caller can't tell "never
+    // existed" from "already revoked," which is fine: both answers
+    // mean "this id is not redeemable from here forward."
+    state
+        .auth_store
+        .transact(move |s| Ok((s.remove_setup_token(&id), ())))
+        .await
+        .map_err(ApiError::from)?;
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/server/src/api/tokens.rs
+++ b/crates/server/src/api/tokens.rs
@@ -56,7 +56,11 @@ struct TokenListEntry {
     id: String,
     name: Option<String>,
     /// Unix millis. Clients compute "expires in" locally.
-    expires_at_millis: u128,
+    /// Unix-millis encoded as `u64`. `u128` would overflow
+    /// `serde_json`'s 2^53 safe-integer range into a string, which
+    /// JS clients parsing `v.as_u64()` would then drop. u64 holds
+    /// unix-ms out to year 584,554,051 — ample.
+    expires_at_millis: u64,
     /// Stable semantic tag:
     /// - `"live"` — not used, not expired, redeemable by a new device
     /// - `"used"` — already consumed; linked credential still paired
@@ -68,6 +72,10 @@ struct TokenListEntry {
     credential_id: Option<String>,
 }
 
+/// List setup tokens. Auth-only (no CSRF) because GET is a safe
+/// method — no state change to protect against cross-site replay.
+/// Write-path handlers in this module use `CsrfProtected`; the
+/// distinction is intentional and consistent with axum/HTTP norms.
 async fn list_tokens(
     State(state): State<AppState>,
     Authenticated(_): Authenticated,
@@ -83,7 +91,7 @@ async fn list_tokens(
             expires_at_millis: t
                 .expires_at
                 .duration_since(SystemTime::UNIX_EPOCH)
-                .map(|d| d.as_millis())
+                .map(|d| d.as_millis() as u64)
                 .unwrap_or(0),
             status: if t.is_consumed() {
                 "used"
@@ -113,7 +121,11 @@ struct CreateTokenResponse {
     /// Hand this to the user. Once the HTTP response is sent, the
     /// server holds only the scrypt hash — recovery is impossible.
     plaintext: PlaintextToken,
-    expires_at_millis: u128,
+    /// Unix-millis encoded as `u64`. `u128` would overflow
+    /// `serde_json`'s 2^53 safe-integer range into a string, which
+    /// JS clients parsing `v.as_u64()` would then drop. u64 holds
+    /// unix-ms out to year 584,554,051 — ample.
+    expires_at_millis: u64,
 }
 
 /// Max length for the human-readable `name` field. Chosen so a
@@ -154,7 +166,7 @@ async fn create_token(
             plaintext,
             expires_at_millis: expires_at
                 .duration_since(SystemTime::UNIX_EPOCH)
-                .map(|d| d.as_millis())
+                .map(|d| d.as_millis() as u64)
                 .unwrap_or(0),
         }),
     ))
@@ -169,10 +181,12 @@ async fn revoke_token(
     // as idempotent success (204). The caller can't tell "never
     // existed" from "already revoked," which is fine: both answers
     // mean "this id is not redeemable from here forward."
+    let id_for_log = id.clone();
     state
         .auth_store
         .transact(move |s| Ok((s.remove_setup_token(&id), ())))
         .await
         .map_err(ApiError::from)?;
+    tracing::info!(token_id = %id_for_log, "setup token revoked");
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/server/src/auth_middleware.rs
+++ b/crates/server/src/auth_middleware.rs
@@ -26,21 +26,37 @@ use std::time::SystemTime;
 /// The rich result produced when a request is authenticated.
 ///
 /// `Localhost` carries no session — the peer is this machine and that's
-/// the whole auth story. `Remote` carries both the session and the
-/// credential it was bound to, so handlers that need one or the other
-/// don't go back to the store.
+/// the whole auth story. `Remote` carries the session, the credential
+/// it was bound to, AND the plaintext session-token that unlocked
+/// them. Handlers that need to invalidate the session (logout) or echo
+/// the identity (e.g. `/api/me`) read from this context rather than
+/// re-parsing the cookie header.
 ///
-/// Clippy flags the size imbalance (Remote ≈ 240 bytes, Localhost 0)
-/// and suggests boxing `credential`. We decline: `Remote` is the common
-/// case on every authenticated remote request, and adding a heap
-/// allocation to the hot path to save zeroing 240 stack bytes on the
+/// Carrying `plaintext_token` closes a structural gap that the slice-6
+/// review flagged: `AuthState::remove_session` keys off the plaintext
+/// (it hashes internally) but `Session` only stores the hash. Before
+/// this field existed, the logout handler had to re-extract the
+/// cookie — duplicating work the extractor had already done.
+///
+/// Clippy flags the size imbalance (Remote ≈ 300 bytes, Localhost 0)
+/// and suggests boxing. We decline: `Remote` is the common case on
+/// every authenticated remote request, and adding a heap allocation
+/// to the hot path to save zeroing a few hundred stack bytes on the
 /// rare `Localhost` path is the wrong tradeoff for single-user
 /// katulong. If this ever shows up in a profile, revisit.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum AuthContext {
     Localhost,
-    Remote { session: Session, credential: Credential },
+    Remote {
+        session: Session,
+        credential: Credential,
+        /// Plaintext session-token as received from the client's
+        /// `Cookie` header. Preserved here so handlers can call
+        /// `AuthState::remove_session` without going back to the raw
+        /// header. Never logged.
+        plaintext_token: String,
+    },
 }
 
 impl AuthContext {
@@ -113,6 +129,7 @@ impl FromRequestParts<AppState> for Authenticated {
         Ok(Authenticated(AuthContext::Remote {
             session,
             credential,
+            plaintext_token: token,
         }))
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -12,6 +12,7 @@ pub mod cookie;
 pub mod state;
 
 use api::auth::auth_routes;
+use api::tokens::token_routes;
 use auth_middleware::Authenticated;
 use axum::{extract::DefaultBodyLimit, routing::get, Json, Router};
 use katulong_shared::{ServerMessage, PROTOCOL_VERSION};
@@ -59,6 +60,9 @@ pub fn app(state: AppState) -> Router {
         // Auth ceremony routes. Each endpoint's public/protected
         // status is documented on the route line inside the module.
         .merge(auth_routes())
+        // Setup-token management (list/create/revoke). All protected;
+        // state-changing ones additionally require CSRF.
+        .merge(token_routes())
         .layer(DefaultBodyLimit::max(REQUEST_BODY_LIMIT))
         .with_state(state)
 }

--- a/crates/server/tests/common/mod.rs
+++ b/crates/server/tests/common/mod.rs
@@ -5,6 +5,12 @@
 //! `tests/*.rs` file without each being compiled into its own test
 //! binary. Consumers declare `mod common;` at the top of each test
 //! file.
+//!
+//! The crate-level `#![allow(dead_code)]` is deliberate: each
+//! `tests/*.rs` is its own test binary, and a helper used by one
+//! binary appears unused to another. Without the blanket allow, every
+//! fixture would need to justify its compilation unit — noise with no
+//! corresponding safety benefit.
 
 #![allow(dead_code)]
 
@@ -13,7 +19,7 @@ use axum::{
     http::{header, request::Builder as RequestBuilder, Request},
 };
 use http_body_util::BodyExt;
-use katulong_auth::{AuthStore, Credential, WebAuthnService};
+use katulong_auth::{AuthStore, Credential, Session, WebAuthnService, SESSION_TTL};
 use katulong_server::state::{AppState, ServerConfig};
 use serde_json::Value;
 use std::net::SocketAddr;
@@ -77,4 +83,26 @@ pub fn json_body<T: serde::Serialize>(value: &T) -> Body {
 pub async fn body_json(resp: axum::response::Response) -> Value {
     let bytes = resp.into_body().collect().await.unwrap().to_bytes();
     serde_json::from_slice(&bytes).unwrap()
+}
+
+/// Seed an `AuthStore` with a credential + valid session for
+/// `credential_id`, and return the pair `(plaintext_cookie,
+/// csrf_token)` that a test can feed back into a CSRF-protected
+/// request. Both values are minted by the real `Session::mint` so
+/// the hashing + CSRF semantics are exercised end-to-end.
+pub async fn seeded_auth(state: &AppState, credential_id: &str) -> (String, String) {
+    let cred_id = credential_id.to_string();
+    state
+        .auth_store
+        .clone()
+        .transact(move |s| {
+            let credential = stub_credential(&cred_id);
+            let now = SystemTime::now();
+            let (plaintext, session) = Session::mint(cred_id.clone(), now, SESSION_TTL);
+            let csrf = session.csrf_token.clone();
+            let next = s.upsert_credential(credential).upsert_session(session);
+            Ok((next, (plaintext, csrf)))
+        })
+        .await
+        .unwrap()
 }

--- a/crates/server/tests/logout_and_pair.rs
+++ b/crates/server/tests/logout_and_pair.rs
@@ -1,0 +1,448 @@
+//! Integration tests for slice 6 — logout + setup-token management +
+//! pair flow + CSRF enforcement.
+//!
+//! Like the other integration suites, real WebAuthn crypto is out of
+//! reach without a browser-signed assertion. These tests cover:
+//! - CSRF enforcement on state-changing routes
+//! - Logout: 401 without auth, 409 from localhost, 204 + Set-Cookie
+//!   clearing on success
+//! - Setup-token lifecycle: create/list/revoke, cascading revoke
+//! - Pair flow gates: invalid token → 401, revoked-between-start-and-finish
+//!   → 409
+//!
+//! End-to-end pair with a real authenticator belongs in Playwright.
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, StatusCode},
+};
+use common::{body_json, ephemeral_state, json_body, req, stub_credential};
+use katulong_auth::{Session, SESSION_TTL};
+use katulong_server::app;
+use serde_json::{json, Value};
+use std::time::SystemTime;
+use tower::util::ServiceExt;
+
+/// Seed a credential + session and return the cookie plaintext AND
+/// csrf token — the pair every CSRF-protected route needs.
+async fn seeded_auth(state: &katulong_server::state::AppState, cred_id: &str) -> (String, String) {
+    state
+        .auth_store
+        .clone()
+        .transact({
+            let cred_id = cred_id.to_string();
+            move |s| {
+                let credential = stub_credential(&cred_id);
+                let now = SystemTime::now();
+                let (plaintext, session) = Session::mint(cred_id.clone(), now, SESSION_TTL);
+                let csrf = session.csrf_token.clone();
+                let next = s.upsert_credential(credential).upsert_session(session);
+                Ok((next, (plaintext, csrf)))
+            }
+        })
+        .await
+        .unwrap()
+}
+
+// ---------------- logout ----------------
+
+#[tokio::test]
+async fn logout_without_auth_returns_401() {
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/logout")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn logout_without_csrf_returns_403() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "c1").await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/logout")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], "csrf_missing");
+}
+
+#[tokio::test]
+async fn logout_with_wrong_csrf_returns_403_mismatch() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "c1").await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/logout")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", "wrong-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], "csrf_mismatch");
+}
+
+#[tokio::test]
+async fn logout_with_valid_auth_and_csrf_clears_cookie_and_session() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, csrf) = seeded_auth(&state, "c1").await;
+    let resp = app(state.clone())
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/logout")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    let set_cookie = resp
+        .headers()
+        .get(header::SET_COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        set_cookie.contains("Max-Age=0"),
+        "response must clear the cookie: got {set_cookie}"
+    );
+
+    // Session is actually gone from the store.
+    let snap = state.auth_store.snapshot().await;
+    assert!(
+        snap.find_session(&cookie).is_none(),
+        "session should be removed from store after logout"
+    );
+}
+
+#[tokio::test]
+async fn logout_from_localhost_is_conflict() {
+    // Localhost has no session to end; Node hid the button for the
+    // same reason (`23981ca`). Treat as Conflict so the UI doesn't
+    // silently show a fake success.
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::POST)
+                .uri("/api/auth/logout")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+// ---------------- setup-token management ----------------
+
+#[tokio::test]
+async fn list_setup_tokens_requires_auth() {
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::GET)
+                .uri("/api/auth/setup-tokens")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn create_and_list_setup_token_roundtrip() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, csrf) = seeded_auth(&state, "c1").await;
+
+    // Create.
+    let router = app(state);
+    let create = router
+        .clone()
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/setup-tokens")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "name": "iPad" })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create.status(), StatusCode::CREATED);
+    let v = body_json(create).await;
+    let token_id = v["id"].as_str().unwrap().to_string();
+    assert!(!v["plaintext"].as_str().unwrap().is_empty());
+    assert!(v["expires_at_millis"].as_u64().unwrap() > 0);
+
+    // List shows it with status=live.
+    let list = router
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::GET)
+                .uri("/api/auth/setup-tokens")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(list.status(), StatusCode::OK);
+    let entries: Value = body_json(list).await;
+    let entry = entries
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["id"] == token_id)
+        .expect("created token should appear in list");
+    assert_eq!(entry["name"], "iPad");
+    assert_eq!(entry["status"], "live");
+}
+
+#[tokio::test]
+async fn create_setup_token_without_csrf_is_403() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "c1").await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/setup-tokens")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn create_setup_token_rejects_oversized_name() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, csrf) = seeded_auth(&state, "c1").await;
+    let long_name = "x".repeat(200);
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/setup-tokens")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "name": long_name })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn revoke_setup_token_is_idempotent_and_cascades() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, csrf) = seeded_auth(&state, "admin-cred").await;
+    let router = app(state.clone());
+
+    // Create a token then pair a second credential against it (via
+    // direct state mutation — we can't run real WebAuthn inline).
+    let create = router
+        .clone()
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/setup-tokens")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "name": "laptop" })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let v = body_json(create).await;
+    let token_id = v["id"].as_str().unwrap().to_string();
+    let paired_cred_id = "laptop-cred";
+    state
+        .auth_store
+        .clone()
+        .transact({
+            let token_id = token_id.clone();
+            let paired_cred_id = paired_cred_id.to_string();
+            move |s| {
+                let mut cred = stub_credential(&paired_cred_id);
+                cred.setup_token_id = Some(token_id.clone());
+                let next = s
+                    .upsert_credential(cred)
+                    .consume_setup_token(&token_id, &paired_cred_id, SystemTime::now());
+                Ok((next, ()))
+            }
+        })
+        .await
+        .unwrap();
+
+    // First revoke: 204. Paired credential should cascade away.
+    let first = router
+        .clone()
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::DELETE)
+                .uri(format!("/api/auth/setup-tokens/{token_id}"))
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::NO_CONTENT);
+    let snap = state.auth_store.snapshot().await;
+    assert!(
+        snap.find_credential(paired_cred_id).is_none(),
+        "paired credential must cascade-remove on token revoke"
+    );
+    assert!(
+        snap.find_credential("admin-cred").is_some(),
+        "unrelated credential must survive"
+    );
+
+    // Second revoke of the same id: 204 (idempotent).
+    let second = router
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::DELETE)
+                .uri(format!("/api/auth/setup-tokens/{token_id}"))
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::NO_CONTENT);
+}
+
+// ---------------- pair flow ----------------
+
+#[tokio::test]
+async fn pair_start_with_invalid_token_returns_401() {
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/pair/start")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "setup_token": "never-issued" })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn pair_start_with_valid_token_returns_challenge() {
+    // Full pair_start path: seed an admin, mint a setup token via
+    // the HTTP API, then submit its plaintext to pair_start and
+    // confirm it returns a challenge.
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, csrf) = seeded_auth(&state, "admin-cred").await;
+    let router = app(state.clone());
+
+    let create = router
+        .clone()
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/setup-tokens")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "name": "paired-device" })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let plaintext = body_json(create).await["plaintext"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let start = router
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/pair/start")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "setup_token": plaintext })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(start.status(), StatusCode::OK);
+    let v = body_json(start).await;
+    assert!(v["challenge_id"].as_str().is_some_and(|s| s.len() == 32));
+    assert!(v["setup_token_id"].as_str().is_some());
+    assert!(v["options"].is_object());
+}
+
+#[tokio::test]
+async fn pair_finish_with_unknown_challenge_is_challenge_not_found() {
+    let (state, _dir) = ephemeral_state().await;
+    let body = json!({
+        "challenge_id": "deadbeef",
+        "setup_token_id": "any",
+        "response": {
+            "id": "AAAA",
+            "rawId": "AAAA",
+            "response": {"clientDataJSON": "", "attestationObject": ""},
+            "type": "public-key",
+            "extensions": {}
+        }
+    });
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/pair/finish")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], "challenge_not_found");
+}

--- a/crates/server/tests/logout_and_pair.rs
+++ b/crates/server/tests/logout_and_pair.rs
@@ -18,33 +18,11 @@ use axum::{
     body::Body,
     http::{header, Method, StatusCode},
 };
-use common::{body_json, ephemeral_state, json_body, req, stub_credential};
-use katulong_auth::{Session, SESSION_TTL};
+use common::{body_json, ephemeral_state, json_body, req, seeded_auth, stub_credential};
 use katulong_server::app;
 use serde_json::{json, Value};
 use std::time::SystemTime;
 use tower::util::ServiceExt;
-
-/// Seed a credential + session and return the cookie plaintext AND
-/// csrf token — the pair every CSRF-protected route needs.
-async fn seeded_auth(state: &katulong_server::state::AppState, cred_id: &str) -> (String, String) {
-    state
-        .auth_store
-        .clone()
-        .transact({
-            let cred_id = cred_id.to_string();
-            move |s| {
-                let credential = stub_credential(&cred_id);
-                let now = SystemTime::now();
-                let (plaintext, session) = Session::mint(cred_id.clone(), now, SESSION_TTL);
-                let csrf = session.csrf_token.clone();
-                let next = s.upsert_credential(credential).upsert_session(session);
-                Ok((next, (plaintext, csrf)))
-            }
-        })
-        .await
-        .unwrap()
-}
 
 // ---------------- logout ----------------
 


### PR DESCRIPTION
## Summary

Second half of the auth HTTP surface. Closes the "how do I add a second device over a tunnel" story and adds the CSRF plumbing the first half deferred.

- **CSRF double-submit:** new \`CsrfProtected\` extractor; two new \`ApiError\` variants (\`CsrfMissing\` / \`CsrfMismatch\`)
- **Logout:** \`POST /api/auth/logout\` — auth + CSRF, removes session from store, clears cookie; localhost → 409 (no session)
- **Setup-token management:** \`GET/POST/DELETE /api/auth/setup-tokens\` — list, create, revoke (revoke cascades to paired device via the Node \`7742ac3\` bidirectional link)
- **Pair flow:** \`POST /api/auth/pair/{start,finish}\` — public, setup-token-gated second-device registration; token validity re-checked INSIDE \`transact\` (TOCTOU-safe vs concurrent revoke)

## Key design calls

- Persistent \`user_handle\` from slice 5 is reused in pair_start so the authenticator treats all devices as credentials for the same logical user (avoids orphaned passkey-store entries that Node warned about).
- Setup-token plaintext transits the wire exactly once: \`pair_start\` accepts plaintext, returns a \`setup_token_id\`; \`pair_finish\` references the id, not the plaintext.
- \`SETUP_TOKEN_TTL = 1 hour\`. Not caller-tunable. Long enough to copy + walk + paste; short enough that a lost token doesn't sit redeemable overnight.
- Setup-token revoke is idempotent (unknown id → 204). Cascading revoke pulls the paired credential AND its sessions in the same \`transact\`.
- Localhost logout returns 409 — physical access is the trust model, there's no session to end, and the UI hides the button (Node \`23981ca\`).

## Scar tissue referenced

- \`7742ac3\` (Node): bidirectional token↔credential link. Ported in slice 1+2; this slice wires it into the HTTP revoke path.
- \`23981ca\` (Node): localhost hides logout.
- \`9af2bce\` (Node): WS broadcast for multi-client state sync on credential events. Not this slice — deferred with WS upgrade.

## Test plan

- [x] \`cargo test -p katulong-server\` — 44 server tests (13 unit + 12 auth_routes + 6 smoke + 13 new logout_and_pair)
- [x] \`cargo test -p katulong-auth\` — 48 auth tests
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] CSRF coverage: logout rejects no-CSRF / wrong-CSRF; same for setup-token create/revoke
- [x] Logout clears cookie + actually removes session from store
- [x] Revoke cascades: paired credential drops, unrelated credentials survive
- [x] Pair flow: invalid token → 401, valid token → challenge returned, unknown challenge on finish → 401 challenge_not_found
- [ ] Real pair ceremony with browser-signed assertion — belongs in Playwright (every slice has hit this limit)

## Deferred

- \`GET/DELETE /api/auth/devices\` (device listing + individual revoke) — slice 7 alongside dashboard UI
- WebSocket broadcast for real-time device-list updates (Node \`9af2bce\`) — lands with WS upgrade later
- Per-IP rate limiting on pair_start — \`MAX_PENDING_CHALLENGES\` cap remains the current defence