### PR TITLE
rewrite(server): slice 7 — device management + observability pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,6 +1026,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
  "url",
  "uuid",
  "webauthn-rs",

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
 tempfile = { workspace = true }
+tracing = { workspace = true }
 scrypt = { version = "0.11", default-features = false, features = ["simple"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 subtle = { version = "2", default-features = false }

--- a/crates/auth/src/error.rs
+++ b/crates/auth/src/error.rs
@@ -64,6 +64,17 @@ pub enum AuthError {
     /// routing to the same HTTP `Conflict` shape as the outer one.
     #[error("state conflict: {0}")]
     StateConflict(&'static str),
+
+    /// A transact closure refused to remove the only remaining
+    /// credential on this instance. Raised by the device-revoke
+    /// handler for remote callers when `credentials.len() == 1` —
+    /// allowing the deletion would lock them out of their own
+    /// install over the tunnel (Node scar `f25855f`). Dedicated
+    /// variant so the HTTP layer can typed-discriminate without
+    /// matching on `StateConflict`'s string payload; the compiler
+    /// enforces the pairing rather than a literal on both sides.
+    #[error("cannot remove the last credential")]
+    LastCredentialRemoval,
 }
 
 impl AuthError {

--- a/crates/auth/src/webauthn.rs
+++ b/crates/auth/src/webauthn.rs
@@ -237,7 +237,23 @@ impl WebAuthnService {
     ) -> Result<(ChallengeId, RequestChallengeResponse)> {
         let passkeys: Vec<Passkey> = credentials
             .iter()
-            .filter_map(|c| serde_json::from_slice(&c.public_key).ok())
+            .filter_map(|c| match serde_json::from_slice(&c.public_key) {
+                Ok(pk) => Some(pk),
+                Err(e) => {
+                    // A corrupt `public_key` blob would otherwise be
+                    // silently dropped from `allowCredentials`, which
+                    // makes storage corruption invisible to operators
+                    // until a user complains they can't log in. Warn
+                    // per-row without the blob bytes so the log stays
+                    // actionable but doesn't leak material.
+                    tracing::warn!(
+                        credential_id = %c.id,
+                        error = %e,
+                        "dropping credential from allowCredentials: Passkey blob failed to deserialize"
+                    );
+                    None
+                }
+            })
             .collect();
         if passkeys.is_empty() {
             return Err(AuthError::WebAuthn(

--- a/crates/server/src/api/devices.rs
+++ b/crates/server/src/api/devices.rs
@@ -1,0 +1,137 @@
+//! Device (credential) management routes.
+//!
+//! Registered credentials are the user-facing view of "devices"
+//! paired with this instance. Two endpoints:
+//!
+//! - `GET    /api/auth/devices`      — auth required, list with
+//!   per-device metadata
+//! - `DELETE /api/auth/devices/:id`  — auth + CSRF required; removes
+//!   the credential AND its sessions; blocked for remote callers if
+//!   it's the last credential on the instance
+//!
+//! The last-credential guard (Node scar `f25855f`) applies only to
+//! remote callers. A localhost caller has physical access regardless
+//! of whether any credentials exist — locking them out of their own
+//! instance via "delete last passkey" would be a false safety.
+//!
+//! Revoking a credential cascades to its sessions via
+//! `AuthState::remove_credential`. Active WebSocket connections
+//! aren't torn down here — that's a WS-layer concern (Node scar
+//! `c073ec7`), and WS isn't in the Rust port yet. When it lands, the
+//! WS upgrade path should revalidate the session on every message
+//! and close on missing-credential.
+
+use crate::api::csrf::CsrfProtected;
+use crate::api::error::ApiError;
+use crate::auth_middleware::{AuthContext, Authenticated};
+use crate::state::AppState;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    routing::{delete, get},
+    Json, Router,
+};
+use serde::Serialize;
+use std::time::SystemTime;
+
+pub fn device_routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/auth/devices", get(list_devices))
+        .route("/api/auth/devices/:id", delete(revoke_device))
+}
+
+#[derive(Debug, Serialize)]
+struct DeviceEntry {
+    id: String,
+    name: Option<String>,
+    /// Unix-millis of registration. `u64` for JSON integer safety —
+    /// `u128` would serialize as a string past 2^53.
+    created_at_millis: u64,
+    /// Last counter observed from the authenticator. Useful for the
+    /// UI to surface "stale" credentials (counter hasn't moved in a
+    /// long time). Zero for counterless synced passkeys is normal.
+    counter: u32,
+    /// `Some` when this device was paired via a setup token — lets
+    /// the UI show "paired via token <name>". Populated by the
+    /// bidirectional link in `Credential.setup_token_id` (Node scar
+    /// `7742ac3`).
+    paired_via_setup_token_id: Option<String>,
+    /// True when this entry is the credential the caller is
+    /// currently authenticated as. `Localhost` callers have no
+    /// current credential; all entries report `false`. Server-side
+    /// resolution (Node scar `c44bef3`): identity flows authority →
+    /// client, never inferred by localStorage or similar heuristics.
+    is_current: bool,
+}
+
+async fn list_devices(
+    State(state): State<AppState>,
+    Authenticated(ctx): Authenticated,
+) -> Result<Json<Vec<DeviceEntry>>, ApiError> {
+    let current_id = match &ctx {
+        AuthContext::Remote { credential, .. } => Some(credential.id.clone()),
+        AuthContext::Localhost => None,
+    };
+    let snap = state.auth_store.snapshot().await;
+    let entries: Vec<DeviceEntry> = snap
+        .credentials
+        .iter()
+        .map(|c| DeviceEntry {
+            id: c.id.clone(),
+            name: c.name.clone(),
+            created_at_millis: c
+                .created_at
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
+            counter: c.counter,
+            paired_via_setup_token_id: c.setup_token_id.clone(),
+            is_current: current_id.as_deref() == Some(c.id.as_str()),
+        })
+        .collect();
+    Ok(Json(entries))
+}
+
+async fn revoke_device(
+    State(state): State<AppState>,
+    CsrfProtected(ctx): CsrfProtected,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    let is_localhost = matches!(ctx, AuthContext::Localhost);
+
+    // The last-credential check runs inside `transact` so a
+    // concurrent registration (or revocation) cannot slip past on a
+    // stale snapshot. Remote callers fail with `LastCredential` → 409
+    // if the state would hit zero credentials; localhost callers
+    // bypass the check entirely (physical access = no lockout risk).
+    let id_for_log = id.clone();
+    state
+        .auth_store
+        .transact(move |s| {
+            let target_exists = s.find_credential(&id).is_some();
+            if !is_localhost && target_exists && s.credentials.len() == 1 {
+                return Err(katulong_auth::AuthError::StateConflict(
+                    "cannot remove last credential from remote session",
+                ));
+            }
+            // `remove_credential` cascades to the credential's
+            // sessions (slice 1+2 transition). Unknown id is a no-op
+            // — idempotent DELETE.
+            Ok((s.remove_credential(&id), ()))
+        })
+        .await
+        .map_err(|e| match e {
+            // Map the specific state-conflict message back to the
+            // dedicated LastCredential variant so the client sees
+            // `code: "last_credential"` rather than generic
+            // `conflict`. Any other StateConflict goes through the
+            // default path.
+            katulong_auth::AuthError::StateConflict(
+                "cannot remove last credential from remote session",
+            ) => ApiError::LastCredential,
+            other => ApiError::from(other),
+        })?;
+
+    tracing::info!(credential_id = %id_for_log, "device revoked");
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/server/src/api/devices.rs
+++ b/crates/server/src/api/devices.rs
@@ -47,15 +47,14 @@ struct DeviceEntry {
     /// Unix-millis of registration. `u64` for JSON integer safety —
     /// `u128` would serialize as a string past 2^53.
     created_at_millis: u64,
-    /// Last counter observed from the authenticator. Useful for the
-    /// UI to surface "stale" credentials (counter hasn't moved in a
-    /// long time). Zero for counterless synced passkeys is normal.
+    /// Last counter observed from the authenticator. Zero is normal
+    /// for counterless synced passkeys.
     counter: u32,
-    /// `Some` when this device was paired via a setup token — lets
-    /// the UI show "paired via token <name>". Populated by the
-    /// bidirectional link in `Credential.setup_token_id` (Node scar
-    /// `7742ac3`).
-    paired_via_setup_token_id: Option<String>,
+    /// `Some` when this device was paired via a setup token. Mirrors
+    /// `TokenListEntry.credential_id` from the opposite side of the
+    /// bidirectional link (Node scar `7742ac3`). Name matches the
+    /// `Credential.setup_token_id` field directly.
+    setup_token_id: Option<String>,
     /// True when this entry is the credential the caller is
     /// currently authenticated as. `Localhost` callers have no
     /// current credential; all entries report `false`. Server-side
@@ -85,7 +84,7 @@ async fn list_devices(
                 .map(|d| d.as_millis() as u64)
                 .unwrap_or(0),
             counter: c.counter,
-            paired_via_setup_token_id: c.setup_token_id.clone(),
+            setup_token_id: c.setup_token_id.clone(),
             is_current: current_id.as_deref() == Some(c.id.as_str()),
         })
         .collect();
@@ -98,21 +97,26 @@ async fn revoke_device(
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
     let is_localhost = matches!(ctx, AuthContext::Localhost);
+    let revoked_by = match &ctx {
+        AuthContext::Localhost => "localhost".to_string(),
+        AuthContext::Remote { credential, .. } => credential.id.clone(),
+    };
 
     // The last-credential check runs inside `transact` so a
     // concurrent registration (or revocation) cannot slip past on a
-    // stale snapshot. Remote callers fail with `LastCredential` → 409
-    // if the state would hit zero credentials; localhost callers
-    // bypass the check entirely (physical access = no lockout risk).
-    let id_for_log = id.clone();
+    // stale snapshot. Remote callers fail with `LastCredentialRemoval`
+    // → 409 `last_credential` if the state would hit zero
+    // credentials; localhost callers bypass the check entirely
+    // (physical access = no lockout risk). `LastCredentialRemoval`
+    // is a dedicated `AuthError` variant so the HTTP layer's mapping
+    // is compiler-enforced rather than string-matched.
+    let credential_id = id.clone();
     state
         .auth_store
         .transact(move |s| {
             let target_exists = s.find_credential(&id).is_some();
             if !is_localhost && target_exists && s.credentials.len() == 1 {
-                return Err(katulong_auth::AuthError::StateConflict(
-                    "cannot remove last credential from remote session",
-                ));
+                return Err(katulong_auth::AuthError::LastCredentialRemoval);
             }
             // `remove_credential` cascades to the credential's
             // sessions (slice 1+2 transition). Unknown id is a no-op
@@ -120,18 +124,12 @@ async fn revoke_device(
             Ok((s.remove_credential(&id), ()))
         })
         .await
-        .map_err(|e| match e {
-            // Map the specific state-conflict message back to the
-            // dedicated LastCredential variant so the client sees
-            // `code: "last_credential"` rather than generic
-            // `conflict`. Any other StateConflict goes through the
-            // default path.
-            katulong_auth::AuthError::StateConflict(
-                "cannot remove last credential from remote session",
-            ) => ApiError::LastCredential,
-            other => ApiError::from(other),
-        })?;
+        .map_err(ApiError::from)?;
 
-    tracing::info!(credential_id = %id_for_log, "device revoked");
+    tracing::info!(
+        credential_id = %credential_id,
+        revoked_by = %revoked_by,
+        "device revoked"
+    );
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/server/src/api/error.rs
+++ b/crates/server/src/api/error.rs
@@ -139,6 +139,7 @@ impl From<AuthError> for ApiError {
             AuthError::TooManyPendingChallenges => Self::RateLimited,
             AuthError::WebAuthn(_) => Self::Unauthorized,
             AuthError::StateConflict(msg) => Self::Conflict(msg),
+            AuthError::LastCredentialRemoval => Self::LastCredential,
             other => {
                 // Log the full chain for operators; the response body
                 // stays opaque via the unit variant.

--- a/crates/server/src/api/error.rs
+++ b/crates/server/src/api/error.rs
@@ -41,6 +41,15 @@ pub enum ApiError {
     /// this action yet (e.g., login against a fresh install with no
     /// credentials).
     Conflict(&'static str),
+    /// Caller is asking to remove a credential that is the last one on
+    /// the instance, AND the caller is remote (not localhost). Allowing
+    /// the deletion would lock the user out of their own installation
+    /// over the tunnel — localhost access would still work, but
+    /// re-enabling remote access would require going back to the
+    /// first-device registration flow. Node hit this exact bug
+    /// (`f25855f`); the two-tier access model means the guard must
+    /// apply to remote callers only.
+    LastCredential,
     /// State-changing request reached us without an `X-Csrf-Token`
     /// header. Maps to 403 with code `csrf_missing`. Distinct from
     /// `CsrfMismatch` so a client can distinguish "never sent" from
@@ -77,6 +86,11 @@ impl ApiError {
                 "server busy; retry shortly".into(),
             ),
             Self::Conflict(why) => (StatusCode::CONFLICT, "conflict", (*why).into()),
+            Self::LastCredential => (
+                StatusCode::CONFLICT,
+                "last_credential",
+                "cannot remove the last remote-access credential from a non-localhost session".into(),
+            ),
             Self::CsrfMissing => (
                 StatusCode::FORBIDDEN,
                 "csrf_missing",

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod auth;
 pub mod csrf;
+pub mod devices;
 pub mod error;
 pub mod extract;
 pub mod tokens;

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -12,6 +12,7 @@ pub mod cookie;
 pub mod state;
 
 use api::auth::auth_routes;
+use api::devices::device_routes;
 use api::tokens::token_routes;
 use auth_middleware::Authenticated;
 use axum::{extract::DefaultBodyLimit, routing::get, Json, Router};
@@ -63,6 +64,9 @@ pub fn app(state: AppState) -> Router {
         // Setup-token management (list/create/revoke). All protected;
         // state-changing ones additionally require CSRF.
         .merge(token_routes())
+        // Device (credential) management (list/revoke). Same
+        // auth/CSRF shape as tokens.
+        .merge(device_routes())
         .layer(DefaultBodyLimit::max(REQUEST_BODY_LIMIT))
         .with_state(state)
 }

--- a/crates/server/tests/devices.rs
+++ b/crates/server/tests/devices.rs
@@ -97,10 +97,10 @@ async fn list_devices_from_localhost_shows_no_current() {
 }
 
 #[tokio::test]
-async fn list_devices_surfaces_paired_via_setup_token_id() {
-    // Bidirectional link: Credential.setup_token_id surfaces as
-    // paired_via_setup_token_id. Set it directly via state mutation
-    // since we can't run a real pair ceremony inline.
+async fn list_devices_surfaces_setup_token_id() {
+    // Bidirectional link: Credential.setup_token_id surfaces on the
+    // DTO under the same field name. Set it directly via state
+    // mutation since we can't run a real pair ceremony inline.
     let (state, _dir) = ephemeral_state().await;
     let (cookie, _csrf) = seeded_auth(&state, "admin").await;
     state
@@ -132,7 +132,7 @@ async fn list_devices_surfaces_paired_via_setup_token_id() {
         .iter()
         .find(|e| e["id"] == "paired-device")
         .expect("paired device should appear in list");
-    assert_eq!(paired["paired_via_setup_token_id"], "token-abc");
+    assert_eq!(paired["setup_token_id"], "token-abc");
 }
 
 // ---------------- revoke ----------------

--- a/crates/server/tests/devices.rs
+++ b/crates/server/tests/devices.rs
@@ -1,0 +1,277 @@
+//! Integration tests for `/api/auth/devices`.
+//!
+//! Covers listing, current-device marking, CSRF enforcement, revoke
+//! cascade to sessions, idempotent delete, and the last-credential
+//! guard (remote-only; localhost bypasses it).
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, StatusCode},
+};
+use common::{body_json, ephemeral_state, req, seeded_auth, stub_credential};
+use katulong_server::app;
+use serde_json::Value;
+use tower::util::ServiceExt;
+
+// ---------------- list ----------------
+
+#[tokio::test]
+async fn list_devices_requires_auth() {
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::GET)
+                .uri("/api/auth/devices")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn list_devices_returns_is_current_for_remote_caller() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "my-device").await;
+    // Seed another device so we can verify ONLY one row has is_current=true.
+    state
+        .auth_store
+        .clone()
+        .transact(|s| Ok((s.upsert_credential(stub_credential("other-device")), ())))
+        .await
+        .unwrap();
+
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::GET)
+                .uri("/api/auth/devices")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    let entries = v.as_array().expect("array response");
+    assert_eq!(entries.len(), 2);
+
+    let current: Vec<&Value> = entries
+        .iter()
+        .filter(|e| e["is_current"].as_bool() == Some(true))
+        .collect();
+    assert_eq!(current.len(), 1, "exactly one entry should be current");
+    assert_eq!(current[0]["id"], "my-device");
+}
+
+#[tokio::test]
+async fn list_devices_from_localhost_shows_no_current() {
+    // Localhost has no paired credential — every entry reports is_current=false.
+    let (state, _dir) = ephemeral_state().await;
+    state
+        .auth_store
+        .clone()
+        .transact(|s| Ok((s.upsert_credential(stub_credential("c1")), ())))
+        .await
+        .unwrap();
+
+    let resp = app(state)
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::GET)
+                .uri("/api/auth/devices")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v.as_array().unwrap().len(), 1);
+    assert_eq!(v[0]["is_current"], false);
+}
+
+#[tokio::test]
+async fn list_devices_surfaces_paired_via_setup_token_id() {
+    // Bidirectional link: Credential.setup_token_id surfaces as
+    // paired_via_setup_token_id. Set it directly via state mutation
+    // since we can't run a real pair ceremony inline.
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "admin").await;
+    state
+        .auth_store
+        .clone()
+        .transact(|s| {
+            let mut cred = stub_credential("paired-device");
+            cred.setup_token_id = Some("token-abc".into());
+            Ok((s.upsert_credential(cred), ()))
+        })
+        .await
+        .unwrap();
+
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::GET)
+                .uri("/api/auth/devices")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let v = body_json(resp).await;
+    let paired = v
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["id"] == "paired-device")
+        .expect("paired device should appear in list");
+    assert_eq!(paired["paired_via_setup_token_id"], "token-abc");
+}
+
+// ---------------- revoke ----------------
+
+#[tokio::test]
+async fn revoke_device_requires_csrf() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "c1").await;
+    state
+        .auth_store
+        .clone()
+        .transact(|s| Ok((s.upsert_credential(stub_credential("other")), ())))
+        .await
+        .unwrap();
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::DELETE)
+                .uri("/api/auth/devices/other")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn revoke_device_cascades_to_sessions() {
+    let (state, _dir) = ephemeral_state().await;
+    let (admin_cookie, csrf) = seeded_auth(&state, "admin").await;
+    // Seed another credential + session; revoking the credential
+    // should cascade to its sessions.
+    let (target_cookie, _target_csrf) = seeded_auth(&state, "target-device").await;
+
+    let router = app(state.clone());
+    let resp = router
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::DELETE)
+                .uri("/api/auth/devices/target-device")
+                .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let snap = state.auth_store.snapshot().await;
+    assert!(
+        snap.find_credential("target-device").is_none(),
+        "target credential must be gone"
+    );
+    assert!(
+        snap.find_session(&target_cookie).is_none(),
+        "target credential's session must cascade away"
+    );
+    assert!(
+        snap.find_credential("admin").is_some(),
+        "admin credential must survive"
+    );
+}
+
+#[tokio::test]
+async fn revoke_device_is_idempotent() {
+    // Unknown or already-gone id: 204. Caller can't distinguish
+    // "never existed" from "already removed," which matches the
+    // idempotent-DELETE semantics of the setup-token path.
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, csrf) = seeded_auth(&state, "admin").await;
+    state
+        .auth_store
+        .clone()
+        .transact(|s| Ok((s.upsert_credential(stub_credential("other")), ())))
+        .await
+        .unwrap();
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::DELETE)
+                .uri("/api/auth/devices/never-existed")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn revoke_last_credential_from_remote_is_blocked() {
+    // Single credential + remote caller. Guard fires → 409
+    // last_credential.
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, csrf) = seeded_auth(&state, "only-device").await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::DELETE)
+                .uri("/api/auth/devices/only-device")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], "last_credential");
+}
+
+#[tokio::test]
+async fn revoke_last_credential_from_localhost_is_allowed() {
+    // Same last-credential scenario, but caller is localhost. Physical
+    // access trumps the lockout concern — Node scar f25855f.
+    let (state, _dir) = ephemeral_state().await;
+    state
+        .auth_store
+        .clone()
+        .transact(|s| Ok((s.upsert_credential(stub_credential("only-device")), ())))
+        .await
+        .unwrap();
+    let resp = app(state.clone())
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::DELETE)
+                .uri("/api/auth/devices/only-device")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    let snap = state.auth_store.snapshot().await;
+    assert!(snap.credentials.is_empty());
+}


### PR DESCRIPTION
## Summary

Two small follow-ups bundled because they share a home in the auth crate / api layer:

- **Device management routes** — \`GET /api/auth/devices\` (auth; list with \`is_current\` server-resolved per Node scar \`c44bef3\`) and \`DELETE /api/auth/devices/:id\` (auth + CSRF; cascades to sessions, idempotent on unknown id).
- **Last-credential guard** (Node scar \`f25855f\`) — remote callers get 409 \`last_credential\`; localhost bypasses since physical access = no lockout risk. Check runs inside \`transact\` to close TOCTOU.
- **Observability** — \`tracing\` promoted to a direct auth-crate dep; added \`warn!\` on silently-filtered corrupt Passkey blobs in \`start_authentication\` (slice 3 deferred note). Blob bytes never logged, just credential_id + serde error.

## Test plan

- [x] \`cargo test --all\` — 101 tests (48 auth + 13 server unit + 12 auth_routes + 6 smoke + 9 devices + 13 logout_and_pair)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] Integration coverage: list auth gate, is_current mapping (remote+localhost), cascade on revoke, idempotent DELETE, last-credential 409 remote / 204 localhost

## Deferred

- WebSocket tear-down on revoke (Node \`c073ec7\`) — WS not ported yet; lands with WS upgrade slice.