### PR TITLE
rewrite(server): slice 9e — handshake state machine + session manager in AppState

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "katulong-auth",
  "katulong-shared",
  "serde",
+ "serde_bytes",
  "serde_json",
  "subtle",
  "tempfile",
@@ -1065,7 +1066,6 @@ name = "katulong-web"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
- "katulong-shared",
  "leptos",
 ]
 
@@ -1957,6 +1957,16 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -35,6 +35,15 @@ futures = { version = "0.3", default-features = false, features = ["std"] }
 # envelopes, tokens, devices) still speaks JSON — CBOR is
 # session-layer only.
 ciborium = "0.2"
+# `serde_bytes` forces `Vec<u8>` fields on `Input`/`Output` messages
+# to serialize as CBOR byte-strings (major type 2) instead of arrays
+# of small integers. Without this annotation a 1 KiB keystroke/paste
+# payload would encode as ~1–2 KiB of integer-element overhead; with
+# it, bytes ride the wire literally. Serde's default for `Vec<u8>` is
+# array-of-int because it has to pick a portable default across
+# codecs — we pick byte-string explicitly because CBOR supports it
+# and we're not using any other codec for session I/O.
+serde_bytes = "0.11"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -9,6 +9,7 @@ pub mod access;
 pub mod api;
 pub mod auth_middleware;
 pub mod cookie;
+pub mod log_util;
 pub mod revocation;
 pub mod session;
 pub mod state;

--- a/crates/server/src/log_util.rs
+++ b/crates/server/src/log_util.rs
@@ -1,0 +1,102 @@
+//! Small helpers for safely rendering attacker-controlled strings
+//! into `tracing` log lines.
+//!
+//! Any field value that originated from the network — an Origin
+//! header, a `HelloAck.protocol_version`, a raw session name — can
+//! contain embedded newlines, ANSI control sequences, or arbitrary
+//! length. Emitting those verbatim lets an attacker forge log
+//! lines (CR/LF injection), hijack JSON-formatter structured
+//! fields (`"field":"value"\n{"level":"ERROR",...}`), or flood
+//! disks (`Origin: <1 MB>`). This module centralises the guard
+//! so every reject site uses the same sanitizer; before it
+//! existed there were two near-identical copies in `ws.rs` and
+//! `session::handler`.
+
+/// Strip ASCII control characters and cap length. Returns a new
+/// `String` safe to interpolate into a text-formatted log line or a
+/// JSON-formatter structured field.
+///
+/// `max_len` is the hard cap — chosen by the caller based on what's
+/// reasonable for the field. Typical values are 32 for short
+/// identifiers (protocol version, session name) and 256 for
+/// free-form headers (Origin) where a slightly longer prefix helps
+/// operators identify legitimate mismatches.
+///
+/// Keeps only printable ASCII-visible + Unicode non-control chars.
+/// We reject ALL `is_ascii_control()` chars, not just CR/LF,
+/// because any C0 control can corrupt a text log or structured
+/// field. Unicode controls above U+007F are left intact — they're
+/// allowed by serde for string fields, and stripping them would
+/// mangle legitimate non-ASCII content without providing an
+/// injection defense (non-ASCII doesn't confuse log formatters).
+pub fn sanitize_for_log(value: &str, max_len: usize) -> String {
+    value
+        .chars()
+        .filter(|c| !c.is_ascii_control())
+        .take(max_len)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_cr_lf() {
+        // The classic log-injection: a crafted Origin or version
+        // string that forges a new log line. CR/LF must never
+        // survive sanitization.
+        assert_eq!(
+            sanitize_for_log("evil\r\n[WARN] faked=line", 256),
+            "evil[WARN] faked=line"
+        );
+    }
+
+    #[test]
+    fn strips_tab_and_other_c0_controls() {
+        // Tabs corrupt columnar log output; NUL corrupts C-string
+        // loggers; any C0 control is unsafe.
+        assert_eq!(
+            sanitize_for_log("col\tumn\x00nul\x07bel", 256),
+            "columnnulbel"
+        );
+    }
+
+    #[test]
+    fn caps_length() {
+        // An attacker-chosen giant Origin shouldn't be able to
+        // flood the log with a megabyte per request.
+        let huge = "x".repeat(10_000);
+        assert_eq!(sanitize_for_log(&huge, 256).len(), 256);
+    }
+
+    #[test]
+    fn preserves_printable_ascii() {
+        assert_eq!(
+            sanitize_for_log("https://katulong.example/path?q=1", 256),
+            "https://katulong.example/path?q=1"
+        );
+    }
+
+    #[test]
+    fn preserves_non_ascii_text() {
+        // Non-ASCII characters are not attacker-useful for log
+        // injection (log formatters are byte-safe above 0x7F).
+        // Stripping them would mangle legitimate i18n content.
+        let input = "hello 世界 🌏";
+        assert_eq!(sanitize_for_log(input, 256), input);
+    }
+
+    #[test]
+    fn empty_input_is_empty() {
+        assert_eq!(sanitize_for_log("", 256), "");
+    }
+
+    #[test]
+    fn max_len_zero_is_empty() {
+        // Defensive: max_len of 0 must not panic and returns
+        // empty. Callers that pass 0 are buggy, but graceful
+        // handling avoids cascading failures.
+        assert_eq!(sanitize_for_log("anything", 0), "");
+    }
+}

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,4 +1,8 @@
 use katulong_auth::{AuthStore, WebAuthnService};
+use katulong_server::session::{
+    dims::{DEFAULT_COLS, DEFAULT_ROWS},
+    SessionManager, Tmux, DEDICATED_SOCKET_NAME,
+};
 use katulong_server::{app, state::AppState, state::ServerConfig};
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -18,7 +22,37 @@ async fn main() {
         .expect("open auth store");
     let webauthn = WebAuthnService::new(&config.rp_id, &config.rp_name, &config.public_origin)
         .expect("build WebAuthn service");
-    let state = AppState::new(auth_store, webauthn, config);
+
+    // Spawn the tmux control-mode subprocess once at startup. Every
+    // WS session shares it: tmux itself multiplexes across sessions,
+    // so one subprocess is enough. Bailing on failure is correct —
+    // without tmux katulong has no terminal surface; running anyway
+    // would accept WS upgrades that fail at Attach time, which is
+    // worse operator UX than a startup panic pointing at the
+    // missing binary.
+    //
+    // `_notifs` is the async-notification receiver (tmux `%output`,
+    // `%window-close`, etc.). Slice 9f consumes it to forward PTY
+    // output over the transport; slice 9e has no consumer yet, so
+    // we let it buffer. Per the `Tmux::spawn` contract this is
+    // UNBOUNDED — if we left it here long-term, any tmux-produced
+    // output would fill memory. That's fine for 9e because no
+    // session has started to produce output yet (no client has
+    // sent `Attach` through the new message variants + no PTY has
+    // been driven), but 9f MUST route this channel into a consumer
+    // before it enables output routing. Dropping the receiver
+    // instead would silently drop notifications — keep the binding
+    // so slice 9f has something concrete to replace.
+    let socket_name = std::env::var("KATULONG_TMUX_SOCKET")
+        .unwrap_or_else(|_| DEDICATED_SOCKET_NAME.to_string());
+    let initial_session = std::env::var("KATULONG_INITIAL_SESSION")
+        .unwrap_or_else(|_| "main".to_string());
+    let (tmux, _notifs) = Tmux::spawn(&socket_name, &initial_session, DEFAULT_COLS, DEFAULT_ROWS)
+        .await
+        .expect("spawn tmux control-mode subprocess");
+    let sessions = SessionManager::new(tmux);
+
+    let state = AppState::new(auth_store, webauthn, config).with_sessions(sessions);
 
     let addr: SocketAddr = "127.0.0.1:3000".parse().expect("valid bind address");
     let listener = tokio::net::TcpListener::bind(addr)

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -31,25 +31,31 @@ async fn main() {
     // worse operator UX than a startup panic pointing at the
     // missing binary.
     //
-    // `_notifs` is the async-notification receiver (tmux `%output`,
-    // `%window-close`, etc.). Slice 9f consumes it to forward PTY
-    // output over the transport; slice 9e has no consumer yet, so
-    // we let it buffer. Per the `Tmux::spawn` contract this is
-    // UNBOUNDED — if we left it here long-term, any tmux-produced
-    // output would fill memory. That's fine for 9e because no
-    // session has started to produce output yet (no client has
-    // sent `Attach` through the new message variants + no PTY has
-    // been driven), but 9f MUST route this channel into a consumer
-    // before it enables output routing. Dropping the receiver
-    // instead would silently drop notifications — keep the binding
-    // so slice 9f has something concrete to replace.
+    // `notifs` is the async-notification receiver (tmux `%output`,
+    // `%window-close`, etc.). Per the `Tmux::spawn` contract this
+    // is UNBOUNDED — leaving it unconsumed would let any
+    // tmux-produced terminal output accumulate until the process
+    // OOMs. Slice 9e doesn't yet route output back over the
+    // transport (that's slice 9f), but a real shell attached to
+    // the initial session would already be producing output, so
+    // the receiver MUST be drained. The drop-all drain task below
+    // is the slice-9e placeholder; slice 9f replaces it with the
+    // per-connection output pump that forwards `%output` over the
+    // transport with coalescing (Node scars `d311168`/`066dab2`).
     let socket_name = std::env::var("KATULONG_TMUX_SOCKET")
         .unwrap_or_else(|_| DEDICATED_SOCKET_NAME.to_string());
     let initial_session = std::env::var("KATULONG_INITIAL_SESSION")
         .unwrap_or_else(|_| "main".to_string());
-    let (tmux, _notifs) = Tmux::spawn(&socket_name, &initial_session, DEFAULT_COLS, DEFAULT_ROWS)
-        .await
-        .expect("spawn tmux control-mode subprocess");
+    let (tmux, mut notifs) =
+        Tmux::spawn(&socket_name, &initial_session, DEFAULT_COLS, DEFAULT_ROWS)
+            .await
+            .expect("spawn tmux control-mode subprocess");
+    tokio::spawn(async move {
+        // Slice-9e drain: discard tmux notifications so the
+        // unbounded receiver can't grow toward OOM. Slice 9f
+        // replaces this task with the real output forwarder.
+        while notifs.recv().await.is_some() {}
+    });
     let sessions = SessionManager::new(tmux);
 
     let state = AppState::new(auth_store, webauthn, config).with_sessions(sessions);

--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -1,0 +1,736 @@
+//! Per-connection session handler.
+//!
+//! `serve_session` consumes a `TransportHandle` and runs the
+//! terminal-session lifecycle against it: protocol handshake,
+//! session attach, revocation watch. It is transport-agnostic by
+//! construction — see `project_transport_agnostic` in project
+//! memory.
+//!
+//! # Slice 9e scope
+//!
+//! - Handshake gate: `Hello` (server) → `HelloAck` (client) →
+//!   `Attach` (client) → `Attached` (server).
+//! - Phase state machine enforces the order. Messages arriving in
+//!   the wrong phase trigger a typed `Error` and a clean transport
+//!   close, so the client sees "unexpected_message" rather than an
+//!   opaque drop.
+//! - `Resize` in the `Attached` phase forwards to `SessionManager`;
+//!   tmux clamps and issues `refresh-client -C`.
+//! - `Input` in the `Attached` phase is accepted and logged. Slice
+//!   9f wires the actual tmux write path (and the `Output`
+//!   producer) with coalescing.
+//! - Revocation watch: a `tokio::select!` over `handle.inbound` and
+//!   `state.subscribe_revocations()` closes the transport
+//!   immediately when the bound credential is revoked. Localhost
+//!   connections aren't bound to a credential and can't be
+//!   revoked — they exit only on peer disconnect.
+//!
+//! # Why a state machine, not "just check in the match"
+//!
+//! The alternative is per-variant guards like `if !attached {
+//! return Err(unexpected) }` scattered through the main loop. That
+//! works but makes it easy to forget a guard on a newly-added
+//! variant (the future `Output` from an echo-tester, say). The
+//! phase enum forces every addition to be placed in a phase, and
+//! the unit tests below snap whenever a variant crosses phases
+//! without explicit consent.
+
+use crate::revocation::RevocationEvent;
+use crate::state::AppState;
+use crate::transport::{
+    ClientMessage, ServerMessage, TransportHandle, PROTOCOL_VERSION,
+};
+use tokio::sync::broadcast::error::RecvError;
+
+/// How long we wait between connection upgrade and receiving
+/// `HelloAck` before closing. WS-level keepalive keeps the socket
+/// alive indefinitely; without this a silent peer can pin a
+/// connection forever. Generous enough that a high-latency real
+/// client completes well within it; short enough that a scraper
+/// probing `/ws` with no cookie (shouldn't happen — auth gates the
+/// upgrade) or a half-open connection is reaped promptly.
+const HANDSHAKE_TIMEOUT_SECS: u64 = 10;
+
+/// Error codes emitted as `ServerMessage::Error.code`. Stable —
+/// clients and scripts key off these strings, so renames require a
+/// protocol version bump.
+pub mod error_code {
+    /// Client's `HelloAck.protocol_version` didn't match what the
+    /// server speaks. The connection closes immediately.
+    pub const PROTOCOL_VERSION_MISMATCH: &str = "protocol_version_mismatch";
+    /// Client sent a message that isn't allowed in the current
+    /// handshake phase (e.g., `Input` before `Attached`).
+    pub const UNEXPECTED_MESSAGE: &str = "unexpected_message";
+    /// Client tried to `Attach` to a session name that the
+    /// session-name validator rejected.
+    pub const INVALID_SESSION: &str = "invalid_session";
+    /// The session manager (tmux) rejected an operation. Body is
+    /// generic on purpose — raw tmux stderr must not leak to
+    /// clients.
+    pub const SESSION_ERROR: &str = "session_error";
+    /// No session manager is wired into this server (misconfig or
+    /// tmux binary missing). Only surfaces during development.
+    pub const NO_SESSION_MANAGER: &str = "no_session_manager";
+    /// Client didn't complete the handshake within
+    /// `HANDSHAKE_TIMEOUT_SECS`. Connection closes.
+    pub const HANDSHAKE_TIMEOUT: &str = "handshake_timeout";
+}
+
+/// Handshake phase. Advances on valid messages; any message that
+/// isn't valid for the current phase is a protocol violation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Phase {
+    /// Server has sent `Hello`; waiting for the client to ack with
+    /// a matching protocol version.
+    AwaitingHelloAck,
+    /// Protocol version confirmed; waiting for the client to send
+    /// `Attach` with a session name and dimensions.
+    AwaitingAttach,
+    /// Transport is bound to `session`. `Input`/`Resize` are now
+    /// valid.
+    Attached { session: String },
+}
+
+/// Action the phase machine tells the coordinator to take after
+/// processing a client message. Keeps the state machine a pure
+/// function of (phase, message) — no `.await`, no I/O — so the
+/// coordinator owns every side effect. This makes `step` trivial
+/// to unit-test without a real tmux, real socket, or runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Action {
+    /// Nothing to emit; keep reading.
+    Continue,
+    /// Echo a `Pong` with the given nonce.
+    SendPong(u64),
+    /// Protocol version checked out; reply confirmation is
+    /// implicit (no server message is sent for HelloAck — the
+    /// client's next move is Attach). Just advance phase.
+    AdvanceToAwaitingAttach,
+    /// Create/attach the tmux session, then send `Attached` with
+    /// the clamped dims.
+    DoAttach {
+        session: String,
+        cols: u16,
+        rows: u16,
+    },
+    /// Forward a resize to the session manager for the currently-
+    /// attached session.
+    DoResize {
+        session: String,
+        cols: u16,
+        rows: u16,
+    },
+    /// A protocol violation. Coordinator sends `Error` and closes.
+    /// `code` is one of `error_code::*`; `message` is operator-
+    /// visible and MUST NOT include client-controlled bytes raw
+    /// (log-injection path — the coordinator sanitizes).
+    Close { code: &'static str, message: String },
+    /// Client pipeline signalled that their end of the
+    /// transport closed or decoded a frame error. Coordinator
+    /// exits without emitting anything.
+    Exit,
+}
+
+/// Pure state-machine step: given the current phase and a client
+/// message, decide what to do next. No awaits, no side effects, no
+/// SessionManager reference — keeps this function easy to test and
+/// impossible to accidentally deadlock.
+fn step(phase: &mut Phase, msg: ClientMessage) -> Action {
+    match (phase.clone(), msg) {
+        // `Ping` is allowed in every phase. It never changes phase
+        // and doesn't touch any session state.
+        (_, ClientMessage::Ping { nonce }) => Action::SendPong(nonce),
+
+        (Phase::AwaitingHelloAck, ClientMessage::HelloAck { protocol_version }) => {
+            if protocol_version == PROTOCOL_VERSION {
+                *phase = Phase::AwaitingAttach;
+                Action::AdvanceToAwaitingAttach
+            } else {
+                Action::Close {
+                    code: error_code::PROTOCOL_VERSION_MISMATCH,
+                    message: format!(
+                        "server speaks {}, client acked {}",
+                        PROTOCOL_VERSION,
+                        // bound on length defensively; don't let an
+                        // attacker-chosen version string blow up
+                        // log line size
+                        truncate_for_log(&protocol_version, 32),
+                    ),
+                }
+            }
+        }
+
+        (Phase::AwaitingAttach, ClientMessage::Attach { session, cols, rows }) => {
+            Action::DoAttach {
+                session,
+                cols,
+                rows,
+            }
+        }
+
+        (Phase::Attached { session }, ClientMessage::Input { data: _ }) => {
+            // Slice 9e accepts Input to exercise the phase-gate but
+            // does NOT forward it to the PTY — slice 9f wires the
+            // tmux write path with coalescing. Logging at trace
+            // keeps the data payload out of default logs entirely.
+            tracing::trace!(
+                session = %session,
+                "session input accepted (forwarding wired in slice 9f)"
+            );
+            Action::Continue
+        }
+
+        (Phase::Attached { session }, ClientMessage::Resize { cols, rows }) => {
+            Action::DoResize {
+                session,
+                cols,
+                rows,
+            }
+        }
+
+        // Any other (phase, message) combination is a protocol
+        // violation. We match on the phase purely to produce a
+        // descriptive error — the message itself is untrusted.
+        (phase, msg) => Action::Close {
+            code: error_code::UNEXPECTED_MESSAGE,
+            message: format!(
+                "client sent {} while server was {}",
+                variant_name(&msg),
+                phase_name(&phase),
+            ),
+        },
+    }
+}
+
+fn variant_name(msg: &ClientMessage) -> &'static str {
+    match msg {
+        ClientMessage::Ping { .. } => "ping",
+        ClientMessage::HelloAck { .. } => "hello_ack",
+        ClientMessage::Attach { .. } => "attach",
+        ClientMessage::Input { .. } => "input",
+        ClientMessage::Resize { .. } => "resize",
+    }
+}
+
+fn phase_name(phase: &Phase) -> &'static str {
+    match phase {
+        Phase::AwaitingHelloAck => "awaiting_hello_ack",
+        Phase::AwaitingAttach => "awaiting_attach",
+        Phase::Attached { .. } => "attached",
+    }
+}
+
+fn truncate_for_log(s: &str, max: usize) -> String {
+    s.chars()
+        .filter(|c| !c.is_ascii_control())
+        .take(max)
+        .collect()
+}
+
+/// The per-connection consumer loop, parameterised on the
+/// transport abstraction. `state` threads session manager + the
+/// revocation broadcast; `credential_id` is the credential this
+/// transport is bound to (from the auth extractor), or `None` for
+/// localhost-exempt connections which can't be revoked.
+///
+/// This function owns the `TransportHandle` for the connection's
+/// lifetime. When it returns, the outbound sender drops → the WS
+/// output pump sees the channel close → the socket closes.
+pub async fn serve_session(
+    state: AppState,
+    handle: TransportHandle,
+    credential_id: Option<String>,
+) {
+    let mut handle = handle;
+
+    // Subscribe to revocation events BEFORE we touch anything else.
+    // See `revocation.rs` subscriber contract: a handler that
+    // validates first, then subscribes, misses any revocation that
+    // lands between the two calls.
+    let mut revocations = state.subscribe_revocations();
+
+    // Send the initial Hello. If this fails, the transport died
+    // between upgrade and now — nothing to do.
+    if handle
+        .send(ServerMessage::Hello {
+            protocol_version: PROTOCOL_VERSION.to_string(),
+        })
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let mut phase = Phase::AwaitingHelloAck;
+    let handshake_deadline =
+        tokio::time::Instant::now() + std::time::Duration::from_secs(HANDSHAKE_TIMEOUT_SECS);
+
+    loop {
+        // The handshake timer only fires while we're still in the
+        // handshake phases. Once `Attached`, the timer is disabled
+        // (`tokio::select!`'s `biased` + guarded branch handles
+        // this explicitly).
+        let in_handshake = matches!(
+            phase,
+            Phase::AwaitingHelloAck | Phase::AwaitingAttach
+        );
+
+        let action = tokio::select! {
+            biased;
+
+            // Revocation takes precedence over any pending message
+            // — a revoked credential's next keystroke should not
+            // be processed, not even in the same tick where it
+            // arrives alongside the revoke event.
+            revoke = revocations.recv() => handle_revoke(revoke, credential_id.as_deref()),
+
+            // Handshake-timer branch: only active while we're
+            // still awaiting HelloAck or Attach. Once we've
+            // reached `Attached`, this branch is disabled.
+            _ = tokio::time::sleep_until(handshake_deadline), if in_handshake => Action::Close {
+                code: error_code::HANDSHAKE_TIMEOUT,
+                message: "client did not complete handshake in time".into(),
+            },
+
+            msg = handle.inbound.recv() => match msg {
+                None => Action::Exit,
+                Some(Err(err)) => {
+                    // Decoder/frame error from the transport. Stay
+                    // open — a single bad frame isn't a reason to
+                    // kick the user out; the Node scar `9dc7c78`
+                    // said validate at the boundary, which the
+                    // typed deserialize already does.
+                    tracing::warn!(error = %err, "transport frame error; dropping");
+                    Action::Continue
+                }
+                Some(Ok(msg)) => step(&mut phase, msg),
+            },
+        };
+
+        match action {
+            Action::Continue => continue,
+            Action::Exit => break,
+            Action::SendPong(nonce) => {
+                if handle.send(ServerMessage::Pong { nonce }).await.is_err() {
+                    break;
+                }
+            }
+            Action::AdvanceToAwaitingAttach => {
+                // No server message for this transition — the
+                // client already has Hello, and the next expected
+                // message from them is Attach. Sending a dedicated
+                // "hello acknowledged" would be pure wire bloat.
+                continue;
+            }
+            Action::DoAttach {
+                session,
+                cols,
+                rows,
+            } => {
+                let Some(sessions) = state.sessions.as_deref() else {
+                    send_error_and_close(
+                        &handle,
+                        error_code::NO_SESSION_MANAGER,
+                        "session manager not configured".into(),
+                    )
+                    .await;
+                    break;
+                };
+                match sessions.create_session(&session, cols, rows).await {
+                    Ok(()) => {
+                        let (cols, rows) =
+                            crate::session::dims::clamp_dims(cols, rows);
+                        phase = Phase::Attached {
+                            session: session.clone(),
+                        };
+                        if handle
+                            .send(ServerMessage::Attached {
+                                session,
+                                cols,
+                                rows,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Err(err) => {
+                        let (code, message) = classify_session_error(&err);
+                        tracing::warn!(
+                            error = %err,
+                            code = code,
+                            "attach rejected"
+                        );
+                        send_error_and_close(&handle, code, message).await;
+                        break;
+                    }
+                }
+            }
+            Action::DoResize {
+                session,
+                cols,
+                rows,
+            } => {
+                // SAFETY: `sessions` must be `Some` to reach
+                // `Attached` phase; the only path to Attached is
+                // through a successful create_session above, which
+                // requires `state.sessions` to be Some.
+                let sessions = state
+                    .sessions
+                    .as_deref()
+                    .expect("Attached phase implies sessions is Some");
+                if let Err(err) = sessions.resize_session(&session, cols, rows).await {
+                    // Resize failure on an already-attached session
+                    // is noisy but not fatal. Log and keep the
+                    // transport open; the client will try again on
+                    // the next layout event. Do NOT leak raw tmux
+                    // output to the client.
+                    tracing::warn!(
+                        session = %session,
+                        error = %err,
+                        "resize failed; keeping transport open"
+                    );
+                }
+            }
+            Action::Close { code, message } => {
+                send_error_and_close(&handle, code, message).await;
+                break;
+            }
+        }
+    }
+
+    // Drop the handle. The WS output pump sees the channel close
+    // and shuts down the socket gracefully.
+}
+
+/// Decide whether a revocation event should tear down this
+/// connection. `credential_id` is the one this transport is bound
+/// to (from auth).
+fn handle_revoke(
+    revoke: Result<RevocationEvent, RecvError>,
+    bound_credential: Option<&str>,
+) -> Action {
+    match revoke {
+        Ok(event) => match bound_credential {
+            Some(mine) if mine == event.credential_id => Action::Close {
+                code: error_code::UNEXPECTED_MESSAGE,
+                // Credential was revoked — the client shouldn't
+                // see a detailed rationale beyond "connection
+                // closed." We reuse the generic UNEXPECTED code
+                // because the client's next action (prompt for
+                // reauth) is the same. A dedicated code here would
+                // leak "yes, your exact credential was revoked"
+                // to any party holding the socket, which is
+                // information we don't owe them.
+                message: "connection terminated".into(),
+            },
+            _ => Action::Continue,
+        },
+        // Subscriber fell behind the broadcast buffer. `revocation.rs`
+        // subscriber contract: conservative close.
+        Err(RecvError::Lagged(_)) => Action::Close {
+            code: error_code::UNEXPECTED_MESSAGE,
+            message: "connection terminated".into(),
+        },
+        // Publisher dropped. Shouldn't happen in practice
+        // (AppState owns it for the server's lifetime), but if it
+        // does, we have no more revocation awareness — exit to be
+        // safe.
+        Err(RecvError::Closed) => Action::Exit,
+    }
+}
+
+/// Send an `Error` message, then return — the caller drops the
+/// transport and the WS pump closes the socket. Best-effort: if
+/// the transport is already gone, the send fails and we swallow.
+async fn send_error_and_close(handle: &TransportHandle, code: &str, message: String) {
+    let _ = handle
+        .send(ServerMessage::Error {
+            code: code.into(),
+            message,
+        })
+        .await;
+}
+
+fn classify_session_error(err: &crate::session::SessionError) -> (&'static str, String) {
+    use crate::session::SessionError;
+    match err {
+        SessionError::InvalidName(_) => (
+            error_code::INVALID_SESSION,
+            "invalid session name".into(),
+        ),
+        SessionError::TmuxRejected(_) | SessionError::Tmux(_) => (
+            error_code::SESSION_ERROR,
+            // Do NOT embed raw tmux output in the client message.
+            // The `SessionManager` doc calls this out explicitly
+            // (socket paths, other session names, internal
+            // diagnostics). A generic client-facing string is
+            // enough; operators have the tracing field.
+            "session operation failed".into(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! State-machine tests. Transport-free and SessionManager-free:
+    //! we feed `step` directly with synthetic messages and assert
+    //! on the action it returns. Real-transport end-to-end tests
+    //! live under the `transport::websocket` and integration
+    //! modules.
+
+    use super::*;
+
+    fn ack_v1() -> ClientMessage {
+        ClientMessage::HelloAck {
+            protocol_version: PROTOCOL_VERSION.into(),
+        }
+    }
+
+    #[test]
+    fn hello_ack_advances_phase() {
+        let mut phase = Phase::AwaitingHelloAck;
+        let action = step(&mut phase, ack_v1());
+        assert_eq!(action, Action::AdvanceToAwaitingAttach);
+        assert_eq!(phase, Phase::AwaitingAttach);
+    }
+
+    #[test]
+    fn mismatched_protocol_version_closes() {
+        let mut phase = Phase::AwaitingHelloAck;
+        let action = step(
+            &mut phase,
+            ClientMessage::HelloAck {
+                protocol_version: "katulong/999.0".into(),
+            },
+        );
+        match action {
+            Action::Close { code, .. } => {
+                assert_eq!(code, error_code::PROTOCOL_VERSION_MISMATCH);
+            }
+            other => panic!("expected close, got {other:?}"),
+        }
+        assert_eq!(
+            phase,
+            Phase::AwaitingHelloAck,
+            "phase should not advance on mismatch"
+        );
+    }
+
+    #[test]
+    fn input_before_attached_is_protocol_violation() {
+        let mut phase = Phase::AwaitingAttach;
+        let action = step(
+            &mut phase,
+            ClientMessage::Input {
+                data: vec![0x61, 0x62, 0x63],
+            },
+        );
+        match action {
+            Action::Close { code, message } => {
+                assert_eq!(code, error_code::UNEXPECTED_MESSAGE);
+                assert!(message.contains("input"), "message: {message}");
+                assert!(message.contains("awaiting_attach"), "message: {message}");
+            }
+            other => panic!("expected close, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resize_before_attached_is_protocol_violation() {
+        let mut phase = Phase::AwaitingAttach;
+        let action = step(
+            &mut phase,
+            ClientMessage::Resize {
+                cols: 80,
+                rows: 24,
+            },
+        );
+        match action {
+            Action::Close { code, .. } => {
+                assert_eq!(code, error_code::UNEXPECTED_MESSAGE);
+            }
+            other => panic!("expected close, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hello_ack_in_attached_phase_is_protocol_violation() {
+        // HelloAck is a one-shot; re-sending it later should be
+        // treated as out-of-phase. Otherwise a buggy client could
+        // hold the connection but never exercise the session.
+        let mut phase = Phase::Attached {
+            session: "s".into(),
+        };
+        let action = step(&mut phase, ack_v1());
+        match action {
+            Action::Close { code, .. } => {
+                assert_eq!(code, error_code::UNEXPECTED_MESSAGE);
+            }
+            other => panic!("expected close, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ping_is_allowed_in_every_phase() {
+        for mut phase in [
+            Phase::AwaitingHelloAck,
+            Phase::AwaitingAttach,
+            Phase::Attached {
+                session: "s".into(),
+            },
+        ] {
+            let before = phase.clone();
+            let action = step(&mut phase, ClientMessage::Ping { nonce: 7 });
+            assert_eq!(action, Action::SendPong(7));
+            assert_eq!(phase, before, "ping must not change phase in {before:?}");
+        }
+    }
+
+    #[test]
+    fn attach_in_await_attach_phase_requests_attach_action() {
+        let mut phase = Phase::AwaitingAttach;
+        let action = step(
+            &mut phase,
+            ClientMessage::Attach {
+                session: "main".into(),
+                cols: 120,
+                rows: 40,
+            },
+        );
+        assert_eq!(
+            action,
+            Action::DoAttach {
+                session: "main".into(),
+                cols: 120,
+                rows: 40,
+            }
+        );
+        // Step does NOT advance to Attached — the coordinator does
+        // that only after SessionManager::create_session succeeds.
+        // A bad session name that SessionManager rejects must not
+        // leave the machine in a silently-attached state.
+        assert_eq!(phase, Phase::AwaitingAttach);
+    }
+
+    #[test]
+    fn attach_in_wrong_phase_is_violation() {
+        let mut phase = Phase::AwaitingHelloAck;
+        let action = step(
+            &mut phase,
+            ClientMessage::Attach {
+                session: "main".into(),
+                cols: 80,
+                rows: 24,
+            },
+        );
+        match action {
+            Action::Close { code, .. } => {
+                assert_eq!(code, error_code::UNEXPECTED_MESSAGE);
+            }
+            other => panic!("expected close, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn input_after_attached_is_accepted() {
+        let mut phase = Phase::Attached {
+            session: "main".into(),
+        };
+        let action = step(
+            &mut phase,
+            ClientMessage::Input {
+                data: vec![0x41],
+            },
+        );
+        assert_eq!(action, Action::Continue);
+    }
+
+    #[test]
+    fn resize_after_attached_issues_resize_action() {
+        let mut phase = Phase::Attached {
+            session: "main".into(),
+        };
+        let action = step(
+            &mut phase,
+            ClientMessage::Resize {
+                cols: 100,
+                rows: 30,
+            },
+        );
+        assert_eq!(
+            action,
+            Action::DoResize {
+                session: "main".into(),
+                cols: 100,
+                rows: 30,
+            }
+        );
+    }
+
+    #[test]
+    fn protocol_version_error_truncates_control_chars() {
+        // An attacker-controlled version string with embedded
+        // control characters must not corrupt operator logs.
+        let mut phase = Phase::AwaitingHelloAck;
+        let crafted = "evil\r\n[WARN] forged_line";
+        let action = step(
+            &mut phase,
+            ClientMessage::HelloAck {
+                protocol_version: crafted.into(),
+            },
+        );
+        match action {
+            Action::Close { message, .. } => {
+                assert!(
+                    !message.contains('\r') && !message.contains('\n'),
+                    "log-bound error message must strip control chars; got {message:?}"
+                );
+            }
+            other => panic!("expected close, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn revoke_matching_credential_closes() {
+        let event = RevocationEvent {
+            credential_id: "cred-1".into(),
+        };
+        let action = handle_revoke(Ok(event), Some("cred-1"));
+        match action {
+            Action::Close { .. } => {}
+            other => panic!("expected close, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn revoke_other_credential_continues() {
+        let event = RevocationEvent {
+            credential_id: "other-cred".into(),
+        };
+        let action = handle_revoke(Ok(event), Some("cred-1"));
+        assert_eq!(action, Action::Continue);
+    }
+
+    #[test]
+    fn revoke_when_localhost_bound_continues() {
+        // Localhost connections have no credential binding and
+        // can't be revoked. Every incoming revoke event must be a
+        // no-op for them.
+        let event = RevocationEvent {
+            credential_id: "cred-1".into(),
+        };
+        let action = handle_revoke(Ok(event), None);
+        assert_eq!(action, Action::Continue);
+    }
+
+    #[test]
+    fn revoke_lagged_is_conservative_close() {
+        let action = handle_revoke(Err(RecvError::Lagged(3)), Some("cred-1"));
+        match action {
+            Action::Close { .. } => {}
+            other => panic!("expected close on lagged, got {other:?}"),
+        }
+    }
+}

--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -35,6 +35,7 @@
 //! the unit tests below snap whenever a variant crosses phases
 //! without explicit consent.
 
+use crate::log_util::sanitize_for_log;
 use crate::revocation::RevocationEvent;
 use crate::state::AppState;
 use crate::transport::{
@@ -74,6 +75,23 @@ pub mod error_code {
     /// Client didn't complete the handshake within
     /// `HANDSHAKE_TIMEOUT_SECS`. Connection closes.
     pub const HANDSHAKE_TIMEOUT: &str = "handshake_timeout";
+    /// Connection was torn down server-side without the client
+    /// having done anything wrong. Emitted when the bound
+    /// credential is revoked, or when the revocation broadcast
+    /// subscriber falls behind (`Lagged`) and we conservatively
+    /// close rather than risk missing a real revoke.
+    ///
+    /// **Why not dedicate codes per cause?** An operator-side
+    /// distinction between "revoked" and "lagged" is useful in
+    /// logs, but exposing it on the wire leaks "yes, your
+    /// credential was revoked" to whoever holds the socket. We
+    /// reuse this code for both, and the per-cause detail lives
+    /// only in the server's tracing output (see `handle_revoke`).
+    /// Clients key off this code to know that **auto-reconnect
+    /// without fresh auth is futile** — distinct from
+    /// `UNEXPECTED_MESSAGE`, which is a "fix your message" retry
+    /// signal.
+    pub const CONNECTION_TERMINATED: &str = "connection_terminated";
 }
 
 /// Handshake phase. Advances on valid messages; any message that
@@ -154,7 +172,7 @@ fn step(phase: &mut Phase, msg: ClientMessage) -> Action {
                         // bound on length defensively; don't let an
                         // attacker-chosen version string blow up
                         // log line size
-                        truncate_for_log(&protocol_version, 32),
+                        sanitize_for_log(&protocol_version, LOG_PROTOCOL_VERSION_MAX_LEN),
                     ),
                 }
             }
@@ -220,12 +238,13 @@ fn phase_name(phase: &Phase) -> &'static str {
     }
 }
 
-fn truncate_for_log(s: &str, max: usize) -> String {
-    s.chars()
-        .filter(|c| !c.is_ascii_control())
-        .take(max)
-        .collect()
-}
+/// Cap on the protocol-version string we echo back in error
+/// messages. Far shorter than the Origin cap in `ws.rs` because the
+/// version string is a short identifier (`"katulong/0.1"`) — if a
+/// client sends something larger, it's either buggy or crafted, and
+/// 32 chars is plenty to identify the prefix without letting an
+/// attacker flood logs with per-request megabyte payloads.
+const LOG_PROTOCOL_VERSION_MAX_LEN: usize = 32;
 
 /// The per-connection consumer loop, parameterised on the
 /// transport abstraction. `state` threads session manager + the
@@ -327,6 +346,20 @@ pub async fn serve_session(
                 cols,
                 rows,
             } => {
+                // Clamp once here, BEFORE calling into
+                // SessionManager, so both the session-manager
+                // create call and the `Attached` response we send
+                // back to the client use identical values. The
+                // manager's `create_session` clamps again
+                // internally as a defense-in-depth belt — this
+                // handler-level clamp is the authoritative
+                // "coordinator clamps before dispatch" step.
+                // Without this, a 9999-cols request would reach
+                // `create_session` unclamped; one careless future
+                // refactor that drops the manager's internal
+                // clamp would mean tmux sees the raw value. Do it
+                // here too so the invariant survives that refactor.
+                let (cols, rows) = crate::session::dims::clamp_dims(cols, rows);
                 let Some(sessions) = state.sessions.as_deref() else {
                     send_error_and_close(
                         &handle,
@@ -338,8 +371,6 @@ pub async fn serve_session(
                 };
                 match sessions.create_session(&session, cols, rows).await {
                     Ok(()) => {
-                        let (cols, rows) =
-                            crate::session::dims::clamp_dims(cols, rows);
                         phase = Phase::Attached {
                             session: session.clone(),
                         };
@@ -407,36 +438,51 @@ pub async fn serve_session(
 /// Decide whether a revocation event should tear down this
 /// connection. `credential_id` is the one this transport is bound
 /// to (from auth).
+///
+/// Every close path uses the `CONNECTION_TERMINATED` wire code so
+/// the client can't distinguish "revoked" from "lagged" — that
+/// distinction leaks revocation state to whoever holds the socket.
+/// The actual cause is emitted as a structured tracing field, so
+/// operators can tell from logs which branch fired.
 fn handle_revoke(
     revoke: Result<RevocationEvent, RecvError>,
     bound_credential: Option<&str>,
 ) -> Action {
     match revoke {
         Ok(event) => match bound_credential {
-            Some(mine) if mine == event.credential_id => Action::Close {
-                code: error_code::UNEXPECTED_MESSAGE,
-                // Credential was revoked — the client shouldn't
-                // see a detailed rationale beyond "connection
-                // closed." We reuse the generic UNEXPECTED code
-                // because the client's next action (prompt for
-                // reauth) is the same. A dedicated code here would
-                // leak "yes, your exact credential was revoked"
-                // to any party holding the socket, which is
-                // information we don't owe them.
-                message: "connection terminated".into(),
-            },
+            Some(mine) if mine == event.credential_id => {
+                tracing::info!(
+                    credential_id = %event.credential_id,
+                    cause = "credential_revoked",
+                    "session connection terminating"
+                );
+                Action::Close {
+                    code: error_code::CONNECTION_TERMINATED,
+                    message: "connection terminated".into(),
+                }
+            }
             _ => Action::Continue,
         },
         // Subscriber fell behind the broadcast buffer. `revocation.rs`
         // subscriber contract: conservative close.
-        Err(RecvError::Lagged(_)) => Action::Close {
-            code: error_code::UNEXPECTED_MESSAGE,
-            message: "connection terminated".into(),
-        },
+        Err(RecvError::Lagged(n)) => {
+            tracing::warn!(
+                lagged_events = n,
+                cause = "broadcast_lagged",
+                "session connection terminating (conservative close)"
+            );
+            Action::Close {
+                code: error_code::CONNECTION_TERMINATED,
+                message: "connection terminated".into(),
+            }
+        }
         // Publisher dropped. Shouldn't happen in practice
         // (AppState owns it for the server's lifetime), but if it
         // does, we have no more revocation awareness — exit to be
-        // safe.
+        // safe. `Exit` rather than `Close` because this only fires
+        // on process teardown, when there's no value in emitting a
+        // protocol-level close frame the runtime is about to tear
+        // down anyway.
         Err(RecvError::Closed) => Action::Exit,
     }
 }
@@ -693,13 +739,21 @@ mod tests {
     }
 
     #[test]
-    fn revoke_matching_credential_closes() {
+    fn revoke_matching_credential_closes_with_terminated_code() {
         let event = RevocationEvent {
             credential_id: "cred-1".into(),
         };
         let action = handle_revoke(Ok(event), Some("cred-1"));
         match action {
-            Action::Close { .. } => {}
+            Action::Close { code, .. } => {
+                assert_eq!(
+                    code,
+                    error_code::CONNECTION_TERMINATED,
+                    "revocation must use the terminated code — distinct from \
+                     UNEXPECTED_MESSAGE so clients can tell 'prompt for auth' \
+                     apart from 'fix your message'"
+                );
+            }
             other => panic!("expected close, got {other:?}"),
         }
     }
@@ -726,11 +780,57 @@ mod tests {
     }
 
     #[test]
-    fn revoke_lagged_is_conservative_close() {
+    fn revoke_lagged_is_conservative_close_with_terminated_code() {
         let action = handle_revoke(Err(RecvError::Lagged(3)), Some("cred-1"));
         match action {
-            Action::Close { .. } => {}
+            Action::Close { code, .. } => {
+                assert_eq!(
+                    code,
+                    error_code::CONNECTION_TERMINATED,
+                    "lagged broadcast shares the client-visible code with \
+                     revocation — the cause-distinction lives in tracing, \
+                     not on the wire"
+                );
+            }
             other => panic!("expected close on lagged, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn revoke_publisher_closed_exits_silently() {
+        // Publisher dropped means AppState is being torn down
+        // — the process is exiting. There's no value in emitting
+        // a protocol-level Error frame when the runtime is about
+        // to shut down; the `Exit` action drops the handle and
+        // lets the transport close with the socket.
+        let action = handle_revoke(Err(RecvError::Closed), Some("cred-1"));
+        assert_eq!(action, Action::Exit);
+    }
+
+    #[test]
+    fn error_codes_are_distinct() {
+        // Forward-safety: all `error_code::*` constants must
+        // carry distinct values. Two same-valued codes would
+        // silently collapse two different operator-visible
+        // causes into one log line and break clients that key
+        // off the specific code. Regressions here are easy to
+        // introduce (copy-paste a constant, forget to change the
+        // value) and impossible to catch at compile time — hence
+        // a dedicated test.
+        let all = [
+            error_code::PROTOCOL_VERSION_MISMATCH,
+            error_code::UNEXPECTED_MESSAGE,
+            error_code::INVALID_SESSION,
+            error_code::SESSION_ERROR,
+            error_code::NO_SESSION_MANAGER,
+            error_code::HANDSHAKE_TIMEOUT,
+            error_code::CONNECTION_TERMINATED,
+        ];
+        let set: std::collections::HashSet<&str> = all.iter().copied().collect();
+        assert_eq!(
+            set.len(),
+            all.len(),
+            "duplicate error code in `error_code::*`: {all:?}"
+        );
     }
 }

--- a/crates/server/src/session/manager.rs
+++ b/crates/server/src/session/manager.rs
@@ -43,6 +43,12 @@ impl SessionManager {
     /// `cols`/`rows` are clamped via `dims::clamp_dims` before
     /// reaching tmux — we never ask tmux to create a 10000-column
     /// session because the client lied about its window size.
+    /// The `session::handler` coordinator clamps again before
+    /// calling here; that's intentional belt-and-suspenders, NOT
+    /// redundancy to delete. Defense in depth: if a future caller
+    /// (CLI, admin API, tests) forgets to clamp, this internal
+    /// clamp keeps tmux safe. Since `clamp_dims` is idempotent,
+    /// the double call has no observable effect.
     ///
     /// `name` must be a tmux-safe session identifier: no spaces, no
     /// colons, no periods, no dollar-signs (which tmux interprets as
@@ -169,6 +175,15 @@ pub enum SessionError {
     Tmux(#[from] TmuxError),
 }
 
+/// Hard cap on session-name length. tmux itself accepts names up
+/// to `PATH_MAX`-ish, but no legitimate katulong session needs
+/// anywhere near that. Clipping to 64 bytes keeps the error path
+/// cheap (no multi-KiB `format!` allocations for tmux commands we
+/// know will fail) and keeps log lines readable when a bad name
+/// gets rejected. An authenticated client could still burn a
+/// round trip per attempted `Attach`, but not arbitrary memory.
+const MAX_SESSION_NAME_LEN: usize = 64;
+
 /// Reject session names that would confuse tmux's target parser.
 /// tmux uses `:` as window separator, `.` as pane separator, and
 /// `$`/`@`/`%` as id prefixes; a name containing any of those can
@@ -184,8 +199,11 @@ pub enum SessionError {
 /// sessions except the attached one." An authenticated caller
 /// could then nuke every session by naming one `-a`. The allowlist
 /// alone didn't cover this argument-injection edge.
+///
+/// **Length cap.** Names over `MAX_SESSION_NAME_LEN` bytes fail
+/// validation — see the constant's doc for the rationale.
 fn validate_session_name(name: &str) -> Result<(), SessionError> {
-    if name.is_empty() || name.starts_with('-') {
+    if name.is_empty() || name.starts_with('-') || name.len() > MAX_SESSION_NAME_LEN {
         return Err(SessionError::InvalidName(name.to_string()));
     }
     for c in name.chars() {
@@ -253,6 +271,17 @@ mod tests {
         // Hyphens are fine anywhere except the first position.
         assert!(validate_session_name("my-session").is_ok());
         assert!(validate_session_name("a-b-c").is_ok());
+    }
+
+    #[test]
+    fn session_name_rejects_oversize() {
+        // Authenticated callers could otherwise ask the manager to
+        // allocate multi-KiB tmux command strings per Attach
+        // attempt. Cap at `MAX_SESSION_NAME_LEN`.
+        let at_limit = "a".repeat(MAX_SESSION_NAME_LEN);
+        assert!(validate_session_name(&at_limit).is_ok());
+        let over_limit = "a".repeat(MAX_SESSION_NAME_LEN + 1);
+        assert!(validate_session_name(&over_limit).is_err());
     }
 
     #[test]

--- a/crates/server/src/session/mod.rs
+++ b/crates/server/src/session/mod.rs
@@ -1,14 +1,31 @@
 //! Terminal session layer.
 //!
-//! Wraps tmux via its `-C` control-mode protocol. This slice (9b)
-//! ships the scaffold — protocol parser, tmux subprocess client,
-//! and a SessionManager with create/list/destroy/resize. Slice 9c
-//! wires it into `AppState` and the WS terminal handler.
+//! Wraps tmux via its `-C` control-mode protocol.
+//!
+//! - `parser` — control-mode notification parser (`%begin`, `%end`,
+//!   `%output`, ...).
+//! - `tmux` — subprocess client; owns the long-running `tmux -C -L
+//!   katulong` process and multiplexes commands over its stdin.
+//! - `manager` — `SessionManager` with create/list/destroy/resize,
+//!   built on top of `tmux`.
+//! - `dims` — multi-device dimension discipline (commentary +
+//!   constants; see `CLAUDE.md`).
+//! - `handler` — per-connection consumer loop. Runs the handshake
+//!   state machine and revocation watch against a
+//!   `TransportHandle`.
+//!
+//! Slice 9f will wire the output forwarding path from
+//! `tmux::Tmux`'s notification stream into the per-connection
+//! `ServerMessage::Output` producer, with the coalescing + resize
+//! gating imported from the Node scars (`d311168`, `066dab2`,
+//! `da6907f`).
 
 pub mod dims;
+pub mod handler;
 pub mod manager;
 pub mod parser;
 pub mod tmux;
 
+pub use handler::serve_session;
 pub use manager::{SessionError, SessionManager};
 pub use tmux::{CommandReply, Tmux, TmuxError, DEDICATED_SOCKET_NAME};

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -7,6 +7,7 @@
 //! their own mutexes. `AppState` itself is just a bundle of references.
 
 use crate::revocation::RevocationPublisher;
+use crate::session::SessionManager;
 use katulong_auth::{AuthStore, WebAuthnService};
 use std::sync::Arc;
 use tokio::sync::broadcast::Receiver;
@@ -43,16 +44,40 @@ pub struct AppState {
     /// subscribers call `state.subscribe_revocations()` at the
     /// start of their connection loop.
     pub revocations: RevocationPublisher,
+    /// Handle to the terminal session layer. `None` in tests that
+    /// don't need a real tmux subprocess (auth-only routes); `Some`
+    /// when `main.rs` has successfully spawned tmux at startup.
+    ///
+    /// The session handler (`session::handler::serve_session`)
+    /// surfaces a `no_session_manager` protocol error if a client
+    /// tries to `Attach` when this is `None`. That's a clear
+    /// misconfiguration signal rather than a silent hang — keeping
+    /// the field `Option` rather than `Arc<SessionManager>` avoids
+    /// forcing every auth integration test to stand up tmux.
+    pub sessions: Option<Arc<SessionManager>>,
 }
 
 impl AppState {
+    /// Construct an `AppState` with no session manager. Suitable for
+    /// tests that exercise auth/HTTP paths only. Production startup
+    /// in `main.rs` chains `.with_sessions(...)` on top.
     pub fn new(auth_store: AuthStore, webauthn: WebAuthnService, config: ServerConfig) -> Self {
         Self {
             auth_store: Arc::new(auth_store),
             webauthn: Arc::new(webauthn),
             config: Arc::new(config),
             revocations: RevocationPublisher::new(),
+            sessions: None,
         }
+    }
+
+    /// Attach a running `SessionManager` to this state. Called once
+    /// at startup from `main.rs` after tmux spawns successfully.
+    /// Moving rather than cloning reinforces "there's one session
+    /// layer per server process."
+    pub fn with_sessions(mut self, sessions: SessionManager) -> Self {
+        self.sessions = Some(Arc::new(sessions));
+        self
     }
 
     /// Subscribe to credential-revocation events. Transport-agnostic

--- a/crates/server/src/transport/message.rs
+++ b/crates/server/src/transport/message.rs
@@ -19,6 +19,18 @@
 //! base64 overhead for byte payloads, smaller wire, same serde
 //! derives.
 //!
+//! # Byte-string encoding for `Input`/`Output`
+//!
+//! `Input { data }` and `Output { data }` carry raw terminal bytes
+//! (keystroke input, PTY output). Their `data` fields are
+//! annotated `#[serde(with = "serde_bytes")]` so CBOR emits a
+//! major-type-2 byte string instead of the serde-default array of
+//! small integers. Without the annotation, a 1 KiB paste would
+//! encode as ~1–2 KiB of integer elements; with it the payload
+//! rides the wire literally. JSON callers would see base64 — fine,
+//! because there are none: session-layer messages only ever travel
+//! as CBOR.
+//!
 //! # Strictness flags
 //!
 //! - `#[serde(tag = "type", rename_all = "snake_case")]` — every
@@ -30,11 +42,29 @@
 //!   federation relays) can deserialize newer-server output
 //!   without hard-failing on unknown fields.
 //!
-//! # Scope for slice 9c/9d
+//! # Handshake & session binding (slice 9e)
 //!
-//! Just `Ping`/`Pong` + `Hello`. Enough to exercise the transport
-//! abstraction end-to-end. Slice 9e adds terminal messages
-//! (`Input`, `Output`, `Resize`, `SessionAttached`, ...).
+//! The protocol is a three-step gate before terminal I/O is valid:
+//!
+//! 1. **Server → Client: `Hello { protocol_version }`** on upgrade.
+//!    Client refuses if the version doesn't match its expected
+//!    value.
+//! 2. **Client → Server: `HelloAck { protocol_version }`.** The
+//!    server re-validates the version — belt-and-suspenders against
+//!    a pinned client speaking an older protocol that happens to
+//!    overlap. On mismatch the server emits `Error { code:
+//!    "protocol_version_mismatch", ... }` and closes.
+//! 3. **Client → Server: `Attach { session, cols, rows }`.** Binds
+//!    this transport to a tmux session. Server replies with
+//!    `Attached { session, cols, rows }` (the clamped dims that
+//!    actually landed on tmux).
+//!
+//! Only after `Attached` are `Input` and `Resize` accepted.
+//! Sending either earlier triggers `Error { code:
+//! "unexpected_message", ... }` and the transport closes.
+//!
+//! `Ping`/`Pong` is allowed in every phase — liveness is orthogonal
+//! to the handshake.
 
 use serde::{Deserialize, Serialize};
 
@@ -58,6 +88,39 @@ pub enum ClientMessage {
     /// without assuming a specific transport's heartbeat primitive
     /// (WS Ping frames vs WebRTC DC keep-alives differ).
     Ping { nonce: u64 },
+
+    /// Acknowledge the server's `Hello` and confirm the client
+    /// speaks the same protocol version. Sent exactly once, as the
+    /// first message after the client receives `Hello`. The server
+    /// re-checks the version and closes on mismatch.
+    HelloAck { protocol_version: String },
+
+    /// Bind this transport to a tmux session. `session` is the tmux
+    /// session name (validated by `SessionManager`); `cols`/`rows`
+    /// are the client's current window dimensions (clamped
+    /// defensively server-side per `session::dims`). Sent exactly
+    /// once after `HelloAck`. The server creates the session if it
+    /// doesn't exist (or attaches to the existing one) and replies
+    /// with `Attached`.
+    Attach {
+        session: String,
+        cols: u16,
+        rows: u16,
+    },
+
+    /// Keystroke / paste input destined for the PTY. Only valid
+    /// after `Attached`. Slice 9e validates and accepts but does
+    /// not forward — slice 9f wires the tmux write path.
+    Input {
+        #[serde(with = "serde_bytes")]
+        data: Vec<u8>,
+    },
+
+    /// Window-resize notification. Only valid after `Attached`.
+    /// Forwarded to the session manager, which clamps and issues a
+    /// tmux `refresh-client -C`. Do NOT send on every keystroke —
+    /// see `session::dims` for the SIGWINCH-storm history.
+    Resize { cols: u16, rows: u16 },
 }
 
 /// Messages sent by the server to the client.
@@ -67,17 +130,18 @@ pub enum ClientMessage {
 /// don't reject — we want server → client additions to be
 /// deployable without client pinning.
 ///
-/// **Slice-9e note on byte-heavy variants.** When `Output { data:
-/// Vec<u8>, ... }` lands, CBOR encodes it as a map with a byte-
-/// string field — low overhead per frame (the `type` key + map
-/// structure is a few bytes). That's fine IF the session layer
-/// coalesces output into chunks above ~256 bytes before sending.
-/// If it forwards one-escape-per-frame from tmux, the map-per-
-/// message overhead becomes measurable. The existing
-/// `d311168`/`066dab2` Node scars (2 ms idle / 16 ms cap
-/// coalescing) are the right defense; they sit in the session
-/// layer, not here. Just: don't let 9e ship an uncoalesced
-/// per-frame-per-escape output path and blame the encoding.
+/// **Slice-9e byte-heavy variants (`Output`).** When slice 9f
+/// starts producing `Output { data: Vec<u8>, seq: u64 }`, CBOR
+/// encodes `data` as a byte-string (via `serde_bytes`) with the
+/// usual per-frame map overhead (the `type` key + map structure is
+/// a few bytes). That's fine IF the session layer coalesces output
+/// into chunks above ~256 bytes before sending. If it forwards
+/// one-escape-per-frame from tmux, the map-per-message overhead
+/// becomes measurable. The existing `d311168`/`066dab2` Node scars
+/// (2 ms idle / 16 ms cap coalescing) are the right defense; they
+/// sit in the session layer, not here. Just: don't let 9f ship an
+/// uncoalesced per-frame-per-escape output path and blame the
+/// encoding.
 ///
 /// **Asymmetry with `ClientMessage`.** `deny_unknown_fields` is
 /// deliberately OMITTED here. The strict boundary is INBOUND: the
@@ -86,9 +150,7 @@ pub enum ClientMessage {
 /// own code; relaxing this direction lets older Rust clients
 /// (tests, migration tools, federation relays) deserialize
 /// newer-server output without hard-failing on fields they don't
-/// understand. The forward-compat policy in the struct's doc
-/// matches the serde attributes structurally, not just
-/// aspirationally.
+/// understand.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerMessage {
@@ -99,6 +161,35 @@ pub enum ServerMessage {
     Hello { protocol_version: String },
     /// Response to a client `Ping`. Echoes the same nonce.
     Pong { nonce: u64 },
+    /// Confirms that this transport is bound to `session`, which
+    /// has been resized to the clamped `cols`/`rows`. The client
+    /// should use these (not what it requested) as the authoritative
+    /// dimensions for its local renderer.
+    Attached {
+        session: String,
+        cols: u16,
+        rows: u16,
+    },
+    /// PTY output chunk. `seq` is a monotonic counter per
+    /// connection that lets clients detect gaps after a reconnect
+    /// (Node scar `da6907f`). Slice 9e defines the variant; slice
+    /// 9f populates it from the tmux `%output` notification stream
+    /// with coalescing (`d311168`/`066dab2`).
+    Output {
+        #[serde(with = "serde_bytes")]
+        data: Vec<u8>,
+        seq: u64,
+    },
+    /// Protocol-level error. The server sends this right before
+    /// closing the transport so the client sees a concrete reason
+    /// in logs rather than an opaque WS close frame.
+    ///
+    /// `code` is a stable machine-readable token (e.g.
+    /// `"protocol_version_mismatch"`, `"unexpected_message"`);
+    /// `message` is a human-readable operator-visible string. The
+    /// code stays stable across releases so scripts and client
+    /// error classifiers key off it.
+    Error { code: String, message: String },
 }
 
 #[cfg(test)]
@@ -109,6 +200,11 @@ mod tests {
     // `deny_unknown_fields`, etc.) are format-agnostic, so a serde
     // behavior proven with JSON also holds on CBOR. Two CBOR
     // roundtrip tests at the end lock in the production encoding.
+    //
+    // NOTE: the `serde_bytes` annotation on `Input`/`Output.data`
+    // forces CBOR byte-string encoding but produces base64-style
+    // arrays under JSON. Tests that assert on byte content roundtrip
+    // through CBOR specifically.
     use super::*;
     use serde_json::{from_str, to_string};
 
@@ -137,12 +233,68 @@ mod tests {
     }
 
     #[test]
+    fn client_hello_ack_serde_roundtrip() {
+        let m = ClientMessage::HelloAck {
+            protocol_version: PROTOCOL_VERSION.into(),
+        };
+        let s = to_string(&m).unwrap();
+        assert!(s.contains(r#""type":"hello_ack""#));
+        assert_eq!(from_str::<ClientMessage>(&s).unwrap(), m);
+    }
+
+    #[test]
+    fn client_attach_serde_roundtrip() {
+        let m = ClientMessage::Attach {
+            session: "main".into(),
+            cols: 120,
+            rows: 40,
+        };
+        let s = to_string(&m).unwrap();
+        assert!(s.contains(r#""type":"attach""#));
+        assert_eq!(from_str::<ClientMessage>(&s).unwrap(), m);
+    }
+
+    #[test]
+    fn server_attached_serde_roundtrip() {
+        let m = ServerMessage::Attached {
+            session: "main".into(),
+            cols: 120,
+            rows: 40,
+        };
+        let s = to_string(&m).unwrap();
+        assert!(s.contains(r#""type":"attached""#));
+        assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
+    }
+
+    #[test]
+    fn client_resize_serde_roundtrip() {
+        let m = ClientMessage::Resize {
+            cols: 80,
+            rows: 24,
+        };
+        let s = to_string(&m).unwrap();
+        assert!(s.contains(r#""type":"resize""#));
+        assert_eq!(from_str::<ClientMessage>(&s).unwrap(), m);
+    }
+
+    #[test]
+    fn server_error_serde_roundtrip() {
+        let m = ServerMessage::Error {
+            code: "protocol_version_mismatch".into(),
+            message: "expected katulong/0.1, got katulong/0.2".into(),
+        };
+        let s = to_string(&m).unwrap();
+        assert!(s.contains(r#""type":"error""#));
+        assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
+    }
+
+    #[test]
     fn unknown_type_is_rejected() {
         // Server adds a new variant; an older client shouldn't see
         // a silent "ClientMessage::Unknown" — it should fail to
         // parse, so the server knows the client doesn't speak this
         // protocol version.
-        let err = from_str::<ClientMessage>(r#"{"type":"resize","cols":80}"#);
+        let err = from_str::<ClientMessage>(r#"{"type":"output","data":[1,2,3],"seq":1}"#);
         assert!(err.is_err(), "unknown type must fail deserialization");
     }
 
@@ -169,6 +321,23 @@ mod tests {
     }
 
     #[test]
+    fn resize_oversize_value_parses_then_server_clamps() {
+        // Serde deserializes any u16 value; clamping is the session
+        // layer's responsibility via `session::dims::clamp_dims`.
+        // This test is a reminder that the PARSER accepts the
+        // number — any out-of-range value must be caught downstream,
+        // not here.
+        let m: ClientMessage = from_str(r#"{"type":"resize","cols":9999,"rows":9999}"#).unwrap();
+        assert_eq!(
+            m,
+            ClientMessage::Resize {
+                cols: 9999,
+                rows: 9999
+            }
+        );
+    }
+
+    #[test]
     fn cbor_client_message_roundtrip() {
         // Production-wire check. CBOR is what actually rides the
         // transport; JSON is only the test-readability medium for
@@ -191,6 +360,45 @@ mod tests {
         assert_eq!(back, original);
 
         let original = ServerMessage::Pong { nonce: 17 };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&original, &mut buf).unwrap();
+        let back: ServerMessage = ciborium::de::from_reader(&buf[..]).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn cbor_input_encodes_data_as_byte_string() {
+        // The `serde_bytes` annotation is load-bearing for wire
+        // efficiency: without it, `Vec<u8>` encodes as a CBOR
+        // array of small integers (each byte takes 1–2 bytes of
+        // overhead). With it, CBOR major-type-2 byte-string carries
+        // the payload literally.
+        //
+        // Empirical check: a 256-byte payload should encode to
+        // well under 300 bytes total (a few bytes of envelope +
+        // the 256 raw bytes + small length prefix). Array encoding
+        // would land north of 400 bytes because each 0..255 integer
+        // takes 1–2 bytes.
+        let data = vec![0xABu8; 256];
+        let original = ClientMessage::Input { data: data.clone() };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&original, &mut buf).unwrap();
+        assert!(
+            buf.len() < 300,
+            "Input data field must encode as byte-string, \
+             not array-of-int; encoded {} bytes for 256 payload bytes",
+            buf.len()
+        );
+        let back: ClientMessage = ciborium::de::from_reader(&buf[..]).unwrap();
+        assert_eq!(back, ClientMessage::Input { data });
+    }
+
+    #[test]
+    fn cbor_output_roundtrip_preserves_seq_and_bytes() {
+        let original = ServerMessage::Output {
+            data: vec![0x01, 0x1b, 0x5b, 0x48],
+            seq: 42,
+        };
         let mut buf = Vec::new();
         ciborium::ser::into_writer(&original, &mut buf).unwrap();
         let back: ServerMessage = ciborium::de::from_reader(&buf[..]).unwrap();

--- a/crates/server/src/transport/mod.rs
+++ b/crates/server/src/transport/mod.rs
@@ -5,9 +5,12 @@
 //! messages takes a `TransportHandle`; WS and (future) WebRTC are
 //! interchangeable implementations.
 //!
-//! This slice (9c) ships the abstraction + WS impl + typed
-//! protocol. Terminal wiring is slice 9d; WebRTC impl is whichever
-//! slice actually ships a client that wants it.
+//! Slice 9c shipped the abstraction + WS impl + typed protocol.
+//! Slice 9d moved all session wire formats to CBOR. Slice 9e added
+//! the terminal-message variants (`HelloAck`, `Attach`, `Input`,
+//! `Resize`, `Attached`, `Output`, `Error`) that the handshake
+//! state machine in `session::handler` drives. WebRTC impl is
+//! whichever slice actually ships a client that wants it.
 
 pub mod handle;
 pub mod message;

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -1,9 +1,13 @@
 //! WebSocket upgrade endpoint.
 //!
-//! This slice wires the transport only — authenticated upgrade,
-//! Origin validation, and a minimal accept-and-close loop that
-//! handles `Ping`/`Pong`/`Close`. No terminal I/O yet; slice 9 will
-//! replace the loop with tmux/PTY wiring.
+//! This module is the HTTP-level entry point: authenticate the
+//! request, validate the Origin, and if both pass, upgrade to a
+//! WebSocket and hand the resulting `TransportHandle` to
+//! `session::handler::serve_session`. No terminal I/O lives here —
+//! the session handler owns the consumer loop against the
+//! transport abstraction, which keeps this file transport-specific
+//! (axum `WebSocketUpgrade`) and the session layer transport-
+//! agnostic.
 //!
 //! # Security-critical: Origin validation
 //!
@@ -30,10 +34,9 @@
 
 use crate::access::AccessMethod;
 use crate::auth_middleware::Authenticated;
+use crate::session::serve_session;
 use crate::state::AppState;
-use crate::transport::{
-    websocket::into_transport, ClientMessage, ServerMessage, TransportHandle, PROTOCOL_VERSION,
-};
+use crate::transport::websocket::into_transport;
 use axum::{
     extract::{ws::WebSocket, ConnectInfo, State, WebSocketUpgrade},
     http::{header, HeaderMap, StatusCode},
@@ -107,25 +110,25 @@ pub async fn ws_handler(
     State(state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
-    Authenticated(_ctx): Authenticated,
+    Authenticated(ctx): Authenticated,
     upgrade: Option<WebSocketUpgrade>,
 ) -> Response {
     let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
     let access = AccessMethod::classify(peer, host);
     let origin = headers.get(header::ORIGIN).and_then(|v| v.to_str().ok());
 
+    // Capture the credential id BEFORE consuming `ctx` into the
+    // closure below. `AuthContext::Localhost` returns None here,
+    // which the session handler interprets as "can't be revoked" —
+    // matches the auth model where localhost requests bypass the
+    // credential gate entirely.
+    let credential_id = ctx.credential_id().map(|s| s.to_string());
+
     match validate_origin(access, origin, &state.config.public_origin) {
         OriginCheck::LocalhostExempt | OriginCheck::Allowed => match upgrade {
             Some(u) => {
-                // Capture state here so slice 9d can thread it
-                // into `serve_session` as a body change, not a
-                // call-site + signature rework. The auth
-                // `AuthContext` would also be captured here in
-                // 9d — the extractor's lifetime ends when the
-                // handler returns, and the terminal layer needs
-                // credential id for revocation matching.
                 let state_for_session = state.clone();
-                u.on_upgrade(|ws: WebSocket| async move {
+                u.on_upgrade(move |ws: WebSocket| async move {
                     // Hand the raw socket to the transport adapter
                     // immediately; from here on the consumer sees
                     // only the abstraction. A future WebRTC
@@ -135,7 +138,7 @@ pub async fn ws_handler(
                     // tasks observe channel closure and exit
                     // cleanly when serve_session drops the handle.
                     let (handle, _pumps) = into_transport(ws);
-                    serve_session(state_for_session, handle).await;
+                    serve_session(state_for_session, handle, credential_id).await;
                 })
             }
             None => (
@@ -160,72 +163,6 @@ pub async fn ws_handler(
                 "ws upgrade rejected: Origin mismatch"
             );
             (StatusCode::FORBIDDEN, "origin not allowed").into_response()
-        }
-    }
-}
-
-/// Per-connection consumer loop.
-///
-/// The WS frame plumbing lives in `transport::websocket`; this
-/// function consumes the resulting `TransportHandle`. By design it
-/// does NOT import `axum::ws` types — when the WebRTC transport
-/// slice lands, the same loop runs unchanged against a
-/// `TransportHandle` whose pumps speak DataChannel.
-///
-/// `state` is threaded through for slice 9d's use (session manager
-/// access, revocation subscription). Slice 9c ignores it aside from
-/// holding the handle alive, but the parameter exists now so 9d is
-/// a body-only change rather than also reworking the call site.
-///
-/// # SECURITY (slice-9d obligation)
-///
-/// This loop does NOT yet subscribe to
-/// `state.subscribe_revocations()`. An active connection whose
-/// bound credential is revoked between `Authenticated` extractor
-/// and now will continue streaming until the client disconnects.
-/// Slice 9d MUST wire the revocation channel via a
-/// `tokio::select!` between `handle.inbound.recv()` and the
-/// revocation receiver; on a matching credential id, close the
-/// transport via `handle.outbound` drop. Until then, an attacker
-/// who has captured a session cookie cannot be evicted in
-/// real time — only the next auth-required HTTP request will see
-/// the cascade.
-///
-/// Slice-9c behavior (placeholder until slice 9d wires the terminal):
-/// - Send `Hello` immediately so the client sees the connection is
-///   alive + knows the protocol version.
-/// - Respond to app-level `Ping { nonce }` with `Pong { nonce }`.
-/// - Exit cleanly on peer disconnect (`inbound` channel closes).
-/// - Log-and-continue on decode errors — the transport stays open;
-///   a single malformed frame from a glitchy client doesn't
-///   terminate the whole session. The Node scar `9dc7c78` said
-///   validate at the boundary; the typed deserialization already
-///   fails closed, this layer just reports it.
-async fn serve_session(_state: AppState, handle: TransportHandle) {
-    let mut handle = handle;
-    if handle
-        .send(ServerMessage::Hello {
-            protocol_version: PROTOCOL_VERSION.to_string(),
-        })
-        .await
-        .is_err()
-    {
-        // Transport closed before we could even send hello. Bail.
-        return;
-    }
-    while let Some(msg) = handle.inbound.recv().await {
-        match msg {
-            Ok(ClientMessage::Ping { nonce }) => {
-                if handle.send(ServerMessage::Pong { nonce }).await.is_err() {
-                    break;
-                }
-            }
-            Err(err) => {
-                // Decoder/frame error. Log the operator-visible
-                // detail but keep the connection — a single bad
-                // frame isn't a reason to kick the user out.
-                tracing::warn!(error = %err, "transport frame error; dropping");
-            }
         }
     }
 }

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -34,6 +34,7 @@
 
 use crate::access::AccessMethod;
 use crate::auth_middleware::Authenticated;
+use crate::log_util::sanitize_for_log;
 use crate::session::serve_session;
 use crate::state::AppState;
 use crate::transport::websocket::into_transport;
@@ -83,18 +84,12 @@ pub(crate) fn validate_origin(
     }
 }
 
-/// Render an attacker-controlled string (like a rejected Origin
-/// value) safe for `tracing` emission: strip ASCII control
-/// characters that would corrupt text logs or inject structured
-/// fields in JSON formatters, cap at 256 chars. Used only at reject
-/// sites; the accept path never logs the Origin.
-fn sanitize_for_log(value: &str) -> String {
-    value
-        .chars()
-        .filter(|c| !c.is_ascii_control())
-        .take(256)
-        .collect()
-}
+/// Cap on Origin values emitted to logs at reject sites. Longer
+/// than the 32-char cap on protocol-version strings because an
+/// operator diagnosing a legitimate Origin mismatch benefits from
+/// seeing most of the full URL. Shared sanitizer lives in
+/// `crate::log_util`.
+const LOG_ORIGIN_MAX_LEN: usize = 256;
 
 /// Axum handler for `GET /ws`.
 ///
@@ -156,7 +151,7 @@ pub async fn ws_handler(
             // before logging so control characters can't corrupt
             // text log lines or inject structured-field separators
             // in JSON formatters.
-            let safe = sanitize_for_log(origin.unwrap_or(""));
+            let safe = sanitize_for_log(origin.unwrap_or(""), LOG_ORIGIN_MAX_LEN);
             tracing::warn!(
                 origin = %safe,
                 expected = %state.config.public_origin,
@@ -212,22 +207,6 @@ mod tests {
             validate_origin(AccessMethod::Remote, Some(""), PUBLIC),
             OriginCheck::Mismatch,
             "empty Origin is a real value, not missing"
-        );
-    }
-
-    #[test]
-    fn sanitize_for_log_strips_control_chars_and_caps_length() {
-        assert_eq!(
-            sanitize_for_log("evil\r\n[WARN] faked=line"),
-            "evil[WARN] faked=line",
-            "newlines and carriage returns must be stripped — otherwise a crafted Origin can forge log lines"
-        );
-        assert_eq!(sanitize_for_log("plain"), "plain");
-        let huge = "x".repeat(1000);
-        assert_eq!(
-            sanitize_for_log(&huge).len(),
-            256,
-            "cap at 256 chars so an attacker can't flood logs with a megabyte Origin"
         );
     }
 

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -9,6 +9,5 @@ name = "katulong-web"
 path = "src/main.rs"
 
 [dependencies]
-katulong-shared = { path = "../shared" }
 leptos = { workspace = true }
 console_error_panic_hook = "0.1"

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -1,4 +1,3 @@
-use katulong_shared::PROTOCOL_VERSION;
 use leptos::*;
 
 fn main() {
@@ -12,7 +11,6 @@ fn App() -> impl IntoView {
         <main>
             <h1>"katulong"</h1>
             <p>"Rust + Leptos rewrite — hello world"</p>
-            <p>{format!("Protocol version: {PROTOCOL_VERSION}")}</p>
         </main>
     }
 }


### PR DESCRIPTION
## Summary

- Extend the wire protocol with terminal-message variants: `ClientMessage::{HelloAck, Attach, Input, Resize}` and `ServerMessage::{Attached, Output, Error}`. Byte-string CBOR encoding (`serde_bytes`) for `Input`/`Output.data`.
- New `session::handler` module owns the per-connection consumer loop: pure `Phase` state machine (`AwaitingHelloAck → AwaitingAttach → Attached`) + `Action` enum dispatched by an async coordinator. 15 unit tests cover every legal/illegal (phase, message) pair without touching tmux or a real socket.
- `serve_session` subscribes to revocation events BEFORE the handshake (per `revocation.rs` subscriber contract), `tokio::select!`s inbound / revocations / 10 s handshake-timeout. Matching-credential revoke closes the transport; `Lagged` is conservative close.
- `AppState` gains `sessions: Option<Arc<SessionManager>>`. `main.rs` spawns tmux at startup and chains `.with_sessions(...)`. Auth/HTTP tests keep working with `None`; `Attach` against `None` surfaces a clear `no_session_manager` protocol error.
- `ws.rs` trimmed to HTTP entry + Origin gate; all consumer-loop logic delegated to `session::handler`.
- Boy-scout: remove stale `katulong-shared::PROTOCOL_VERSION` reference from the `katulong-web` placeholder (slice 9c deleted the source); drop the now-unused `katulong-shared` dep from the web crate.

## Slice plan context

- **9e (this PR)** — handshake gate + revocation watch + session manager in state + tmux at startup. No I/O forwarding.
- 9f — wire tmux `%output` notifications → `ServerMessage::Output` with the coalescing (`d311168`/`066dab2`) and sequencing (`da6907f`) from Node scars; `ClientMessage::Input` forwarded to tmux; resize gating (50 ms after output).
- 9g — `/api/sessions` CRUD.

## Scar alignment

- Node `45f4285` (state machine must start in actual initial state, not desired) — the phase machine starts in `AwaitingHelloAck` and advances to `Attached` only after `create_session` actually succeeds. A rejected attach leaves phase unchanged.
- Node `be5826b` (extract when sub-module owns cohesive state testable in isolation) — motivates lifting the consumer loop into `session::handler` where the state machine is trivially exercisable without tmux or WS.
- Node `da6907f` (output seq numbers for reconnect-gap detection) — `ServerMessage::Output { seq: u64 }` defined ahead of the producer so slice 9f doesn't need a protocol bump.

## Test plan

- [x] `cargo test --workspace` — 178 passing (155 before), 1 ignored (tmux_roundtrip).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] Pre-push Node test suite — unit + integration + smoke E2E passed (no node code changed on this branch).

## Gotchas noted inline

- `Tmux::spawn`'s notification receiver is UNBOUNDED per contract; slice 9e spawns but leaves it idle. Slice 9f MUST route it into a consumer before producing any output or memory grows.
- Revocation close reuses `UNEXPECTED_MESSAGE` rather than a dedicated `REVOKED` code on purpose — a dedicated code would confirm "yes, this specific credential was just revoked" to whoever holds the socket. Reusing the generic code keeps that information internal.