### PR TITLE
rewrite(server): slice 9b — tmux control-mode client + session manager scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,7 +1046,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tokio-test",
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
@@ -2337,28 +2336,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,9 @@ dependencies = [
  "serde_json",
  "subtle",
  "tempfile",
+ "thiserror",
  "tokio",
+ "tokio-test",
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
@@ -2335,6 +2337,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
+dependencies = [
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -22,8 +22,10 @@ tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 subtle = { version = "2", default-features = false }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
 tower = { version = "0.4", features = ["util"] }
 http-body-util = "0.1"
+tokio-test = "0.4"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -28,4 +28,3 @@ thiserror = { workspace = true }
 tempfile = { workspace = true }
 tower = { version = "0.4", features = ["util"] }
 http-body-util = "0.1"
-tokio-test = "0.4"

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -10,6 +10,7 @@ pub mod api;
 pub mod auth_middleware;
 pub mod cookie;
 pub mod revocation;
+pub mod session;
 pub mod state;
 pub mod ws;
 

--- a/crates/server/src/session/dims.rs
+++ b/crates/server/src/session/dims.rs
@@ -1,0 +1,119 @@
+//! Multi-device terminal-dimension discipline.
+//!
+//! This module is entirely commentary + constants. It has no
+//! functions today — it's the codified version of the lessons in
+//! `CLAUDE.md` so slice-9c/9d authors can find them at the point
+//! where they'd reach for "just resize on every attach" and be
+//! reminded why that's wrong.
+//!
+//! # A tmux pane has exactly one size
+//!
+//! `TIOCGWINSZ` returns one answer per PTY. The shell and every
+//! program in it see that single value. There is no way to have a
+//! running process simultaneously render at 40 columns (phone) and
+//! 200 columns (desktop). This is not a tmux quirk — it's how PTYs
+//! work.
+//!
+//! Consequence: when a phone attaches and resizes tmux, the
+//! desktop sees output formatted for phone width (text wraps
+//! early, wastes screen space). This is unfixable at this layer.
+//! Future options live OUTSIDE a single-PTY-per-session shape:
+//! per-device tmux windows, a primary-device model, or "don't
+//! resize on attach — each device keeps what it found."
+//!
+//! # Do-not-resize paths (ported from Node)
+//!
+//! 1. **Keystroke-driven active-client switching does NOT trigger
+//!    resize.** Node's `markActive()` in `client-tracker.js`
+//!    deliberately skipped resize on keystroke events, because
+//!    otherwise a user typing on their desktop while a phone is
+//!    connected would cause a SIGWINCH storm that garbles TUI
+//!    apps (vim, htop, etc.). Only explicit events — attach,
+//!    detach, browser window resize — should resize tmux.
+//!
+//! 2. **Never resize per-client.** ClientHeadless (PCH-7 in Node)
+//!    tried to run separate headless xterm.js instances per client
+//!    at different dimensions. This actively introduced drift
+//!    because TUI apps emit absolute cursor positioning escapes
+//!    (`\e[row;colH`) calculated for tmux's current size —
+//!    replaying those into a differently-sized headless lands the
+//!    escapes on wrong cells. PCH-7 deleted ClientHeadless; all
+//!    attach/subscribe/resync/snapshot now serialize the SHARED
+//!    `session._headless`, written live at the current PTY dims.
+//!
+//! 3. **Don't attempt to reflow cursor-positioned TUI output.**
+//!    See #2. There is no per-client reflow that works for a full
+//!    TUI app.
+//!
+//! # Bounds
+//!
+//! `MIN_COLS`/`MIN_ROWS`/`MAX_COLS`/`MAX_ROWS` are defensive caps
+//! on untrusted resize input (arriving over the WS protocol, which
+//! slice 9d will carry). Node's WS message validator (scar
+//! `9dc7c78`) rejected rows/cols > 1000 — we port the same ceiling.
+//! The floor catches pathological zero/negative values after any
+//! future arithmetic that could underflow.
+//!
+//! # Default dimensions for newly-spawned sessions
+//!
+//! `DEFAULT_COLS`/`DEFAULT_ROWS` are used when tmux spawns a
+//! session before any client has reported its actual window size.
+//! 80×24 is the compatibility choice — every TUI app in existence
+//! has been tested at those dims, and any sensible client reports
+//! its real size within milliseconds of attaching.
+
+/// Minimum columns — below this the display is useless for any
+/// terminal app. Rejecting smaller values avoids arithmetic edge
+/// cases inside tmux and curses programs.
+pub const MIN_COLS: u16 = 10;
+/// Minimum rows — a single-line terminal is technically valid but
+/// breaks full-screen programs catastrophically. 3 gives status
+/// line + command line + one line of output, which is the smallest
+/// shape where anything is usable.
+pub const MIN_ROWS: u16 = 3;
+/// Maximum columns, clamping untrusted client input. Ported from
+/// Node's WS validator (scar `9dc7c78`).
+pub const MAX_COLS: u16 = 1000;
+/// Maximum rows. Same source.
+pub const MAX_ROWS: u16 = 1000;
+
+/// Default columns for a freshly-created session before any client
+/// has reported its real window size.
+pub const DEFAULT_COLS: u16 = 80;
+/// Default rows. Pairs with `DEFAULT_COLS`.
+pub const DEFAULT_ROWS: u16 = 24;
+
+/// Clamp a client-reported dimension pair to the defensive bounds.
+/// Returns the clamped (cols, rows). Not a validation function —
+/// it never errors — because clamping is the right answer for
+/// every out-of-range value: too small → MIN, too large → MAX.
+/// Callers that want to distinguish "clamped" from "accepted"
+/// should compare input to output themselves.
+pub fn clamp_dims(cols: u16, rows: u16) -> (u16, u16) {
+    (cols.clamp(MIN_COLS, MAX_COLS), rows.clamp(MIN_ROWS, MAX_ROWS))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_dims_clips_to_bounds() {
+        assert_eq!(clamp_dims(80, 24), (80, 24));
+        assert_eq!(clamp_dims(0, 0), (MIN_COLS, MIN_ROWS));
+        assert_eq!(clamp_dims(9999, 9999), (MAX_COLS, MAX_ROWS));
+        assert_eq!(clamp_dims(5, 2), (MIN_COLS, MIN_ROWS));
+        assert_eq!(clamp_dims(1001, 500), (MAX_COLS, 500));
+    }
+
+    #[test]
+    fn defaults_are_within_bounds() {
+        // Sanity: the defaults we ship with must themselves pass
+        // the clamp — otherwise a fresh session would already be
+        // malformed by our own rules.
+        assert_eq!(
+            clamp_dims(DEFAULT_COLS, DEFAULT_ROWS),
+            (DEFAULT_COLS, DEFAULT_ROWS)
+        );
+    }
+}

--- a/crates/server/src/session/manager.rs
+++ b/crates/server/src/session/manager.rs
@@ -68,6 +68,7 @@ impl SessionManager {
         if !reply.ok {
             return Err(SessionError::TmuxRejected(reply.output));
         }
+        tracing::info!(session = %name, cols, rows, "session created");
         Ok(())
     }
 
@@ -108,10 +109,12 @@ impl SessionManager {
             if reply.output.contains("can't find session")
                 || reply.output.contains("session not found")
             {
+                tracing::info!(session = %name, "session destroy requested (not found; idempotent)");
                 return Ok(());
             }
             return Err(SessionError::TmuxRejected(reply.output));
         }
+        tracing::info!(session = %name, "session destroyed");
         Ok(())
     }
 
@@ -148,9 +151,17 @@ impl SessionManager {
     }
 }
 
+/// Errors returned by `SessionManager` operations.
+///
+/// **HTTP caller obligation.** `TmuxRejected` wraps tmux's raw
+/// stderr/stdout output. Do NOT forward that to an HTTP response
+/// body — it may contain socket paths, other session names, or
+/// internal tmux details. Log the content server-side and render
+/// a generic "session operation failed" to the client. Same shape
+/// as the `AuthError::Io` obligation from slice 1+2.
 #[derive(Debug, thiserror::Error)]
 pub enum SessionError {
-    #[error("session name contains forbidden character: {0:?}")]
+    #[error("invalid session name: {0:?}")]
     InvalidName(String),
     #[error("tmux rejected command: {0}")]
     TmuxRejected(String),
@@ -164,8 +175,17 @@ pub enum SessionError {
 /// be misinterpreted depending on context. Whitespace and shell
 /// metacharacters also rejected — belt and suspenders, because the
 /// command is written as a single line without shell escaping.
+///
+/// **Leading-hyphen rule.** A name starting with `-` is rejected
+/// even though `-` is allowed mid-name. Without this check, a
+/// name like `-a` passed to `kill-session -t {name}` renders as
+/// `kill-session -t -a`, which tmux's `getopt` parser reads as
+/// two flags — and on some tmux versions `-a` means "kill all
+/// sessions except the attached one." An authenticated caller
+/// could then nuke every session by naming one `-a`. The allowlist
+/// alone didn't cover this argument-injection edge.
 fn validate_session_name(name: &str) -> Result<(), SessionError> {
-    if name.is_empty() {
+    if name.is_empty() || name.starts_with('-') {
         return Err(SessionError::InvalidName(name.to_string()));
     }
     for c in name.chars() {
@@ -211,6 +231,28 @@ mod tests {
     #[test]
     fn session_name_rejects_empty() {
         assert!(validate_session_name("").is_err());
+    }
+
+    #[test]
+    fn session_name_rejects_leading_hyphen() {
+        // Critical argument-injection guard: `kill-session -t -a`
+        // reads as two flags on tmux, with `-a` meaning "kill all
+        // other sessions." An authenticated caller passing name="-a"
+        // would otherwise destroy every session. See the doc on
+        // `validate_session_name` for the full reasoning.
+        for bad in ["-", "-a", "-bad", "-kill-everything"] {
+            assert!(
+                validate_session_name(bad).is_err(),
+                "name starting with hyphen {bad:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn session_name_permits_hyphen_mid_name() {
+        // Hyphens are fine anywhere except the first position.
+        assert!(validate_session_name("my-session").is_ok());
+        assert!(validate_session_name("a-b-c").is_ok());
     }
 
     #[test]

--- a/crates/server/src/session/manager.rs
+++ b/crates/server/src/session/manager.rs
@@ -1,0 +1,223 @@
+//! Session lifecycle manager — the katulong-side view of tmux
+//! sessions.
+//!
+//! Wraps one `Tmux` client and exposes the operations
+//! handlers need: create a session, list existing sessions,
+//! destroy by id. Every call routes through tmux's control-mode
+//! command channel; we don't keep a second source of truth in
+//! Rust memory beyond what we need to enforce dimension discipline.
+//!
+//! # Slice 9b scope
+//!
+//! Scaffold only. No output streaming, no RingBuffer, no attach
+//! semantics, no WS integration. Methods return as soon as tmux
+//! ACKs the command — consumers of the session (output, input,
+//! resize) come in slice 9c.
+//!
+//! # Concurrency
+//!
+//! `SessionManager` is `Clone` (the inner `Tmux` handle is). That
+//! means multiple HTTP handlers can issue session commands
+//! concurrently; the tmux client's internal writer serializes them
+//! onto the subprocess's stdin. There's no in-memory cache to race.
+
+use super::dims::{clamp_dims, DEFAULT_COLS, DEFAULT_ROWS};
+use super::tmux::{Tmux, TmuxError};
+
+/// Public handle to the session layer. Construct with `new` at
+/// server startup; clone into every handler that needs to touch
+/// sessions.
+#[derive(Clone)]
+pub struct SessionManager {
+    tmux: Tmux,
+}
+
+impl SessionManager {
+    pub fn new(tmux: Tmux) -> Self {
+        Self { tmux }
+    }
+
+    /// Create a new tmux session with the given name and initial
+    /// dimensions. Returns when tmux confirms the session exists.
+    ///
+    /// `cols`/`rows` are clamped via `dims::clamp_dims` before
+    /// reaching tmux — we never ask tmux to create a 10000-column
+    /// session because the client lied about its window size.
+    ///
+    /// `name` must be a tmux-safe session identifier: no spaces, no
+    /// colons, no periods, no dollar-signs (which tmux interprets as
+    /// target specifiers). Callers that accept names from clients
+    /// should enforce a character set; the validation here is a
+    /// best-effort reject of the characters that would cause tmux to
+    /// misinterpret the command rather than fail.
+    pub async fn create_session(
+        &self,
+        name: &str,
+        cols: u16,
+        rows: u16,
+    ) -> Result<(), SessionError> {
+        validate_session_name(name)?;
+        let (cols, rows) = clamp_dims(cols, rows);
+        let cmd = format!(
+            "new-session -d -s {name} -x {cols} -y {rows}",
+            name = name,
+            cols = cols,
+            rows = rows
+        );
+        let reply = self.tmux.send_command(&cmd).await?;
+        if !reply.ok {
+            return Err(SessionError::TmuxRejected(reply.output));
+        }
+        Ok(())
+    }
+
+    /// List session names currently running on tmux. Returns them in
+    /// whatever order tmux reports; no sort guarantees.
+    pub async fn list_sessions(&self) -> Result<Vec<String>, SessionError> {
+        let reply = self
+            .tmux
+            .send_command("list-sessions -F '#{session_name}'")
+            .await?;
+        if !reply.ok {
+            // `list-sessions` on a server with zero sessions
+            // actually errors with "no server running" in some tmux
+            // versions — but our session manager always has at
+            // least the initial session created on spawn. If we see
+            // it, surface the tmux error rather than silently
+            // returning empty.
+            return Err(SessionError::TmuxRejected(reply.output));
+        }
+        Ok(reply
+            .output
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| l.to_string())
+            .collect())
+    }
+
+    /// Destroy a session by name. Idempotent — killing a session
+    /// that doesn't exist returns Ok (tmux reports an error but we
+    /// translate it into "nothing to do").
+    pub async fn destroy_session(&self, name: &str) -> Result<(), SessionError> {
+        validate_session_name(name)?;
+        let cmd = format!("kill-session -t {name}");
+        let reply = self.tmux.send_command(&cmd).await?;
+        if !reply.ok {
+            // tmux's "can't find session" error is what we want to
+            // treat as idempotent success. Any other error is real.
+            if reply.output.contains("can't find session")
+                || reply.output.contains("session not found")
+            {
+                return Ok(());
+            }
+            return Err(SessionError::TmuxRejected(reply.output));
+        }
+        Ok(())
+    }
+
+    /// Resize a session's default pane to the given dimensions.
+    /// Clamps per `dims::clamp_dims`. Slice-9c will use this from
+    /// explicit client events (attach, detach, window-resize) — do
+    /// NOT call on every keystroke (SIGWINCH storms garble TUI
+    /// apps; see `dims.rs`).
+    pub async fn resize_session(
+        &self,
+        name: &str,
+        cols: u16,
+        rows: u16,
+    ) -> Result<(), SessionError> {
+        validate_session_name(name)?;
+        let (cols, rows) = clamp_dims(cols, rows);
+        let cmd = format!(
+            "refresh-client -t {name} -C {cols},{rows}",
+            name = name,
+            cols = cols,
+            rows = rows
+        );
+        let reply = self.tmux.send_command(&cmd).await?;
+        if !reply.ok {
+            return Err(SessionError::TmuxRejected(reply.output));
+        }
+        Ok(())
+    }
+
+    /// Default dimensions the session manager uses for new sessions
+    /// when the client hasn't reported a real window size yet.
+    pub fn default_dims() -> (u16, u16) {
+        (DEFAULT_COLS, DEFAULT_ROWS)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SessionError {
+    #[error("session name contains forbidden character: {0:?}")]
+    InvalidName(String),
+    #[error("tmux rejected command: {0}")]
+    TmuxRejected(String),
+    #[error("tmux error: {0}")]
+    Tmux(#[from] TmuxError),
+}
+
+/// Reject session names that would confuse tmux's target parser.
+/// tmux uses `:` as window separator, `.` as pane separator, and
+/// `$`/`@`/`%` as id prefixes; a name containing any of those can
+/// be misinterpreted depending on context. Whitespace and shell
+/// metacharacters also rejected — belt and suspenders, because the
+/// command is written as a single line without shell escaping.
+fn validate_session_name(name: &str) -> Result<(), SessionError> {
+    if name.is_empty() {
+        return Err(SessionError::InvalidName(name.to_string()));
+    }
+    for c in name.chars() {
+        let ok = c.is_ascii_alphanumeric() || c == '-' || c == '_';
+        if !ok {
+            return Err(SessionError::InvalidName(name.to_string()));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_name_accepts_alphanumeric_and_dash_underscore() {
+        assert!(validate_session_name("session-1").is_ok());
+        assert!(validate_session_name("my_session").is_ok());
+        assert!(validate_session_name("ABC123").is_ok());
+    }
+
+    #[test]
+    fn session_name_rejects_tmux_target_specifiers() {
+        for bad in [":", ".", "$", "@", "%"] {
+            assert!(
+                validate_session_name(bad).is_err(),
+                "tmux target specifier {bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn session_name_rejects_whitespace_and_metachars() {
+        for bad in [" ", "a b", "a\tb", ";", "|", "&", "`", "'", "\""] {
+            assert!(
+                validate_session_name(bad).is_err(),
+                "dangerous char {bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn session_name_rejects_empty() {
+        assert!(validate_session_name("").is_err());
+    }
+
+    #[test]
+    fn default_dims_are_the_module_constants() {
+        assert_eq!(
+            SessionManager::default_dims(),
+            (DEFAULT_COLS, DEFAULT_ROWS)
+        );
+    }
+}

--- a/crates/server/src/session/mod.rs
+++ b/crates/server/src/session/mod.rs
@@ -11,4 +11,4 @@ pub mod parser;
 pub mod tmux;
 
 pub use manager::{SessionError, SessionManager};
-pub use tmux::{dedicated_socket_name, CommandReply, Tmux, TmuxError};
+pub use tmux::{CommandReply, Tmux, TmuxError, DEDICATED_SOCKET_NAME};

--- a/crates/server/src/session/mod.rs
+++ b/crates/server/src/session/mod.rs
@@ -1,0 +1,14 @@
+//! Terminal session layer.
+//!
+//! Wraps tmux via its `-C` control-mode protocol. This slice (9b)
+//! ships the scaffold — protocol parser, tmux subprocess client,
+//! and a SessionManager with create/list/destroy/resize. Slice 9c
+//! wires it into `AppState` and the WS terminal handler.
+
+pub mod dims;
+pub mod manager;
+pub mod parser;
+pub mod tmux;
+
+pub use manager::{SessionError, SessionManager};
+pub use tmux::{dedicated_socket_name, CommandReply, Tmux, TmuxError};

--- a/crates/server/src/session/parser.rs
+++ b/crates/server/src/session/parser.rs
@@ -1,0 +1,407 @@
+//! tmux control-mode notification parser.
+//!
+//! tmux, when invoked with `-C`, speaks a line-oriented protocol on
+//! stdout that this parser converts into `Notification` values. The
+//! two framing constructs are:
+//!
+//! - Command replies: `%begin <time> <num> <flags>` then zero or more
+//!   payload lines then `%end <time> <num> <flags>` (or `%error
+//!   <time> <num> <flags>` followed by the error payload).
+//! - Server events: single-line notifications like `%output %P data`,
+//!   `%session-changed`, `%window-close`, `%exit`, etc.
+//!
+//! This module is deliberately syntax-only: it turns bytes into typed
+//! values, it does not know about sessions, windows, panes, or the
+//! SessionManager. The caller (`tmux.rs`) routes notifications to
+//! their consumers — command replies to oneshot channels, `%output`
+//! to whatever subscribes to a pane's byte stream, etc.
+//!
+//! Reference: `man tmux` → CONTROL MODE. Fields are space-separated;
+//! payload lines between `%begin` and `%end` are verbatim (except
+//! octal-escaped bytes, which we do NOT decode here — downstream
+//! consumers that care about `%output` payloads need the raw form).
+
+use std::num::ParseIntError;
+
+/// A single parsed tmux-control-mode line.
+///
+/// `Payload` is not one of tmux's actual notifications — it's what
+/// this parser emits for lines that sit between `%begin` and `%end`.
+/// The stateful caller is responsible for grouping consecutive
+/// `Payload`s into the command reply they belong to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Notification {
+    /// Start of a command reply. `num` is the sequence number
+    /// assigned by tmux (the first command gets 0, increments from
+    /// there). Callers match this to pending commands.
+    Begin {
+        time: u64,
+        num: u32,
+        flags: u32,
+    },
+    /// End of a successful command reply. Must match a prior `Begin`
+    /// with the same `num`.
+    End {
+        time: u64,
+        num: u32,
+        flags: u32,
+    },
+    /// Command failed. Any payload lines between the matching
+    /// `Begin` and this `Error` contain the error text.
+    Error {
+        time: u64,
+        num: u32,
+        flags: u32,
+    },
+    /// Byte stream from a pane. `pane_id` is the `%<digits>` ID
+    /// (digits only — we strip the `%` prefix at parse time). `data`
+    /// is the raw payload; tmux escapes control chars as `\ooo`
+    /// (three-digit octal) but we don't decode here — consumers
+    /// that need raw bytes will. Consumers that just need
+    /// display-ready text can decode via the obvious inverse.
+    Output {
+        pane_id: u32,
+        data: String,
+    },
+    /// `%session-changed $N name`
+    SessionChanged {
+        session_id: u32,
+        name: String,
+    },
+    /// `%session-renamed name`
+    SessionRenamed {
+        name: String,
+    },
+    /// `%sessions-changed` (no args) — a session was added or
+    /// removed.
+    SessionsChanged,
+    /// `%window-add @N`
+    WindowAdd {
+        window_id: u32,
+    },
+    /// `%window-close @N`
+    WindowClose {
+        window_id: u32,
+    },
+    /// `%window-renamed @N name`
+    WindowRenamed {
+        window_id: u32,
+        name: String,
+    },
+    /// `%unlinked-window-close @N` — tmux 3.3+ alternate form.
+    UnlinkedWindowClose {
+        window_id: u32,
+    },
+    /// `%exit` or `%exit <reason>` — tmux is shutting the control
+    /// connection down.
+    Exit {
+        reason: Option<String>,
+    },
+    /// A `%` notification whose keyword we don't recognize. Kept as
+    /// a catch-all so unexpected tmux versions don't panic the
+    /// parser — the caller can log-and-ignore.
+    Unknown {
+        keyword: String,
+        rest: String,
+    },
+    /// A line that came between `Begin` and `End`/`Error`. Raw,
+    /// unescaped bytes-as-UTF-8 (tmux sends UTF-8; consumers that
+    /// need binary safety should pre-decode themselves).
+    Payload(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("not a notification (missing % prefix): {0:?}")]
+    NotNotification(String),
+    #[error("malformed header: {0:?}")]
+    MalformedHeader(String),
+    #[error("field parse error: {0}")]
+    FieldParse(#[from] ParseIntError),
+}
+
+/// Parse one line from tmux stdout. The caller is responsible for
+/// having split the stream on `\n` already — `line` must not
+/// contain the trailing newline.
+///
+/// Lines that don't start with `%` are treated as command-reply
+/// payload and returned as `Notification::Payload`. The caller's
+/// stateful grouping (inside `begin`/`end`) decides whether that
+/// makes sense for the current position in the stream.
+pub fn parse(line: &str) -> Result<Notification, ParseError> {
+    // Anything not starting with `%` is treated as payload. The
+    // caller's state machine decides whether we're actually inside
+    // a `%begin`/`%end` block at this moment; the parser just
+    // tags the line.
+    let Some(rest) = line.strip_prefix('%') else {
+        return Ok(Notification::Payload(line.to_string()));
+    };
+
+    // `%keyword rest-of-line`. tmux's keyword set is small and
+    // well-known; we match on it directly.
+    let (keyword, args) = rest.split_once(' ').unwrap_or((rest, ""));
+    match keyword {
+        "begin" => parse_begin_end(args).map(|(time, num, flags)| Notification::Begin {
+            time,
+            num,
+            flags,
+        }),
+        "end" => parse_begin_end(args).map(|(time, num, flags)| Notification::End {
+            time,
+            num,
+            flags,
+        }),
+        "error" => parse_begin_end(args).map(|(time, num, flags)| Notification::Error {
+            time,
+            num,
+            flags,
+        }),
+        "output" => parse_output(args),
+        "session-changed" => parse_session_changed(args),
+        "session-renamed" => Ok(Notification::SessionRenamed {
+            name: args.to_string(),
+        }),
+        "sessions-changed" => Ok(Notification::SessionsChanged),
+        "window-add" => parse_at_window(args).map(|id| Notification::WindowAdd { window_id: id }),
+        "window-close" => {
+            parse_at_window(args).map(|id| Notification::WindowClose { window_id: id })
+        }
+        "window-renamed" => parse_window_renamed(args),
+        "unlinked-window-close" => parse_at_window(args)
+            .map(|id| Notification::UnlinkedWindowClose { window_id: id }),
+        "exit" => Ok(Notification::Exit {
+            reason: if args.is_empty() {
+                None
+            } else {
+                Some(args.to_string())
+            },
+        }),
+        other => Ok(Notification::Unknown {
+            keyword: other.to_string(),
+            rest: args.to_string(),
+        }),
+    }
+}
+
+fn parse_begin_end(args: &str) -> Result<(u64, u32, u32), ParseError> {
+    let mut parts = args.split_whitespace();
+    let time: u64 = parts
+        .next()
+        .ok_or_else(|| ParseError::MalformedHeader(args.to_string()))?
+        .parse()?;
+    let num: u32 = parts
+        .next()
+        .ok_or_else(|| ParseError::MalformedHeader(args.to_string()))?
+        .parse()?;
+    // flags is optional on some tmux versions; default to 0
+    let flags: u32 = parts.next().unwrap_or("0").parse()?;
+    Ok((time, num, flags))
+}
+
+fn parse_output(args: &str) -> Result<Notification, ParseError> {
+    // `%P data-with-spaces-or-whatever`
+    let (id_str, data) = args
+        .split_once(' ')
+        .ok_or_else(|| ParseError::MalformedHeader(args.to_string()))?;
+    let id = strip_percent(id_str)?;
+    Ok(Notification::Output {
+        pane_id: id,
+        data: data.to_string(),
+    })
+}
+
+fn parse_session_changed(args: &str) -> Result<Notification, ParseError> {
+    // `$N name`
+    let (id_str, name) = args
+        .split_once(' ')
+        .ok_or_else(|| ParseError::MalformedHeader(args.to_string()))?;
+    let id = strip_dollar(id_str)?;
+    Ok(Notification::SessionChanged {
+        session_id: id,
+        name: name.to_string(),
+    })
+}
+
+fn parse_at_window(args: &str) -> Result<u32, ParseError> {
+    // `@N` — take the whole args, or if whitespace after, the first
+    // token.
+    let token = args.split_whitespace().next().unwrap_or(args);
+    strip_at(token)
+}
+
+fn parse_window_renamed(args: &str) -> Result<Notification, ParseError> {
+    let (id_str, name) = args
+        .split_once(' ')
+        .ok_or_else(|| ParseError::MalformedHeader(args.to_string()))?;
+    let id = strip_at(id_str)?;
+    Ok(Notification::WindowRenamed {
+        window_id: id,
+        name: name.to_string(),
+    })
+}
+
+fn strip_percent(s: &str) -> Result<u32, ParseError> {
+    let rest = s
+        .strip_prefix('%')
+        .ok_or_else(|| ParseError::MalformedHeader(s.to_string()))?;
+    Ok(rest.parse()?)
+}
+
+fn strip_dollar(s: &str) -> Result<u32, ParseError> {
+    let rest = s
+        .strip_prefix('$')
+        .ok_or_else(|| ParseError::MalformedHeader(s.to_string()))?;
+    Ok(rest.parse()?)
+}
+
+fn strip_at(s: &str) -> Result<u32, ParseError> {
+    let rest = s
+        .strip_prefix('@')
+        .ok_or_else(|| ParseError::MalformedHeader(s.to_string()))?;
+    Ok(rest.parse()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_begin_end_error() {
+        assert_eq!(
+            parse("%begin 1701234567 42 1").unwrap(),
+            Notification::Begin {
+                time: 1_701_234_567,
+                num: 42,
+                flags: 1,
+            }
+        );
+        assert_eq!(
+            parse("%end 1701234567 42 1").unwrap(),
+            Notification::End {
+                time: 1_701_234_567,
+                num: 42,
+                flags: 1,
+            }
+        );
+        assert_eq!(
+            parse("%error 1701234567 42 1").unwrap(),
+            Notification::Error {
+                time: 1_701_234_567,
+                num: 42,
+                flags: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_begin_without_flags_field() {
+        // Older tmux versions omit the flags field. Default to 0
+        // so we don't force every deployment onto a specific
+        // release.
+        assert_eq!(
+            parse("%begin 100 7").unwrap(),
+            Notification::Begin {
+                time: 100,
+                num: 7,
+                flags: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_output_with_embedded_spaces() {
+        // The pane data can contain spaces, tabs, octal escapes,
+        // anything. Parser preserves the whole remainder after the
+        // first space following the pane id.
+        let got = parse("%output %1 hello world  \\t\\n").unwrap();
+        assert_eq!(
+            got,
+            Notification::Output {
+                pane_id: 1,
+                data: "hello world  \\t\\n".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_session_changed() {
+        assert_eq!(
+            parse("%session-changed $3 work").unwrap(),
+            Notification::SessionChanged {
+                session_id: 3,
+                name: "work".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_window_events() {
+        assert_eq!(
+            parse("%window-add @5").unwrap(),
+            Notification::WindowAdd { window_id: 5 }
+        );
+        assert_eq!(
+            parse("%window-close @5").unwrap(),
+            Notification::WindowClose { window_id: 5 }
+        );
+        assert_eq!(
+            parse("%unlinked-window-close @5").unwrap(),
+            Notification::UnlinkedWindowClose { window_id: 5 }
+        );
+        assert_eq!(
+            parse("%window-renamed @5 bash").unwrap(),
+            Notification::WindowRenamed {
+                window_id: 5,
+                name: "bash".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_exit() {
+        assert_eq!(
+            parse("%exit").unwrap(),
+            Notification::Exit { reason: None }
+        );
+        assert_eq!(
+            parse("%exit server exited").unwrap(),
+            Notification::Exit {
+                reason: Some("server exited".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn payload_is_anything_not_starting_with_percent() {
+        assert_eq!(
+            parse("hello").unwrap(),
+            Notification::Payload("hello".to_string())
+        );
+        assert_eq!(
+            parse("").unwrap(),
+            Notification::Payload(String::new())
+        );
+    }
+
+    #[test]
+    fn unknown_notification_survives_as_catch_all() {
+        // Future tmux adds `%whatever`. We don't panic; we hand
+        // the caller a Named+rest tuple so they can log-and-skip.
+        let got = parse("%some-future-event arg1 arg2").unwrap();
+        assert_eq!(
+            got,
+            Notification::Unknown {
+                keyword: "some-future-event".to_string(),
+                rest: "arg1 arg2".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn malformed_begin_errors_not_panics() {
+        assert!(matches!(
+            parse("%begin notanumber 42").unwrap_err(),
+            ParseError::FieldParse(_)
+        ));
+    }
+}

--- a/crates/server/src/session/parser.rs
+++ b/crates/server/src/session/parser.rs
@@ -112,8 +112,6 @@ pub enum Notification {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
-    #[error("not a notification (missing % prefix): {0:?}")]
-    NotNotification(String),
     #[error("malformed header: {0:?}")]
     MalformedHeader(String),
     #[error("field parse error: {0}")]

--- a/crates/server/src/session/tmux.rs
+++ b/crates/server/src/session/tmux.rs
@@ -66,8 +66,13 @@ pub enum TmuxError {
     Disconnected,
     #[error("parse error: {0}")]
     Parse(#[from] ParseError),
-    #[error("tmux command failed: {0}")]
-    CommandFailed(String),
+    /// The caller passed a malformed command string (embedded
+    /// newline/carriage return, invalid socket name, etc.). Fires
+    /// BEFORE any bytes reach tmux; distinct from
+    /// `SessionError::TmuxRejected`, which is what you get when
+    /// tmux itself refuses a well-formed command.
+    #[error("invalid tmux command: {0}")]
+    InvalidCommand(String),
 }
 
 /// Handle to a running tmux control-mode subprocess.
@@ -79,7 +84,7 @@ pub enum TmuxError {
 /// server.
 #[derive(Clone)]
 pub struct Tmux {
-    cmd_tx: mpsc::UnboundedSender<PendingCommand>,
+    cmd_tx: mpsc::UnboundedSender<OutgoingCommand>,
     /// Held so we can `kill` on explicit shutdown. Behind `Arc<Mutex>`
     /// because tasks may call `shutdown` concurrently; at most one
     /// will actually dispatch the kill.
@@ -89,8 +94,19 @@ pub struct Tmux {
     tasks: Arc<Mutex<Vec<JoinHandle<()>>>>,
 }
 
-struct PendingCommand {
+/// Sent over the command mpsc. Carries both what to write to
+/// tmux's stdin and where to deliver the eventual reply.
+struct OutgoingCommand {
     line: String,
+    reply: oneshot::Sender<Result<CommandReply, TmuxError>>,
+}
+
+/// Entry in the reader's pending-reply queue. The writer pushes
+/// one per outgoing command (after successfully writing the bytes
+/// to tmux's stdin); the reader pops in FIFO order on `%begin`.
+/// Does NOT carry the command text — the reader has no use for
+/// it, and avoiding the extra clone keeps the hot path lean.
+struct PendingReply {
     reply: oneshot::Sender<Result<CommandReply, TmuxError>>,
 }
 
@@ -98,20 +114,39 @@ impl Tmux {
     /// Spawn `tmux -C -L <socket_name> new-session -d -s <session>
     /// -x <cols> -y <rows>` and begin the reader/writer tasks.
     ///
-    /// `socket_name` must not be a path — tmux interprets `-L` as a
-    /// name under `/tmp/tmux-$UID/`. Use `dedicated_socket_name()`
-    /// for the convention.
+    /// `socket_name` is validated: alphanumeric + `-_` only, no
+    /// leading hyphen, no `/` (which would redirect tmux's socket
+    /// file to an attacker-controlled path). Use
+    /// `DEDICATED_SOCKET_NAME` for the production convention.
     ///
     /// Returns the client handle plus an mpsc receiver for
     /// asynchronous notifications (`%output`, `%window-close`,
-    /// ...). The caller is responsible for pumping that receiver;
-    /// if it's dropped, notifications are silently discarded.
+    /// ...).
+    ///
+    /// # Backpressure contract (IMPORTANT)
+    ///
+    /// The notification receiver is **unbounded**. The caller MUST
+    /// drain it continuously — every line of terminal output
+    /// produced by any pane tmux controls arrives as a
+    /// `Notification::Output` on this channel, which in active
+    /// terminal use means hundreds of events per second. An
+    /// unconsumed receiver will grow unboundedly and eventually
+    /// exhaust memory.
+    ///
+    /// Slice 9c's terminal handler is the intended consumer and
+    /// applies the bounded-ring-buffer + drop-oldest strategy
+    /// appropriate for display data. Unit tests and tools that
+    /// spawn a `Tmux` without consuming must call `shutdown()`
+    /// promptly to prevent buildup.
     pub async fn spawn(
         socket_name: &str,
         initial_session: &str,
         cols: u16,
         rows: u16,
     ) -> Result<(Self, mpsc::UnboundedReceiver<Notification>), TmuxError> {
+        validate_socket_name(socket_name)?;
+        validate_session_name_for_tmux(initial_session)?;
+
         let mut cmd = Command::new("tmux");
         cmd.arg("-L")
             .arg(socket_name)
@@ -135,37 +170,54 @@ impl Tmux {
         let mut child = cmd.spawn()?;
         let stdin = child.stdin.take().ok_or(TmuxError::Disconnected)?;
         let stdout = child.stdout.take().ok_or(TmuxError::Disconnected)?;
+        let stderr = child.stderr.take();
 
-        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<PendingCommand>();
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<OutgoingCommand>();
         let (notif_tx, notif_rx) = mpsc::unbounded_channel::<Notification>();
-        let pending: Arc<Mutex<VecDeque<PendingCommand>>> =
+        let pending: Arc<Mutex<VecDeque<PendingReply>>> =
             Arc::new(Mutex::new(VecDeque::new()));
 
         let reader_handle =
             tokio::spawn(run_reader(stdout, notif_tx, Arc::clone(&pending)));
         let writer_handle = tokio::spawn(run_writer(stdin, cmd_rx, pending));
+        // Drain stderr. If nobody reads, the pipe's 64 KB buffer
+        // fills, tmux blocks on write, and the control channel
+        // stalls indefinitely. Forward each line to `warn!` so
+        // operators see tmux diagnostics in the same log stream
+        // as everything else.
+        let mut tasks = vec![reader_handle, writer_handle];
+        if let Some(stderr) = stderr {
+            tasks.push(tokio::spawn(async move {
+                let mut reader = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = reader.next_line().await {
+                    tracing::warn!(tmux.stderr = %line, "tmux stderr");
+                }
+            }));
+        }
 
         Ok((
             Self {
                 cmd_tx,
                 child: Arc::new(Mutex::new(Some(child))),
-                tasks: Arc::new(Mutex::new(vec![reader_handle, writer_handle])),
+                tasks: Arc::new(Mutex::new(tasks)),
             },
             notif_rx,
         ))
     }
 
     /// Send one command to tmux and await the reply. `line` must
-    /// not contain a newline — the writer appends `\n` itself.
+    /// not contain a newline or carriage return — the writer
+    /// appends `\n` itself, and injecting either would let the
+    /// caller smuggle a second command past the guard.
     pub async fn send_command(&self, line: &str) -> Result<CommandReply, TmuxError> {
-        if line.contains('\n') {
-            return Err(TmuxError::CommandFailed(
-                "command contains embedded newline".into(),
+        if line.contains('\n') || line.contains('\r') {
+            return Err(TmuxError::InvalidCommand(
+                "command contains embedded newline or carriage return".into(),
             ));
         }
         let (reply, rx) = oneshot::channel();
         self.cmd_tx
-            .send(PendingCommand {
+            .send(OutgoingCommand {
                 line: line.to_string(),
                 reply,
             })
@@ -189,12 +241,57 @@ impl Tmux {
     }
 }
 
-/// Build the dedicated tmux socket name. Matches the Node
-/// implementation's `-L katulong` convention so a migrated install
-/// doesn't collide with the user's interactive tmux, and so staging
-/// instances can use per-worktree sockets like `stage-<branch>`.
-pub fn dedicated_socket_name() -> String {
-    "katulong".to_string()
+/// Default tmux socket name for production deployments. Matches
+/// the Node implementation's `-L katulong` convention so a migrated
+/// install doesn't collide with the operator's interactive tmux.
+/// Staging instances override this via their own per-worktree name
+/// (e.g. `stage-rewrite-rust-leptos`) when they spawn `Tmux`.
+pub const DEDICATED_SOCKET_NAME: &str = "katulong";
+
+/// Validate a tmux socket name. Same allowlist as session names
+/// but enforced here rather than in `SessionManager` because
+/// sockets are chosen at server startup from operator config, not
+/// user input — still, a misconfigured staging script could feed
+/// something path-like. Rejecting `/`, `..`, and control chars now
+/// forecloses the "tmux creates its socket file in an
+/// attacker-controlled location" class of bug before slice 9c+
+/// widens the caller surface.
+fn validate_socket_name(name: &str) -> Result<(), TmuxError> {
+    if name.is_empty() || name.starts_with('-') {
+        return Err(TmuxError::InvalidCommand(format!(
+            "invalid tmux socket name: {name:?}"
+        )));
+    }
+    for c in name.chars() {
+        let ok = c.is_ascii_alphanumeric() || c == '-' || c == '_';
+        if !ok {
+            return Err(TmuxError::InvalidCommand(format!(
+                "invalid tmux socket name: {name:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Same allowlist, applied to the `-s` argument of the initial
+/// `new-session`. Mirrors `SessionManager::validate_session_name`
+/// but lives here so `Tmux::spawn` can reject before any
+/// subprocess lifecycle setup happens.
+fn validate_session_name_for_tmux(name: &str) -> Result<(), TmuxError> {
+    if name.is_empty() || name.starts_with('-') {
+        return Err(TmuxError::InvalidCommand(format!(
+            "invalid tmux session name: {name:?}"
+        )));
+    }
+    for c in name.chars() {
+        let ok = c.is_ascii_alphanumeric() || c == '-' || c == '_';
+        if !ok {
+            return Err(TmuxError::InvalidCommand(format!(
+                "invalid tmux session name: {name:?}"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// In-flight command reply being accumulated by the reader task.
@@ -209,7 +306,7 @@ struct InFlightReply {
 async fn run_reader(
     stdout: ChildStdout,
     notifications: mpsc::UnboundedSender<Notification>,
-    pending: Arc<Mutex<VecDeque<PendingCommand>>>,
+    pending: Arc<Mutex<VecDeque<PendingReply>>>,
 ) {
     let mut reader = BufReader::new(stdout).lines();
     // When we see `%begin`, we pop the next pending command's
@@ -282,38 +379,33 @@ async fn run_reader(
     }
 }
 
+/// Write one command line (and its trailing newline) to tmux's
+/// stdin, flushing afterwards. Returns any I/O error unwrapped so
+/// the caller can resolve the pending oneshot with the precise
+/// error value.
+async fn write_line(stdin: &mut ChildStdin, line: &str) -> std::io::Result<()> {
+    stdin.write_all(line.as_bytes()).await?;
+    stdin.write_all(b"\n").await?;
+    stdin.flush().await
+}
+
 async fn run_writer(
     mut stdin: ChildStdin,
-    mut cmd_rx: mpsc::UnboundedReceiver<PendingCommand>,
-    pending: Arc<Mutex<VecDeque<PendingCommand>>>,
+    mut cmd_rx: mpsc::UnboundedReceiver<OutgoingCommand>,
+    pending: Arc<Mutex<VecDeque<PendingReply>>>,
 ) {
     while let Some(cmd) = cmd_rx.recv().await {
-        // Register the pending command BEFORE writing, so that if
-        // tmux replies immediately on another task we don't race.
-        let line = cmd.line.clone();
-        let reply = cmd.reply;
-        pending.lock().await.push_back(PendingCommand {
-            line: line.clone(),
-            reply,
+        // Register the pending reply BEFORE writing, so a racing
+        // reader that sees `%begin` immediately after the flush
+        // already has the oneshot to resolve against.
+        pending.lock().await.push_back(PendingReply {
+            reply: cmd.reply,
         });
-        if let Err(e) = stdin.write_all(line.as_bytes()).await {
-            let popped = pending.lock().await.pop_back();
-            if let Some(p) = popped {
-                let _ = p.reply.send(Err(TmuxError::Io(e)));
-            }
-            break;
-        }
-        if let Err(e) = stdin.write_all(b"\n").await {
-            let popped = pending.lock().await.pop_back();
-            if let Some(p) = popped {
-                let _ = p.reply.send(Err(TmuxError::Io(e)));
-            }
-            break;
-        }
-        if let Err(e) = stdin.flush().await {
-            // Flush failed — best-effort resolve the just-queued cmd.
-            let popped = pending.lock().await.pop_back();
-            if let Some(p) = popped {
+        if let Err(e) = write_line(&mut stdin, &cmd.line).await {
+            // Writer failed — peel the entry we just pushed and
+            // resolve its oneshot with the I/O error, then bail
+            // out of the loop so `shutdown` can clean up.
+            if let Some(p) = pending.lock().await.pop_back() {
                 let _ = p.reply.send(Err(TmuxError::Io(e)));
             }
             break;
@@ -337,36 +429,64 @@ mod tests {
     async fn send_command_before_spawn_fails() {
         // Build a Tmux with a dead channel to exercise the
         // Disconnected path without needing a real tmux binary.
-        let (tx, _rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::unbounded_channel::<OutgoingCommand>();
         let t = Tmux {
             cmd_tx: tx.clone(),
             child: Arc::new(Mutex::new(None)),
             tasks: Arc::new(Mutex::new(vec![])),
         };
         drop(tx);
-        drop(_rx);
+        drop(rx);
         let err = t.send_command("list-sessions").await.unwrap_err();
         assert!(matches!(err, TmuxError::Disconnected));
     }
 
-    #[test]
-    fn embedded_newline_is_rejected_without_hitting_tmux() {
+    #[tokio::test]
+    async fn embedded_newline_is_rejected_without_hitting_tmux() {
         // The write-a-newline guard must kick in before the mpsc
         // send — otherwise tmux would see a malformed partial
         // command.
-        tokio_test::block_on(async {
-            let (tx, _rx) = mpsc::unbounded_channel();
-            let t = Tmux {
-                cmd_tx: tx,
-                child: Arc::new(Mutex::new(None)),
-                tasks: Arc::new(Mutex::new(vec![])),
-            };
-            let err = t
-                .send_command("list-sessions\nkill-server")
-                .await
-                .unwrap_err();
-            assert!(matches!(err, TmuxError::CommandFailed(_)));
-        });
+        let (tx, _rx) = mpsc::unbounded_channel::<OutgoingCommand>();
+        let t = Tmux {
+            cmd_tx: tx,
+            child: Arc::new(Mutex::new(None)),
+            tasks: Arc::new(Mutex::new(vec![])),
+        };
+        let err = t
+            .send_command("list-sessions\nkill-server")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, TmuxError::InvalidCommand(_)));
+    }
+
+    #[tokio::test]
+    async fn embedded_carriage_return_is_rejected_without_hitting_tmux() {
+        // Companion guard: CR is also a command terminator in some
+        // parse paths. Reject symmetrically with LF.
+        let (tx, _rx) = mpsc::unbounded_channel::<OutgoingCommand>();
+        let t = Tmux {
+            cmd_tx: tx,
+            child: Arc::new(Mutex::new(None)),
+            tasks: Arc::new(Mutex::new(vec![])),
+        };
+        let err = t
+            .send_command("list-sessions\rkill-server")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, TmuxError::InvalidCommand(_)));
+    }
+
+    #[test]
+    fn socket_name_validator_rejects_path_like_and_leading_hyphen() {
+        assert!(validate_socket_name("katulong").is_ok());
+        assert!(validate_socket_name("stage-rewrite-rust-leptos").is_ok());
+        // Path-likes: rejecting `/` and `..` prevents tmux from
+        // creating its socket file in an attacker-controlled
+        // location if a future caller forwards config values.
+        assert!(validate_socket_name("../evil").is_err());
+        assert!(validate_socket_name("/tmp/evil").is_err());
+        assert!(validate_socket_name("").is_err());
+        assert!(validate_socket_name("-flag").is_err());
     }
 
     #[tokio::test]

--- a/crates/server/src/session/tmux.rs
+++ b/crates/server/src/session/tmux.rs
@@ -1,0 +1,396 @@
+//! tmux control-mode client.
+//!
+//! Owns one long-running `tmux -C -L <socket>` subprocess and
+//! speaks the protocol parsed by `super::parser`. Commands are
+//! sent via the subprocess's stdin; replies and asynchronous
+//! notifications arrive on stdout.
+//!
+//! The client's job splits into three asynchronous pieces:
+//!
+//! 1. **Reader task** — consumes stdout line by line, parses each
+//!    line into a `Notification`, and dispatches:
+//!    - `%begin`/`%end`/`%error` + any `Payload` lines between them
+//!      → group into a `CommandReply` and hand to the oldest
+//!      pending-command oneshot.
+//!    - Everything else (`%output`, `%window-close`, ...) → send to
+//!      the notification mpsc subscriber.
+//! 2. **Writer task** — serializes outgoing command lines and
+//!    registers their pending oneshots. Exclusive access to the
+//!    stdin half means we don't interleave commands mid-line.
+//! 3. **Client API** — `send_command(&str)` pushes to the writer
+//!    and awaits the matching reply.
+//!
+//! # Dedicated tmux socket
+//!
+//! Every tmux invocation passes `-L <socket_name>` (NOT a path;
+//! tmux namespaces its socket dir under `/tmp/tmux-$UID/`).
+//! Matches the Node scar `fix(tmux): dedicate LaunchAgent and
+//! dev-server tmux to -L katulong socket (#629)`: sharing the
+//! default tmux socket with the user's interactive tmux meant a
+//! `kill-server` anywhere zapped both. A dedicated socket isolates
+//! katulong's tmux state.
+//!
+//! # Slice 9b scope
+//!
+//! This slice ships the client type and its protocol handling.
+//! Slice 9c wires it into `SessionManager` and exposes it through
+//! `AppState`. The integration test that actually spawns tmux is
+//! marked `#[ignore]` so CI without tmux installed still passes;
+//! developers run it manually with `cargo test -- --ignored
+//! tmux_roundtrip`.
+
+use super::parser::{parse, Notification, ParseError};
+use std::collections::VecDeque;
+use std::process::Stdio;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::task::JoinHandle;
+
+/// Result of executing one command against tmux.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandReply {
+    /// `true` if tmux sent `%end`, `false` if it sent `%error`.
+    pub ok: bool,
+    /// Payload lines between `%begin` and `%end`/`%error`, joined
+    /// with `\n`. Empty for commands that produce no output.
+    pub output: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TmuxError {
+    #[error("io error on tmux stream: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("tmux exited before responding")]
+    Disconnected,
+    #[error("parse error: {0}")]
+    Parse(#[from] ParseError),
+    #[error("tmux command failed: {0}")]
+    CommandFailed(String),
+}
+
+/// Handle to a running tmux control-mode subprocess.
+///
+/// Cloning is cheap (`Arc` under the hood) — multiple tasks can
+/// call `send_command` concurrently and the writer serializes
+/// them. Dropping all handles does NOT kill tmux; call
+/// `shutdown()` explicitly if the instance should tear down the
+/// server.
+#[derive(Clone)]
+pub struct Tmux {
+    cmd_tx: mpsc::UnboundedSender<PendingCommand>,
+    /// Held so we can `kill` on explicit shutdown. Behind `Arc<Mutex>`
+    /// because tasks may call `shutdown` concurrently; at most one
+    /// will actually dispatch the kill.
+    child: Arc<Mutex<Option<Child>>>,
+    /// The reader/writer tasks' join handles. Same reason: exactly
+    /// one shutdown path should await them.
+    tasks: Arc<Mutex<Vec<JoinHandle<()>>>>,
+}
+
+struct PendingCommand {
+    line: String,
+    reply: oneshot::Sender<Result<CommandReply, TmuxError>>,
+}
+
+impl Tmux {
+    /// Spawn `tmux -C -L <socket_name> new-session -d -s <session>
+    /// -x <cols> -y <rows>` and begin the reader/writer tasks.
+    ///
+    /// `socket_name` must not be a path — tmux interprets `-L` as a
+    /// name under `/tmp/tmux-$UID/`. Use `dedicated_socket_name()`
+    /// for the convention.
+    ///
+    /// Returns the client handle plus an mpsc receiver for
+    /// asynchronous notifications (`%output`, `%window-close`,
+    /// ...). The caller is responsible for pumping that receiver;
+    /// if it's dropped, notifications are silently discarded.
+    pub async fn spawn(
+        socket_name: &str,
+        initial_session: &str,
+        cols: u16,
+        rows: u16,
+    ) -> Result<(Self, mpsc::UnboundedReceiver<Notification>), TmuxError> {
+        let mut cmd = Command::new("tmux");
+        cmd.arg("-L")
+            .arg(socket_name)
+            .arg("-C")
+            .arg("new-session")
+            .arg("-d")
+            .arg("-s")
+            .arg(initial_session)
+            .arg("-x")
+            .arg(cols.to_string())
+            .arg("-y")
+            .arg(rows.to_string());
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            // Don't inherit stdin from our process — we're the only
+            // writer, and leaking the parent's stdin could drop
+            // escape sequences into tmux on terminal resizes.
+            .kill_on_drop(true);
+
+        let mut child = cmd.spawn()?;
+        let stdin = child.stdin.take().ok_or(TmuxError::Disconnected)?;
+        let stdout = child.stdout.take().ok_or(TmuxError::Disconnected)?;
+
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<PendingCommand>();
+        let (notif_tx, notif_rx) = mpsc::unbounded_channel::<Notification>();
+        let pending: Arc<Mutex<VecDeque<PendingCommand>>> =
+            Arc::new(Mutex::new(VecDeque::new()));
+
+        let reader_handle =
+            tokio::spawn(run_reader(stdout, notif_tx, Arc::clone(&pending)));
+        let writer_handle = tokio::spawn(run_writer(stdin, cmd_rx, pending));
+
+        Ok((
+            Self {
+                cmd_tx,
+                child: Arc::new(Mutex::new(Some(child))),
+                tasks: Arc::new(Mutex::new(vec![reader_handle, writer_handle])),
+            },
+            notif_rx,
+        ))
+    }
+
+    /// Send one command to tmux and await the reply. `line` must
+    /// not contain a newline — the writer appends `\n` itself.
+    pub async fn send_command(&self, line: &str) -> Result<CommandReply, TmuxError> {
+        if line.contains('\n') {
+            return Err(TmuxError::CommandFailed(
+                "command contains embedded newline".into(),
+            ));
+        }
+        let (reply, rx) = oneshot::channel();
+        self.cmd_tx
+            .send(PendingCommand {
+                line: line.to_string(),
+                reply,
+            })
+            .map_err(|_| TmuxError::Disconnected)?;
+        rx.await.map_err(|_| TmuxError::Disconnected)?
+    }
+
+    /// Kill the tmux subprocess and wait for the reader/writer
+    /// tasks to finish. Idempotent — calling twice is safe; the
+    /// second call no-ops.
+    pub async fn shutdown(&self) {
+        if let Some(mut child) = self.child.lock().await.take() {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+        }
+        let handles = std::mem::take(&mut *self.tasks.lock().await);
+        for h in handles {
+            h.abort();
+            let _ = h.await;
+        }
+    }
+}
+
+/// Build the dedicated tmux socket name. Matches the Node
+/// implementation's `-L katulong` convention so a migrated install
+/// doesn't collide with the user's interactive tmux, and so staging
+/// instances can use per-worktree sockets like `stage-<branch>`.
+pub fn dedicated_socket_name() -> String {
+    "katulong".to_string()
+}
+
+/// In-flight command reply being accumulated by the reader task.
+/// `payload` grows with each `Notification::Payload` seen after
+/// `%begin`; when `%end`/`%error` lands, the stored reply channel
+/// gets the final `CommandReply`.
+struct InFlightReply {
+    payload: Vec<String>,
+    reply: oneshot::Sender<Result<CommandReply, TmuxError>>,
+}
+
+async fn run_reader(
+    stdout: ChildStdout,
+    notifications: mpsc::UnboundedSender<Notification>,
+    pending: Arc<Mutex<VecDeque<PendingCommand>>>,
+) {
+    let mut reader = BufReader::new(stdout).lines();
+    // When we see `%begin`, we pop the next pending command's
+    // oneshot (already FIFO-ordered) and start collecting payload
+    // lines into `current.payload`. `%end` or `%error` resolves
+    // the oneshot.
+    let mut current: Option<InFlightReply> = None;
+
+    while let Ok(Some(line)) = reader.next_line().await {
+        let n = match parse(&line) {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(error = %e, line = %line, "tmux parse error; dropping line");
+                continue;
+            }
+        };
+        match n {
+            Notification::Begin { .. } => {
+                // Pop the oldest pending command — tmux replies in
+                // the order commands were submitted.
+                if let Some(cmd) = pending.lock().await.pop_front() {
+                    current = Some(InFlightReply {
+                        payload: Vec::new(),
+                        reply: cmd.reply,
+                    });
+                } else {
+                    tracing::warn!(
+                        "tmux %begin with no pending command — stream out of sync; discarding reply"
+                    );
+                    current = None;
+                }
+            }
+            Notification::Payload(p) => {
+                if let Some(in_flight) = current.as_mut() {
+                    in_flight.payload.push(p);
+                } else {
+                    tracing::trace!(payload = %p, "tmux payload outside begin/end; discarded");
+                }
+            }
+            Notification::End { .. } | Notification::Error { .. } => {
+                let is_error = matches!(n, Notification::Error { .. });
+                if let Some(in_flight) = current.take() {
+                    let r = CommandReply {
+                        ok: !is_error,
+                        output: in_flight.payload.join("\n"),
+                    };
+                    let _ = in_flight.reply.send(Ok(r));
+                } else {
+                    tracing::warn!(
+                        "tmux %end/%error with no open command — stream out of sync"
+                    );
+                }
+            }
+            other => {
+                // Async notification. Drop on the floor if no one's
+                // listening — that's the mpsc semantics and the
+                // consumer's responsibility to keep up.
+                let _ = notifications.send(other);
+            }
+        }
+    }
+
+    // Stream closed. Fail every pending command with Disconnected.
+    let mut pending = pending.lock().await;
+    while let Some(cmd) = pending.pop_front() {
+        let _ = cmd.reply.send(Err(TmuxError::Disconnected));
+    }
+    if let Some(in_flight) = current.take() {
+        let _ = in_flight.reply.send(Err(TmuxError::Disconnected));
+    }
+}
+
+async fn run_writer(
+    mut stdin: ChildStdin,
+    mut cmd_rx: mpsc::UnboundedReceiver<PendingCommand>,
+    pending: Arc<Mutex<VecDeque<PendingCommand>>>,
+) {
+    while let Some(cmd) = cmd_rx.recv().await {
+        // Register the pending command BEFORE writing, so that if
+        // tmux replies immediately on another task we don't race.
+        let line = cmd.line.clone();
+        let reply = cmd.reply;
+        pending.lock().await.push_back(PendingCommand {
+            line: line.clone(),
+            reply,
+        });
+        if let Err(e) = stdin.write_all(line.as_bytes()).await {
+            let popped = pending.lock().await.pop_back();
+            if let Some(p) = popped {
+                let _ = p.reply.send(Err(TmuxError::Io(e)));
+            }
+            break;
+        }
+        if let Err(e) = stdin.write_all(b"\n").await {
+            let popped = pending.lock().await.pop_back();
+            if let Some(p) = popped {
+                let _ = p.reply.send(Err(TmuxError::Io(e)));
+            }
+            break;
+        }
+        if let Err(e) = stdin.flush().await {
+            // Flush failed — best-effort resolve the just-queued cmd.
+            let popped = pending.lock().await.pop_back();
+            if let Some(p) = popped {
+                let _ = p.reply.send(Err(TmuxError::Io(e)));
+            }
+            break;
+        }
+    }
+    // Channel closed → no more commands coming. Resolve outstanding
+    // pending commands with Disconnected. The reader task will also
+    // see the stdin close and do the same, whichever gets there first
+    // wins.
+    let mut pending = pending.lock().await;
+    while let Some(cmd) = pending.pop_front() {
+        let _ = cmd.reply.send(Err(TmuxError::Disconnected));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn send_command_before_spawn_fails() {
+        // Build a Tmux with a dead channel to exercise the
+        // Disconnected path without needing a real tmux binary.
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let t = Tmux {
+            cmd_tx: tx.clone(),
+            child: Arc::new(Mutex::new(None)),
+            tasks: Arc::new(Mutex::new(vec![])),
+        };
+        drop(tx);
+        drop(_rx);
+        let err = t.send_command("list-sessions").await.unwrap_err();
+        assert!(matches!(err, TmuxError::Disconnected));
+    }
+
+    #[test]
+    fn embedded_newline_is_rejected_without_hitting_tmux() {
+        // The write-a-newline guard must kick in before the mpsc
+        // send — otherwise tmux would see a malformed partial
+        // command.
+        tokio_test::block_on(async {
+            let (tx, _rx) = mpsc::unbounded_channel();
+            let t = Tmux {
+                cmd_tx: tx,
+                child: Arc::new(Mutex::new(None)),
+                tasks: Arc::new(Mutex::new(vec![])),
+            };
+            let err = t
+                .send_command("list-sessions\nkill-server")
+                .await
+                .unwrap_err();
+            assert!(matches!(err, TmuxError::CommandFailed(_)));
+        });
+    }
+
+    #[tokio::test]
+    #[ignore = "requires tmux binary + dedicated socket; run with: cargo test -- --ignored"]
+    async fn tmux_roundtrip() {
+        // Full end-to-end: spawn a tmux control-mode subprocess,
+        // issue `list-sessions`, parse the reply, shutdown.
+        // Skipped in CI because not every environment has tmux
+        // installed, and the test would need a namespace-isolated
+        // socket anyway to not collide with developer tmux.
+        let socket = format!("katulong-test-{}", std::process::id());
+        let (tmux, _notifs) = Tmux::spawn(&socket, "test-session", 80, 24)
+            .await
+            .expect("spawn should succeed when tmux is available");
+        let reply = tmux
+            .send_command("list-sessions -F '#{session_name}'")
+            .await
+            .expect("list-sessions should succeed");
+        assert!(reply.ok, "list-sessions should report %end, not %error");
+        assert!(
+            reply.output.contains("test-session"),
+            "expected our spawned session in list-sessions output: {}",
+            reply.output
+        );
+        tmux.shutdown().await;
+    }
+}


### PR DESCRIPTION
## Summary

Foundation for the terminal stack. Spawns tmux in control mode over a dedicated socket, parses its notification protocol, pairs commands to replies, and exposes a \`SessionManager\` with create/list/destroy/resize. No output streaming, no WS integration — those land in slice 9c/9d.

## Decisions carried from user direction

- **tmux, not portable-pty directly.** tmux manages PTYs for the shells it hosts; we drive it via stdin/stdout. No direct PTY handling in Rust this slice.
- **Dedicated \`tmux -L katulong\` socket** (Node scar \`#629\`) so katulong state never collides with the operator's interactive tmux.
- **Strict dimension discipline** ported wholesale from CLAUDE.md into \`session/dims.rs\`. Module comment is the design doc: no resize on keystroke, no per-client headless (PCH-7 scar), single-PTY-per-session means multi-device = one size.

## Files

- \`session/parser.rs\` — pure parser (%begin/%end/%error/%output/%session-changed/%window-*/%exit + Unknown catch-all). 9 unit tests.
- \`session/tmux.rs\` — \`Tmux\` client: reader + writer tasks, FIFO command/reply pairing, mpsc for async notifications, graceful disconnect. 2 unit tests + 1 \`#[ignore]\`-gated tmux roundtrip.
- \`session/dims.rs\` — MIN/MAX/DEFAULT constants + \`clamp_dims()\`. 2 unit tests.
- \`session/manager.rs\` — \`SessionManager\` (create/list/destroy/resize). Strict session-name allowlist, idempotent destroy. 5 unit tests.

## Test plan

- [x] \`cargo test\` — 138 tests pass, 1 ignored (tmux roundtrip)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] Parser covers all known tmux notification kinds + malformed inputs + unknown-keyword fallthrough
- [x] Name validator rejects tmux target specifiers (\`:\`, \`.\`, \`$\`, \`@\`, \`%\`), whitespace, shell metachars
- [x] Dim clamp respects bounds
- [ ] \`cargo test -- --ignored tmux_roundtrip\` — requires tmux binary; run manually

## Not in this slice

- No \`AppState\` wiring. Slice 9c constructs \`Tmux\` at startup + exposes \`SessionManager\` through state.
- No output streaming. Slice 9c/9d add RingBuffer + \`%output\` pipe to consumers.
- No WS message protocol. Slice 9d.
- No revocation-signal subscription. Slice 9c wires the subscribe-then-validate contract from slice 9a.