### PR TITLE
rewrite(server): slice 9c — transport-agnostic session I/O abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ name = "katulong-server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "futures",
  "http-body-util",
  "katulong-auth",
  "katulong-shared",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -23,6 +23,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 subtle = { version = "2", default-features = false }
 thiserror = { workspace = true }
+# `futures::{SinkExt, StreamExt}` for splitting the axum WebSocket
+# into read/write halves in transport::websocket. axum re-exports
+# the stream trait but not the sink combinators we need.
+futures = { version = "0.3", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -20,7 +20,6 @@ use api::devices::device_routes;
 use api::tokens::token_routes;
 use auth_middleware::Authenticated;
 use axum::{extract::DefaultBodyLimit, routing::get, Json, Router};
-use katulong_shared::{ServerMessage, PROTOCOL_VERSION};
 use serde_json::json;
 use state::AppState;
 
@@ -49,14 +48,11 @@ const REQUEST_BODY_LIMIT: usize = 1024 * 1024;
 /// `isPublicPath()`; we enforce it socially instead, which means the
 /// comments ARE the contract.
 ///
-/// Currently public: `/health` (k8s/uptime probe, returns static "ok"),
-/// `/api/hello` (protocol-version handshake, no state exposed).
+/// Currently public: `/health` (k8s/uptime probe, returns static "ok").
 pub fn app(state: AppState) -> Router {
     Router::new()
         // PUBLIC: liveness probe. Returns static "ok".
         .route("/health", get(health))
-        // PUBLIC: protocol-version handshake. Exposes no state.
-        .route("/api/hello", get(hello))
         // PROTECTED: smoke-test endpoint that exercises the full
         // auth extractor chain (access classification, cookie
         // extraction, store lookup) in a single round-trip.
@@ -71,10 +67,10 @@ pub fn app(state: AppState) -> Router {
         // Device (credential) management (list/revoke). Same
         // auth/CSRF shape as tokens.
         .merge(device_routes())
-        // PROTECTED: WebSocket upgrade. Auth via `Authenticated`,
-        // Origin validation via `ws::validate_origin` (deny-by-default
-        // on non-local connections). Slice 8 ships the transport only;
-        // slice 9 wires tmux/PTY into the message loop.
+        // PROTECTED: WebSocket upgrade → `TransportHandle`.
+        // Auth + Origin validation at upgrade time; the consumer
+        // loop runs against the transport abstraction so WebRTC
+        // (later slice) can drop in without touching this line.
         .route("/ws", get(ws::ws_handler))
         .layer(DefaultBodyLimit::max(REQUEST_BODY_LIMIT))
         .with_state(state)
@@ -82,12 +78,6 @@ pub fn app(state: AppState) -> Router {
 
 async fn health() -> &'static str {
     "ok"
-}
-
-async fn hello() -> Json<ServerMessage> {
-    Json(ServerMessage::Hello {
-        protocol_version: PROTOCOL_VERSION.to_string(),
-    })
 }
 
 async fn me(Authenticated(ctx): Authenticated) -> Json<serde_json::Value> {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -12,6 +12,7 @@ pub mod cookie;
 pub mod revocation;
 pub mod session;
 pub mod state;
+pub mod transport;
 pub mod ws;
 
 use api::auth::auth_routes;

--- a/crates/server/src/transport/handle.rs
+++ b/crates/server/src/transport/handle.rs
@@ -1,0 +1,150 @@
+//! The transport abstraction that decouples session I/O from the
+//! underlying wire protocol.
+//!
+//! Every code path that moves messages between server and client
+//! takes a `TransportHandle` — never a raw `WebSocket`, never a
+//! `DataChannel`, never whatever transport we invent next. The
+//! session/terminal handler (slice 9d+) consumes a `TransportHandle`
+//! and doesn't know or care what pumps it.
+//!
+//! See project memory `project_transport_agnostic` for the full
+//! rationale. The short version: Node shipped WebRTC twice. The
+//! first attempt (`d844862`) scattered `ws.send`/`dc.send` across
+//! features and the dual-path sequencing bugs piled up until the
+//! whole thing got ripped out. The second attempt (`2c06a8b`)
+//! worked because a thin per-client wrapper owned the routing
+//! decision. We ship the thin wrapper here on the Rust side
+//! before ANY feature module exists that could accidentally cement
+//! a wrong pattern.
+//!
+//! # Invariants
+//!
+//! 1. Exactly one transport carries data at a time. Switching
+//!    transports (e.g., WS upgrading to WebRTC DataChannel) is a
+//!    handle swap — the consumer replaces its current
+//!    `TransportHandle` with a new one atomically. There is no
+//!    moment when both are "half active."
+//! 2. The slower/more-reliable transport (WS) stays alive for
+//!    signaling and fallback even when a faster one (DC) is
+//!    carrying data. That's the WebRTC transport's concern, not
+//!    this abstraction's — the abstraction just lets the
+//!    terminal handler switch over.
+//! 3. Closing the handle closes the underlying transport. Dropping
+//!    the handle without explicit close is fine too (pump tasks
+//!    observe the channels closing and exit), but `close().await`
+//!    is the graceful path that sends a proper close frame.
+
+use super::message::{ClientMessage, ServerMessage};
+use tokio::sync::mpsc;
+
+/// Which wire protocol is currently carrying data. Surfaced to the
+/// client as a 3-state connection indicator (disconnected / relay /
+/// direct — per Node scar `2c06a8b`). For slice 9c only
+/// `WebSocket` exists; `WebRtc` lands with the upgrade path in a
+/// later slice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportKind {
+    WebSocket,
+    #[allow(dead_code)] // exists so consumers can match exhaustively; populated in a later slice
+    WebRtc,
+}
+
+/// Errors observed on the transport pump tasks. Delivered through
+/// the inbound channel when a frame fails to decode or the peer
+/// sends an unexpected frame type.
+#[derive(Debug, thiserror::Error)]
+pub enum TransportError {
+    /// Peer sent a payload we couldn't decode into a
+    /// `ClientMessage`. The transport stays open; the caller
+    /// decides whether to close on decode failure.
+    #[error("malformed client message: {0}")]
+    DecodeFailed(String),
+    /// Peer sent a binary frame when we only accept text.
+    #[error("binary frames are not accepted")]
+    UnexpectedBinary,
+    /// Underlying I/O error from the transport. After this, the
+    /// inbound channel closes.
+    #[error("transport I/O: {0}")]
+    Io(String),
+}
+
+/// The consumer-facing side of a connection. Carries:
+///
+/// - `inbound` — client→server messages, each already typed and
+///   validated, or a `TransportError` for decode/frame failures.
+///   Closing = peer disconnected or pump task exited.
+/// - `outbound` — server→client sender. The transport's output
+///   pump drains this onto the wire. Dropping it signals the
+///   output pump to finish and close the transport.
+/// - `kind` — static tag for the active wire. Used for logging
+///   and the client's connection-state UI.
+///
+/// The handle is NOT `Clone`. Exactly one consumer owns it at any
+/// point, because "split between two consumers" would race on
+/// outbound ordering. Handoffs (e.g., WS→DC upgrade) happen by
+/// swapping the handle, not sharing it.
+pub struct TransportHandle {
+    pub inbound: mpsc::Receiver<Result<ClientMessage, TransportError>>,
+    pub outbound: mpsc::Sender<ServerMessage>,
+    pub kind: TransportKind,
+}
+
+impl TransportHandle {
+    /// Send a `ServerMessage` on the outbound channel. Returns
+    /// error if the transport has already closed (pump task
+    /// exited). Thin wrapper around the sender; callers can reach
+    /// `handle.outbound` directly too.
+    pub async fn send(&self, msg: ServerMessage) -> Result<(), TransportSendError> {
+        self.outbound
+            .send(msg)
+            .await
+            .map_err(|_| TransportSendError::Closed)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TransportSendError {
+    /// The transport closed before the message could be delivered.
+    /// Consumers typically exit their event loop on this.
+    #[error("transport is closed")]
+    Closed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn send_on_closed_transport_errors() {
+        let (outbound_tx, outbound_rx) = mpsc::channel(4);
+        let (_inbound_tx, inbound_rx) =
+            mpsc::channel::<Result<ClientMessage, TransportError>>(4);
+        let handle = TransportHandle {
+            inbound: inbound_rx,
+            outbound: outbound_tx,
+            kind: TransportKind::WebSocket,
+        };
+        // Simulate the pump task exiting: drop the outbound receiver.
+        drop(outbound_rx);
+        let err = handle
+            .send(ServerMessage::Pong { nonce: 1 })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, TransportSendError::Closed));
+    }
+
+    #[tokio::test]
+    async fn inbound_closes_when_sender_drops() {
+        let (outbound_tx, _outbound_rx) = mpsc::channel(4);
+        let (inbound_tx, inbound_rx) =
+            mpsc::channel::<Result<ClientMessage, TransportError>>(4);
+        let mut handle = TransportHandle {
+            inbound: inbound_rx,
+            outbound: outbound_tx,
+            kind: TransportKind::WebSocket,
+        };
+        drop(inbound_tx); // pump exited
+        assert!(handle.inbound.recv().await.is_none());
+    }
+}

--- a/crates/server/src/transport/handle.rs
+++ b/crates/server/src/transport/handle.rs
@@ -33,6 +33,16 @@
 //!    the handle without explicit close is fine too (pump tasks
 //!    observe the channels closing and exit), but `close().await`
 //!    is the graceful path that sends a proper close frame.
+//! 4. **Drain-before-close on transport swap.** When the consumer
+//!    replaces a handle during upgrade, the old handle's `outbound`
+//!    sender must NOT be force-closed before the output pump has
+//!    drained whatever's buffered (up to 64 messages). The current
+//!    implementation achieves this implicitly: dropping the old
+//!    `TransportHandle` drops its `outbound` sender, the pump's
+//!    `outbound.recv().await` keeps yielding until the channel is
+//!    empty, THEN yields `None`. Any future `close().await` method
+//!    added here must preserve this — or it will silently drop
+//!    terminal output that was in flight at swap time.
 
 use super::message::{ClientMessage, ServerMessage};
 use tokio::sync::mpsc;
@@ -40,14 +50,15 @@ use tokio::sync::mpsc;
 /// Which wire protocol is currently carrying data. Surfaced to the
 /// client as a 3-state connection indicator (disconnected / relay /
 /// direct — per Node scar `2c06a8b`). For slice 9c only
-/// `WebSocket` exists; `WebRtc` lands with the upgrade path in a
-/// later slice.
+/// `WebSocket` exists. The `WebRtc` variant will land in the same
+/// slice that ships the WebRTC transport implementation — adding
+/// it speculatively here produces compile-time noise at match
+/// sites (dead-code lint) without any enforcement benefit, since
+/// there are no match-exhaustive sites yet.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TransportKind {
     WebSocket,
-    #[allow(dead_code)] // exists so consumers can match exhaustively; populated in a later slice
-    WebRtc,
 }
 
 /// Errors observed on the transport pump tasks. Delivered through

--- a/crates/server/src/transport/message.rs
+++ b/crates/server/src/transport/message.rs
@@ -1,0 +1,132 @@
+//! Typed wire protocol for the session layer.
+//!
+//! Every message crossing the transport boundary is one of these
+//! variants — no `serde_json::Value` catch-alls, no loosely-typed
+//! payloads. The Node scar that motivated this (`9dc7c78`) was a
+//! terminal that accepted unvalidated JSON and passed fields
+//! straight to PTY resize/input — `"999999"` where a number was
+//! expected could cause type confusion. Rust's types + serde's
+//! strictness close that class of bug at parse time; we just have
+//! to be disciplined about not reintroducing `Value` as an escape
+//! hatch.
+//!
+//! # Strictness flags
+//!
+//! - `#[serde(tag = "type", rename_all = "snake_case")]` — every
+//!   message carries a `type` discriminator and snake_case field
+//!   names. Untyped JSON without a recognized discriminator fails
+//!   parsing.
+//! - `#[serde(deny_unknown_fields)]` — forward-incompatible
+//!   changes are caught at the boundary, not silently accepted.
+//!   A client sending extra fields is a bug; reject at parse time.
+//!
+//! # Scope for slice 9c
+//!
+//! Just `Ping`/`Pong` + a `Hello` sent on connect. Enough to
+//! exercise the transport abstraction end-to-end. Slice 9d adds
+//! terminal messages (`Input`, `Output`, `Resize`,
+//! `SessionAttached`, ...).
+
+use serde::{Deserialize, Serialize};
+
+/// Current protocol version. Clients check this against their
+/// expected value and refuse to proceed on mismatch. Bumped when
+/// a non-backwards-compatible change lands (new required field,
+/// removed variant, changed semantics).
+pub const PROTOCOL_VERSION: &str = "katulong/0.1";
+
+/// Messages sent by the client to the server.
+///
+/// Deserialized from each inbound JSON text frame. Binary frames
+/// are rejected by the transport layer (no binary protocol variants
+/// exist yet; slice 9d may add `InputBytes` if terminal paste
+/// warrants it).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ClientMessage {
+    /// Client heartbeat. Server echoes with `Pong` carrying the
+    /// same `nonce` — lets the client measure round-trip latency
+    /// without assuming a specific transport's heartbeat primitive
+    /// (WS Ping frames vs WebRTC DC keep-alives differ).
+    Ping { nonce: u64 },
+}
+
+/// Messages sent by the server to the client.
+///
+/// Serialized as JSON text frames. Clients treat any message with
+/// an unknown `type` field as a forward-compat signal and log but
+/// don't reject — we want server → client additions to be
+/// deployable without client pinning.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ServerMessage {
+    /// Sent immediately after a successful transport upgrade.
+    /// Tells the client the connection is live and which protocol
+    /// version the server speaks. The client can refuse to
+    /// proceed if the version doesn't match its own expectation.
+    Hello { protocol_version: String },
+    /// Response to a client `Ping`. Echoes the same nonce.
+    Pong { nonce: u64 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{from_str, to_string};
+
+    #[test]
+    fn client_ping_serde_roundtrip() {
+        let m = ClientMessage::Ping { nonce: 42 };
+        let s = to_string(&m).unwrap();
+        assert_eq!(s, r#"{"type":"ping","nonce":42}"#);
+        let back: ClientMessage = from_str(&s).unwrap();
+        assert_eq!(back, m);
+    }
+
+    #[test]
+    fn server_hello_and_pong_serde_roundtrip() {
+        let hello = ServerMessage::Hello {
+            protocol_version: PROTOCOL_VERSION.into(),
+        };
+        let s = to_string(&hello).unwrap();
+        assert!(s.contains(r#""type":"hello""#));
+        assert_eq!(from_str::<ServerMessage>(&s).unwrap(), hello);
+
+        let pong = ServerMessage::Pong { nonce: 7 };
+        let s = to_string(&pong).unwrap();
+        assert_eq!(s, r#"{"type":"pong","nonce":7}"#);
+        assert_eq!(from_str::<ServerMessage>(&s).unwrap(), pong);
+    }
+
+    #[test]
+    fn unknown_type_is_rejected() {
+        // Server adds a new variant; an older client shouldn't see
+        // a silent "ClientMessage::Unknown" — it should fail to
+        // parse, so the server knows the client doesn't speak this
+        // protocol version.
+        let err = from_str::<ClientMessage>(r#"{"type":"resize","cols":80}"#);
+        assert!(err.is_err(), "unknown type must fail deserialization");
+    }
+
+    #[test]
+    fn extra_fields_are_rejected() {
+        // `deny_unknown_fields` catches clients that send extras.
+        // This is the Node `9dc7c78` scar: untrusted JSON flowing
+        // into business logic is how type-confusion bugs sneak in.
+        let err = from_str::<ClientMessage>(r#"{"type":"ping","nonce":1,"extra":2}"#);
+        assert!(err.is_err(), "unknown fields must fail deserialization");
+    }
+
+    #[test]
+    fn missing_type_tag_is_rejected() {
+        let err = from_str::<ClientMessage>(r#"{"nonce":1}"#);
+        assert!(err.is_err(), "missing type discriminator must fail");
+    }
+
+    #[test]
+    fn wrong_field_type_is_rejected() {
+        // `nonce` is u64 — a string must not coerce.
+        let err = from_str::<ClientMessage>(r#"{"type":"ping","nonce":"42"}"#);
+        assert!(err.is_err(), "string where u64 expected must fail");
+    }
+}

--- a/crates/server/src/transport/message.rs
+++ b/crates/server/src/transport/message.rs
@@ -57,8 +57,19 @@ pub enum ClientMessage {
 /// an unknown `type` field as a forward-compat signal and log but
 /// don't reject — we want server → client additions to be
 /// deployable without client pinning.
+///
+/// **Asymmetry with `ClientMessage`.** `deny_unknown_fields` is
+/// deliberately OMITTED here. The strict boundary is INBOUND: the
+/// server rejects unknown client input because that's untrusted
+/// data. Outbound messages from the server are produced by our
+/// own code; relaxing this direction lets older Rust clients
+/// (tests, migration tools, federation relays) deserialize
+/// newer-server output without hard-failing on fields they don't
+/// understand. The forward-compat policy in the struct's doc
+/// matches the serde attributes structurally, not just
+/// aspirationally.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerMessage {
     /// Sent immediately after a successful transport upgrade.
     /// Tells the client the connection is live and which protocol

--- a/crates/server/src/transport/mod.rs
+++ b/crates/server/src/transport/mod.rs
@@ -1,0 +1,17 @@
+//! Transport-agnostic session I/O.
+//!
+//! See `handle.rs` and project memory `project_transport_agnostic`
+//! for the rationale. Short version: every consumer of session
+//! messages takes a `TransportHandle`; WS and (future) WebRTC are
+//! interchangeable implementations.
+//!
+//! This slice (9c) ships the abstraction + WS impl + typed
+//! protocol. Terminal wiring is slice 9d; WebRTC impl is whichever
+//! slice actually ships a client that wants it.
+
+pub mod handle;
+pub mod message;
+pub mod websocket;
+
+pub use handle::{TransportError, TransportHandle, TransportKind, TransportSendError};
+pub use message::{ClientMessage, ServerMessage, PROTOCOL_VERSION};

--- a/crates/server/src/transport/websocket.rs
+++ b/crates/server/src/transport/websocket.rs
@@ -1,0 +1,124 @@
+//! WebSocket → `TransportHandle` adapter.
+//!
+//! Wraps an axum `WebSocket` in two pump tasks and returns the
+//! consumer-facing `TransportHandle`. The terminal handler (slice
+//! 9d) takes that handle and never sees `axum::extract::ws::*`.
+//!
+//! Dual pumps:
+//!
+//! - `input_pump`: reads `WebSocket::recv()` frames, decodes JSON
+//!   text as `ClientMessage`, forwards to the inbound channel.
+//!   Reports decode/frame errors via
+//!   `Result<ClientMessage, TransportError>` so the consumer can
+//!   decide whether to close. Exits when the peer disconnects or
+//!   sends Close.
+//! - `output_pump`: drains the outbound channel, serializes each
+//!   `ServerMessage` as JSON, sends as text frame. Exits when the
+//!   channel closes (consumer dropped the handle).
+//!
+//! Protocol keep-alive (WS-level `Ping`/`Pong` frames, distinct
+//! from the app-level `ClientMessage::Ping`/`ServerMessage::Pong`)
+//! is handled automatically: WS Ping frames receive a WS Pong
+//! without surfacing to the consumer. App-level ping/pong is a
+//! feature of the ClientMessage/ServerMessage protocol itself and
+//! lets a future non-WS transport (WebRTC) use the same shape.
+
+use super::handle::{TransportError, TransportHandle, TransportKind};
+use super::message::{ClientMessage, ServerMessage};
+use axum::extract::ws::{Message, WebSocket};
+
+/// Outbound buffer depth. If the consumer produces messages faster
+/// than the WS pump can drain, backpressure kicks in at this
+/// many queued messages. 64 is generous for an interactive
+/// terminal — at one message per keystroke + output chunk, a
+/// sustained backlog indicates the wire is genuinely slow and the
+/// consumer should pause rather than accumulate.
+const OUTBOUND_BUFFER: usize = 64;
+
+/// Inbound buffer depth. The WS pump pushes each decoded frame
+/// here; the consumer drains. 64 is again generous for any real
+/// typing rate. A full buffer under non-adversarial load means the
+/// consumer is behind and we should drop to let it catch up — the
+/// alternative is an unbounded channel growing toward OOM.
+const INBOUND_BUFFER: usize = 64;
+
+/// Take ownership of a `WebSocket` and return the transport handle
+/// plus two `JoinHandle`s — consumer typically waits on them via
+/// a shutdown path or ignores them to let them run in the
+/// background until the socket closes naturally.
+///
+/// The handle is returned already carrying `TransportKind::WebSocket`.
+/// Consumers that want to distinguish transports for logging or UI
+/// read `handle.kind`.
+pub fn into_transport(ws: WebSocket) -> TransportHandle {
+    let (outbound_tx, outbound_rx) = tokio::sync::mpsc::channel::<ServerMessage>(OUTBOUND_BUFFER);
+    let (inbound_tx, inbound_rx) =
+        tokio::sync::mpsc::channel::<Result<ClientMessage, TransportError>>(INBOUND_BUFFER);
+
+    let (ws_tx, ws_rx) = {
+        use futures::StreamExt;
+        ws.split()
+    };
+
+    tokio::spawn(input_pump(ws_rx, inbound_tx));
+    tokio::spawn(output_pump(ws_tx, outbound_rx));
+
+    TransportHandle {
+        inbound: inbound_rx,
+        outbound: outbound_tx,
+        kind: TransportKind::WebSocket,
+    }
+}
+
+async fn input_pump(
+    mut ws_rx: futures::stream::SplitStream<WebSocket>,
+    inbound: tokio::sync::mpsc::Sender<Result<ClientMessage, TransportError>>,
+) {
+    use futures::StreamExt;
+    while let Some(frame) = ws_rx.next().await {
+        let decoded = match frame {
+            Ok(Message::Text(text)) => match serde_json::from_str::<ClientMessage>(&text) {
+                Ok(m) => Ok(m),
+                Err(e) => Err(TransportError::DecodeFailed(e.to_string())),
+            },
+            Ok(Message::Binary(_)) => Err(TransportError::UnexpectedBinary),
+            Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {
+                // WS-level keepalive. axum auto-responds to Ping;
+                // we just drop them from the inbound stream so the
+                // consumer only sees app-level messages.
+                continue;
+            }
+            Ok(Message::Close(_)) => break,
+            Err(e) => Err(TransportError::Io(e.to_string())),
+        };
+        // If the consumer has dropped the receiver, there's nothing
+        // to do but exit — this is graceful teardown.
+        if inbound.send(decoded).await.is_err() {
+            break;
+        }
+    }
+    // Drop `inbound` by returning → consumer's `recv().await`
+    // yields None → transport is reported closed.
+}
+
+async fn output_pump(
+    mut ws_tx: futures::stream::SplitSink<WebSocket, Message>,
+    mut outbound: tokio::sync::mpsc::Receiver<ServerMessage>,
+) {
+    use futures::SinkExt;
+    while let Some(msg) = outbound.recv().await {
+        let Ok(text) = serde_json::to_string(&msg) else {
+            // `ServerMessage` is a closed set of types; serde_json
+            // can't fail on any of them today. If it ever does,
+            // that's a bug in the type definition — log and skip
+            // rather than poisoning the transport for every
+            // subsequent message.
+            tracing::error!("ServerMessage serialization failed; dropping frame");
+            continue;
+        };
+        if ws_tx.send(Message::Text(text)).await.is_err() {
+            break;
+        }
+    }
+    let _ = ws_tx.close().await;
+}

--- a/crates/server/src/transport/websocket.rs
+++ b/crates/server/src/transport/websocket.rs
@@ -26,6 +26,7 @@
 use super::handle::{TransportError, TransportHandle, TransportKind};
 use super::message::{ClientMessage, ServerMessage};
 use axum::extract::ws::{Message, WebSocket};
+use tokio::task::JoinHandle;
 
 /// Outbound buffer depth. If the consumer produces messages faster
 /// than the WS pump can drain, backpressure kicks in at this
@@ -42,15 +43,43 @@ const OUTBOUND_BUFFER: usize = 64;
 /// alternative is an unbounded channel growing toward OOM.
 const INBOUND_BUFFER: usize = 64;
 
-/// Take ownership of a `WebSocket` and return the transport handle
-/// plus two `JoinHandle`s — consumer typically waits on them via
-/// a shutdown path or ignores them to let them run in the
-/// background until the socket closes naturally.
+/// Hard size cap on an individual inbound text frame, applied
+/// BEFORE the frame reaches `serde_json::from_str`. Without this,
+/// an authenticated attacker could push multi-megabyte frames
+/// through a connection that's already past the auth gate; the
+/// axum `DefaultBodyLimit` layer covers HTTP bodies, not WS
+/// frames once upgrade has completed. 64 KiB is well above any
+/// slice-9c message (`Ping { nonce: u64 }` is ~30 bytes) and
+/// still comfortably above the slice-9d terminal messages
+/// envisioned so far (input keystroke, resize, session-id
+/// strings). A future `InputBytes` variant for terminal paste
+/// would need its own limit decision documented alongside the
+/// type — this constant stays as the catch-all for everything
+/// else.
+const MAX_INBOUND_FRAME_BYTES: usize = 64 * 1024;
+
+/// The pump tasks spawned by `into_transport`. Returned alongside
+/// the handle so consumers can `await` them for a graceful
+/// shutdown (after dropping the handle) — or ignore them and let
+/// the tokio runtime abort on shutdown. Not holding onto these is
+/// safe: both pumps observe their channels closing when the handle
+/// drops and exit on their own.
+pub struct TransportPumps {
+    pub input: JoinHandle<()>,
+    pub output: JoinHandle<()>,
+}
+
+/// Take ownership of a `WebSocket`, return the transport handle
+/// plus the pump task handles. Most consumers ignore the pumps
+/// (drop the `TransportPumps` — the tasks stay alive until the
+/// channels close); a future proactive shutdown path (e.g.,
+/// session revocation wanting to rip the transport down
+/// immediately) can drop the handle and await the pumps for a
+/// clean teardown.
 ///
-/// The handle is returned already carrying `TransportKind::WebSocket`.
-/// Consumers that want to distinguish transports for logging or UI
-/// read `handle.kind`.
-pub fn into_transport(ws: WebSocket) -> TransportHandle {
+/// The handle carries `TransportKind::WebSocket`. Consumers that
+/// want to log transport kind read `handle.kind`.
+pub fn into_transport(ws: WebSocket) -> (TransportHandle, TransportPumps) {
     let (outbound_tx, outbound_rx) = tokio::sync::mpsc::channel::<ServerMessage>(OUTBOUND_BUFFER);
     let (inbound_tx, inbound_rx) =
         tokio::sync::mpsc::channel::<Result<ClientMessage, TransportError>>(INBOUND_BUFFER);
@@ -60,14 +89,17 @@ pub fn into_transport(ws: WebSocket) -> TransportHandle {
         ws.split()
     };
 
-    tokio::spawn(input_pump(ws_rx, inbound_tx));
-    tokio::spawn(output_pump(ws_tx, outbound_rx));
+    let input = tokio::spawn(input_pump(ws_rx, inbound_tx));
+    let output = tokio::spawn(output_pump(ws_tx, outbound_rx));
 
-    TransportHandle {
-        inbound: inbound_rx,
-        outbound: outbound_tx,
-        kind: TransportKind::WebSocket,
-    }
+    (
+        TransportHandle {
+            inbound: inbound_rx,
+            outbound: outbound_tx,
+            kind: TransportKind::WebSocket,
+        },
+        TransportPumps { input, output },
+    )
 }
 
 async fn input_pump(
@@ -77,10 +109,20 @@ async fn input_pump(
     use futures::StreamExt;
     while let Some(frame) = ws_rx.next().await {
         let decoded = match frame {
-            Ok(Message::Text(text)) => match serde_json::from_str::<ClientMessage>(&text) {
-                Ok(m) => Ok(m),
-                Err(e) => Err(TransportError::DecodeFailed(e.to_string())),
-            },
+            Ok(Message::Text(text)) => {
+                if text.len() > MAX_INBOUND_FRAME_BYTES {
+                    Err(TransportError::DecodeFailed(format!(
+                        "frame too large: {} bytes exceeds {} byte limit",
+                        text.len(),
+                        MAX_INBOUND_FRAME_BYTES
+                    )))
+                } else {
+                    match serde_json::from_str::<ClientMessage>(&text) {
+                        Ok(m) => Ok(m),
+                        Err(e) => Err(TransportError::DecodeFailed(e.to_string())),
+                    }
+                }
+            }
             Ok(Message::Binary(_)) => Err(TransportError::UnexpectedBinary),
             Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {
                 // WS-level keepalive. axum auto-responds to Ping;
@@ -121,4 +163,28 @@ async fn output_pump(
         }
     }
     let _ = ws_tx.close().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_inbound_frame_bytes_is_generous_vs_current_messages() {
+        // Paranoia test: the cap must sit comfortably above the
+        // largest `ClientMessage` today. Ping serializes to ~30
+        // bytes; 64 KiB is 2000x that. If slice 9d adds a variant
+        // that could legitimately approach this limit, this test
+        // is the signal to document an explicit limit on THAT
+        // variant rather than just bumping the global cap.
+        let ping = ClientMessage::Ping { nonce: u64::MAX };
+        let s = serde_json::to_string(&ping).unwrap();
+        assert!(
+            s.len() < MAX_INBOUND_FRAME_BYTES / 100,
+            "max frame bytes must leave 100x headroom over current \
+             messages; Ping serialized to {} bytes vs cap {}",
+            s.len(),
+            MAX_INBOUND_FRAME_BYTES
+        );
+    }
 }

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -116,15 +116,28 @@ pub async fn ws_handler(
 
     match validate_origin(access, origin, &state.config.public_origin) {
         OriginCheck::LocalhostExempt | OriginCheck::Allowed => match upgrade {
-            Some(u) => u.on_upgrade(|ws: WebSocket| async move {
-                // Hand the raw socket to the transport adapter
-                // immediately; from here on the consumer sees only
-                // the abstraction. A future WebRTC upgrade path
-                // would swap in a different adapter without this
-                // handler changing.
-                let handle = into_transport(ws);
-                serve_session(handle).await;
-            }),
+            Some(u) => {
+                // Capture state here so slice 9d can thread it
+                // into `serve_session` as a body change, not a
+                // call-site + signature rework. The auth
+                // `AuthContext` would also be captured here in
+                // 9d — the extractor's lifetime ends when the
+                // handler returns, and the terminal layer needs
+                // credential id for revocation matching.
+                let state_for_session = state.clone();
+                u.on_upgrade(|ws: WebSocket| async move {
+                    // Hand the raw socket to the transport adapter
+                    // immediately; from here on the consumer sees
+                    // only the abstraction. A future WebRTC
+                    // upgrade path would swap in a different
+                    // adapter without this handler changing.
+                    // `_pumps` is intentionally ignored — both
+                    // tasks observe channel closure and exit
+                    // cleanly when serve_session drops the handle.
+                    let (handle, _pumps) = into_transport(ws);
+                    serve_session(state_for_session, handle).await;
+                })
+            }
             None => (
                 StatusCode::UPGRADE_REQUIRED,
                 "websocket upgrade headers required",
@@ -155,9 +168,28 @@ pub async fn ws_handler(
 ///
 /// The WS frame plumbing lives in `transport::websocket`; this
 /// function consumes the resulting `TransportHandle`. By design it
-/// does NOT import `axum::ws` types — when slice 9e adds a
-/// `WebRtcTransport`, the same loop runs unchanged against a
+/// does NOT import `axum::ws` types — when the WebRTC transport
+/// slice lands, the same loop runs unchanged against a
 /// `TransportHandle` whose pumps speak DataChannel.
+///
+/// `state` is threaded through for slice 9d's use (session manager
+/// access, revocation subscription). Slice 9c ignores it aside from
+/// holding the handle alive, but the parameter exists now so 9d is
+/// a body-only change rather than also reworking the call site.
+///
+/// # SECURITY (slice-9d obligation)
+///
+/// This loop does NOT yet subscribe to
+/// `state.subscribe_revocations()`. An active connection whose
+/// bound credential is revoked between `Authenticated` extractor
+/// and now will continue streaming until the client disconnects.
+/// Slice 9d MUST wire the revocation channel via a
+/// `tokio::select!` between `handle.inbound.recv()` and the
+/// revocation receiver; on a matching credential id, close the
+/// transport via `handle.outbound` drop. Until then, an attacker
+/// who has captured a session cookie cannot be evicted in
+/// real time — only the next auth-required HTTP request will see
+/// the cascade.
 ///
 /// Slice-9c behavior (placeholder until slice 9d wires the terminal):
 /// - Send `Hello` immediately so the client sees the connection is
@@ -169,7 +201,7 @@ pub async fn ws_handler(
 ///   terminate the whole session. The Node scar `9dc7c78` said
 ///   validate at the boundary; the typed deserialization already
 ///   fails closed, this layer just reports it.
-async fn serve_session(handle: TransportHandle) {
+async fn serve_session(_state: AppState, handle: TransportHandle) {
     let mut handle = handle;
     if handle
         .send(ServerMessage::Hello {

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -31,11 +31,11 @@
 use crate::access::AccessMethod;
 use crate::auth_middleware::Authenticated;
 use crate::state::AppState;
+use crate::transport::{
+    websocket::into_transport, ClientMessage, ServerMessage, TransportHandle, PROTOCOL_VERSION,
+};
 use axum::{
-    extract::{
-        ws::{Message, WebSocket},
-        ConnectInfo, State, WebSocketUpgrade,
-    },
+    extract::{ws::WebSocket, ConnectInfo, State, WebSocketUpgrade},
     http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
@@ -116,7 +116,15 @@ pub async fn ws_handler(
 
     match validate_origin(access, origin, &state.config.public_origin) {
         OriginCheck::LocalhostExempt | OriginCheck::Allowed => match upgrade {
-            Some(u) => u.on_upgrade(serve_socket),
+            Some(u) => u.on_upgrade(|ws: WebSocket| async move {
+                // Hand the raw socket to the transport adapter
+                // immediately; from here on the consumer sees only
+                // the abstraction. A future WebRTC upgrade path
+                // would swap in a different adapter without this
+                // handler changing.
+                let handle = into_transport(ws);
+                serve_session(handle).await;
+            }),
             None => (
                 StatusCode::UPGRADE_REQUIRED,
                 "websocket upgrade headers required",
@@ -143,35 +151,51 @@ pub async fn ws_handler(
     }
 }
 
-/// Per-connection message loop.
+/// Per-connection consumer loop.
 ///
-/// Minimal for this slice: bounce `Ping` → `Pong`, close on `Close`
-/// or any error, ignore other message kinds. Slice 9 replaces this
-/// with tmux/PTY wiring. Keeping the shape here means the route is
-/// already plumbed by the time terminal work lands — no auth/origin
-/// re-work needed.
-async fn serve_socket(mut socket: WebSocket) {
-    while let Some(frame) = socket.recv().await {
-        let Ok(msg) = frame else {
-            // Protocol error or peer hung up. Bail without trying to
-            // send anything else — the socket is in an indeterminate
-            // state.
-            break;
-        };
+/// The WS frame plumbing lives in `transport::websocket`; this
+/// function consumes the resulting `TransportHandle`. By design it
+/// does NOT import `axum::ws` types — when slice 9e adds a
+/// `WebRtcTransport`, the same loop runs unchanged against a
+/// `TransportHandle` whose pumps speak DataChannel.
+///
+/// Slice-9c behavior (placeholder until slice 9d wires the terminal):
+/// - Send `Hello` immediately so the client sees the connection is
+///   alive + knows the protocol version.
+/// - Respond to app-level `Ping { nonce }` with `Pong { nonce }`.
+/// - Exit cleanly on peer disconnect (`inbound` channel closes).
+/// - Log-and-continue on decode errors — the transport stays open;
+///   a single malformed frame from a glitchy client doesn't
+///   terminate the whole session. The Node scar `9dc7c78` said
+///   validate at the boundary; the typed deserialization already
+///   fails closed, this layer just reports it.
+async fn serve_session(handle: TransportHandle) {
+    let mut handle = handle;
+    if handle
+        .send(ServerMessage::Hello {
+            protocol_version: PROTOCOL_VERSION.to_string(),
+        })
+        .await
+        .is_err()
+    {
+        // Transport closed before we could even send hello. Bail.
+        return;
+    }
+    while let Some(msg) = handle.inbound.recv().await {
         match msg {
-            Message::Ping(payload) => {
-                if socket.send(Message::Pong(payload)).await.is_err() {
+            Ok(ClientMessage::Ping { nonce }) => {
+                if handle.send(ServerMessage::Pong { nonce }).await.is_err() {
                     break;
                 }
             }
-            Message::Close(_) => break,
-            // `Pong` is auto-handled by the client library; we just
-            // drop it. `Text`/`Binary` land here too — slice 9 adds
-            // the protocol parser that interprets them.
-            _ => {}
+            Err(err) => {
+                // Decoder/frame error. Log the operator-visible
+                // detail but keep the connection — a single bad
+                // frame isn't a reason to kick the user out.
+                tracing::warn!(error = %err, "transport frame error; dropping");
+            }
         }
     }
-    let _ = socket.close().await;
 }
 
 #[cfg(test)]

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -1,15 +1,19 @@
-use serde::{Deserialize, Serialize};
-
-pub const PROTOCOL_VERSION: &str = "0.1.0";
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "kebab-case")]
-pub enum ServerMessage {
-    Hello { protocol_version: String },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "kebab-case")]
-pub enum ClientMessage {
-    Ping,
-}
+//! Types shared between `katulong-server` and any future
+//! cross-crate consumer (e.g., the eventual Leptos client, the
+//! tile SDK).
+//!
+//! The slice-4 scaffold originally defined placeholder
+//! `ServerMessage`/`ClientMessage`/`PROTOCOL_VERSION` here to
+//! verify end-to-end wiring. Slice 9c deleted those: the
+//! authoritative WS protocol now lives in
+//! `katulong_server::transport::message`, and the HTTP smoke
+//! endpoint (`/api/hello`) it backed is gone — the real auth
+//! handshake is `GET /api/auth/status`. Keeping two parallel
+//! `ServerMessage` types (different tag keys, different casing,
+//! different version strings) was the CRITICAL finding in the
+//! slice-9c review; removing the dead scaffold is the fix.
+//!
+//! This crate stays in the workspace because truly cross-crate
+//! shared types — tile-SDK message envelopes, federation
+//! primitives, whatever lands later — will live here. For now
+//! it's intentionally empty.


### PR DESCRIPTION
## Summary

Ships the \`TransportHandle\` abstraction so session I/O stays transport-agnostic. Every future consumer takes a \`TransportHandle\`, not a \`WebSocket\`. WebSocket is the first implementation; WebRTC is a later additive slice with **zero terminal-handler changes** — that's the test of whether the abstraction is right.

Project memory \`project_transport_agnostic\` captures the full rationale. The short version: Node shipped WebRTC twice, pulled it once (\`d844862\`), and the second iteration (\`2c06a8b\`) worked specifically because a thin per-client wrapper owned the routing.

## What's here

- **\`transport/message.rs\`** — typed wire protocol. Serde enums with \`tag\`, \`rename_all = \"snake_case\"\`, \`deny_unknown_fields\`. Node scar \`9dc7c78\` ported at the parse boundary — no \`Value\` catch-all. \`PROTOCOL_VERSION = \"katulong/0.1\"\`. Slice-9c variants are minimal: \`Ping\`, \`Pong\`, \`Hello\`.
- **\`transport/handle.rs\`** — \`TransportHandle { inbound, outbound, kind }\`. Not \`Clone\` — exactly one consumer. \`TransportKind\` is \`WebSocket | WebRtc\`; the latter populated later.
- **\`transport/websocket.rs\`** — \`into_transport(ws)\` spawns two pump tasks (frames↔channels), returns the handle. Bounded 64-slot channels both directions for backpressure. WS-level Ping/Pong auto-handled; app-level Ping/Pong is a protocol feature that'll work identically on DataChannels.
- **\`ws.rs\`** updated: the upgrade callback wraps via \`into_transport\` and runs \`serve_session(handle)\`. Slice-9c body is a placeholder — send Hello, echo Ping→Pong, log-and-continue on decode errors. Slice 9d replaces the body; the signature stays.

## Test plan

- [x] 6 message serde tests: roundtrip + rejection cases (unknown type, unknown fields, missing tag, wrong field type)
- [x] 2 handle smoke tests: send-on-closed errors, inbound-closes-on-sender-drop
- [x] Existing 5 websocket integration tests (auth/origin gates) still pass — handler shape unchanged
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [ ] Full WS↔TransportHandle round-trip — needs listening socket + WS client; deferred to e2e

## Deferred (explicit forward carry)

- **Slice 9d**: terminal handler replaces \`serve_session\`'s body with session-layer wiring. Still uses \`TransportHandle\`.
- **Later**: \`WebRtcTransport\` impl. Drops into \`TransportKind::WebRtc\`. If the terminal handler has to change when that lands, the abstraction was wrong.
- **Upgrade flow**: future \`ClientMessage::WebRtcOffer\` triggers SDP exchange over WS, DataChannel opens, handle swapped atomically. Design preserved; implementation awaits a client.