### PR TITLE
rewrite(server): slice 9d — CBOR over the wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ name = "katulong-server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "ciborium",
  "futures",
  "http-body-util",
  "katulong-auth",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -27,6 +27,14 @@ thiserror = { workspace = true }
 # into read/write halves in transport::websocket. axum re-exports
 # the stream trait but not the sink combinators we need.
 futures = { version = "0.3", default-features = false, features = ["std"] }
+# CBOR wire format for session I/O. Uniform binary over both WS and
+# WebRTC DataChannel; no base64 overhead, self-describing for
+# schema evolution. `ciborium` is pure Rust, well-maintained, and
+# integrates with serde (same derives as serde_json). `serde_json`
+# stays in the dep tree because the HTTP API (cookies, error
+# envelopes, tokens, devices) still speaks JSON — CBOR is
+# session-layer only.
+ciborium = "0.2"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/server/src/transport/handle.rs
+++ b/crates/server/src/transport/handle.rs
@@ -71,9 +71,13 @@ pub enum TransportError {
     /// decides whether to close on decode failure.
     #[error("malformed client message: {0}")]
     DecodeFailed(String),
-    /// Peer sent a binary frame when we only accept text.
-    #[error("binary frames are not accepted")]
-    UnexpectedBinary,
+    /// Peer sent a text frame when we accept only CBOR-encoded
+    /// binary. Distinct from `DecodeFailed` because a text frame
+    /// is the right-shape-wrong-encoding case — often a
+    /// wrong-client-version probe rather than corruption. The WS
+    /// impl rejects text frames without attempting to decode.
+    #[error("text frames are not accepted; protocol is CBOR over binary frames")]
+    UnexpectedText,
     /// Underlying I/O error from the transport. After this, the
     /// inbound channel closes.
     #[error("transport I/O: {0}")]

--- a/crates/server/src/transport/handle.rs
+++ b/crates/server/src/transport/handle.rs
@@ -7,6 +7,20 @@
 //! session/terminal handler (slice 9d+) consumes a `TransportHandle`
 //! and doesn't know or care what pumps it.
 //!
+//! # Encoding convention (binding for all implementations)
+//!
+//! While `TransportHandle` moves typed `ClientMessage` /
+//! `ServerMessage` values (encoding-agnostic at the handle
+//! boundary), every wire implementation MUST encode them as CBOR.
+//! WS uses binary frames carrying CBOR; WebRTC DataChannel will
+//! use the same; any future transport (raw TLS, QUIC, whatever)
+//! picks up the same convention. This keeps tooling, test
+//! fixtures, and operator debugging uniform across transports —
+//! see slice 9d's module doc in `transport/websocket.rs` for the
+//! full rationale. If a future transport has a structural reason
+//! to diverge, revisit this invariant explicitly; don't quietly
+//! pick a different codec.
+//!
 //! See project memory `project_transport_agnostic` for the full
 //! rationale. The short version: Node shipped WebRTC twice. The
 //! first attempt (`d844862`) scattered `ws.send`/`dc.send` across

--- a/crates/server/src/transport/message.rs
+++ b/crates/server/src/transport/message.rs
@@ -46,10 +46,10 @@ pub const PROTOCOL_VERSION: &str = "katulong/0.1";
 
 /// Messages sent by the client to the server.
 ///
-/// Deserialized from each inbound JSON text frame. Binary frames
-/// are rejected by the transport layer (no binary protocol variants
-/// exist yet; slice 9d may add `InputBytes` if terminal paste
-/// warrants it).
+/// Deserialized from each inbound CBOR binary frame. Text frames
+/// are rejected by the transport layer. Byte payloads (terminal
+/// input, future image paste) carry directly via CBOR's byte-
+/// string type — no base64 wrapper needed.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum ClientMessage {
@@ -62,10 +62,22 @@ pub enum ClientMessage {
 
 /// Messages sent by the server to the client.
 ///
-/// Serialized as JSON text frames. Clients treat any message with
+/// Serialized as CBOR binary frames. Clients treat any message with
 /// an unknown `type` field as a forward-compat signal and log but
 /// don't reject — we want server → client additions to be
 /// deployable without client pinning.
+///
+/// **Slice-9e note on byte-heavy variants.** When `Output { data:
+/// Vec<u8>, ... }` lands, CBOR encodes it as a map with a byte-
+/// string field — low overhead per frame (the `type` key + map
+/// structure is a few bytes). That's fine IF the session layer
+/// coalesces output into chunks above ~256 bytes before sending.
+/// If it forwards one-escape-per-frame from tmux, the map-per-
+/// message overhead becomes measurable. The existing
+/// `d311168`/`066dab2` Node scars (2 ms idle / 16 ms cap
+/// coalescing) are the right defense; they sit in the session
+/// layer, not here. Just: don't let 9e ship an uncoalesced
+/// per-frame-per-escape output path and blame the encoding.
 ///
 /// **Asymmetry with `ClientMessage`.** `deny_unknown_fields` is
 /// deliberately OMITTED here. The strict boundary is INBOUND: the

--- a/crates/server/src/transport/message.rs
+++ b/crates/server/src/transport/message.rs
@@ -10,22 +10,31 @@
 //! to be disciplined about not reintroducing `Value` as an escape
 //! hatch.
 //!
+//! # Wire format: CBOR
+//!
+//! Messages encode via CBOR (`ciborium`) into binary frames. JSON
+//! is used only for the HTTP API (cookies, error envelopes, token
+//! CRUD). See `transport::websocket` for the wire-level rationale
+//! — tl;dr: uniform binary over both WS and WebRTC DataChannel, no
+//! base64 overhead for byte payloads, smaller wire, same serde
+//! derives.
+//!
 //! # Strictness flags
 //!
 //! - `#[serde(tag = "type", rename_all = "snake_case")]` — every
 //!   message carries a `type` discriminator and snake_case field
-//!   names. Untyped JSON without a recognized discriminator fails
-//!   parsing.
-//! - `#[serde(deny_unknown_fields)]` — forward-incompatible
-//!   changes are caught at the boundary, not silently accepted.
-//!   A client sending extra fields is a bug; reject at parse time.
+//!   names. Missing discriminator fails parsing.
+//! - `#[serde(deny_unknown_fields)]` on `ClientMessage` only —
+//!   inbound strictness is a security property; outbound
+//!   `ServerMessage` stays lenient so older Rust consumers (tests,
+//!   federation relays) can deserialize newer-server output
+//!   without hard-failing on unknown fields.
 //!
-//! # Scope for slice 9c
+//! # Scope for slice 9c/9d
 //!
-//! Just `Ping`/`Pong` + a `Hello` sent on connect. Enough to
-//! exercise the transport abstraction end-to-end. Slice 9d adds
-//! terminal messages (`Input`, `Output`, `Resize`,
-//! `SessionAttached`, ...).
+//! Just `Ping`/`Pong` + `Hello`. Enough to exercise the transport
+//! abstraction end-to-end. Slice 9e adds terminal messages
+//! (`Input`, `Output`, `Resize`, `SessionAttached`, ...).
 
 use serde::{Deserialize, Serialize};
 
@@ -82,6 +91,12 @@ pub enum ServerMessage {
 
 #[cfg(test)]
 mod tests {
+    // Most tests here use JSON as the serialization medium because
+    // it's human-readable in assertions — but the production wire
+    // is CBOR. The serde attributes under test (`tag`,
+    // `deny_unknown_fields`, etc.) are format-agnostic, so a serde
+    // behavior proven with JSON also holds on CBOR. Two CBOR
+    // roundtrip tests at the end lock in the production encoding.
     use super::*;
     use serde_json::{from_str, to_string};
 
@@ -139,5 +154,34 @@ mod tests {
         // `nonce` is u64 — a string must not coerce.
         let err = from_str::<ClientMessage>(r#"{"type":"ping","nonce":"42"}"#);
         assert!(err.is_err(), "string where u64 expected must fail");
+    }
+
+    #[test]
+    fn cbor_client_message_roundtrip() {
+        // Production-wire check. CBOR is what actually rides the
+        // transport; JSON is only the test-readability medium for
+        // the other cases in this module.
+        let original = ClientMessage::Ping { nonce: 0xDEAD_BEEF };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&original, &mut buf).unwrap();
+        let back: ClientMessage = ciborium::de::from_reader(&buf[..]).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn cbor_server_message_roundtrip() {
+        let original = ServerMessage::Hello {
+            protocol_version: PROTOCOL_VERSION.to_string(),
+        };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&original, &mut buf).unwrap();
+        let back: ServerMessage = ciborium::de::from_reader(&buf[..]).unwrap();
+        assert_eq!(back, original);
+
+        let original = ServerMessage::Pong { nonce: 17 };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&original, &mut buf).unwrap();
+        let back: ServerMessage = ciborium::de::from_reader(&buf[..]).unwrap();
+        assert_eq!(back, original);
     }
 }

--- a/crates/server/src/transport/websocket.rs
+++ b/crates/server/src/transport/websocket.rs
@@ -149,6 +149,10 @@ async fn input_pump(
             // Text frames are rejected: CBOR is the sole wire format.
             // A client sending text is either wrong-version or
             // probing; reject cleanly and let the consumer decide.
+            // This rejection is permanent — if a future debug
+            // surface wants human-readable wire traffic, it lives
+            // as a separate HTTP route (e.g. `/api/debug/ws-trace`),
+            // not as a mode flag on the session transport.
             Ok(Message::Text(_)) => Err(TransportError::UnexpectedText),
             Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {
                 // WS-level keepalive. axum auto-responds to Ping;
@@ -222,6 +226,17 @@ mod tests {
         // benefit we're trading JSON readability for actually
         // shows up. If this ever fails, CBOR encoding changed
         // behavior and the trade needs re-examination.
+        //
+        // NOTE: CBOR integer encoding scales with the magnitude
+        // of the value (a 1-byte header + up to 8 payload bytes
+        // for u64::MAX). JSON encodes integers as ASCII digits
+        // (20 chars for u64::MAX). At `nonce: 42` CBOR is
+        // unambiguously smaller; for very large nonces CBOR's
+        // 9-byte integer vs JSON's 20-char digit string still
+        // favors CBOR, but the margin shrinks. Keep the test
+        // value small so the assertion stays a clean statement
+        // about the encoding's typical shape, not a claim about
+        // every u64 value.
         let ping = ClientMessage::Ping { nonce: 42 };
         let mut cbor = Vec::new();
         ciborium::ser::into_writer(&ping, &mut cbor).unwrap();

--- a/crates/server/src/transport/websocket.rs
+++ b/crates/server/src/transport/websocket.rs
@@ -1,27 +1,54 @@
-//! WebSocket → `TransportHandle` adapter.
+//! WebSocket → `TransportHandle` adapter with CBOR wire format.
 //!
 //! Wraps an axum `WebSocket` in two pump tasks and returns the
-//! consumer-facing `TransportHandle`. The terminal handler (slice
-//! 9d) takes that handle and never sees `axum::extract::ws::*`.
+//! consumer-facing `TransportHandle`. The terminal handler takes
+//! that handle and never sees `axum::extract::ws::*`.
 //!
-//! Dual pumps:
+//! # Why CBOR, not JSON
 //!
-//! - `input_pump`: reads `WebSocket::recv()` frames, decodes JSON
-//!   text as `ClientMessage`, forwards to the inbound channel.
-//!   Reports decode/frame errors via
-//!   `Result<ClientMessage, TransportError>` so the consumer can
-//!   decide whether to close. Exits when the peer disconnects or
-//!   sends Close.
+//! katulong is one-user-many-devices and performance-sensitive
+//! (the whole WS → WebRTC progressive enhancement exists to save
+//! milliseconds). CBOR gives us:
+//!
+//! - **No base64 overhead** on byte payloads (image paste, raw
+//!   terminal input/output). JSON forces string encoding for any
+//!   binary field; CBOR's byte-string type carries bytes directly.
+//! - **Smaller wire** — typically 30-50% of JSON size for mixed
+//!   structured + byte data.
+//! - **Uniform wire across transports**. WS binary frames and
+//!   WebRTC DataChannel are both native binary; CBOR is the
+//!   single encoding that works on both without per-transport
+//!   shims.
+//! - **Schema evolution**. Self-describing format + serde means
+//!   new fields + new variants migrate the same way they did
+//!   under JSON.
+//!
+//! Lost: human-readable frames in Wireshark. The trade is
+//! deliberate — CBOR has well-understood debug tooling
+//! (`cbor.me`, `cborcli`) and our operator debugging surface is
+//! structured logs anyway, not wire captures.
+//!
+//! # Wire-level responsibilities
+//!
+//! Two pump tasks:
+//!
+//! - `input_pump`: reads `WebSocket::recv()` frames, decodes each
+//!   binary frame as a `ClientMessage` via CBOR, forwards to the
+//!   inbound channel. Rejects text frames (wrong encoding) and
+//!   binary frames above the size cap. Reports decode/frame
+//!   errors via `Result<ClientMessage, TransportError>` so the
+//!   consumer can decide whether to close. Exits on peer Close
+//!   or disconnect.
 //! - `output_pump`: drains the outbound channel, serializes each
-//!   `ServerMessage` as JSON, sends as text frame. Exits when the
-//!   channel closes (consumer dropped the handle).
+//!   `ServerMessage` to CBOR, sends as binary frame. Exits when
+//!   the channel closes (consumer dropped the handle).
 //!
 //! Protocol keep-alive (WS-level `Ping`/`Pong` frames, distinct
 //! from the app-level `ClientMessage::Ping`/`ServerMessage::Pong`)
 //! is handled automatically: WS Ping frames receive a WS Pong
 //! without surfacing to the consumer. App-level ping/pong is a
-//! feature of the ClientMessage/ServerMessage protocol itself and
-//! lets a future non-WS transport (WebRTC) use the same shape.
+//! feature of the ClientMessage/ServerMessage protocol itself so a
+//! future non-WS transport (WebRTC) uses the same shape.
 
 use super::handle::{TransportError, TransportHandle, TransportKind};
 use super::message::{ClientMessage, ServerMessage};
@@ -43,19 +70,17 @@ const OUTBOUND_BUFFER: usize = 64;
 /// alternative is an unbounded channel growing toward OOM.
 const INBOUND_BUFFER: usize = 64;
 
-/// Hard size cap on an individual inbound text frame, applied
-/// BEFORE the frame reaches `serde_json::from_str`. Without this,
-/// an authenticated attacker could push multi-megabyte frames
-/// through a connection that's already past the auth gate; the
-/// axum `DefaultBodyLimit` layer covers HTTP bodies, not WS
-/// frames once upgrade has completed. 64 KiB is well above any
-/// slice-9c message (`Ping { nonce: u64 }` is ~30 bytes) and
-/// still comfortably above the slice-9d terminal messages
-/// envisioned so far (input keystroke, resize, session-id
-/// strings). A future `InputBytes` variant for terminal paste
-/// would need its own limit decision documented alongside the
-/// type — this constant stays as the catch-all for everything
-/// else.
+/// Hard size cap on an individual inbound binary frame, applied
+/// BEFORE CBOR decode. Without this, an authenticated attacker
+/// could push multi-megabyte frames through a connection that's
+/// already past the auth gate; the axum `DefaultBodyLimit` layer
+/// covers HTTP bodies, not WS frames once upgrade has completed.
+/// 64 KiB is well above any current message and still comfortably
+/// above the terminal messages envisioned for slice 9e/9f
+/// (keystroke input, resize, session-id strings, small output
+/// chunks after coalescing). Large paste payloads that exceed
+/// this get fragmented at the client; the CBOR-native byte-string
+/// type keeps that overhead minimal without needing base64.
 const MAX_INBOUND_FRAME_BYTES: usize = 64 * 1024;
 
 /// The pump tasks spawned by `into_transport`. Returned alongside
@@ -109,21 +134,22 @@ async fn input_pump(
     use futures::StreamExt;
     while let Some(frame) = ws_rx.next().await {
         let decoded = match frame {
-            Ok(Message::Text(text)) => {
-                if text.len() > MAX_INBOUND_FRAME_BYTES {
+            Ok(Message::Binary(bytes)) => {
+                if bytes.len() > MAX_INBOUND_FRAME_BYTES {
                     Err(TransportError::DecodeFailed(format!(
                         "frame too large: {} bytes exceeds {} byte limit",
-                        text.len(),
+                        bytes.len(),
                         MAX_INBOUND_FRAME_BYTES
                     )))
                 } else {
-                    match serde_json::from_str::<ClientMessage>(&text) {
-                        Ok(m) => Ok(m),
-                        Err(e) => Err(TransportError::DecodeFailed(e.to_string())),
-                    }
+                    ciborium::de::from_reader::<ClientMessage, _>(&bytes[..])
+                        .map_err(|e| TransportError::DecodeFailed(e.to_string()))
                 }
             }
-            Ok(Message::Binary(_)) => Err(TransportError::UnexpectedBinary),
+            // Text frames are rejected: CBOR is the sole wire format.
+            // A client sending text is either wrong-version or
+            // probing; reject cleanly and let the consumer decide.
+            Ok(Message::Text(_)) => Err(TransportError::UnexpectedText),
             Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {
                 // WS-level keepalive. axum auto-responds to Ping;
                 // we just drop them from the inbound stream so the
@@ -149,16 +175,17 @@ async fn output_pump(
 ) {
     use futures::SinkExt;
     while let Some(msg) = outbound.recv().await {
-        let Ok(text) = serde_json::to_string(&msg) else {
-            // `ServerMessage` is a closed set of types; serde_json
-            // can't fail on any of them today. If it ever does,
-            // that's a bug in the type definition — log and skip
-            // rather than poisoning the transport for every
-            // subsequent message.
-            tracing::error!("ServerMessage serialization failed; dropping frame");
+        let mut buf = Vec::new();
+        if let Err(e) = ciborium::ser::into_writer(&msg, &mut buf) {
+            // `ServerMessage` is a closed set of serde-derived
+            // types; CBOR encoding can't fail on any of them today.
+            // If it ever does, that's a bug in the type definition
+            // — log and skip rather than poisoning the transport
+            // for every subsequent message.
+            tracing::error!(error = %e, "ServerMessage CBOR encoding failed; dropping frame");
             continue;
-        };
-        if ws_tx.send(Message::Text(text)).await.is_err() {
+        }
+        if ws_tx.send(Message::Binary(buf)).await.is_err() {
             break;
         }
     }
@@ -172,19 +199,47 @@ mod tests {
     #[test]
     fn max_inbound_frame_bytes_is_generous_vs_current_messages() {
         // Paranoia test: the cap must sit comfortably above the
-        // largest `ClientMessage` today. Ping serializes to ~30
-        // bytes; 64 KiB is 2000x that. If slice 9d adds a variant
-        // that could legitimately approach this limit, this test
-        // is the signal to document an explicit limit on THAT
-        // variant rather than just bumping the global cap.
+        // largest `ClientMessage` today. Ping serializes to ~10
+        // bytes in CBOR; 64 KiB is 6000x that. If slice 9e/9f adds
+        // a variant that could legitimately approach this limit,
+        // this test is the signal to document an explicit limit
+        // on THAT variant rather than just bumping the global cap.
         let ping = ClientMessage::Ping { nonce: u64::MAX };
-        let s = serde_json::to_string(&ping).unwrap();
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&ping, &mut buf).unwrap();
         assert!(
-            s.len() < MAX_INBOUND_FRAME_BYTES / 100,
+            buf.len() < MAX_INBOUND_FRAME_BYTES / 100,
             "max frame bytes must leave 100x headroom over current \
-             messages; Ping serialized to {} bytes vs cap {}",
-            s.len(),
+             messages; Ping encoded to {} bytes vs cap {}",
+            buf.len(),
             MAX_INBOUND_FRAME_BYTES
         );
+    }
+
+    #[test]
+    fn cbor_is_smaller_than_json_for_ping() {
+        // Not a correctness check; a sanity check that the wire
+        // benefit we're trading JSON readability for actually
+        // shows up. If this ever fails, CBOR encoding changed
+        // behavior and the trade needs re-examination.
+        let ping = ClientMessage::Ping { nonce: 42 };
+        let mut cbor = Vec::new();
+        ciborium::ser::into_writer(&ping, &mut cbor).unwrap();
+        let json = serde_json::to_string(&ping).unwrap();
+        assert!(
+            cbor.len() < json.len(),
+            "CBOR ({} bytes) should be smaller than JSON ({} bytes) for Ping",
+            cbor.len(),
+            json.len()
+        );
+    }
+
+    #[test]
+    fn cbor_roundtrip_preserves_message() {
+        let original = ClientMessage::Ping { nonce: 12345 };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&original, &mut buf).unwrap();
+        let back: ClientMessage = ciborium::de::from_reader(&buf[..]).unwrap();
+        assert_eq!(back, original);
     }
 }


### PR DESCRIPTION
## Summary

Moves session-layer transport from JSON text to CBOR binary. Single-format wire for both WS and WebRTC DataChannel; no base64 overhead for byte payloads; same serde derives.

## Why

katulong is single-user-multi-device and optimized for latency (hence the WS→WebRTC progressive enhancement). JSON over WS baked two costs:

1. **Base64 overhead on byte payloads.** Terminal output, input paste, image paste all pay 33% string-encoding tax under JSON. CBOR's native byte-string skips it.
2. **Dual-encoding tax for WebRTC.** DataChannel is binary-native; a JSON-WS protocol would need per-transport text/binary shims. CBOR rides unchanged on either.

## Changes

- \`ciborium = "0.2"\` added (pure Rust, serde-integrated).
- \`transport/websocket.rs\`: input decodes from \`Message::Binary\` via CBOR; output serializes as \`Message::Binary\`. Text frames now rejected (\`TransportError::UnexpectedText\`, replacing \`UnexpectedBinary\`).
- \`transport/message.rs\`: module doc sections strictness flags from wire format. Tests clarify they use JSON as a readable assertion medium (serde behavior is format-agnostic); two CBOR roundtrip tests added at the end.
- Frame-size cap (64 KiB) still applies, now to CBOR byte length before decode.

## Test plan

- [x] \`cargo test\` — 155 tests (+4 CBOR coverage)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] All existing auth/ws/devices/tokens/revocation integration tests still pass — CBOR migration is transparent outside \`transport/websocket.rs\`
- [ ] Real WS round-trip with CBOR client — needs a WS client implementation, lands in e2e

## Forward carry

- Slice 9e adds \`SessionManager\` into \`AppState\`, tmux spawn at startup, terminal message variants (Input/Output/Resize), handshake gate, revocation subscribe.
- Slice 9f adds the actual I/O loop (coalescing, sequencing, resize gating).
- WebRTC transport slice: drops in unchanged encoding-wise — DataChannel + CBOR is the same wire.