### PR TITLE
rewrite(server): slice 9a — transport-agnostic revocation broadcast channel

### DIFF
--- a/crates/server/src/api/devices.rs
+++ b/crates/server/src/api/devices.rs
@@ -111,7 +111,11 @@ async fn revoke_device(
     // is a dedicated `AuthError` variant so the HTTP layer's mapping
     // is compiler-enforced rather than string-matched.
     let credential_id = id.clone();
-    state
+    // `transact` returns whether the credential actually existed —
+    // used below to decide whether to emit the revocation broadcast.
+    // Unknown id → no state change → no signal (no one has a
+    // live connection bound to an id that never existed).
+    let existed = state
         .auth_store
         .transact(move |s| {
             let target_exists = s.find_credential(&id).is_some();
@@ -121,10 +125,14 @@ async fn revoke_device(
             // `remove_credential` cascades to the credential's
             // sessions (slice 1+2 transition). Unknown id is a no-op
             // — idempotent DELETE.
-            Ok((s.remove_credential(&id), ()))
+            Ok((s.remove_credential(&id), target_exists))
         })
         .await
         .map_err(ApiError::from)?;
+
+    if existed {
+        state.revocations.emit(&credential_id);
+    }
 
     tracing::info!(
         credential_id = %credential_id,

--- a/crates/server/src/api/tokens.rs
+++ b/crates/server/src/api/tokens.rs
@@ -181,12 +181,33 @@ async fn revoke_token(
     // as idempotent success (204). The caller can't tell "never
     // existed" from "already revoked," which is fine: both answers
     // mean "this id is not redeemable from here forward."
-    let id_for_log = id.clone();
-    state
+    //
+    // Revoking a token cascades (via `AuthState::remove_setup_token`)
+    // to removing the credential it paired and that credential's
+    // sessions. Any transport currently holding a connection bound
+    // to that credential needs the revocation broadcast, same as
+    // direct device-revoke. We read the paired credential id BEFORE
+    // the transact closure runs so we know what to emit afterwards.
+    let token_id = id.clone();
+    let paired_credential_id = state
         .auth_store
-        .transact(move |s| Ok((s.remove_setup_token(&id), ())))
+        .transact(move |s| {
+            let paired = s
+                .find_setup_token(&id)
+                .and_then(|t| t.credential_id.clone());
+            Ok((s.remove_setup_token(&id), paired))
+        })
         .await
         .map_err(ApiError::from)?;
-    tracing::info!(token_id = %id_for_log, "setup token revoked");
+
+    if let Some(ref cred_id) = paired_credential_id {
+        state.revocations.emit(cred_id);
+    }
+
+    tracing::info!(
+        token_id = %token_id,
+        paired_credential_id = paired_credential_id.as_deref().unwrap_or("none"),
+        "setup token revoked"
+    );
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/server/src/api/tokens.rs
+++ b/crates/server/src/api/tokens.rs
@@ -200,14 +200,27 @@ async fn revoke_token(
         .await
         .map_err(ApiError::from)?;
 
-    if let Some(ref cred_id) = paired_credential_id {
-        state.revocations.emit(cred_id);
+    // Two distinct log messages so a log-aggregation query can
+    // cleanly separate "revoked a live paired device" from "revoked
+    // an unused token" for incident response. A single message with
+    // an optional field makes the two cases structurally identical
+    // at query time, which is exactly what incident responders want
+    // to avoid.
+    match paired_credential_id {
+        Some(cred_id) => {
+            state.revocations.emit(&cred_id);
+            tracing::info!(
+                token_id = %token_id,
+                credential_id = %cred_id,
+                "setup token revoked; paired credential removed"
+            );
+        }
+        None => {
+            tracing::info!(
+                token_id = %token_id,
+                "setup token revoked (no paired credential)"
+            );
+        }
     }
-
-    tracing::info!(
-        token_id = %token_id,
-        paired_credential_id = paired_credential_id.as_deref().unwrap_or("none"),
-        "setup token revoked"
-    );
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -9,6 +9,7 @@ pub mod access;
 pub mod api;
 pub mod auth_middleware;
 pub mod cookie;
+pub mod revocation;
 pub mod state;
 pub mod ws;
 

--- a/crates/server/src/revocation.rs
+++ b/crates/server/src/revocation.rs
@@ -31,6 +31,38 @@
 //!   must subscribe BEFORE they touch anything they'd want to tear
 //!   down on revoke (e.g., a WS handler subscribes at upgrade time,
 //!   then enters its message loop).
+//!
+//! # Subscriber contract (read before slice 9c wires WS consumption)
+//!
+//! 1. **Subscribe before you validate.** A WS handler that accepts
+//!    the upgrade, reads the session cookie, validates it against
+//!    `AuthStore`, THEN subscribes will miss any revocation that
+//!    landed between the validate and the subscribe. Correct order:
+//!    subscribe first, then snapshot+validate. The snapshot IS the
+//!    "still valid?" check; the subscribe is the "will stay valid?"
+//!    guarantee for the lifetime of the connection.
+//!
+//! 2. **On `Lagged`, close.** Don't try to catch up — the
+//!    conservative failure is to assume your credential was among
+//!    the lost events. A fresh connection is cheap.
+//!
+//! 3. **Credential-id equality is the only check.** Subscribers
+//!    compare `event.credential_id` to the credential their
+//!    connection is bound to. No wildcards, no tree matches.
+//!
+//! # Emitter contract
+//!
+//! Any code path that removes a `Credential` from the store must
+//! emit on this channel after the transact commits. Today that's
+//! enforced socially in two call sites (`revoke_device`,
+//! `revoke_token`'s cascade). Future `AuthState` transitions that
+//! call `remove_credential` MUST also emit — this obligation has no
+//! type-system enforcement. If a background task (e.g., an
+//! eventual "expired unused tokens" pruner that cascades to
+//! credentials) ever adds a third removal path, wire it through
+//! `AppState::revocations.emit(cred_id)` or the WS layer will keep
+//! a ghost shell connection against a credential nobody can see
+//! anymore.
 
 use tokio::sync::broadcast::{self, error::SendError, Receiver, Sender};
 

--- a/crates/server/src/revocation.rs
+++ b/crates/server/src/revocation.rs
@@ -1,0 +1,162 @@
+//! Credential-revocation broadcast channel.
+//!
+//! When a credential is removed (directly via `/api/auth/devices/:id`
+//! or transitively via `/api/auth/setup-tokens/:id` cascading to its
+//! paired device), every long-lived connection bound to that
+//! credential must tear down immediately. Without that, a
+//! WebSocket — or a future WebRTC peer-link — continues streaming
+//! terminal I/O against a credential the operator has already pulled
+//! (Node scar `c073ec7`).
+//!
+//! This module owns the primitive: a `tokio::sync::broadcast` channel
+//! emitting `RevocationEvent` values. The design is deliberately
+//! transport-agnostic — WS, WebRTC, and any future long-lived
+//! bidirectional transport subscribe the same way via
+//! `AppState::subscribe_revocations()`. The auth/revoke handlers
+//! never know which transports (if any) are listening; they just
+//! `.emit(credential_id)` and move on.
+//!
+//! Broadcast semantics:
+//! - Each subscriber gets an independent queue. A slow subscriber
+//!   can't backpressure the emitter.
+//! - The channel has a bounded capacity; if a subscriber's queue
+//!   fills, they receive `Lagged` the next time they poll. For
+//!   revocation events this is fine — the receiver can respond to
+//!   `Lagged` by assuming the worst and closing its connection,
+//!   which is strictly more conservative than what a fresh event
+//!   would have triggered. Losing a revocation event is never safe;
+//!   losing knowledge of which specific events you missed and
+//!   responding defensively is.
+//! - Subscribing after an event has fired doesn't see it. Handlers
+//!   must subscribe BEFORE they touch anything they'd want to tear
+//!   down on revoke (e.g., a WS handler subscribes at upgrade time,
+//!   then enters its message loop).
+
+use tokio::sync::broadcast::{self, error::SendError, Receiver, Sender};
+
+/// Capacity of the revocation broadcast buffer. A subscriber that
+/// falls more than this many events behind gets `Lagged` on its
+/// next `recv`. 64 is comfortably above what a single-user
+/// installation could produce in any realistic interval — the
+/// operator would have to be revoking credentials in a tight loop.
+const REVOCATION_CHANNEL_CAPACITY: usize = 64;
+
+/// Event published when a credential is revoked. Carries only the
+/// credential id, because that's all any subscriber needs — they
+/// compare against the credential their connection is bound to and
+/// tear down on match.
+#[derive(Debug, Clone)]
+pub struct RevocationEvent {
+    pub credential_id: String,
+}
+
+/// Sender half of the broadcast channel, held by `AppState`. Cheap
+/// to clone; each clone shares the same broadcast state.
+#[derive(Clone)]
+pub struct RevocationPublisher {
+    sender: Sender<RevocationEvent>,
+}
+
+impl RevocationPublisher {
+    pub fn new() -> Self {
+        let (sender, _) = broadcast::channel(REVOCATION_CHANNEL_CAPACITY);
+        Self { sender }
+    }
+
+    /// Publish a revocation. The `Result` conveys whether any
+    /// subscribers received it, which callers are free to ignore:
+    /// with zero subscribers the channel drops the event, and
+    /// that's correct — nothing is currently holding a connection
+    /// against that credential.
+    pub fn emit(&self, credential_id: impl Into<String>) {
+        let event = RevocationEvent {
+            credential_id: credential_id.into(),
+        };
+        let credential_id = event.credential_id.clone();
+        match self.sender.send(event) {
+            Ok(receiver_count) => {
+                tracing::debug!(
+                    credential_id = %credential_id,
+                    subscribers = receiver_count,
+                    "revocation broadcast emitted"
+                );
+            }
+            Err(SendError(_)) => {
+                // No active subscribers. Fine — the event had no
+                // one to signal. Log at trace so it's observable
+                // during debugging without cluttering normal output.
+                tracing::trace!(
+                    credential_id = %credential_id,
+                    "revocation broadcast: no subscribers"
+                );
+            }
+        }
+    }
+
+    /// Get a fresh subscriber queue. Handlers subscribe BEFORE they
+    /// start whatever long-lived work needs torn down on revoke.
+    /// Events emitted before the subscribe call are not delivered
+    /// — intentional; a subscriber that just connected can't be
+    /// bound to a credential revoked before it arrived.
+    pub fn subscribe(&self) -> Receiver<RevocationEvent> {
+        self.sender.subscribe()
+    }
+}
+
+impl Default for RevocationPublisher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn emit_reaches_every_subscriber() {
+        let pub_ = RevocationPublisher::new();
+        let mut a = pub_.subscribe();
+        let mut b = pub_.subscribe();
+        pub_.emit("cred-1");
+
+        let got_a = a.recv().await.expect("subscriber a received");
+        assert_eq!(got_a.credential_id, "cred-1");
+        let got_b = b.recv().await.expect("subscriber b received");
+        assert_eq!(got_b.credential_id, "cred-1");
+    }
+
+    #[tokio::test]
+    async fn emit_with_no_subscribers_is_noop() {
+        let pub_ = RevocationPublisher::new();
+        // Should not panic, should not hang.
+        pub_.emit("cred-1");
+    }
+
+    #[tokio::test]
+    async fn late_subscriber_misses_earlier_events() {
+        let pub_ = RevocationPublisher::new();
+        pub_.emit("cred-earlier");
+        // Subscribe AFTER the event fires. tokio::broadcast drops
+        // events with no subscribers at emit time — intentional,
+        // and documented.
+        let mut late = pub_.subscribe();
+
+        pub_.emit("cred-later");
+        let got = late.recv().await.expect("late subscriber gets only post-subscribe events");
+        assert_eq!(
+            got.credential_id, "cred-later",
+            "late subscriber must not see 'cred-earlier' — it connected after that revocation"
+        );
+    }
+
+    #[tokio::test]
+    async fn publisher_clone_shares_channel() {
+        let pub_a = RevocationPublisher::new();
+        let pub_b = pub_a.clone();
+        let mut rx = pub_a.subscribe();
+        pub_b.emit("cred-1");
+        let got = rx.recv().await.unwrap();
+        assert_eq!(got.credential_id, "cred-1");
+    }
+}

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -6,8 +6,10 @@
 //! mutex, `WebAuthnService` holds its in-memory challenge maps behind
 //! their own mutexes. `AppState` itself is just a bundle of references.
 
+use crate::revocation::RevocationPublisher;
 use katulong_auth::{AuthStore, WebAuthnService};
 use std::sync::Arc;
+use tokio::sync::broadcast::Receiver;
 
 /// Operator-supplied configuration captured at startup.
 #[derive(Debug, Clone)]
@@ -35,6 +37,12 @@ pub struct AppState {
     pub auth_store: Arc<AuthStore>,
     pub webauthn: Arc<WebAuthnService>,
     pub config: Arc<ServerConfig>,
+    /// Publishes credential-revocation events to every long-lived
+    /// transport (WS, future WebRTC peer-links). Handlers call
+    /// `state.revocations.emit(...)` after a successful revoke;
+    /// subscribers call `state.subscribe_revocations()` at the
+    /// start of their connection loop.
+    pub revocations: RevocationPublisher,
 }
 
 impl AppState {
@@ -43,6 +51,16 @@ impl AppState {
             auth_store: Arc::new(auth_store),
             webauthn: Arc::new(webauthn),
             config: Arc::new(config),
+            revocations: RevocationPublisher::new(),
         }
+    }
+
+    /// Subscribe to credential-revocation events. Transport-agnostic
+    /// — the returned receiver delivers the same events to a WS
+    /// handler or a future WebRTC peer connection. Subscribers
+    /// compare each event's `credential_id` to the credential their
+    /// connection is bound to and tear down on match.
+    pub fn subscribe_revocations(&self) -> Receiver<crate::revocation::RevocationEvent> {
+        self.revocations.subscribe()
     }
 }

--- a/crates/server/tests/revocation_broadcast.rs
+++ b/crates/server/tests/revocation_broadcast.rs
@@ -1,0 +1,223 @@
+//! End-to-end tests that the revocation broadcast channel fires
+//! through the actual HTTP revoke routes — covers the wiring from
+//! handler → `transact` → `AppState::revocations.emit()`.
+//!
+//! Transport-agnostic by design: these tests subscribe via
+//! `AppState::subscribe_revocations()` as any future WS or WebRTC
+//! handler would. Confirms the two revocation paths (direct device
+//! revoke; indirect via setup-token revoke that cascades to a
+//! paired credential) both publish the event.
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, StatusCode},
+};
+use common::{ephemeral_state, json_body, req, seeded_auth, stub_credential};
+use katulong_server::app;
+use serde_json::json;
+use std::time::{Duration, SystemTime};
+use tokio::time::timeout;
+use tower::util::ServiceExt;
+
+#[tokio::test]
+async fn direct_device_revoke_emits_broadcast() {
+    let (state, _dir) = ephemeral_state().await;
+    let (admin_cookie, csrf) = seeded_auth(&state, "admin").await;
+    // Seed a second credential so admin isn't the last one.
+    state
+        .auth_store
+        .clone()
+        .transact(|s| Ok((s.upsert_credential(stub_credential("target")), ())))
+        .await
+        .unwrap();
+
+    // Subscribe BEFORE the revoke fires — tokio::broadcast drops
+    // events for which there are zero subscribers at emit time.
+    let mut rx = state.subscribe_revocations();
+
+    // Clone state so the test keeps a Sender handle alive after the
+    // router (and its state clone) gets dropped at the end of
+    // `oneshot`. Without this, the channel closes the instant the
+    // router drops and `rx.recv()` returns `Closed`.
+    let resp = app(state.clone())
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::DELETE)
+                .uri("/api/auth/devices/target")
+                .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let event = timeout(Duration::from_millis(500), rx.recv())
+        .await
+        .expect("broadcast must fire within 500ms")
+        .expect("receiver must get the event");
+    assert_eq!(event.credential_id, "target");
+}
+
+#[tokio::test]
+async fn device_revoke_on_unknown_id_does_not_emit() {
+    let (state, _dir) = ephemeral_state().await;
+    let (admin_cookie, csrf) = seeded_auth(&state, "admin").await;
+    // Second credential so admin isn't last.
+    state
+        .auth_store
+        .clone()
+        .transact(|s| Ok((s.upsert_credential(stub_credential("other")), ())))
+        .await
+        .unwrap();
+
+    let mut rx = state.subscribe_revocations();
+    let resp = app(state.clone())
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::DELETE)
+                .uri("/api/auth/devices/never-existed")
+                .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // Unknown id → no state change → no emission. A short timeout
+    // that MUST elapse without a message proves the negative.
+    // `state` is still in scope (not moved into app), so the Sender
+    // stays open and we get Elapsed from the timeout rather than
+    // Closed from the channel.
+    let result = timeout(Duration::from_millis(100), rx.recv()).await;
+    assert!(
+        result.is_err(),
+        "expected timeout (no broadcast) for unknown-id DELETE; got {:?}",
+        result
+    );
+    // Keep state alive explicitly so the compiler doesn't decide
+    // to drop it early.
+    drop(state);
+}
+
+#[tokio::test]
+async fn setup_token_revoke_emits_for_paired_credential() {
+    // The indirect path: DELETE /api/auth/setup-tokens/:id cascades
+    // to removing the paired credential. That cascade must also
+    // publish the revocation broadcast — the credential is
+    // functionally revoked from the consumer's point of view.
+    let (state, _dir) = ephemeral_state().await;
+    let (admin_cookie, csrf) = seeded_auth(&state, "admin").await;
+    let router = app(state.clone());
+
+    // Mint a token via the HTTP API, then directly seed a paired
+    // credential (we can't run a real WebAuthn pair in-process).
+    let create = router
+        .clone()
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/setup-tokens")
+                .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
+                .header("x-csrf-token", &csrf)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "name": "phone" })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let v = common::body_json(create).await;
+    let token_id = v["id"].as_str().unwrap().to_string();
+
+    let paired_cred_id = "phone-cred";
+    state
+        .auth_store
+        .clone()
+        .transact({
+            let token_id = token_id.clone();
+            let paired_cred_id = paired_cred_id.to_string();
+            move |s| {
+                let mut cred = stub_credential(&paired_cred_id);
+                cred.setup_token_id = Some(token_id.clone());
+                let next = s
+                    .upsert_credential(cred)
+                    .consume_setup_token(&token_id, &paired_cred_id, SystemTime::now());
+                Ok((next, ()))
+            }
+        })
+        .await
+        .unwrap();
+
+    let mut rx = state.subscribe_revocations();
+
+    let resp = router
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::DELETE)
+                .uri(format!("/api/auth/setup-tokens/{token_id}"))
+                .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let event = timeout(Duration::from_millis(500), rx.recv())
+        .await
+        .expect("broadcast must fire within 500ms for the cascade")
+        .expect("receiver must get the cascade event");
+    assert_eq!(event.credential_id, paired_cred_id);
+}
+
+#[tokio::test]
+async fn setup_token_revoke_without_paired_credential_does_not_emit() {
+    let (state, _dir) = ephemeral_state().await;
+    let (admin_cookie, csrf) = seeded_auth(&state, "admin").await;
+    let router = app(state.clone());
+
+    // Mint a token, don't pair it to any credential.
+    let create = router
+        .clone()
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/auth/setup-tokens")
+                .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
+                .header("x-csrf-token", &csrf)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "name": "unused" })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let v = common::body_json(create).await;
+    let token_id = v["id"].as_str().unwrap().to_string();
+
+    let mut rx = state.subscribe_revocations();
+    let resp = router
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::DELETE)
+                .uri(format!("/api/auth/setup-tokens/{token_id}"))
+                .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let result = timeout(Duration::from_millis(100), rx.recv()).await;
+    assert!(
+        result.is_err(),
+        "unused-token revoke must not broadcast — nothing to tear down"
+    );
+}


### PR DESCRIPTION
## Summary

First of the terminal-path slices. Closes the deferred item from slices 7 and 8 (Node scar \`c073ec7\`: revoking a credential must tear down long-lived connections bound to it, not just cookies/sessions).

**Design decision carried from user direction:** the broadcast primitive is transport-agnostic. WS, future WebRTC peer-links, any other long-lived transport subscribes via \`AppState::subscribe_revocations()\`. The auth/revoke layer emits and moves on — it never learns about transports.

## Changes

- \`crates/server/src/revocation.rs\` — \`RevocationEvent\`, \`RevocationPublisher\` over \`tokio::sync::broadcast\` (64-slot capacity)
- \`AppState::revocations\` + \`AppState::subscribe_revocations()\`
- \`revoke_device\` emits iff the credential existed (no emission on unknown-id DELETE)
- \`revoke_token\` emits for the cascade-removed credential iff the token was paired to one

## Not in this slice (intentionally deferred)

- No subscribers yet — slice 9b's tmux session manager + slice 9c's WS terminal wiring will consume the channel. Shipping the primitive first means those slices have a stable pattern to plug into.
- No tmux, no PTY, no protocol. Those are slice 9b/9c work.

## Test plan

- [x] 4 unit tests: fan-out, no-subscriber, late-subscriber, clone-shares-channel
- [x] 4 integration tests: direct-device-revoke emits, unknown-id doesn't, token-with-paired-cred emits, unused-token doesn't
- [x] 120 tests total, clippy clean