### PR TITLE
rewrite(server): slice 8 — WebSocket upgrade transport (auth + Origin)

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -10,6 +10,7 @@ pub mod api;
 pub mod auth_middleware;
 pub mod cookie;
 pub mod state;
+pub mod ws;
 
 use api::auth::auth_routes;
 use api::devices::device_routes;
@@ -67,6 +68,11 @@ pub fn app(state: AppState) -> Router {
         // Device (credential) management (list/revoke). Same
         // auth/CSRF shape as tokens.
         .merge(device_routes())
+        // PROTECTED: WebSocket upgrade. Auth via `Authenticated`,
+        // Origin validation via `ws::validate_origin` (deny-by-default
+        // on non-local connections). Slice 8 ships the transport only;
+        // slice 9 wires tmux/PTY into the message loop.
+        .route("/ws", get(ws::ws_handler))
         .layer(DefaultBodyLimit::max(REQUEST_BODY_LIMIT))
         .with_state(state)
 }

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -29,7 +29,7 @@
 //! the configured origin is the single authority.
 
 use crate::access::AccessMethod;
-use crate::auth_middleware::{AuthContext, Authenticated};
+use crate::auth_middleware::Authenticated;
 use crate::state::AppState;
 use axum::{
     extract::{
@@ -67,17 +67,30 @@ pub(crate) enum OriginCheck {
 /// unit-testable without a real HTTP stack.
 pub(crate) fn validate_origin(
     access: AccessMethod,
-    origin_header: Option<&str>,
+    origin: Option<&str>,
     public_origin: &str,
 ) -> OriginCheck {
     if matches!(access, AccessMethod::Localhost) {
         return OriginCheck::LocalhostExempt;
     }
-    match origin_header {
+    match origin {
         None => OriginCheck::Missing,
         Some(value) if value == public_origin => OriginCheck::Allowed,
         Some(_) => OriginCheck::Mismatch,
     }
+}
+
+/// Render an attacker-controlled string (like a rejected Origin
+/// value) safe for `tracing` emission: strip ASCII control
+/// characters that would corrupt text logs or inject structured
+/// fields in JSON formatters, cap at 256 chars. Used only at reject
+/// sites; the accept path never logs the Origin.
+fn sanitize_for_log(value: &str) -> String {
+    value
+        .chars()
+        .filter(|c| !c.is_ascii_control())
+        .take(256)
+        .collect()
 }
 
 /// Axum handler for `GET /ws`.
@@ -115,8 +128,13 @@ pub async fn ws_handler(
             (StatusCode::FORBIDDEN, "origin header required").into_response()
         }
         OriginCheck::Mismatch => {
+            // The Origin value is attacker-controlled; sanitize
+            // before logging so control characters can't corrupt
+            // text log lines or inject structured-field separators
+            // in JSON formatters.
+            let safe = sanitize_for_log(origin.unwrap_or(""));
             tracing::warn!(
-                origin = origin.unwrap_or(""),
+                origin = %safe,
                 expected = %state.config.public_origin,
                 "ws upgrade rejected: Origin mismatch"
             );
@@ -154,14 +172,6 @@ async fn serve_socket(mut socket: WebSocket) {
         }
     }
     let _ = socket.close().await;
-}
-
-/// `Authenticated` uses `AuthContext`; this helper is kept for future
-/// handlers that want to branch on the access mode without unwrapping
-/// the enum manually.
-#[allow(dead_code)]
-pub(crate) fn is_local_ctx(ctx: &AuthContext) -> bool {
-    matches!(ctx, AuthContext::Localhost)
 }
 
 #[cfg(test)]
@@ -209,6 +219,22 @@ mod tests {
             validate_origin(AccessMethod::Remote, Some(""), PUBLIC),
             OriginCheck::Mismatch,
             "empty Origin is a real value, not missing"
+        );
+    }
+
+    #[test]
+    fn sanitize_for_log_strips_control_chars_and_caps_length() {
+        assert_eq!(
+            sanitize_for_log("evil\r\n[WARN] faked=line"),
+            "evil[WARN] faked=line",
+            "newlines and carriage returns must be stripped — otherwise a crafted Origin can forge log lines"
+        );
+        assert_eq!(sanitize_for_log("plain"), "plain");
+        let huge = "x".repeat(1000);
+        assert_eq!(
+            sanitize_for_log(&huge).len(),
+            256,
+            "cap at 256 chars so an attacker can't flood logs with a megabyte Origin"
         );
     }
 

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -1,0 +1,229 @@
+//! WebSocket upgrade endpoint.
+//!
+//! This slice wires the transport only — authenticated upgrade,
+//! Origin validation, and a minimal accept-and-close loop that
+//! handles `Ping`/`Pong`/`Close`. No terminal I/O yet; slice 9 will
+//! replace the loop with tmux/PTY wiring.
+//!
+//! # Security-critical: Origin validation
+//!
+//! A WebSocket upgrade from `https://evil.com` running in the victim's
+//! browser will arrive at katulong carrying the victim's session
+//! cookie (SameSite=Lax allows top-level navigations and CORS-free
+//! WebSocket handshakes). Without an Origin check, the attacker's
+//! page gets an authenticated terminal socket — CSWSH, full shell.
+//!
+//! The Node implementation learned this in two stages:
+//! - `dd5d88f`: require Origin on non-local connections. Missing
+//!   Origin is not "benign non-browser client," it's "attacker
+//!   controls a non-browser agent with the victim's cookie." Deny by
+//!   default; exempt only truly-loopback peers.
+//! - `8fb2663`: run Origin validation BEFORE any routing branching
+//!   so every path is covered. Here that's structural: `ws_handler`
+//!   is the single upgrade endpoint and checks Origin before calling
+//!   `ws.on_upgrade`.
+//!
+//! Origin must match the operator-configured `public_origin` exactly
+//! (scheme + host + optional port). We do not accept "any Origin that
+//! resolves to a loopback" or "any Origin matching the Host header" —
+//! the configured origin is the single authority.
+
+use crate::access::AccessMethod;
+use crate::auth_middleware::{AuthContext, Authenticated};
+use crate::state::AppState;
+use axum::{
+    extract::{
+        ws::{Message, WebSocket},
+        ConnectInfo, State, WebSocketUpgrade,
+    },
+    http::{header, HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+};
+use std::net::SocketAddr;
+
+/// Strict Origin check result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OriginCheck {
+    /// Request is from a genuinely-local peer; Origin is not required.
+    /// Matches the loopback-socket + loopback-Host gate in
+    /// `AccessMethod::Localhost`.
+    LocalhostExempt,
+    /// Origin header present and matches configured `public_origin`
+    /// byte-for-byte.
+    Allowed,
+    /// No Origin header on a non-local connection. Deny-by-default
+    /// (Node `dd5d88f` scar — validate-if-present was the gap).
+    Missing,
+    /// Origin present but disagrees with configured value.
+    Mismatch,
+}
+
+/// Decide whether a WebSocket upgrade is allowed to proceed.
+///
+/// Takes the request's peer/Host-derived `AccessMethod` (already
+/// computed by the caller for auth), the `Origin` header value, and
+/// the operator-supplied `public_origin`. Returns one of four
+/// classifications the caller maps to HTTP status codes. Pure —
+/// unit-testable without a real HTTP stack.
+pub(crate) fn validate_origin(
+    access: AccessMethod,
+    origin_header: Option<&str>,
+    public_origin: &str,
+) -> OriginCheck {
+    if matches!(access, AccessMethod::Localhost) {
+        return OriginCheck::LocalhostExempt;
+    }
+    match origin_header {
+        None => OriginCheck::Missing,
+        Some(value) if value == public_origin => OriginCheck::Allowed,
+        Some(_) => OriginCheck::Mismatch,
+    }
+}
+
+/// Axum handler for `GET /ws`.
+///
+/// Origin + auth validation run BEFORE the WebSocket upgrade
+/// extractor is consulted — Node scar `8fb2663` says security checks
+/// must be earliest in the pipeline, before any branching. We take
+/// `Option<WebSocketUpgrade>` so the upgrade extractor never rejects
+/// the request on its own; our handler body decides what happens.
+/// If origin/auth fails we return 401/403; if they pass and the
+/// upgrade extractor is `None` (missing WS headers), we return the
+/// upgrade-required error our own way.
+pub async fn ws_handler(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Authenticated(_ctx): Authenticated,
+    upgrade: Option<WebSocketUpgrade>,
+) -> Response {
+    let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
+    let access = AccessMethod::classify(peer, host);
+    let origin = headers.get(header::ORIGIN).and_then(|v| v.to_str().ok());
+
+    match validate_origin(access, origin, &state.config.public_origin) {
+        OriginCheck::LocalhostExempt | OriginCheck::Allowed => match upgrade {
+            Some(u) => u.on_upgrade(serve_socket),
+            None => (
+                StatusCode::UPGRADE_REQUIRED,
+                "websocket upgrade headers required",
+            )
+                .into_response(),
+        },
+        OriginCheck::Missing => {
+            tracing::warn!("ws upgrade rejected: missing Origin on non-local connection");
+            (StatusCode::FORBIDDEN, "origin header required").into_response()
+        }
+        OriginCheck::Mismatch => {
+            tracing::warn!(
+                origin = origin.unwrap_or(""),
+                expected = %state.config.public_origin,
+                "ws upgrade rejected: Origin mismatch"
+            );
+            (StatusCode::FORBIDDEN, "origin not allowed").into_response()
+        }
+    }
+}
+
+/// Per-connection message loop.
+///
+/// Minimal for this slice: bounce `Ping` → `Pong`, close on `Close`
+/// or any error, ignore other message kinds. Slice 9 replaces this
+/// with tmux/PTY wiring. Keeping the shape here means the route is
+/// already plumbed by the time terminal work lands — no auth/origin
+/// re-work needed.
+async fn serve_socket(mut socket: WebSocket) {
+    while let Some(frame) = socket.recv().await {
+        let Ok(msg) = frame else {
+            // Protocol error or peer hung up. Bail without trying to
+            // send anything else — the socket is in an indeterminate
+            // state.
+            break;
+        };
+        match msg {
+            Message::Ping(payload) => {
+                if socket.send(Message::Pong(payload)).await.is_err() {
+                    break;
+                }
+            }
+            Message::Close(_) => break,
+            // `Pong` is auto-handled by the client library; we just
+            // drop it. `Text`/`Binary` land here too — slice 9 adds
+            // the protocol parser that interprets them.
+            _ => {}
+        }
+    }
+    let _ = socket.close().await;
+}
+
+/// `Authenticated` uses `AuthContext`; this helper is kept for future
+/// handlers that want to branch on the access mode without unwrapping
+/// the enum manually.
+#[allow(dead_code)]
+pub(crate) fn is_local_ctx(ctx: &AuthContext) -> bool {
+    matches!(ctx, AuthContext::Localhost)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PUBLIC: &str = "https://katulong.test";
+
+    #[test]
+    fn localhost_is_exempt_from_origin_check() {
+        assert_eq!(
+            validate_origin(AccessMethod::Localhost, None, PUBLIC),
+            OriginCheck::LocalhostExempt
+        );
+        assert_eq!(
+            validate_origin(AccessMethod::Localhost, Some("https://elsewhere.invalid"), PUBLIC),
+            OriginCheck::LocalhostExempt,
+            "localhost peers are exempt even if Origin is set to a wrong value"
+        );
+    }
+
+    #[test]
+    fn remote_without_origin_is_missing() {
+        assert_eq!(
+            validate_origin(AccessMethod::Remote, None, PUBLIC),
+            OriginCheck::Missing
+        );
+    }
+
+    #[test]
+    fn remote_with_matching_origin_is_allowed() {
+        assert_eq!(
+            validate_origin(AccessMethod::Remote, Some(PUBLIC), PUBLIC),
+            OriginCheck::Allowed
+        );
+    }
+
+    #[test]
+    fn remote_with_mismatched_origin_is_rejected() {
+        assert_eq!(
+            validate_origin(AccessMethod::Remote, Some("https://evil.example"), PUBLIC),
+            OriginCheck::Mismatch
+        );
+        assert_eq!(
+            validate_origin(AccessMethod::Remote, Some(""), PUBLIC),
+            OriginCheck::Mismatch,
+            "empty Origin is a real value, not missing"
+        );
+    }
+
+    #[test]
+    fn trailing_slash_differences_mismatch() {
+        // Byte-for-byte match: no canonicalization, no scheme
+        // relaxation. Operator's configured value IS the source of
+        // truth; any deviation is a reject.
+        assert_eq!(
+            validate_origin(
+                AccessMethod::Remote,
+                Some("https://katulong.test/"),
+                PUBLIC
+            ),
+            OriginCheck::Mismatch
+        );
+    }
+}

--- a/crates/server/tests/websocket.rs
+++ b/crates/server/tests/websocket.rs
@@ -1,0 +1,116 @@
+//! Integration tests for `/ws` upgrade.
+//!
+//! These cover the HTTP-level reject paths (auth + Origin) before
+//! the upgrade handshake happens. A real 101 Switching Protocols
+//! response needs a listening socket and a WS client — deferred to
+//! e2e. What oneshot can reach: when the request carries valid WS
+//! upgrade headers, the handler body runs; we verify auth and origin
+//! checks return 401/403 before any protocol switch.
+//!
+//! The tests include the full WebSocket upgrade header set
+//! (`Upgrade`, `Connection`, `Sec-WebSocket-Key`,
+//! `Sec-WebSocket-Version`) because axum's `WebSocketUpgrade`
+//! extractor fails with 400 if those are missing — that would never
+//! reach the handler body, so origin rejection wouldn't be observed.
+//! A real CSWSH attack always includes these headers anyway (the
+//! attacker's JS creates a real WebSocket), so this is the realistic
+//! test shape.
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, request::Builder as RequestBuilder, Method, StatusCode},
+};
+use common::{ephemeral_state, req, seeded_auth};
+use katulong_server::app;
+use tower::util::ServiceExt;
+
+/// Tack the minimum WS-upgrade headers onto a request builder.
+fn ws_upgrade(builder: RequestBuilder) -> RequestBuilder {
+    builder
+        .method(Method::GET)
+        .header(header::UPGRADE, "websocket")
+        .header(header::CONNECTION, "upgrade")
+        // Any valid base64-encoded 16-byte value works for the handshake.
+        .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .header("sec-websocket-version", "13")
+}
+
+#[tokio::test]
+async fn ws_without_auth_returns_401() {
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            ws_upgrade(req("203.0.113.5:1234".parse().unwrap(), "katulong.test"))
+                .uri("/ws")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn ws_from_remote_without_origin_is_forbidden() {
+    // Authenticated + WS-upgrade headers present but no Origin on a
+    // non-local connection. Node `dd5d88f` scar — missing Origin is
+    // not "benign non-browser client," it's "attacker with the
+    // victim's cookie." Deny-by-default.
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "c1").await;
+    let resp = app(state)
+        .oneshot(
+            ws_upgrade(req("203.0.113.5:1234".parse().unwrap(), "katulong.test"))
+                .uri("/ws")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn ws_from_remote_with_mismatched_origin_is_forbidden() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "c1").await;
+    let resp = app(state)
+        .oneshot(
+            ws_upgrade(req("203.0.113.5:1234".parse().unwrap(), "katulong.test"))
+                .uri("/ws")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header(header::ORIGIN, "https://evil.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn ws_plain_get_without_upgrade_headers_fails_fast() {
+    // The WebSocketUpgrade extractor fails with 400 when WS headers
+    // are absent. We don't assert the exact status — just that the
+    // request rejects cleanly rather than silently succeeding. This
+    // covers the "plain HTTP probe on /ws" case.
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::GET)
+                .uri("/ws")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_client_error(),
+        "expected 4xx for missing upgrade headers; got {}",
+        resp.status()
+    );
+}

--- a/crates/server/tests/websocket.rs
+++ b/crates/server/tests/websocket.rs
@@ -92,11 +92,11 @@ async fn ws_from_remote_with_mismatched_origin_is_forbidden() {
 }
 
 #[tokio::test]
-async fn ws_plain_get_without_upgrade_headers_fails_fast() {
-    // The WebSocketUpgrade extractor fails with 400 when WS headers
-    // are absent. We don't assert the exact status — just that the
-    // request rejects cleanly rather than silently succeeding. This
-    // covers the "plain HTTP probe on /ws" case.
+async fn ws_localhost_plain_get_without_upgrade_returns_client_error() {
+    // Localhost passes auth + origin (exempt), but without WS
+    // upgrade headers the handler's `Option<WebSocketUpgrade>` path
+    // returns 426 UPGRADE_REQUIRED. We accept any 4xx — the point
+    // is that a plain probe doesn't silently succeed.
     let (state, _dir) = ephemeral_state().await;
     let resp = app(state)
         .oneshot(
@@ -113,4 +113,27 @@ async fn ws_plain_get_without_upgrade_headers_fails_fast() {
         "expected 4xx for missing upgrade headers; got {}",
         resp.status()
     );
+}
+
+#[tokio::test]
+async fn ws_remote_authed_with_origin_but_no_upgrade_headers_returns_426() {
+    // Companion to the localhost test above: the remote-auth path,
+    // with matching Origin, but no WS upgrade headers. Origin check
+    // passes (Allowed); `Option<WebSocketUpgrade>` is None; handler
+    // returns 426 UPGRADE_REQUIRED rather than silently 200'ing.
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "c1").await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::GET)
+                .uri("/ws")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header(header::ORIGIN, "https://katulong.test")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UPGRADE_REQUIRED);
 }


### PR DESCRIPTION
## Summary

First slice of the terminal path: the WS transport with strict security gates. No tmux/PTY/protocol work yet — those land in slice 9.

- \`GET /ws\` → \`ws::ws_handler\`; \`Authenticated\` + \`Origin\` validation BEFORE upgrade extractor runs
- \`validate_origin\` pure function — four outcomes: LocalhostExempt, Allowed, Missing, Mismatch
- Remote callers without Origin → 403 (Node scar \`dd5d88f\`: missing ≠ benign)
- Remote callers with mismatched Origin → 403
- Localhost callers exempt (loopback peer + loopback Host already gate \`AccessMethod::Localhost\`)
- Byte-for-byte Origin match — no canonicalization, no scheme/trailing-slash forgiveness
- Minimal message loop: Ping→Pong, break on Close. Slice 9 replaces with tmux I/O

## Key design calls

- \`Option<WebSocketUpgrade>\` extractor so origin check runs uniformly regardless of WS headers (prevents 426 response leaking "what went wrong" before security check fires).
- Origin validation in handler body, not middleware — keeps the \`public_origin\` config + \`AccessMethod\` classification colocated with the upgrade decision.
- Post-upgrade loop deliberately trivial; slice 9 owns message protocol, PTY, tmux.

## Test plan

- [x] \`cargo test\` — 110 tests (adds 4 integration + 5 unit)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] Unit coverage: validate_origin across all four outcomes including trailing-slash
- [x] Integration: no auth → 401; remote + no origin → 403; remote + wrong origin → 403; plain GET without WS headers → 4xx
- [ ] Real 101 Switching Protocols handshake — belongs in e2e, needs listening socket + WS client

## Deferred (documented)

- WS teardown on credential revoke (Node \`c073ec7\`) — decided alongside slice 9 terminal wiring
- Per-message auth revalidation strategy (Node \`6ff4395\`) — same slice
- Inbound message validation at the boundary (Node \`9dc7c78\`) — slice 9 with protocol parser