### PR TITLE
rewrite(server): slice 9f — tmux output/input forwarding + coalescing + resize gating

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -49,3 +49,8 @@ serde_bytes = "0.11"
 tempfile = { workspace = true }
 tower = { version = "0.4", features = ["util"] }
 http-body-util = "0.1"
+# `test-util` enables `#[tokio::test(start_paused = true)]` used by
+# the output coalescer's timer tests. `tokio`'s `full` feature
+# does NOT include it — `test-util` is explicitly test-only and
+# opting out of the production build is the point.
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,7 +1,8 @@
 use katulong_auth::{AuthStore, WebAuthnService};
 use katulong_server::session::{
     dims::{DEFAULT_COLS, DEFAULT_ROWS},
-    SessionManager, Tmux, DEDICATED_SOCKET_NAME,
+    parser::Notification,
+    OutputRouter, SessionManager, Tmux, DEDICATED_SOCKET_NAME,
 };
 use katulong_server::{app, state::AppState, state::ServerConfig};
 use std::net::SocketAddr;
@@ -30,18 +31,6 @@ async fn main() {
     // would accept WS upgrades that fail at Attach time, which is
     // worse operator UX than a startup panic pointing at the
     // missing binary.
-    //
-    // `notifs` is the async-notification receiver (tmux `%output`,
-    // `%window-close`, etc.). Per the `Tmux::spawn` contract this
-    // is UNBOUNDED — leaving it unconsumed would let any
-    // tmux-produced terminal output accumulate until the process
-    // OOMs. Slice 9e doesn't yet route output back over the
-    // transport (that's slice 9f), but a real shell attached to
-    // the initial session would already be producing output, so
-    // the receiver MUST be drained. The drop-all drain task below
-    // is the slice-9e placeholder; slice 9f replaces it with the
-    // per-connection output pump that forwards `%output` over the
-    // transport with coalescing (Node scars `d311168`/`066dab2`).
     let socket_name = std::env::var("KATULONG_TMUX_SOCKET")
         .unwrap_or_else(|_| DEDICATED_SOCKET_NAME.to_string());
     let initial_session = std::env::var("KATULONG_INITIAL_SESSION")
@@ -50,15 +39,43 @@ async fn main() {
         Tmux::spawn(&socket_name, &initial_session, DEFAULT_COLS, DEFAULT_ROWS)
             .await
             .expect("spawn tmux control-mode subprocess");
-    tokio::spawn(async move {
-        // Slice-9e drain: discard tmux notifications so the
-        // unbounded receiver can't grow toward OOM. Slice 9f
-        // replaces this task with the real output forwarder.
-        while notifs.recv().await.is_some() {}
-    });
     let sessions = SessionManager::new(tmux);
+    let output_router = OutputRouter::new();
 
-    let state = AppState::new(auth_store, webauthn, config).with_sessions(sessions);
+    // Dispatcher task: drain the (unbounded per `Tmux::spawn`
+    // contract) notification receiver, route `%output` events
+    // through the router's decoder + per-pane fan-out, and log
+    // anything else. MUST keep up: if this task blocks, the
+    // unbounded `notifs` grows toward OOM. The router's
+    // `dispatch` is non-blocking (try_send drops on full
+    // subscriber — better a visible terminal glitch than a
+    // globally-stalled tmux stream; see router.rs).
+    let dispatcher_router = output_router.clone();
+    tokio::spawn(async move {
+        while let Some(notif) = notifs.recv().await {
+            match notif {
+                Notification::Output { pane_id, data } => {
+                    dispatcher_router.dispatch(pane_id, &data);
+                }
+                Notification::Exit { reason } => {
+                    tracing::warn!(?reason, "tmux control-mode exited");
+                    break;
+                }
+                other => {
+                    // Other notifications (session-changed,
+                    // window-close, ...) aren't consumed yet.
+                    // Logged at trace so operators can enable
+                    // them selectively when diagnosing.
+                    tracing::trace!(?other, "tmux notification (no consumer yet)");
+                }
+            }
+        }
+    });
+
+    let state = AppState {
+        output_router,
+        ..AppState::new(auth_store, webauthn, config).with_sessions(sessions)
+    };
 
     let addr: SocketAddr = "127.0.0.1:3000".parse().expect("valid bind address");
     let listener = tokio::net::TcpListener::bind(addr)

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,7 +1,6 @@
 use katulong_auth::{AuthStore, WebAuthnService};
 use katulong_server::session::{
     dims::{DEFAULT_COLS, DEFAULT_ROWS},
-    parser::Notification,
     OutputRouter, SessionManager, Tmux, DEDICATED_SOCKET_NAME,
 };
 use katulong_server::{app, state::AppState, state::ServerConfig};
@@ -35,47 +34,25 @@ async fn main() {
         .unwrap_or_else(|_| DEDICATED_SOCKET_NAME.to_string());
     let initial_session = std::env::var("KATULONG_INITIAL_SESSION")
         .unwrap_or_else(|_| "main".to_string());
-    let (tmux, mut notifs) =
-        Tmux::spawn(&socket_name, &initial_session, DEFAULT_COLS, DEFAULT_ROWS)
-            .await
-            .expect("spawn tmux control-mode subprocess");
+    let (tmux, notifs) = Tmux::spawn(&socket_name, &initial_session, DEFAULT_COLS, DEFAULT_ROWS)
+        .await
+        .expect("spawn tmux control-mode subprocess");
     let sessions = SessionManager::new(tmux);
     let output_router = OutputRouter::new();
 
-    // Dispatcher task: drain the (unbounded per `Tmux::spawn`
-    // contract) notification receiver, route `%output` events
-    // through the router's decoder + per-pane fan-out, and log
-    // anything else. MUST keep up: if this task blocks, the
-    // unbounded `notifs` grows toward OOM. The router's
-    // `dispatch` is non-blocking (try_send drops on full
-    // subscriber — better a visible terminal glitch than a
-    // globally-stalled tmux stream; see router.rs).
-    let dispatcher_router = output_router.clone();
-    tokio::spawn(async move {
-        while let Some(notif) = notifs.recv().await {
-            match notif {
-                Notification::Output { pane_id, data } => {
-                    dispatcher_router.dispatch(pane_id, &data);
-                }
-                Notification::Exit { reason } => {
-                    tracing::warn!(?reason, "tmux control-mode exited");
-                    break;
-                }
-                other => {
-                    // Other notifications (session-changed,
-                    // window-close, ...) aren't consumed yet.
-                    // Logged at trace so operators can enable
-                    // them selectively when diagnosing.
-                    tracing::trace!(?other, "tmux notification (no consumer yet)");
-                }
-            }
-        }
-    });
+    // The dispatcher task drains the (unbounded per `Tmux::spawn`
+    // contract) notification receiver and routes `%output`
+    // events through the router's decoder + per-pane fan-out.
+    // The task's non-blocking invariant lives inside
+    // `OutputRouter::spawn_dispatcher` itself — documented on
+    // the method and enforced by `dispatch`'s `try_send` path.
+    // Letting the tokio runtime abort the task on process exit
+    // is fine; we ignore the `JoinHandle`.
+    let _dispatcher = output_router.spawn_dispatcher(notifs);
 
-    let state = AppState {
-        output_router,
-        ..AppState::new(auth_store, webauthn, config).with_sessions(sessions)
-    };
+    let state = AppState::new(auth_store, webauthn, config)
+        .with_sessions(sessions)
+        .with_output_router(output_router);
 
     let addr: SocketAddr = "127.0.0.1:3000".parse().expect("valid bind address");
     let listener = tokio::net::TcpListener::bind(addr)

--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -2,46 +2,75 @@
 //!
 //! `serve_session` consumes a `TransportHandle` and runs the
 //! terminal-session lifecycle against it: protocol handshake,
-//! session attach, revocation watch. It is transport-agnostic by
+//! session attach, output forwarding, input forwarding, resize
+//! gating, and revocation watch. It is transport-agnostic by
 //! construction — see `project_transport_agnostic` in project
 //! memory.
 //!
-//! # Slice 9e scope
+//! # What's in scope
 //!
-//! - Handshake gate: `Hello` (server) → `HelloAck` (client) →
-//!   `Attach` (client) → `Attached` (server).
-//! - Phase state machine enforces the order. Messages arriving in
-//!   the wrong phase trigger a typed `Error` and a clean transport
-//!   close, so the client sees "unexpected_message" rather than an
-//!   opaque drop.
-//! - `Resize` in the `Attached` phase forwards to `SessionManager`;
-//!   tmux clamps and issues `refresh-client -C`.
-//! - `Input` in the `Attached` phase is accepted and logged. Slice
-//!   9f wires the actual tmux write path (and the `Output`
-//!   producer) with coalescing.
-//! - Revocation watch: a `tokio::select!` over `handle.inbound` and
-//!   `state.subscribe_revocations()` closes the transport
-//!   immediately when the bound credential is revoked. Localhost
-//!   connections aren't bound to a credential and can't be
-//!   revoked — they exit only on peer disconnect.
+//! - **Handshake gate** (slice 9e): `Hello` (server) → `HelloAck`
+//!   (client) → `Attach` (client) → `Attached` (server). The
+//!   phase state machine enforces the order; messages arriving
+//!   in the wrong phase trigger a typed `Error` and clean close.
+//! - **Output forwarding** (slice 9f): after `Attached`, the
+//!   handler subscribes to `state.output_router` for its pane
+//!   and forwards decoded bytes through the coalescer to
+//!   `ServerMessage::Output { data, seq }`. `seq` is per-
+//!   connection-monotonic (Node scar `da6907f` — lets the
+//!   client detect gaps on reconnect).
+//! - **Output coalescing** (slice 9f): buffer bursts with a
+//!   2 ms idle / 16 ms cap schedule (Node scars
+//!   `d311168`/`066dab2`). Individual `%output` chunks below
+//!   the idle window fuse into one wire message; continuous
+//!   streams still flush every 16 ms.
+//! - **Input forwarding** (slice 9f): `ClientMessage::Input`
+//!   bytes go to `SessionManager::send_input`, which encodes
+//!   them as `send-keys -t %<pane_id> -H <hex>`. Binary-safe —
+//!   control chars, arrow keys, Ctrl-C all traverse correctly.
+//! - **Resize gating** (slice 9f): `ClientMessage::Resize`
+//!   applies immediately if no output landed within 50 ms;
+//!   otherwise defers until output has been idle for 50 ms OR
+//!   500 ms have elapsed (whichever is sooner). Node scar
+//!   `066dab2` — SIGWINCH mid-render interleaves old and new
+//!   paint sequences; the gate avoids that.
+//! - **Revocation watch**: `tokio::select!` over `handle.inbound`
+//!   and `state.subscribe_revocations()` closes the transport on
+//!   matching credential. Localhost connections have no
+//!   credential binding and are immune to revoke events.
+//!
+//! # Not in scope (deferred)
+//!
+//! - **Ring buffer + reconnect replay** (slice 9g): `seq` is
+//!   emitted but no history is kept. Slice 9g adds per-pane
+//!   ring storage and an `Attach { resume_from_seq }` variant
+//!   so a reconnecting client can rebuild state without a full
+//!   screen redraw.
+//! - **Multi-device output fan-out** (slice 9h): the router
+//!   rejects a second subscriber per pane. The octal decoder
+//!   already lives upstream of the fan-out (in the router), so
+//!   9h lifts the single-subscriber restriction without moving
+//!   state.
 //!
 //! # Why a state machine, not "just check in the match"
 //!
 //! The alternative is per-variant guards like `if !attached {
-//! return Err(unexpected) }` scattered through the main loop. That
-//! works but makes it easy to forget a guard on a newly-added
-//! variant (the future `Output` from an echo-tester, say). The
-//! phase enum forces every addition to be placed in a phase, and
-//! the unit tests below snap whenever a variant crosses phases
-//! without explicit consent.
+//! return Err(unexpected) }` scattered through the main loop.
+//! That works but makes it easy to forget a guard on a newly-
+//! added variant. The phase enum + `Action` values force every
+//! addition to be placed in a phase, and the unit tests below
+//! snap whenever a variant crosses phases without explicit
+//! consent.
 
 use crate::log_util::sanitize_for_log;
 use crate::revocation::RevocationEvent;
+use crate::session::output::Coalescer;
 use crate::state::AppState;
-use crate::transport::{
-    ClientMessage, ServerMessage, TransportHandle, PROTOCOL_VERSION,
-};
+use crate::transport::{ClientMessage, ServerMessage, TransportHandle, PROTOCOL_VERSION};
+use std::time::Duration;
 use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::mpsc;
+use tokio::time::Instant;
 
 /// How long we wait between connection upgrade and receiving
 /// `HelloAck` before closing. WS-level keepalive keeps the socket
@@ -51,6 +80,29 @@ use tokio::sync::broadcast::error::RecvError;
 /// probing `/ws` with no cookie (shouldn't happen — auth gates the
 /// upgrade) or a half-open connection is reaped promptly.
 const HANDSHAKE_TIMEOUT_SECS: u64 = 10;
+
+/// Output-idle window before a pending resize can apply. Node
+/// scar `066dab2`: SIGWINCH arriving mid-render interleaves old
+/// partial-frame escapes with the new redraw, garbling TUI apps.
+/// Waiting 50 ms after the last output byte lets in-flight paints
+/// complete before the resize punches through.
+const RESIZE_GATE: Duration = Duration::from_millis(50);
+
+/// Cap on how long a pending resize can wait for output-idle.
+/// Without this, a continuous-output command like `tail -f` (which
+/// keeps resetting the idle window) starves resize forever. Same
+/// Node scar (`066dab2`): 500 ms is short enough to feel
+/// responsive yet long enough that any interactive TUI would have
+/// paused between frames.
+const RESIZE_MAX_DEFER: Duration = Duration::from_millis(500);
+
+/// Cap on the protocol-version string we echo back in error
+/// messages. Far shorter than the Origin cap in `ws.rs` because the
+/// version string is a short identifier (`"katulong/0.1"`) — if a
+/// client sends something larger, it's either buggy or crafted, and
+/// 32 chars is plenty to identify the prefix without letting an
+/// attacker flood logs with per-request megabyte payloads.
+const LOG_PROTOCOL_VERSION_MAX_LEN: usize = 32;
 
 /// Error codes emitted as `ServerMessage::Error.code`. Stable —
 /// clients and scripts key off these strings, so renames require a
@@ -75,6 +127,10 @@ pub mod error_code {
     /// Client didn't complete the handshake within
     /// `HANDSHAKE_TIMEOUT_SECS`. Connection closes.
     pub const HANDSHAKE_TIMEOUT: &str = "handshake_timeout";
+    /// Another connection is already bound to the requested
+    /// session's pane. Slice 9f enforces single-subscriber per
+    /// pane; slice 9h relaxes this with multi-device fan-out.
+    pub const SESSION_BUSY: &str = "session_busy";
     /// Connection was torn down server-side without the client
     /// having done anything wrong. Emitted when the bound
     /// credential is revoked, or when the revocation broadcast
@@ -96,6 +152,13 @@ pub mod error_code {
 
 /// Handshake phase. Advances on valid messages; any message that
 /// isn't valid for the current phase is a protocol violation.
+///
+/// The `Attached` variant is intentionally data-less: the session
+/// name and pane id live in the coordinator's `AttachedState`
+/// alongside async resources (the pane output receiver, the
+/// coalescer, the resize timer state) that can't sit in a
+/// clonable phase enum. The phase is the "protocol gate"; the
+/// I/O state is the "active work."
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Phase {
     /// Server has sent `Hello`; waiting for the client to ack with
@@ -104,9 +167,10 @@ enum Phase {
     /// Protocol version confirmed; waiting for the client to send
     /// `Attach` with a session name and dimensions.
     AwaitingAttach,
-    /// Transport is bound to `session`. `Input`/`Resize` are now
-    /// valid.
-    Attached { session: String },
+    /// Transport is bound to a tmux pane. `Input`/`Resize` are now
+    /// valid. The pane id + session name + output subscription
+    /// live in the coordinator's `AttachedState`.
+    Attached,
 }
 
 /// Action the phase machine tells the coordinator to take after
@@ -124,20 +188,18 @@ enum Action {
     /// implicit (no server message is sent for HelloAck — the
     /// client's next move is Attach). Just advance phase.
     AdvanceToAwaitingAttach,
-    /// Create/attach the tmux session, then send `Attached` with
-    /// the clamped dims.
+    /// Create/attach the tmux session, subscribe to its pane,
+    /// then send `Attached` with the clamped dims.
     DoAttach {
         session: String,
         cols: u16,
         rows: u16,
     },
-    /// Forward a resize to the session manager for the currently-
-    /// attached session.
-    DoResize {
-        session: String,
-        cols: u16,
-        rows: u16,
-    },
+    /// Forward client input bytes to the attached pane.
+    ForwardInput { data: Vec<u8> },
+    /// Queue a resize for the attached session — the coordinator
+    /// applies immediately or defers based on the resize gate.
+    QueueResize { cols: u16, rows: u16 },
     /// A protocol violation. Coordinator sends `Error` and closes.
     /// `code` is one of `error_code::*`; `message` is operator-
     /// visible and MUST NOT include client-controlled bytes raw
@@ -169,9 +231,6 @@ fn step(phase: &mut Phase, msg: ClientMessage) -> Action {
                     message: format!(
                         "server speaks {}, client acked {}",
                         PROTOCOL_VERSION,
-                        // bound on length defensively; don't let an
-                        // attacker-chosen version string blow up
-                        // log line size
                         sanitize_for_log(&protocol_version, LOG_PROTOCOL_VERSION_MAX_LEN),
                     ),
                 }
@@ -186,24 +245,10 @@ fn step(phase: &mut Phase, msg: ClientMessage) -> Action {
             }
         }
 
-        (Phase::Attached { session }, ClientMessage::Input { data: _ }) => {
-            // Slice 9e accepts Input to exercise the phase-gate but
-            // does NOT forward it to the PTY — slice 9f wires the
-            // tmux write path with coalescing. Logging at trace
-            // keeps the data payload out of default logs entirely.
-            tracing::trace!(
-                session = %session,
-                "session input accepted (forwarding wired in slice 9f)"
-            );
-            Action::Continue
-        }
+        (Phase::Attached, ClientMessage::Input { data }) => Action::ForwardInput { data },
 
-        (Phase::Attached { session }, ClientMessage::Resize { cols, rows }) => {
-            Action::DoResize {
-                session,
-                cols,
-                rows,
-            }
+        (Phase::Attached, ClientMessage::Resize { cols, rows }) => {
+            Action::QueueResize { cols, rows }
         }
 
         // Any other (phase, message) combination is a protocol
@@ -234,23 +279,79 @@ fn phase_name(phase: &Phase) -> &'static str {
     match phase {
         Phase::AwaitingHelloAck => "awaiting_hello_ack",
         Phase::AwaitingAttach => "awaiting_attach",
-        Phase::Attached { .. } => "attached",
+        Phase::Attached => "attached",
     }
 }
 
-/// Cap on the protocol-version string we echo back in error
-/// messages. Far shorter than the Origin cap in `ws.rs` because the
-/// version string is a short identifier (`"katulong/0.1"`) — if a
-/// client sends something larger, it's either buggy or crafted, and
-/// 32 chars is plenty to identify the prefix without letting an
-/// attacker flood logs with per-request megabyte payloads.
-const LOG_PROTOCOL_VERSION_MAX_LEN: usize = 32;
+/// Per-connection I/O state populated after a successful `Attach`.
+/// Holds every resource that can't sit in `Phase::Attached`
+/// (async receivers, timing state, mutable buffers).
+///
+/// Drop behavior is load-bearing: dropping `AttachedState` drops
+/// the `mpsc::Receiver`, which tells the router the subscriber is
+/// gone; the explicit `unsubscribe` call in `serve_session`'s
+/// cleanup removes the decoder too. Never return early from
+/// `serve_session` without passing through the cleanup path.
+struct AttachedState {
+    session: String,
+    pane_id: u32,
+    /// Decoded bytes from this pane's `%output` stream.
+    output_rx: mpsc::Receiver<Vec<u8>>,
+    /// Monotonic sequence number for each `ServerMessage::Output`
+    /// we emit. Increments per-emission, NOT per-byte — the
+    /// client reads `seq` to detect gaps after reconnect.
+    output_seq: u64,
+    /// Coalesces raw bytes from `output_rx` into chunky Output
+    /// messages. See `output::Coalescer` for timing.
+    coalescer: Coalescer,
+    /// When we last received bytes from `output_rx`. `None` until
+    /// the first chunk lands. Used by the resize gate — a resize
+    /// that arrives within `RESIZE_GATE` of this time defers.
+    last_output_at: Option<Instant>,
+    /// Resize queued while output was recent. `None` means no
+    /// resize waiting. The `queued_at` field lets us cap the
+    /// deferral at `RESIZE_MAX_DEFER`.
+    pending_resize: Option<PendingResize>,
+}
+
+struct PendingResize {
+    cols: u16,
+    rows: u16,
+    queued_at: Instant,
+}
+
+impl AttachedState {
+    /// When to flush the coalescer. `None` when no output is
+    /// buffered.
+    fn coalesce_deadline(&self) -> Option<Instant> {
+        self.coalescer.next_deadline()
+    }
+
+    /// When to apply a pending resize. `None` when no resize is
+    /// queued. The deadline is the earlier of:
+    /// - `last_output_at + RESIZE_GATE` (apply after output idle)
+    /// - `pending.queued_at + RESIZE_MAX_DEFER` (apply anyway)
+    ///
+    /// A pending resize with NO prior output (client resized
+    /// before the shell had a chance to print) resolves
+    /// immediately — use `queued_at` as both the "since output"
+    /// and the "max defer" reference, yielding a past deadline.
+    fn resize_deadline(&self) -> Option<Instant> {
+        let pending = self.pending_resize.as_ref()?;
+        let idle_target = self
+            .last_output_at
+            .map_or(pending.queued_at, |t| t + RESIZE_GATE);
+        let cap_target = pending.queued_at + RESIZE_MAX_DEFER;
+        Some(idle_target.min(cap_target))
+    }
+}
 
 /// The per-connection consumer loop, parameterised on the
-/// transport abstraction. `state` threads session manager + the
-/// revocation broadcast; `credential_id` is the credential this
-/// transport is bound to (from the auth extractor), or `None` for
-/// localhost-exempt connections which can't be revoked.
+/// transport abstraction. `state` threads session manager +
+/// revocation broadcast + output router; `credential_id` is the
+/// credential this transport is bound to (from the auth
+/// extractor), or `None` for localhost-exempt connections which
+/// can't be revoked.
 ///
 /// This function owns the `TransportHandle` for the connection's
 /// lifetime. When it returns, the outbound sender drops → the WS
@@ -263,9 +364,7 @@ pub async fn serve_session(
     let mut handle = handle;
 
     // Subscribe to revocation events BEFORE we touch anything else.
-    // See `revocation.rs` subscriber contract: a handler that
-    // validates first, then subscribes, misses any revocation that
-    // lands between the two calls.
+    // See `revocation.rs` subscriber contract.
     let mut revocations = state.subscribe_revocations();
 
     // Send the initial Hello. If this fails, the transport died
@@ -281,18 +380,20 @@ pub async fn serve_session(
     }
 
     let mut phase = Phase::AwaitingHelloAck;
-    let handshake_deadline =
-        tokio::time::Instant::now() + std::time::Duration::from_secs(HANDSHAKE_TIMEOUT_SECS);
+    let mut attached: Option<AttachedState> = None;
+    let handshake_deadline = Instant::now() + Duration::from_secs(HANDSHAKE_TIMEOUT_SECS);
 
     loop {
-        // The handshake timer only fires while we're still in the
-        // handshake phases. Once `Attached`, the timer is disabled
-        // (`tokio::select!`'s `biased` + guarded branch handles
-        // this explicitly).
+        // Guard flags for conditional select branches. Assigning
+        // to locals reads more clearly than inlining the matches
+        // in the select macro (and rustc has been known to
+        // misjudge `if matches!(...)` in select guards).
         let in_handshake = matches!(
             phase,
             Phase::AwaitingHelloAck | Phase::AwaitingAttach
         );
+        let coalesce_deadline = attached.as_ref().and_then(|a| a.coalesce_deadline());
+        let resize_deadline = attached.as_ref().and_then(|a| a.resize_deadline());
 
         let action = tokio::select! {
             biased;
@@ -304,27 +405,88 @@ pub async fn serve_session(
             revoke = revocations.recv() => handle_revoke(revoke, credential_id.as_deref()),
 
             // Handshake-timer branch: only active while we're
-            // still awaiting HelloAck or Attach. Once we've
-            // reached `Attached`, this branch is disabled.
+            // still awaiting HelloAck or Attach.
             _ = tokio::time::sleep_until(handshake_deadline), if in_handshake => Action::Close {
                 code: error_code::HANDSHAKE_TIMEOUT,
                 message: "client did not complete handshake in time".into(),
             },
 
+            // Coalescer flush: elapsed idle or cap deadline.
+            // Second priority after revoke so a single slow
+            // client can't stall a revocation.
+            _ = sleep_until_opt(coalesce_deadline), if coalesce_deadline.is_some() => {
+                Action::Continue  // handled below in post-select block
+            }
+
+            // Pending resize ready to apply.
+            _ = sleep_until_opt(resize_deadline), if resize_deadline.is_some() => {
+                Action::Continue  // handled below in post-select block
+            }
+
+            // Output from this pane. Only active when we're
+            // attached. Each `Some` is a Vec<u8> of decoded
+            // bytes from the router.
+            Some(bytes) = maybe_recv_output(attached.as_mut()) => {
+                if let Some(a) = attached.as_mut() {
+                    a.last_output_at = Some(Instant::now());
+                    a.coalescer.push(&bytes);
+                }
+                Action::Continue
+            }
+
             msg = handle.inbound.recv() => match msg {
                 None => Action::Exit,
                 Some(Err(err)) => {
-                    // Decoder/frame error from the transport. Stay
-                    // open — a single bad frame isn't a reason to
-                    // kick the user out; the Node scar `9dc7c78`
-                    // said validate at the boundary, which the
-                    // typed deserialize already does.
                     tracing::warn!(error = %err, "transport frame error; dropping");
                     Action::Continue
                 }
                 Some(Ok(msg)) => step(&mut phase, msg),
             },
         };
+
+        // Post-select: coalescer flush + resize flush are driven
+        // by deadlines, not `Action` values — the timer branches
+        // above just wake the loop, and we check here whether the
+        // deadline is actually past. This keeps the state machine
+        // decoupled from timer wake-up without needing a new
+        // Action variant per deadline kind.
+        if let Some(a) = attached.as_mut() {
+            let now = Instant::now();
+            if a.coalesce_deadline().is_some_and(|d| now >= d) && !a.coalescer.is_empty() {
+                let bytes = a.coalescer.take();
+                a.output_seq += 1;
+                if handle
+                    .send(ServerMessage::Output {
+                        data: bytes,
+                        seq: a.output_seq,
+                    })
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            if a.resize_deadline().is_some_and(|d| now >= d) {
+                let pending = a
+                    .pending_resize
+                    .take()
+                    .expect("resize_deadline implies pending_resize is Some");
+                let sessions = state
+                    .sessions
+                    .as_deref()
+                    .expect("Attached phase implies sessions is Some");
+                if let Err(err) = sessions
+                    .resize_session(&a.session, pending.cols, pending.rows)
+                    .await
+                {
+                    tracing::warn!(
+                        session = %a.session,
+                        error = %err,
+                        "deferred resize failed; keeping transport open"
+                    );
+                }
+            }
+        }
 
         match action {
             Action::Continue => continue,
@@ -335,10 +497,8 @@ pub async fn serve_session(
                 }
             }
             Action::AdvanceToAwaitingAttach => {
-                // No server message for this transition — the
-                // client already has Hello, and the next expected
-                // message from them is Attach. Sending a dedicated
-                // "hello acknowledged" would be pure wire bloat.
+                // No server message; the client already has Hello
+                // and its next move is Attach.
                 continue;
             }
             Action::DoAttach {
@@ -346,19 +506,9 @@ pub async fn serve_session(
                 cols,
                 rows,
             } => {
-                // Clamp once here, BEFORE calling into
-                // SessionManager, so both the session-manager
-                // create call and the `Attached` response we send
-                // back to the client use identical values. The
-                // manager's `create_session` clamps again
-                // internally as a defense-in-depth belt — this
-                // handler-level clamp is the authoritative
-                // "coordinator clamps before dispatch" step.
-                // Without this, a 9999-cols request would reach
-                // `create_session` unclamped; one careless future
-                // refactor that drops the manager's internal
-                // clamp would mean tmux sees the raw value. Do it
-                // here too so the invariant survives that refactor.
+                // Clamp once at the coordinator before dispatch.
+                // SessionManager clamps internally too as
+                // defense-in-depth (see its docstring).
                 let (cols, rows) = crate::session::dims::clamp_dims(cols, rows);
                 let Some(sessions) = state.sessions.as_deref() else {
                     send_error_and_close(
@@ -369,11 +519,10 @@ pub async fn serve_session(
                     .await;
                     break;
                 };
-                match sessions.create_session(&session, cols, rows).await {
-                    Ok(()) => {
-                        phase = Phase::Attached {
-                            session: session.clone(),
-                        };
+                match try_attach(sessions, &state, &session, cols, rows).await {
+                    Ok(new_state) => {
+                        attached = Some(new_state);
+                        phase = Phase::Attached;
                         if handle
                             .send(ServerMessage::Attached {
                                 session,
@@ -386,10 +535,9 @@ pub async fn serve_session(
                             break;
                         }
                     }
-                    Err(err) => {
-                        let (code, message) = classify_session_error(&err);
+                    Err(AttachFailure { code, message, err }) => {
                         tracing::warn!(
-                            error = %err,
+                            error = err.as_deref().unwrap_or(""),
                             code = code,
                             "attach rejected"
                         );
@@ -398,30 +546,70 @@ pub async fn serve_session(
                     }
                 }
             }
-            Action::DoResize {
-                session,
-                cols,
-                rows,
-            } => {
-                // SAFETY: `sessions` must be `Some` to reach
-                // `Attached` phase; the only path to Attached is
-                // through a successful create_session above, which
-                // requires `state.sessions` to be Some.
+            Action::ForwardInput { data } => {
+                let a = attached
+                    .as_ref()
+                    .expect("Attached phase implies attached is Some");
                 let sessions = state
                     .sessions
                     .as_deref()
                     .expect("Attached phase implies sessions is Some");
-                if let Err(err) = sessions.resize_session(&session, cols, rows).await {
-                    // Resize failure on an already-attached session
-                    // is noisy but not fatal. Log and keep the
-                    // transport open; the client will try again on
-                    // the next layout event. Do NOT leak raw tmux
-                    // output to the client.
+                if let Err(err) = sessions.send_input(a.pane_id, &data).await {
+                    // Forwarding failure is operator-visible but
+                    // not a reason to close — a glitchy write may
+                    // be followed by success on the next input,
+                    // and closing would kick the user for tmux's
+                    // transient failure.
                     tracing::warn!(
-                        session = %session,
+                        pane_id = a.pane_id,
                         error = %err,
-                        "resize failed; keeping transport open"
+                        "input forward failed; keeping transport open"
                     );
+                }
+            }
+            Action::QueueResize { cols, rows } => {
+                let a = attached
+                    .as_mut()
+                    .expect("Attached phase implies attached is Some");
+                let (cols, rows) = crate::session::dims::clamp_dims(cols, rows);
+                let now = Instant::now();
+                let recent_output = a
+                    .last_output_at
+                    .is_some_and(|t| now.duration_since(t) < RESIZE_GATE);
+                if !recent_output {
+                    // No recent output — apply immediately. This
+                    // is the initial-attach path (no output yet)
+                    // and the quiet-shell path.
+                    a.pending_resize = None;
+                    let sessions = state
+                        .sessions
+                        .as_deref()
+                        .expect("Attached phase implies sessions is Some");
+                    if let Err(err) = sessions.resize_session(&a.session, cols, rows).await {
+                        tracing::warn!(
+                            session = %a.session,
+                            error = %err,
+                            "resize failed; keeping transport open"
+                        );
+                    }
+                } else {
+                    // Defer: stash and let the timer branch
+                    // pick it up. If a resize is already pending,
+                    // overwrite — the most recent client
+                    // dimensions win, and the queued_at stays at
+                    // the oldest time so the 500 ms max-defer cap
+                    // still applies from the first attempt (an
+                    // attacker-paced resize every 400 ms should
+                    // not extend the defer forever).
+                    let queued_at = a
+                        .pending_resize
+                        .as_ref()
+                        .map_or(now, |p| p.queued_at);
+                    a.pending_resize = Some(PendingResize {
+                        cols,
+                        rows,
+                        queued_at,
+                    });
                 }
             }
             Action::Close { code, message } => {
@@ -431,8 +619,91 @@ pub async fn serve_session(
         }
     }
 
+    // Cleanup: unsubscribe from the router so the decoder's
+    // carry buffer doesn't leak and the pane is available for a
+    // fresh connection. Safe to call even if we never attached.
+    if let Some(a) = attached {
+        state.output_router.unsubscribe(a.pane_id);
+    }
     // Drop the handle. The WS output pump sees the channel close
     // and shuts down the socket gracefully.
+}
+
+/// Helper: await a deadline if set, otherwise never resolve. Used
+/// in `tokio::select!` branches whose activation is guarded by a
+/// `.is_some()` condition — the `pending` branch never actually
+/// runs thanks to the guard, but its future still needs to be
+/// constructable.
+async fn sleep_until_opt(deadline: Option<Instant>) {
+    match deadline {
+        Some(d) => tokio::time::sleep_until(d).await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+/// Helper: read from the pane output receiver if we're attached,
+/// otherwise never resolve. Same guard-+-pending pattern as
+/// `sleep_until_opt`.
+async fn maybe_recv_output(attached: Option<&mut AttachedState>) -> Option<Vec<u8>> {
+    match attached {
+        Some(a) => a.output_rx.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Attach-result payload so the serve loop can branch cleanly on
+/// the several ways `DoAttach` can go wrong.
+struct AttachFailure {
+    code: &'static str,
+    message: String,
+    /// Original error rendered as a string for tracing; None when
+    /// the failure came from the router (no underlying error).
+    err: Option<String>,
+}
+
+async fn try_attach(
+    sessions: &crate::session::SessionManager,
+    state: &AppState,
+    session: &str,
+    cols: u16,
+    rows: u16,
+) -> Result<AttachedState, AttachFailure> {
+    sessions
+        .create_session(session, cols, rows)
+        .await
+        .map_err(|err| {
+            let (code, message) = classify_session_error(&err);
+            AttachFailure {
+                code,
+                message,
+                err: Some(err.to_string()),
+            }
+        })?;
+    let pane_id = sessions.query_default_pane(session).await.map_err(|err| {
+        let (code, message) = classify_session_error(&err);
+        AttachFailure {
+            code,
+            message,
+            err: Some(err.to_string()),
+        }
+    })?;
+    let output_rx = state
+        .output_router
+        .subscribe(pane_id)
+        .map_err(|err| AttachFailure {
+            code: error_code::SESSION_BUSY,
+            message: "session already attached".into(),
+            err: Some(err.to_string()),
+        })?;
+    Ok(AttachedState {
+        session: session.to_string(),
+        pane_id,
+        output_rx,
+        output_seq: 0,
+        coalescer: Coalescer::new(),
+        last_output_at: None,
+        pending_resize: None,
+    })
 }
 
 /// Decide whether a revocation event should tear down this
@@ -463,8 +734,6 @@ fn handle_revoke(
             }
             _ => Action::Continue,
         },
-        // Subscriber fell behind the broadcast buffer. `revocation.rs`
-        // subscriber contract: conservative close.
         Err(RecvError::Lagged(n)) => {
             tracing::warn!(
                 lagged_events = n,
@@ -476,13 +745,6 @@ fn handle_revoke(
                 message: "connection terminated".into(),
             }
         }
-        // Publisher dropped. Shouldn't happen in practice
-        // (AppState owns it for the server's lifetime), but if it
-        // does, we have no more revocation awareness — exit to be
-        // safe. `Exit` rather than `Close` because this only fires
-        // on process teardown, when there's no value in emitting a
-        // protocol-level close frame the runtime is about to tear
-        // down anyway.
         Err(RecvError::Closed) => Action::Exit,
     }
 }
@@ -520,11 +782,11 @@ fn classify_session_error(err: &crate::session::SessionError) -> (&'static str, 
 
 #[cfg(test)]
 mod tests {
-    //! State-machine tests. Transport-free and SessionManager-free:
-    //! we feed `step` directly with synthetic messages and assert
-    //! on the action it returns. Real-transport end-to-end tests
-    //! live under the `transport::websocket` and integration
-    //! modules.
+    //! State-machine tests. Transport-free and SessionManager-free
+    //! where possible; the I/O integration tests for the output/
+    //! input/resize paths live alongside their modules
+    //! (`output.rs`, `router.rs`, `manager.rs`) because the
+    //! integration points are small and directly testable.
 
     use super::*;
 
@@ -533,6 +795,8 @@ mod tests {
             protocol_version: PROTOCOL_VERSION.into(),
         }
     }
+
+    // ---------- Phase machine (unchanged from slice 9e) ----------
 
     #[test]
     fn hello_ack_advances_phase() {
@@ -557,11 +821,7 @@ mod tests {
             }
             other => panic!("expected close, got {other:?}"),
         }
-        assert_eq!(
-            phase,
-            Phase::AwaitingHelloAck,
-            "phase should not advance on mismatch"
-        );
+        assert_eq!(phase, Phase::AwaitingHelloAck);
     }
 
     #[test]
@@ -594,26 +854,17 @@ mod tests {
             },
         );
         match action {
-            Action::Close { code, .. } => {
-                assert_eq!(code, error_code::UNEXPECTED_MESSAGE);
-            }
+            Action::Close { code, .. } => assert_eq!(code, error_code::UNEXPECTED_MESSAGE),
             other => panic!("expected close, got {other:?}"),
         }
     }
 
     #[test]
     fn hello_ack_in_attached_phase_is_protocol_violation() {
-        // HelloAck is a one-shot; re-sending it later should be
-        // treated as out-of-phase. Otherwise a buggy client could
-        // hold the connection but never exercise the session.
-        let mut phase = Phase::Attached {
-            session: "s".into(),
-        };
+        let mut phase = Phase::Attached;
         let action = step(&mut phase, ack_v1());
         match action {
-            Action::Close { code, .. } => {
-                assert_eq!(code, error_code::UNEXPECTED_MESSAGE);
-            }
+            Action::Close { code, .. } => assert_eq!(code, error_code::UNEXPECTED_MESSAGE),
             other => panic!("expected close, got {other:?}"),
         }
     }
@@ -623,9 +874,7 @@ mod tests {
         for mut phase in [
             Phase::AwaitingHelloAck,
             Phase::AwaitingAttach,
-            Phase::Attached {
-                session: "s".into(),
-            },
+            Phase::Attached,
         ] {
             let before = phase.clone();
             let action = step(&mut phase, ClientMessage::Ping { nonce: 7 });
@@ -635,7 +884,7 @@ mod tests {
     }
 
     #[test]
-    fn attach_in_await_attach_phase_requests_attach_action() {
+    fn attach_in_await_attach_issues_do_attach() {
         let mut phase = Phase::AwaitingAttach;
         let action = step(
             &mut phase,
@@ -653,11 +902,12 @@ mod tests {
                 rows: 40,
             }
         );
-        // Step does NOT advance to Attached — the coordinator does
-        // that only after SessionManager::create_session succeeds.
-        // A bad session name that SessionManager rejects must not
-        // leave the machine in a silently-attached state.
-        assert_eq!(phase, Phase::AwaitingAttach);
+        assert_eq!(
+            phase,
+            Phase::AwaitingAttach,
+            "step does not advance to Attached — the coordinator does \
+             that only after SessionManager::create_session succeeds"
+        );
     }
 
     #[test]
@@ -672,32 +922,31 @@ mod tests {
             },
         );
         match action {
-            Action::Close { code, .. } => {
-                assert_eq!(code, error_code::UNEXPECTED_MESSAGE);
-            }
+            Action::Close { code, .. } => assert_eq!(code, error_code::UNEXPECTED_MESSAGE),
             other => panic!("expected close, got {other:?}"),
         }
     }
 
     #[test]
-    fn input_after_attached_is_accepted() {
-        let mut phase = Phase::Attached {
-            session: "main".into(),
-        };
+    fn input_after_attached_issues_forward() {
+        let mut phase = Phase::Attached;
         let action = step(
             &mut phase,
             ClientMessage::Input {
-                data: vec![0x41],
+                data: vec![0x41, 0x42],
             },
         );
-        assert_eq!(action, Action::Continue);
+        assert_eq!(
+            action,
+            Action::ForwardInput {
+                data: vec![0x41, 0x42],
+            }
+        );
     }
 
     #[test]
-    fn resize_after_attached_issues_resize_action() {
-        let mut phase = Phase::Attached {
-            session: "main".into(),
-        };
+    fn resize_after_attached_issues_queue_resize() {
+        let mut phase = Phase::Attached;
         let action = step(
             &mut phase,
             ClientMessage::Resize {
@@ -707,8 +956,7 @@ mod tests {
         );
         assert_eq!(
             action,
-            Action::DoResize {
-                session: "main".into(),
+            Action::QueueResize {
                 cols: 100,
                 rows: 30,
             }
@@ -717,8 +965,6 @@ mod tests {
 
     #[test]
     fn protocol_version_error_truncates_control_chars() {
-        // An attacker-controlled version string with embedded
-        // control characters must not corrupt operator logs.
         let mut phase = Phase::AwaitingHelloAck;
         let crafted = "evil\r\n[WARN] forged_line";
         let action = step(
@@ -738,6 +984,8 @@ mod tests {
         }
     }
 
+    // ---------- Revocation ----------
+
     #[test]
     fn revoke_matching_credential_closes_with_terminated_code() {
         let event = RevocationEvent {
@@ -745,15 +993,7 @@ mod tests {
         };
         let action = handle_revoke(Ok(event), Some("cred-1"));
         match action {
-            Action::Close { code, .. } => {
-                assert_eq!(
-                    code,
-                    error_code::CONNECTION_TERMINATED,
-                    "revocation must use the terminated code — distinct from \
-                     UNEXPECTED_MESSAGE so clients can tell 'prompt for auth' \
-                     apart from 'fix your message'"
-                );
-            }
+            Action::Close { code, .. } => assert_eq!(code, error_code::CONNECTION_TERMINATED),
             other => panic!("expected close, got {other:?}"),
         }
     }
@@ -763,60 +1003,36 @@ mod tests {
         let event = RevocationEvent {
             credential_id: "other-cred".into(),
         };
-        let action = handle_revoke(Ok(event), Some("cred-1"));
-        assert_eq!(action, Action::Continue);
+        assert_eq!(handle_revoke(Ok(event), Some("cred-1")), Action::Continue);
     }
 
     #[test]
     fn revoke_when_localhost_bound_continues() {
-        // Localhost connections have no credential binding and
-        // can't be revoked. Every incoming revoke event must be a
-        // no-op for them.
         let event = RevocationEvent {
             credential_id: "cred-1".into(),
         };
-        let action = handle_revoke(Ok(event), None);
-        assert_eq!(action, Action::Continue);
+        assert_eq!(handle_revoke(Ok(event), None), Action::Continue);
     }
 
     #[test]
     fn revoke_lagged_is_conservative_close_with_terminated_code() {
         let action = handle_revoke(Err(RecvError::Lagged(3)), Some("cred-1"));
         match action {
-            Action::Close { code, .. } => {
-                assert_eq!(
-                    code,
-                    error_code::CONNECTION_TERMINATED,
-                    "lagged broadcast shares the client-visible code with \
-                     revocation — the cause-distinction lives in tracing, \
-                     not on the wire"
-                );
-            }
+            Action::Close { code, .. } => assert_eq!(code, error_code::CONNECTION_TERMINATED),
             other => panic!("expected close on lagged, got {other:?}"),
         }
     }
 
     #[test]
     fn revoke_publisher_closed_exits_silently() {
-        // Publisher dropped means AppState is being torn down
-        // — the process is exiting. There's no value in emitting
-        // a protocol-level Error frame when the runtime is about
-        // to shut down; the `Exit` action drops the handle and
-        // lets the transport close with the socket.
-        let action = handle_revoke(Err(RecvError::Closed), Some("cred-1"));
-        assert_eq!(action, Action::Exit);
+        assert_eq!(
+            handle_revoke(Err(RecvError::Closed), Some("cred-1")),
+            Action::Exit,
+        );
     }
 
     #[test]
     fn error_codes_are_distinct() {
-        // Forward-safety: all `error_code::*` constants must
-        // carry distinct values. Two same-valued codes would
-        // silently collapse two different operator-visible
-        // causes into one log line and break clients that key
-        // off the specific code. Regressions here are easy to
-        // introduce (copy-paste a constant, forget to change the
-        // value) and impossible to catch at compile time — hence
-        // a dedicated test.
         let all = [
             error_code::PROTOCOL_VERSION_MISMATCH,
             error_code::UNEXPECTED_MESSAGE,
@@ -824,13 +1040,90 @@ mod tests {
             error_code::SESSION_ERROR,
             error_code::NO_SESSION_MANAGER,
             error_code::HANDSHAKE_TIMEOUT,
+            error_code::SESSION_BUSY,
             error_code::CONNECTION_TERMINATED,
         ];
         let set: std::collections::HashSet<&str> = all.iter().copied().collect();
-        assert_eq!(
-            set.len(),
-            all.len(),
-            "duplicate error code in `error_code::*`: {all:?}"
-        );
+        assert_eq!(set.len(), all.len(), "duplicate error code: {all:?}");
+    }
+
+    // ---------- Resize gate deadline math (pure, no runtime) ----------
+
+    fn attached_state_for_gate_tests() -> AttachedState {
+        // Build a minimal AttachedState by hand — output_rx is
+        // required by the struct but the gate-math helpers don't
+        // touch it.
+        let (_tx, rx) = mpsc::channel(1);
+        AttachedState {
+            session: "s".into(),
+            pane_id: 0,
+            output_rx: rx,
+            output_seq: 0,
+            coalescer: Coalescer::new(),
+            last_output_at: None,
+            pending_resize: None,
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resize_deadline_none_when_no_pending() {
+        let a = attached_state_for_gate_tests();
+        assert_eq!(a.resize_deadline(), None);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resize_deadline_immediate_when_no_prior_output() {
+        // A pending resize with no prior output: idle-target ==
+        // queued_at, cap-target == queued_at + 500ms. min is
+        // queued_at (in the past by the time we check, in real
+        // time). Deadline is "already elapsed", so the resize
+        // flushes on the very next select iteration.
+        let mut a = attached_state_for_gate_tests();
+        let now = Instant::now();
+        a.pending_resize = Some(PendingResize {
+            cols: 80,
+            rows: 24,
+            queued_at: now,
+        });
+        assert_eq!(a.resize_deadline(), Some(now));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resize_deadline_picks_idle_target_under_cap() {
+        // Output landed t=0, resize queued at t=10ms. Idle target
+        // is t=50ms (output+50). Cap target is t=510ms (queued+500).
+        // min = idle, 50ms.
+        let mut a = attached_state_for_gate_tests();
+        let t0 = Instant::now();
+        a.last_output_at = Some(t0);
+        tokio::time::advance(Duration::from_millis(10)).await;
+        let queued = Instant::now();
+        a.pending_resize = Some(PendingResize {
+            cols: 80,
+            rows: 24,
+            queued_at: queued,
+        });
+        assert_eq!(a.resize_deadline(), Some(t0 + RESIZE_GATE));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resize_deadline_picks_cap_when_idle_would_starve() {
+        // Simulating `tail -f`: output keeps landing, so
+        // last_output_at stays recent. If the idle-target
+        // perpetually resets further than the cap, cap wins.
+        // Here we fake it by setting last_output_at FAR in the
+        // future relative to queued_at, so idle-target (far +
+        // 50ms) is beyond cap-target (queued + 500ms).
+        let mut a = attached_state_for_gate_tests();
+        let queued = Instant::now();
+        a.pending_resize = Some(PendingResize {
+            cols: 80,
+            rows: 24,
+            queued_at: queued,
+        });
+        // Pretend an output burst landed 600ms "after" queued
+        // (tail -f scenario) — its GATE-offset is beyond the cap.
+        a.last_output_at = Some(queued + Duration::from_millis(600));
+        assert_eq!(a.resize_deadline(), Some(queued + RESIZE_MAX_DEFER));
     }
 }

--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -127,10 +127,6 @@ pub mod error_code {
     /// Client didn't complete the handshake within
     /// `HANDSHAKE_TIMEOUT_SECS`. Connection closes.
     pub const HANDSHAKE_TIMEOUT: &str = "handshake_timeout";
-    /// Another connection is already bound to the requested
-    /// session's pane. Slice 9f enforces single-subscriber per
-    /// pane; slice 9h relaxes this with multi-device fan-out.
-    pub const SESSION_BUSY: &str = "session_busy";
     /// Connection was torn down server-side without the client
     /// having done anything wrong. Emitted when the bound
     /// credential is revoked, or when the revocation broadcast
@@ -423,16 +419,28 @@ pub async fn serve_session(
                 Action::Continue  // handled below in post-select block
             }
 
-            // Output from this pane. Only active when we're
-            // attached. Each `Some` is a Vec<u8> of decoded
-            // bytes from the router.
-            Some(bytes) = maybe_recv_output(attached.as_mut()) => {
-                if let Some(a) = attached.as_mut() {
-                    a.last_output_at = Some(Instant::now());
-                    a.coalescer.push(&bytes);
+            // Output from this pane. `maybe_recv_output` yields
+            // `None` if the output channel closed (displacing
+            // attach from another connection, or dispatcher
+            // pruned us after a panic) — that MUST be a clean
+            // exit, otherwise the loop sits forever on a dead
+            // channel.
+            bytes_opt = maybe_recv_output(attached.as_mut()) => match bytes_opt {
+                Some(bytes) => {
+                    if let Some(a) = attached.as_mut() {
+                        a.last_output_at = Some(Instant::now());
+                        a.coalescer.push(&bytes);
+                    }
+                    Action::Continue
                 }
-                Action::Continue
-            }
+                None => {
+                    tracing::info!(
+                        cause = "output_channel_closed",
+                        "session connection terminating"
+                    );
+                    Action::Exit
+                }
+            },
 
             msg = handle.inbound.recv() => match msg {
                 None => Action::Exit,
@@ -471,10 +479,7 @@ pub async fn serve_session(
                     .pending_resize
                     .take()
                     .expect("resize_deadline implies pending_resize is Some");
-                let sessions = state
-                    .sessions
-                    .as_deref()
-                    .expect("Attached phase implies sessions is Some");
+                let sessions = require_sessions(&state);
                 if let Err(err) = sessions
                     .resize_session(&a.session, pending.cols, pending.rows)
                     .await
@@ -537,7 +542,7 @@ pub async fn serve_session(
                     }
                     Err(AttachFailure { code, message, err }) => {
                         tracing::warn!(
-                            error = err.as_deref().unwrap_or(""),
+                            error = %err,
                             code = code,
                             "attach rejected"
                         );
@@ -550,10 +555,7 @@ pub async fn serve_session(
                 let a = attached
                     .as_ref()
                     .expect("Attached phase implies attached is Some");
-                let sessions = state
-                    .sessions
-                    .as_deref()
-                    .expect("Attached phase implies sessions is Some");
+                let sessions = require_sessions(&state);
                 if let Err(err) = sessions.send_input(a.pane_id, &data).await {
                     // Forwarding failure is operator-visible but
                     // not a reason to close — a glitchy write may
@@ -561,7 +563,9 @@ pub async fn serve_session(
                     // and closing would kick the user for tmux's
                     // transient failure.
                     tracing::warn!(
+                        session = %a.session,
                         pane_id = a.pane_id,
+                        credential = credential_id.as_deref().unwrap_or("localhost"),
                         error = %err,
                         "input forward failed; keeping transport open"
                     );
@@ -581,10 +585,7 @@ pub async fn serve_session(
                     // is the initial-attach path (no output yet)
                     // and the quiet-shell path.
                     a.pending_resize = None;
-                    let sessions = state
-                        .sessions
-                        .as_deref()
-                        .expect("Attached phase implies sessions is Some");
+                    let sessions = require_sessions(&state);
                     if let Err(err) = sessions.resize_session(&a.session, cols, rows).await {
                         tracing::warn!(
                             session = %a.session,
@@ -656,9 +657,8 @@ async fn maybe_recv_output(attached: Option<&mut AttachedState>) -> Option<Vec<u
 struct AttachFailure {
     code: &'static str,
     message: String,
-    /// Original error rendered as a string for tracing; None when
-    /// the failure came from the router (no underlying error).
-    err: Option<String>,
+    /// Original error rendered as a string for tracing.
+    err: String,
 }
 
 async fn try_attach(
@@ -668,33 +668,31 @@ async fn try_attach(
     cols: u16,
     rows: u16,
 ) -> Result<AttachedState, AttachFailure> {
-    sessions
-        .create_session(session, cols, rows)
-        .await
-        .map_err(|err| {
-            let (code, message) = classify_session_error(&err);
-            AttachFailure {
-                code,
-                message,
-                err: Some(err.to_string()),
-            }
-        })?;
-    let pane_id = sessions.query_default_pane(session).await.map_err(|err| {
+    // Single failure-mapping closure — the two session-manager
+    // calls below share identical "classify + stash err.to_string()"
+    // shape, and this closure is the one place that knows which
+    // fields `AttachFailure` carries.
+    let to_failure = |err: crate::session::SessionError| {
         let (code, message) = classify_session_error(&err);
         AttachFailure {
             code,
             message,
-            err: Some(err.to_string()),
+            err: err.to_string(),
         }
-    })?;
-    let output_rx = state
-        .output_router
-        .subscribe(pane_id)
-        .map_err(|err| AttachFailure {
-            code: error_code::SESSION_BUSY,
-            message: "session already attached".into(),
-            err: Some(err.to_string()),
-        })?;
+    };
+    sessions
+        .create_session(session, cols, rows)
+        .await
+        .map_err(to_failure)?;
+    let pane_id = sessions
+        .query_default_pane(session)
+        .await
+        .map_err(to_failure)?;
+    // `subscribe` is infallible under the attach-displaces-prior
+    // semantics (slice 9f). If another connection had this pane
+    // bound, its subscriber's channel closes on the next recv
+    // and its handler exits via `Action::Exit`.
+    let output_rx = state.output_router.subscribe(pane_id);
     Ok(AttachedState {
         session: session.to_string(),
         pane_id,
@@ -704,6 +702,19 @@ async fn try_attach(
         last_output_at: None,
         pending_resize: None,
     })
+}
+
+/// Get the `SessionManager` out of `AppState`, panicking if it's
+/// `None`. Safe ONLY for call sites that have already verified
+/// we're in `Phase::Attached` — the attach path required
+/// `sessions` to be `Some` to reach `Attached` at all, and the
+/// field never transitions back to `None`. Extracted from three
+/// repeated `.expect(...)` sites in the main loop.
+fn require_sessions(state: &AppState) -> &crate::session::SessionManager {
+    state
+        .sessions
+        .as_deref()
+        .expect("Attached phase implies sessions is Some")
 }
 
 /// Decide whether a revocation event should tear down this
@@ -1040,7 +1051,6 @@ mod tests {
             error_code::SESSION_ERROR,
             error_code::NO_SESSION_MANAGER,
             error_code::HANDSHAKE_TIMEOUT,
-            error_code::SESSION_BUSY,
             error_code::CONNECTION_TERMINATED,
         ];
         let set: std::collections::HashSet<&str> = all.iter().copied().collect();

--- a/crates/server/src/session/manager.rs
+++ b/crates/server/src/session/manager.rs
@@ -166,11 +166,21 @@ impl SessionManager {
     /// default pane, because tmux creates the session with a
     /// single window hosting a single pane.
     ///
-    /// Called exactly once per `Attach` — the session-to-pane
-    /// mapping can change if the user runs tmux commands that
-    /// create windows/panes, but katulong's current single-pane-
-    /// per-session assumption (session 9h will revisit) means
-    /// we resolve once at attach time.
+    /// **Single-pane assumption, load-bearing for slice 9f.**
+    /// This function calls `list-panes -t <session> -F
+    /// '#{pane_id}'` and takes the FIRST line of output as the
+    /// canonical pane. That's correct for a freshly-created
+    /// session with one pane, and for reconnects to an existing
+    /// single-pane session. It is SILENTLY WRONG if a user has
+    /// run `split-window` or `new-window` — the first pane tmux
+    /// lists is not necessarily the one the user is typing in.
+    /// Slice 9h is the right place to decide the product
+    /// semantics here (follow active pane? let the client pick?
+    /// expose multiple pane streams?); until then, multi-pane
+    /// tmux sessions under katulong will show output from the
+    /// wrong pane. If this is ever surfaced to the UI it should
+    /// be a conscious choice, not an accidental artifact of
+    /// `lines().next()`.
     pub async fn query_default_pane(&self, session: &str) -> Result<u32, SessionError> {
         validate_session_name(session)?;
         let cmd = format!("list-panes -t {session} -F '#{{pane_id}}'");

--- a/crates/server/src/session/manager.rs
+++ b/crates/server/src/session/manager.rs
@@ -129,6 +129,15 @@ impl SessionManager {
     /// explicit client events (attach, detach, window-resize) — do
     /// NOT call on every keystroke (SIGWINCH storms garble TUI
     /// apps; see `dims.rs`).
+    ///
+    /// **tmux command choice.** `refresh-client -C` is synchronous
+    /// in control mode: it processes in-band with the command
+    /// stream, so the new window size takes effect before any
+    /// subsequent `%output`. `resize-window` (the async
+    /// alternative) races with the output stream and flips tmux's
+    /// `window-size` to `manual`, breaking subsequent
+    /// `refresh-client -C`s. Node scar `09c0542` says stay in-band
+    /// for operations that must be ordered relative to output.
     pub async fn resize_session(
         &self,
         name: &str,
@@ -143,6 +152,76 @@ impl SessionManager {
             cols = cols,
             rows = rows
         );
+        let reply = self.tmux.send_command(&cmd).await?;
+        if !reply.ok {
+            return Err(SessionError::TmuxRejected(reply.output));
+        }
+        Ok(())
+    }
+
+    /// Look up the default pane id for `session`. Returns the
+    /// numeric pane id (tmux's `%N` with the `%` stripped) that
+    /// the output router keys off. For a session freshly created
+    /// by `create_session`, the first `list-panes` result IS the
+    /// default pane, because tmux creates the session with a
+    /// single window hosting a single pane.
+    ///
+    /// Called exactly once per `Attach` — the session-to-pane
+    /// mapping can change if the user runs tmux commands that
+    /// create windows/panes, but katulong's current single-pane-
+    /// per-session assumption (session 9h will revisit) means
+    /// we resolve once at attach time.
+    pub async fn query_default_pane(&self, session: &str) -> Result<u32, SessionError> {
+        validate_session_name(session)?;
+        let cmd = format!("list-panes -t {session} -F '#{{pane_id}}'");
+        let reply = self.tmux.send_command(&cmd).await?;
+        if !reply.ok {
+            return Err(SessionError::TmuxRejected(reply.output));
+        }
+        let first = reply.output.lines().next().unwrap_or("").trim();
+        let rest = first.strip_prefix('%').ok_or_else(|| {
+            SessionError::TmuxRejected(format!("unexpected pane-id reply: {first:?}"))
+        })?;
+        rest.parse::<u32>().map_err(|_| {
+            SessionError::TmuxRejected(format!("invalid pane-id in reply: {first:?}"))
+        })
+    }
+
+    /// Forward client keystroke bytes to a specific pane as
+    /// `send-keys -t %<pane_id> -H <hex-pairs>`. `-H` takes
+    /// space-separated two-digit hex values, so every byte
+    /// (including control chars like Ctrl-C `0x03` or arrow keys
+    /// `1b 5b 41`) rides through without shell quoting or
+    /// encoding loss.
+    ///
+    /// **Why `send-keys -H` and not stdin write.** tmux in
+    /// control mode exposes stdin for COMMANDS, not for pane
+    /// data — there's no other supported channel from our side
+    /// to the pane. `send-keys -H` is explicitly binary-safe and
+    /// tmux has shipped it since 2.4. Alternatives considered:
+    /// `-l` (literal text) mangles control chars; `paste-buffer`
+    /// requires a second command per paste and is paste-flavored
+    /// (hits paste bracketing).
+    ///
+    /// Empty input is a no-op — we don't bother tmux for zero
+    /// bytes. Slice 9g/9h considerations: large pastes (up to
+    /// the 64 KiB frame cap) encode to ~192 KiB command lines
+    /// (3× hex overhead); tmux accepts multi-hundred-KB command
+    /// strings in practice, but truly enormous pastes should be
+    /// fragmented client-side. The existing client-side
+    /// fragmentation implied by `MAX_INBOUND_FRAME_BYTES`
+    /// handles this.
+    pub async fn send_input(&self, pane_id: u32, data: &[u8]) -> Result<(), SessionError> {
+        if data.is_empty() {
+            return Ok(());
+        }
+        // Pre-size the string: "send-keys -t %<id> -H" + 3 chars/byte.
+        let mut cmd = String::with_capacity(32 + data.len() * 3);
+        use std::fmt::Write;
+        write!(&mut cmd, "send-keys -t %{pane_id} -H").expect("writing to String never fails");
+        for b in data {
+            write!(&mut cmd, " {b:02x}").expect("writing to String never fails");
+        }
         let reply = self.tmux.send_command(&cmd).await?;
         if !reply.ok {
             return Err(SessionError::TmuxRejected(reply.output));

--- a/crates/server/src/session/mod.rs
+++ b/crates/server/src/session/mod.rs
@@ -23,9 +23,12 @@
 pub mod dims;
 pub mod handler;
 pub mod manager;
+pub mod output;
 pub mod parser;
+pub mod router;
 pub mod tmux;
 
 pub use handler::serve_session;
 pub use manager::{SessionError, SessionManager};
+pub use router::{OutputRouter, RouterError};
 pub use tmux::{CommandReply, Tmux, TmuxError, DEDICATED_SOCKET_NAME};

--- a/crates/server/src/session/mod.rs
+++ b/crates/server/src/session/mod.rs
@@ -30,5 +30,5 @@ pub mod tmux;
 
 pub use handler::serve_session;
 pub use manager::{SessionError, SessionManager};
-pub use router::{OutputRouter, RouterError};
+pub use router::OutputRouter;
 pub use tmux::{CommandReply, Tmux, TmuxError, DEDICATED_SOCKET_NAME};

--- a/crates/server/src/session/output.rs
+++ b/crates/server/src/session/output.rs
@@ -1,0 +1,461 @@
+//! Output-path primitives for the tmux → client wire.
+//!
+//! Two independently-testable pieces live here:
+//!
+//! - [`OctalDecoder`] — converts tmux control-mode `%output`'s
+//!   octal-escape-encoded text (`\ooo` for non-printable bytes,
+//!   `\\` for literal backslash) back into the raw byte stream
+//!   the client's terminal emulator wants. **Stateful across
+//!   calls**: tmux wraps long `%output` lines at a byte limit
+//!   that can fall INSIDE a `\NNN` escape (Node scar `4dffb9f`),
+//!   so a partial `\`, `\N`, or `\NN` at the end of one chunk
+//!   must carry over to the next.
+//!
+//! - [`Coalescer`] — buffer for the output coalescing timing
+//!   contract from Node scars `d311168` / `066dab2`: group
+//!   `%output` chunks using a **2 ms idle timer** (resets on each
+//!   arrival, waits for output to stop) combined with a **16 ms
+//!   hard cap** (one 60 fps frame) so continuous streams don't
+//!   starve. A pure timing primitive — no I/O, no awaits — so
+//!   the handler's `tokio::select!` can drive it via
+//!   `next_deadline()`.
+//!
+//! # Why both timers, not just one
+//!
+//! - **Idle alone** means `yes` or any continuous-output command
+//!   never flushes — the idle deadline never elapses.
+//! - **Cap alone** splits TUI frames that span multiple `%output`
+//!   lines across multiple wire messages, breaking xterm.js'
+//!   synchronised output and producing garbled text.
+//!
+//! Both together: complete frames go out as single wire messages,
+//! continuous streams flush every 16 ms. Node shipped
+//! `setImmediate`-style coalescing and an 8 ms fixed timer
+//! before settling on 2 ms/16 ms — the fixed timer split frames
+//! too; `setImmediate` only captured one I/O tick. Don't
+//! reinvent either.
+//!
+//! # Why not decode at the subscriber
+//!
+//! The octal-decoder state is per-**pane**, not per-subscriber —
+//! when slice 9h adds multi-device fan-out to the same pane,
+//! every subscriber needs to see the same fully-decoded byte
+//! stream. Decoding upstream of the fan-out (in the dispatcher)
+//! keeps the carry buffer in one place. Slice 9f only has one
+//! subscriber per pane so the placement is equivalent, but
+//! picking the right home now means the multi-device slice
+//! doesn't have to relocate the state.
+
+use std::time::Duration;
+use tokio::time::Instant;
+
+/// Idle coalesce window. After the last `%output` arrived, wait
+/// this long before flushing — if another chunk lands in that
+/// window we reset and keep buffering. 2 ms was picked in Node
+/// (`d311168`) because a TUI frame's `%output` bursts are
+/// characteristically sub-millisecond between lines, and 2 ms is
+/// long enough to coalesce a burst but short enough that users
+/// don't perceive lag on keystroke echo.
+pub const COALESCE_IDLE: Duration = Duration::from_millis(2);
+
+/// Cap on how long a buffered burst can sit before being flushed
+/// regardless of idleness. 16 ms ≈ one 60 fps frame — guarantees
+/// that under a continuous-output command the client gets at
+/// least 60 updates per second. Shorter values fragment frames;
+/// longer values visibly stall the display.
+pub const COALESCE_CAP: Duration = Duration::from_millis(16);
+
+/// Output-path coalescer. Holds a byte buffer and the two
+/// deadlines that gate its flush. Entirely synchronous — the
+/// caller owns the timer via `next_deadline()` and `take()`.
+///
+/// Typical usage:
+///
+/// ```ignore
+/// coalescer.push(bytes);
+/// // select! on coalescer.next_deadline() alongside other events
+/// let flushed = coalescer.take();
+/// send(flushed);
+/// ```
+#[derive(Debug, Default)]
+pub struct Coalescer {
+    buf: Vec<u8>,
+    /// When to flush because `%output` has been idle long enough
+    /// (reset on each push).
+    idle_deadline: Option<Instant>,
+    /// When to flush regardless of idleness (set once per
+    /// burst, on the first push into an empty buffer).
+    cap_deadline: Option<Instant>,
+}
+
+impl Coalescer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append bytes to the pending burst. The cap deadline is set
+    /// only on the transition from empty → non-empty buffer, so a
+    /// long burst is capped from its FIRST byte; the idle deadline
+    /// resets on every call so idle flushes correctly follow the
+    /// LAST byte.
+    pub fn push(&mut self, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        let now = Instant::now();
+        if self.buf.is_empty() {
+            self.cap_deadline = Some(now + COALESCE_CAP);
+        }
+        self.buf.extend_from_slice(bytes);
+        self.idle_deadline = Some(now + COALESCE_IDLE);
+    }
+
+    /// Earliest deadline the caller should await to flush this
+    /// coalescer. `None` when the buffer is empty (no pending
+    /// flush).
+    pub fn next_deadline(&self) -> Option<Instant> {
+        match (self.idle_deadline, self.cap_deadline) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (Some(d), None) | (None, Some(d)) => Some(d),
+            (None, None) => None,
+        }
+    }
+
+    /// Take the buffered bytes and clear both deadlines. Returns
+    /// an empty vec if the buffer was empty (caller can use
+    /// `is_empty()` to short-circuit).
+    pub fn take(&mut self) -> Vec<u8> {
+        self.idle_deadline = None;
+        self.cap_deadline = None;
+        std::mem::take(&mut self.buf)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buf.is_empty()
+    }
+}
+
+/// Stateful tmux `%output` decoder.
+///
+/// tmux encodes `%output` payloads with two transformations:
+///
+/// - `\\` → literal `\`
+/// - `\NNN` (three octal digits) → the byte whose value is that
+///   octal number
+///
+/// Everything else is passed through byte-identically.
+///
+/// The decoder is stateful because tmux wraps long `%output`
+/// lines at a byte limit that **can fall inside a `\NNN`
+/// escape**. Without a carry buffer, a `\342\226\210` (the UTF-8
+/// encoding of `█`) wrapping as `\342\226\2` + `10` produces a
+/// literal `\` followed by bytes `342 226 2 10` from the first
+/// chunk, and then `10` from the second — total garbage. The
+/// carry buffer defers a trailing `\`, `\N`, or `\NN` until the
+/// next chunk arrives, mirroring how a UTF-8 `StringDecoder`
+/// buffers partial multi-byte sequences at a read boundary.
+///
+/// One decoder instance per pane — the carry spans `%output`
+/// lines for the SAME pane, and tmux interleaves lines from
+/// different panes freely. The dispatcher keyed per-pane-id
+/// handles the 1:N mapping.
+#[derive(Debug, Default)]
+pub struct OctalDecoder {
+    /// Accumulated bytes that LOOK like a partial escape: at most
+    /// 3 bytes (`\`, `\N`, or `\NN`). Never more; once a 4th byte
+    /// arrives we can always classify the escape one way or
+    /// the other.
+    carry: Vec<u8>,
+}
+
+impl OctalDecoder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Decode one `%output` chunk, folding in any carry from the
+    /// previous call. May push a new partial escape into the
+    /// carry before returning; the next call will resume from it.
+    ///
+    /// Input is `&str` because `parser.rs` hands us the already-
+    /// UTF-8-line-read text from tmux's stdout. We treat it as
+    /// bytes anyway — the octal decoder is byte-level and tmux's
+    /// pre-decode escaping keeps non-ASCII bytes inside `\NNN`
+    /// sequences rather than leaking them as raw UTF-8.
+    pub fn decode(&mut self, chunk: &str) -> Vec<u8> {
+        // Fast path: nothing buffered, no backslash in chunk,
+        // decoder is a no-op. Saves one allocation and one walk
+        // on the common "printable ASCII only" case (shell
+        // prompts, bare text).
+        if self.carry.is_empty() && !chunk.contains('\\') {
+            return chunk.as_bytes().to_vec();
+        }
+
+        // General path: concat carry + chunk, walk byte-wise.
+        let mut combined = Vec::with_capacity(self.carry.len() + chunk.len());
+        combined.extend_from_slice(&self.carry);
+        combined.extend_from_slice(chunk.as_bytes());
+        self.carry.clear();
+
+        let mut out = Vec::with_capacity(combined.len());
+        let mut i = 0;
+        while i < combined.len() {
+            if combined[i] != b'\\' {
+                out.push(combined[i]);
+                i += 1;
+                continue;
+            }
+            // We're at a `\`. Decide based on what follows.
+            let remaining = combined.len() - i;
+            if remaining == 1 {
+                // Trailing lone `\` — carry, come back next call.
+                self.carry.push(b'\\');
+                return out;
+            }
+            let next = combined[i + 1];
+            if next == b'\\' {
+                // `\\` → literal `\`
+                out.push(b'\\');
+                i += 2;
+                continue;
+            }
+            if is_octal_digit(next) {
+                if remaining < 4 {
+                    // `\N` or `\NN` spanning the end — carry it.
+                    self.carry.extend_from_slice(&combined[i..]);
+                    return out;
+                }
+                let a = next;
+                let b = combined[i + 2];
+                let c = combined[i + 3];
+                if is_octal_digit(b) && is_octal_digit(c) {
+                    let value = (u16::from(a - b'0') << 6)
+                        | (u16::from(b - b'0') << 3)
+                        | u16::from(c - b'0');
+                    // Three-digit octal can be up to 0o777 = 511.
+                    // Values ≥ 256 cannot come from tmux
+                    // (bytes are 0..=255); guard anyway so a
+                    // malformed input can't write a u16-as-u8
+                    // wrap.
+                    if let Ok(byte) = u8::try_from(value) {
+                        out.push(byte);
+                        i += 4;
+                        continue;
+                    }
+                }
+                // `\N` where the next byte isn't octal (or the
+                // 3-digit octal overflows): treat the `\` as
+                // literal. tmux shouldn't emit this, but a
+                // defensive path beats silent corruption.
+                out.push(b'\\');
+                i += 1;
+                continue;
+            }
+            // `\` followed by a non-octal non-`\`: treat the
+            // `\` as literal. Shouldn't arise from tmux.
+            out.push(b'\\');
+            i += 1;
+        }
+
+        out
+    }
+
+    /// Return any bytes still in the carry buffer and clear it.
+    /// Called at shutdown / detach so trailing malformed escapes
+    /// don't vanish silently. In well-formed tmux output the
+    /// carry is empty between complete escape sequences.
+    pub fn take_carry(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.carry)
+    }
+
+    #[cfg(test)]
+    pub fn carry_len(&self) -> usize {
+        self.carry.len()
+    }
+}
+
+fn is_octal_digit(b: u8) -> bool {
+    (b'0'..=b'7').contains(&b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------- OctalDecoder tests ----------
+
+    #[test]
+    fn plain_ascii_passes_through() {
+        let mut d = OctalDecoder::new();
+        assert_eq!(d.decode("hello world"), b"hello world");
+        assert_eq!(d.carry_len(), 0);
+    }
+
+    #[test]
+    fn double_backslash_decodes_to_single() {
+        let mut d = OctalDecoder::new();
+        assert_eq!(d.decode(r"C:\\Users"), b"C:\\Users");
+    }
+
+    #[test]
+    fn three_digit_octal_decodes() {
+        let mut d = OctalDecoder::new();
+        // \033 = 0o33 = 27 = ESC
+        assert_eq!(d.decode(r"\033[2J"), &[0x1B, b'[', b'2', b'J']);
+    }
+
+    #[test]
+    fn utf8_box_drawing_decodes() {
+        // `█` = U+2588 = UTF-8 0xE2 0x96 0x88 = `\342\226\210`.
+        let mut d = OctalDecoder::new();
+        assert_eq!(d.decode(r"\342\226\210"), &[0xE2, 0x96, 0x88]);
+    }
+
+    #[test]
+    fn carry_resumes_partial_trailing_backslash() {
+        // Node scar `4dffb9f`: tmux can split `\NNN` at byte
+        // boundaries. Single `\` at end must carry.
+        let mut d = OctalDecoder::new();
+        let out1 = d.decode("prefix\\");
+        assert_eq!(out1, b"prefix");
+        assert_eq!(d.carry_len(), 1, "trailing `\\` must be held");
+        let out2 = d.decode("033suffix");
+        assert_eq!(out2, &[0x1B, b's', b'u', b'f', b'f', b'i', b'x']);
+        assert_eq!(d.carry_len(), 0);
+    }
+
+    #[test]
+    fn carry_resumes_partial_backslash_n() {
+        let mut d = OctalDecoder::new();
+        let out1 = d.decode("before\\0");
+        assert_eq!(out1, b"before");
+        assert_eq!(d.carry_len(), 2);
+        let out2 = d.decode("33after");
+        assert_eq!(out2, &[0x1B, b'a', b'f', b't', b'e', b'r']);
+    }
+
+    #[test]
+    fn carry_resumes_partial_backslash_nn() {
+        let mut d = OctalDecoder::new();
+        let out1 = d.decode("x\\34");
+        assert_eq!(out1, b"x");
+        assert_eq!(d.carry_len(), 3);
+        let out2 = d.decode("2y");
+        // \342 = 0xE2
+        assert_eq!(out2, &[0xE2, b'y']);
+    }
+
+    #[test]
+    fn carry_across_utf8_box_boundary() {
+        // The concrete Node-scar scenario: box-drawing char split
+        // mid-escape. `█` = `\342\226\210`. Split after the
+        // partial second escape.
+        let mut d = OctalDecoder::new();
+        let out1 = d.decode(r"\342\226\2");
+        assert_eq!(out1, &[0xE2, 0x96]);
+        let out2 = d.decode("10");
+        assert_eq!(out2, &[0x88]);
+    }
+
+    #[test]
+    fn backslash_followed_by_non_octal_is_literal() {
+        let mut d = OctalDecoder::new();
+        // Shouldn't arise from tmux, but must not corrupt output.
+        assert_eq!(d.decode(r"\x"), b"\\x");
+    }
+
+    #[test]
+    fn take_carry_drains_leftover() {
+        let mut d = OctalDecoder::new();
+        let _ = d.decode("end\\");
+        assert_eq!(d.take_carry(), b"\\");
+        assert_eq!(d.carry_len(), 0);
+    }
+
+    #[test]
+    fn fast_path_no_backslash_no_allocation_correctness() {
+        // The fast-path branch exists for perf, not semantics.
+        // Double-check it matches the slow path byte-for-byte.
+        let mut d = OctalDecoder::new();
+        let input = "a very long prompt with $PATH and numbers 1234567890";
+        assert_eq!(d.decode(input), input.as_bytes());
+    }
+
+    // ---------- Coalescer tests ----------
+
+    #[tokio::test(start_paused = true)]
+    async fn empty_coalescer_has_no_deadline() {
+        let c = Coalescer::new();
+        assert_eq!(c.next_deadline(), None);
+        assert!(c.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn push_sets_idle_and_cap_deadlines() {
+        let mut c = Coalescer::new();
+        let start = Instant::now();
+        c.push(b"hello");
+        let deadline = c.next_deadline().expect("deadline set after push");
+        // next_deadline is min(idle, cap) = idle (2ms < 16ms)
+        assert_eq!(deadline, start + COALESCE_IDLE);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn repeated_push_resets_idle_but_not_cap() {
+        let mut c = Coalescer::new();
+        let start = Instant::now();
+        c.push(b"first");
+        // Advance 1 ms — still inside both deadlines.
+        tokio::time::advance(Duration::from_millis(1)).await;
+        c.push(b"second");
+        let deadline = c.next_deadline().unwrap();
+        // Idle deadline reset to now+2ms = start+3ms. Cap
+        // deadline unchanged = start+16ms. min is idle.
+        assert_eq!(deadline, start + Duration::from_millis(3));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cap_wins_for_continuous_push() {
+        // Continuous push every 1 ms keeps resetting idle, so the
+        // cap deadline takes over — this is the Node scar
+        // "setImmediate never flushes under yes"; with cap we're
+        // guaranteed a flush at 16 ms.
+        let mut c = Coalescer::new();
+        let start = Instant::now();
+        for _ in 0..20 {
+            c.push(b"x");
+            tokio::time::advance(Duration::from_millis(1)).await;
+        }
+        let deadline = c.next_deadline().unwrap();
+        // Cap deadline was set on the FIRST push at t=0 and is at
+        // t+16ms. After 20 ms of advance we're past it.
+        assert_eq!(deadline, start + COALESCE_CAP);
+        // Now we're at t=20ms, so the deadline is in the past.
+        assert!(
+            Instant::now() >= deadline,
+            "cap deadline must have elapsed"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn take_clears_buf_and_deadlines() {
+        let mut c = Coalescer::new();
+        c.push(b"abc");
+        let taken = c.take();
+        assert_eq!(taken, b"abc");
+        assert!(c.is_empty());
+        assert_eq!(c.next_deadline(), None);
+        // A push after take restarts the cap.
+        let resume = Instant::now();
+        c.push(b"d");
+        assert_eq!(c.next_deadline().unwrap(), resume + COALESCE_IDLE);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn push_empty_is_noop() {
+        let mut c = Coalescer::new();
+        c.push(b"");
+        assert!(c.is_empty());
+        assert_eq!(c.next_deadline(), None);
+    }
+}

--- a/crates/server/src/session/output.rs
+++ b/crates/server/src/session/output.rs
@@ -260,14 +260,6 @@ impl OctalDecoder {
         out
     }
 
-    /// Return any bytes still in the carry buffer and clear it.
-    /// Called at shutdown / detach so trailing malformed escapes
-    /// don't vanish silently. In well-formed tmux output the
-    /// carry is empty between complete escape sequences.
-    pub fn take_carry(&mut self) -> Vec<u8> {
-        std::mem::take(&mut self.carry)
-    }
-
     #[cfg(test)]
     pub fn carry_len(&self) -> usize {
         self.carry.len()
@@ -362,14 +354,6 @@ mod tests {
         let mut d = OctalDecoder::new();
         // Shouldn't arise from tmux, but must not corrupt output.
         assert_eq!(d.decode(r"\x"), b"\\x");
-    }
-
-    #[test]
-    fn take_carry_drains_leftover() {
-        let mut d = OctalDecoder::new();
-        let _ = d.decode("end\\");
-        assert_eq!(d.take_carry(), b"\\");
-        assert_eq!(d.carry_len(), 0);
     }
 
     #[test]

--- a/crates/server/src/session/router.rs
+++ b/crates/server/src/session/router.rs
@@ -11,21 +11,25 @@
 //! # Ownership model
 //!
 //! `OutputRouter` is cheap to clone — internals are `Arc`. The
-//! dispatcher task spawned in `main.rs` holds one clone and
-//! calls [`OutputRouter::dispatch`]. Each WS connection handler
-//! holds another clone via `AppState` and calls
+//! dispatcher task spawned via [`OutputRouter::spawn_dispatcher`]
+//! holds one clone and calls [`OutputRouter::dispatch`] for every
+//! `%output` notification. Each WS connection handler holds
+//! another clone via `AppState` and calls
 //! [`OutputRouter::subscribe`] after its `Attach` succeeds.
 //!
-//! # Single-subscriber invariant (slice 9f)
+//! # Attach-displaces-prior semantics (slice 9f)
 //!
-//! At most one subscriber per `pane_id`. A second concurrent
-//! [`OutputRouter::subscribe`] for the same pane returns
-//! [`RouterError::AlreadyAttached`]. Slice 9h (multi-device
-//! output fan-out) replaces the inner map with per-pane
-//! fan-out primitives + a ring buffer for catching up, which is
-//! why the decoder's carry state already lives here (see
-//! `output.rs`) — it's shared across all subscribers for the
-//! pane.
+//! `subscribe(pane_id)` always succeeds. If a prior subscriber
+//! already held the pane, their `mpsc::Receiver` sees its
+//! channel close on the next `recv()` and the handler's loop
+//! treats that as `Action::Exit` (see `handler.rs`). This
+//! matches katulong's one-user-many-devices model: opening the
+//! app in a second browser tab smoothly takes over the terminal
+//! rather than refusing with an error the user has to
+//! troubleshoot. Slice 9h revisits this when multi-device
+//! fan-out lands — at that point the question "displace vs
+//! fan-out" is a product decision rather than a plumbing
+//! constraint.
 //!
 //! # Decoder ownership
 //!
@@ -33,7 +37,11 @@
 //! dispatcher task decodes bytes BEFORE fanning out to the
 //! subscriber, not after: when multi-device lands, every
 //! subscriber gets the same fully-decoded byte stream and the
-//! octal-carry state lives in exactly one place.
+//! octal-carry state lives in exactly one place. The decoder's
+//! carry survives the attach-displaces-prior handoff because
+//! the decoder is keyed per-pane, not per-subscriber — a
+//! reconnecting client picks up mid-escape if the tmux wrap
+//! happened to land there.
 //!
 //! # Backpressure
 //!
@@ -45,14 +53,29 @@
 //! visible to the user as a terminal glitch, but the alternative
 //! — blocking the tmux reader task on one slow client —
 //! starves every other pane's output. Ring-buffer + resync in
-//! slice 9h is the proper fix for drops; until then, generous
+//! slice 9g is the proper fix for drops; until then, generous
 //! buffer depth + fast consumer keeps drops to pathological
 //! cases.
+//!
+//! # Stale-entry cleanup (panicked handler)
+//!
+//! If a handler task panics between `subscribe` and its
+//! explicit `unsubscribe` cleanup, the `mpsc::Receiver` drops
+//! but the `PaneState` (with its decoder carry) remains in the
+//! map. `dispatch`'s `TrySendError::Closed` branch prunes it on
+//! the next attempted send. For a quiet pane (no `%output`
+//! between the panic and a reconnect attempt), this means the
+//! `subscribe` call implicitly overwrites the stale entry —
+//! which is now ALWAYS correct under the replace-semantics
+//! above (it used to also matter for the old
+//! `AlreadyAttached` rejection path, which is gone).
 
 use crate::session::output::OctalDecoder;
+use crate::session::parser::Notification;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 /// Per-pane queue capacity. Tmux emits one `%output` per I/O
 /// boundary; a single TUI frame is typically 1–10 chunks, and
@@ -60,16 +83,6 @@ use tokio::sync::mpsc;
 /// time. 256 gives a generous headroom above any realistic burst
 /// without committing huge memory (each entry is a small `Vec`).
 const PER_PANE_BUFFER: usize = 256;
-
-#[derive(Debug, thiserror::Error)]
-pub enum RouterError {
-    /// Another subscriber is already attached to this pane.
-    /// Slice 9f enforces single-subscriber-per-pane so the
-    /// decoder's carry state has exactly one reader; slice 9h
-    /// with multi-device fan-out relaxes this.
-    #[error("another connection is already attached to pane %{0}")]
-    AlreadyAttached(u32),
-}
 
 /// Router between the global tmux notification stream and the
 /// per-pane subscribers. See the module doc.
@@ -88,34 +101,45 @@ impl OutputRouter {
         Self::default()
     }
 
-    /// Register interest in `pane_id` and get back the receiver
-    /// the dispatcher will push decoded bytes to. Fails if the
-    /// pane is already subscribed.
+    /// Subscribe to `pane_id`'s decoded byte stream. Always
+    /// succeeds — if a prior subscriber is already registered,
+    /// their sender is dropped (their `recv` yields `None` on the
+    /// next poll → handler exits via `Action::Exit`) and the new
+    /// subscriber takes over. The decoder's carry buffer survives
+    /// the swap because it's per-pane, not per-subscriber.
     ///
-    /// The returned receiver is bounded at `PER_PANE_BUFFER`.
-    /// Drop it to unsubscribe; the dispatcher's `try_send` will
-    /// fail silently and the handler's cleanup path calls
-    /// [`OutputRouter::unsubscribe`] to remove the decoder too.
-    pub fn subscribe(&self, pane_id: u32) -> Result<mpsc::Receiver<Vec<u8>>, RouterError> {
+    /// See the "Attach-displaces-prior" section of the module
+    /// doc for the one-user-many-devices rationale.
+    pub fn subscribe(&self, pane_id: u32) -> mpsc::Receiver<Vec<u8>> {
         let mut panes = self.inner.lock().expect("output-router mutex poisoned");
-        if panes.contains_key(&pane_id) {
-            return Err(RouterError::AlreadyAttached(pane_id));
-        }
         let (tx, rx) = mpsc::channel(PER_PANE_BUFFER);
-        panes.insert(
-            pane_id,
-            PaneState {
-                sender: tx,
-                decoder: OctalDecoder::new(),
-            },
-        );
-        Ok(rx)
+        match panes.get_mut(&pane_id) {
+            Some(existing) => {
+                // Replace the sender. The old sender drops when
+                // this assignment lands, which closes the old
+                // receiver and lets the old handler exit cleanly.
+                // KEEP the decoder: carry state is about the tmux
+                // byte stream, not about the subscriber.
+                existing.sender = tx;
+            }
+            None => {
+                panes.insert(
+                    pane_id,
+                    PaneState {
+                        sender: tx,
+                        decoder: OctalDecoder::new(),
+                    },
+                );
+            }
+        }
+        rx
     }
 
     /// Remove a pane's registration. Safe to call when no
     /// subscriber is registered (no-op). Handlers MUST call this
-    /// on Drop so the decoder's carry buffer doesn't leak across
-    /// reconnects on the same pane.
+    /// on clean exit so the decoder's carry buffer doesn't leak.
+    /// On a panicked handler exit, `dispatch`'s stale-entry
+    /// pruning (see the module doc) eventually cleans up.
     pub fn unsubscribe(&self, pane_id: u32) {
         let _ = self
             .inner
@@ -128,6 +152,15 @@ impl OutputRouter {
     /// its subscriber (if any). Decodes octal escapes, folds in
     /// any carry from the previous dispatch to this pane, and
     /// sends the resulting bytes via the per-pane mpsc.
+    ///
+    /// The input `raw` is expected to be tmux control-mode-
+    /// encoded text (the decoder handles `\\` and `\NNN`
+    /// escapes). A future non-tmux transport producing pre-
+    /// decoded bytes would bypass the router's dispatch, NOT
+    /// feed them in raw — the decoder would passthrough safely
+    /// only because it has a fast-path on "no backslash," and
+    /// relying on that is fragile. Keep `dispatch` for
+    /// tmux-encoded input.
     ///
     /// If no subscriber is registered, the notification is
     /// dropped silently — tmux panes unrelated to any katulong
@@ -162,11 +195,71 @@ impl OutputRouter {
                     // Subscriber dropped their receiver without
                     // calling unsubscribe (e.g., handler panic).
                     // Remove the entry so future dispatches and
-                    // subscribes see a clean slate.
+                    // subscribes see a clean slate. A quiet pane
+                    // might not trigger this path until the next
+                    // `%output` arrives — a subscribe() call
+                    // before that would overwrite the stale
+                    // entry anyway (see `subscribe`).
                     panes.remove(&pane_id);
                 }
             }
         }
+    }
+
+    /// Spawn the dispatcher task: a loop that drains `notifs`
+    /// (the `mpsc::UnboundedReceiver<Notification>` handed back
+    /// by `Tmux::spawn`) and routes each `%output` event through
+    /// `dispatch`. Returns the task's `JoinHandle` so the
+    /// caller can await shutdown; in practice `main.rs` lets
+    /// the runtime abort it on process exit.
+    ///
+    /// # Non-blocking invariant
+    ///
+    /// `Tmux::spawn` returns an UNBOUNDED receiver; if this
+    /// task ever blocks in `dispatch`, tmux notifications
+    /// accumulate toward OOM. `dispatch` is `try_send`-based
+    /// (drops on full subscriber rather than awaiting), so the
+    /// only way to block this task is synchronous contention
+    /// on the router's internal mutex. That critical section
+    /// is short (decoder step + try_send) even under slice 9h's
+    /// multi-subscriber fan-out — revisit if a profile ever
+    /// shows the dispatcher as the bottleneck.
+    ///
+    /// # Lifecycle
+    ///
+    /// The task exits when:
+    /// - `notifs` is closed (the `Tmux` client drops or
+    ///   shutdown completes), OR
+    /// - a `Notification::Exit` event fires (tmux's control
+    ///   connection tore down).
+    ///
+    /// On exit it logs and the task terminates; the router
+    /// continues to exist for any handlers that hold clones,
+    /// but nothing feeds it.
+    pub fn spawn_dispatcher(
+        &self,
+        mut notifs: mpsc::UnboundedReceiver<Notification>,
+    ) -> JoinHandle<()> {
+        let router = self.clone();
+        tokio::spawn(async move {
+            while let Some(notif) = notifs.recv().await {
+                match notif {
+                    Notification::Output { pane_id, data } => {
+                        router.dispatch(pane_id, &data);
+                    }
+                    Notification::Exit { reason } => {
+                        tracing::warn!(?reason, "tmux control-mode exited");
+                        break;
+                    }
+                    other => {
+                        // Other notifications aren't consumed
+                        // yet. Logged at trace so operators can
+                        // enable them selectively when diagnosing.
+                        tracing::trace!(?other, "tmux notification (no consumer yet)");
+                    }
+                }
+            }
+        })
     }
 
     /// Number of currently-registered panes. Test-only; not
@@ -186,7 +279,7 @@ mod tests {
     #[tokio::test]
     async fn subscribe_then_dispatch_delivers_bytes() {
         let r = OutputRouter::new();
-        let mut rx = r.subscribe(0).expect("first subscribe succeeds");
+        let mut rx = r.subscribe(0);
         r.dispatch(0, "hello");
         let got = rx.recv().await.expect("bytes arrive");
         assert_eq!(got, b"hello");
@@ -195,7 +288,7 @@ mod tests {
     #[tokio::test]
     async fn dispatch_decodes_octal() {
         let r = OutputRouter::new();
-        let mut rx = r.subscribe(7).unwrap();
+        let mut rx = r.subscribe(7);
         r.dispatch(7, r"\033[2J");
         let got = rx.recv().await.unwrap();
         assert_eq!(got, &[0x1B, b'[', b'2', b'J']);
@@ -208,7 +301,7 @@ mod tests {
         // subscriber. Split a `\342\226\210` mid-escape and
         // confirm the second dispatch reassembles correctly.
         let r = OutputRouter::new();
-        let mut rx = r.subscribe(0).unwrap();
+        let mut rx = r.subscribe(0);
         r.dispatch(0, r"\342\226\2");
         r.dispatch(0, "10");
         let first = rx.recv().await.unwrap();
@@ -219,24 +312,49 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn second_subscribe_to_same_pane_fails() {
-        // Single-subscriber invariant for slice 9f — relaxed
-        // when 9h lands multi-device.
+    async fn second_subscribe_displaces_prior_and_closes_its_channel() {
+        // One-user-many-devices: a second attach should smoothly
+        // take over the pane, not error. The prior subscriber's
+        // receiver sees its channel close on next recv.
         let r = OutputRouter::new();
-        let _rx1 = r.subscribe(0).unwrap();
-        let err = r.subscribe(0).unwrap_err();
-        assert!(matches!(err, RouterError::AlreadyAttached(0)));
+        let mut first = r.subscribe(0);
+        let mut second = r.subscribe(0);
+        r.dispatch(0, "routed");
+
+        // Old subscriber: next recv yields None (closed).
+        assert!(
+            first.recv().await.is_none(),
+            "prior subscription must close when replaced"
+        );
+        // New subscriber: gets the bytes.
+        let got = second.recv().await.expect("new subscriber gets bytes");
+        assert_eq!(got, b"routed");
+    }
+
+    #[tokio::test]
+    async fn displaced_keeps_decoder_carry() {
+        // The decoder is per-pane, not per-subscriber. When we
+        // replace the subscriber mid-escape, the partial escape
+        // must still resolve cleanly on the new subscriber's
+        // bytes.
+        let r = OutputRouter::new();
+        let _old = r.subscribe(0);
+        r.dispatch(0, r"\342\226\2"); // carries one byte
+        let mut new_sub = r.subscribe(0);
+        r.dispatch(0, "10"); // completes the escape
+        // The "\342\226" part went to the old sub (now closed),
+        // dropped silently. The new sub sees only the completion.
+        let got = new_sub.recv().await.unwrap();
+        assert_eq!(got, &[0x88]);
     }
 
     #[tokio::test]
     async fn unsubscribe_allows_resubscribe() {
-        // Reconnect semantics: a client whose handler exits
-        // unsubscribes; a fresh connection can then attach to the
-        // same pane.
         let r = OutputRouter::new();
-        let _rx1 = r.subscribe(0).unwrap();
+        let _rx1 = r.subscribe(0);
         r.unsubscribe(0);
-        let _rx2 = r.subscribe(0).expect("resubscribe after unsubscribe");
+        let _rx2 = r.subscribe(0);
+        assert_eq!(r.registered_count(), 1);
     }
 
     #[tokio::test]
@@ -251,19 +369,19 @@ mod tests {
     #[tokio::test]
     async fn dispatch_prunes_closed_subscriber() {
         let r = OutputRouter::new();
-        let rx = r.subscribe(5).unwrap();
+        let rx = r.subscribe(5);
         drop(rx);
         r.dispatch(5, "posthumous"); // send fails → prune
         assert_eq!(r.registered_count(), 0);
-        // Subscribe now succeeds again.
-        let _rx = r.subscribe(5).unwrap();
+        // Subscribe now succeeds again (with a fresh decoder).
+        let _rx = r.subscribe(5);
     }
 
     #[tokio::test]
     async fn unsubscribe_is_idempotent() {
         let r = OutputRouter::new();
         r.unsubscribe(99); // nothing registered — no-op
-        let _rx = r.subscribe(1).unwrap();
+        let _rx = r.subscribe(1);
         r.unsubscribe(1);
         r.unsubscribe(1); // already gone — no-op
     }
@@ -275,7 +393,7 @@ mod tests {
         // visible on the other.
         let r1 = OutputRouter::new();
         let r2 = r1.clone();
-        let mut rx = r1.subscribe(0).unwrap();
+        let mut rx = r1.subscribe(0);
         r2.dispatch(0, "cross");
         let got = rx.recv().await.unwrap();
         assert_eq!(got, b"cross");
@@ -289,7 +407,7 @@ mod tests {
         // when really we're still waiting for the tail. Silence
         // is the correct signal.
         let r = OutputRouter::new();
-        let mut rx = r.subscribe(0).unwrap();
+        let mut rx = r.subscribe(0);
         r.dispatch(0, r"\");
         // Nothing should be receivable yet.
         let got = rx.try_recv();
@@ -301,5 +419,40 @@ mod tests {
         r.dispatch(0, "033");
         let bytes = rx.recv().await.unwrap();
         assert_eq!(bytes, &[0x1B]);
+    }
+
+    #[tokio::test]
+    async fn spawn_dispatcher_routes_output_and_exits_on_tmux_exit() {
+        let r = OutputRouter::new();
+        let mut rx = r.subscribe(3);
+        let (tx, notifs) = mpsc::unbounded_channel::<Notification>();
+        let handle = r.spawn_dispatcher(notifs);
+
+        tx.send(Notification::Output {
+            pane_id: 3,
+            data: "ping".into(),
+        })
+        .unwrap();
+        let got = rx.recv().await.unwrap();
+        assert_eq!(got, b"ping");
+
+        // Non-routed notifications are logged but not forwarded.
+        tx.send(Notification::WindowClose { window_id: 0 }).unwrap();
+
+        // Exit notification terminates the dispatcher task.
+        tx.send(Notification::Exit {
+            reason: Some("test".into()),
+        })
+        .unwrap();
+        handle.await.expect("dispatcher task joins cleanly");
+    }
+
+    #[tokio::test]
+    async fn spawn_dispatcher_exits_when_notifs_closes() {
+        let r = OutputRouter::new();
+        let (tx, notifs) = mpsc::unbounded_channel::<Notification>();
+        let handle = r.spawn_dispatcher(notifs);
+        drop(tx);
+        handle.await.expect("dispatcher exits on sender drop");
     }
 }

--- a/crates/server/src/session/router.rs
+++ b/crates/server/src/session/router.rs
@@ -1,0 +1,305 @@
+//! Dispatcher from the single global tmux `%output` stream to
+//! per-connection output pumps.
+//!
+//! One tmux subprocess produces notifications for every pane on
+//! every session it hosts. A per-connection handler only cares
+//! about ONE pane (the one its `Attach` bound). The router is
+//! the thin indirection that routes a `%output <pane_id> <data>`
+//! notification to the right subscriber without forcing every
+//! handler to filter the whole stream itself.
+//!
+//! # Ownership model
+//!
+//! `OutputRouter` is cheap to clone — internals are `Arc`. The
+//! dispatcher task spawned in `main.rs` holds one clone and
+//! calls [`OutputRouter::dispatch`]. Each WS connection handler
+//! holds another clone via `AppState` and calls
+//! [`OutputRouter::subscribe`] after its `Attach` succeeds.
+//!
+//! # Single-subscriber invariant (slice 9f)
+//!
+//! At most one subscriber per `pane_id`. A second concurrent
+//! [`OutputRouter::subscribe`] for the same pane returns
+//! [`RouterError::AlreadyAttached`]. Slice 9h (multi-device
+//! output fan-out) replaces the inner map with per-pane
+//! fan-out primitives + a ring buffer for catching up, which is
+//! why the decoder's carry state already lives here (see
+//! `output.rs`) — it's shared across all subscribers for the
+//! pane.
+//!
+//! # Decoder ownership
+//!
+//! Each registered pane carries an [`OctalDecoder`]. The
+//! dispatcher task decodes bytes BEFORE fanning out to the
+//! subscriber, not after: when multi-device lands, every
+//! subscriber gets the same fully-decoded byte stream and the
+//! octal-carry state lives in exactly one place.
+//!
+//! # Backpressure
+//!
+//! The per-pane mpsc channel has a bounded capacity
+//! (`PER_PANE_BUFFER`). If the subscriber's handler falls behind
+//! (slow client, coalescer saturated, etc.), `try_send` fails
+//! and the dispatcher DROPS the bytes with a `warn!` log rather
+//! than backpressuring the whole tmux stream. Output loss is
+//! visible to the user as a terminal glitch, but the alternative
+//! — blocking the tmux reader task on one slow client —
+//! starves every other pane's output. Ring-buffer + resync in
+//! slice 9h is the proper fix for drops; until then, generous
+//! buffer depth + fast consumer keeps drops to pathological
+//! cases.
+
+use crate::session::output::OctalDecoder;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+
+/// Per-pane queue capacity. Tmux emits one `%output` per I/O
+/// boundary; a single TUI frame is typically 1–10 chunks, and
+/// the handler drains each chunk into a coalescer in constant
+/// time. 256 gives a generous headroom above any realistic burst
+/// without committing huge memory (each entry is a small `Vec`).
+const PER_PANE_BUFFER: usize = 256;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RouterError {
+    /// Another subscriber is already attached to this pane.
+    /// Slice 9f enforces single-subscriber-per-pane so the
+    /// decoder's carry state has exactly one reader; slice 9h
+    /// with multi-device fan-out relaxes this.
+    #[error("another connection is already attached to pane %{0}")]
+    AlreadyAttached(u32),
+}
+
+/// Router between the global tmux notification stream and the
+/// per-pane subscribers. See the module doc.
+#[derive(Clone, Default)]
+pub struct OutputRouter {
+    inner: Arc<Mutex<HashMap<u32, PaneState>>>,
+}
+
+struct PaneState {
+    sender: mpsc::Sender<Vec<u8>>,
+    decoder: OctalDecoder,
+}
+
+impl OutputRouter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register interest in `pane_id` and get back the receiver
+    /// the dispatcher will push decoded bytes to. Fails if the
+    /// pane is already subscribed.
+    ///
+    /// The returned receiver is bounded at `PER_PANE_BUFFER`.
+    /// Drop it to unsubscribe; the dispatcher's `try_send` will
+    /// fail silently and the handler's cleanup path calls
+    /// [`OutputRouter::unsubscribe`] to remove the decoder too.
+    pub fn subscribe(&self, pane_id: u32) -> Result<mpsc::Receiver<Vec<u8>>, RouterError> {
+        let mut panes = self.inner.lock().expect("output-router mutex poisoned");
+        if panes.contains_key(&pane_id) {
+            return Err(RouterError::AlreadyAttached(pane_id));
+        }
+        let (tx, rx) = mpsc::channel(PER_PANE_BUFFER);
+        panes.insert(
+            pane_id,
+            PaneState {
+                sender: tx,
+                decoder: OctalDecoder::new(),
+            },
+        );
+        Ok(rx)
+    }
+
+    /// Remove a pane's registration. Safe to call when no
+    /// subscriber is registered (no-op). Handlers MUST call this
+    /// on Drop so the decoder's carry buffer doesn't leak across
+    /// reconnects on the same pane.
+    pub fn unsubscribe(&self, pane_id: u32) {
+        let _ = self
+            .inner
+            .lock()
+            .expect("output-router mutex poisoned")
+            .remove(&pane_id);
+    }
+
+    /// Route a raw `%output <pane_id> <data>` notification to
+    /// its subscriber (if any). Decodes octal escapes, folds in
+    /// any carry from the previous dispatch to this pane, and
+    /// sends the resulting bytes via the per-pane mpsc.
+    ///
+    /// If no subscriber is registered, the notification is
+    /// dropped silently — tmux panes unrelated to any katulong
+    /// connection still produce output (e.g., the initial
+    /// session hosting a detached shell) and the router isn't
+    /// the right place to noise-log them.
+    pub fn dispatch(&self, pane_id: u32, raw: &str) {
+        let mut panes = self.inner.lock().expect("output-router mutex poisoned");
+        let Some(state) = panes.get_mut(&pane_id) else {
+            return;
+        };
+        let decoded = state.decoder.decode(raw);
+        if decoded.is_empty() {
+            // Entire chunk was absorbed into the carry (a single
+            // trailing `\` for example). Nothing to dispatch
+            // yet; the next chunk will carry through.
+            return;
+        }
+        if let Err(err) = state.sender.try_send(decoded) {
+            match err {
+                mpsc::error::TrySendError::Full(_) => {
+                    // Subscriber fell behind. Dropping here is a
+                    // visible glitch; blocking the dispatcher
+                    // would starve every other pane. Logged so
+                    // operators see the pressure.
+                    tracing::warn!(
+                        pane_id,
+                        "output dispatch dropped — subscriber queue full"
+                    );
+                }
+                mpsc::error::TrySendError::Closed(_) => {
+                    // Subscriber dropped their receiver without
+                    // calling unsubscribe (e.g., handler panic).
+                    // Remove the entry so future dispatches and
+                    // subscribes see a clean slate.
+                    panes.remove(&pane_id);
+                }
+            }
+        }
+    }
+
+    /// Number of currently-registered panes. Test-only; not
+    /// exposed in release builds so callers can't build load-
+    /// bearing logic on it (the map's contents are a dispatch
+    /// implementation detail).
+    #[cfg(test)]
+    pub fn registered_count(&self) -> usize {
+        self.inner.lock().unwrap().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn subscribe_then_dispatch_delivers_bytes() {
+        let r = OutputRouter::new();
+        let mut rx = r.subscribe(0).expect("first subscribe succeeds");
+        r.dispatch(0, "hello");
+        let got = rx.recv().await.expect("bytes arrive");
+        assert_eq!(got, b"hello");
+    }
+
+    #[tokio::test]
+    async fn dispatch_decodes_octal() {
+        let r = OutputRouter::new();
+        let mut rx = r.subscribe(7).unwrap();
+        r.dispatch(7, r"\033[2J");
+        let got = rx.recv().await.unwrap();
+        assert_eq!(got, &[0x1B, b'[', b'2', b'J']);
+    }
+
+    #[tokio::test]
+    async fn dispatch_carries_partial_escape_across_calls() {
+        // The multi-device rationale lives or dies on the
+        // decoder state being held by the router, not by the
+        // subscriber. Split a `\342\226\210` mid-escape and
+        // confirm the second dispatch reassembles correctly.
+        let r = OutputRouter::new();
+        let mut rx = r.subscribe(0).unwrap();
+        r.dispatch(0, r"\342\226\2");
+        r.dispatch(0, "10");
+        let first = rx.recv().await.unwrap();
+        let second = rx.recv().await.unwrap();
+        let mut combined = first;
+        combined.extend(second);
+        assert_eq!(combined, &[0xE2, 0x96, 0x88]);
+    }
+
+    #[tokio::test]
+    async fn second_subscribe_to_same_pane_fails() {
+        // Single-subscriber invariant for slice 9f — relaxed
+        // when 9h lands multi-device.
+        let r = OutputRouter::new();
+        let _rx1 = r.subscribe(0).unwrap();
+        let err = r.subscribe(0).unwrap_err();
+        assert!(matches!(err, RouterError::AlreadyAttached(0)));
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_allows_resubscribe() {
+        // Reconnect semantics: a client whose handler exits
+        // unsubscribes; a fresh connection can then attach to the
+        // same pane.
+        let r = OutputRouter::new();
+        let _rx1 = r.subscribe(0).unwrap();
+        r.unsubscribe(0);
+        let _rx2 = r.subscribe(0).expect("resubscribe after unsubscribe");
+    }
+
+    #[tokio::test]
+    async fn dispatch_with_no_subscriber_is_silent() {
+        // The initial tmux session hosts output unrelated to any
+        // connection — those panes must not log-spam the router.
+        let r = OutputRouter::new();
+        r.dispatch(42, "orphaned output");
+        assert_eq!(r.registered_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn dispatch_prunes_closed_subscriber() {
+        let r = OutputRouter::new();
+        let rx = r.subscribe(5).unwrap();
+        drop(rx);
+        r.dispatch(5, "posthumous"); // send fails → prune
+        assert_eq!(r.registered_count(), 0);
+        // Subscribe now succeeds again.
+        let _rx = r.subscribe(5).unwrap();
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_is_idempotent() {
+        let r = OutputRouter::new();
+        r.unsubscribe(99); // nothing registered — no-op
+        let _rx = r.subscribe(1).unwrap();
+        r.unsubscribe(1);
+        r.unsubscribe(1); // already gone — no-op
+    }
+
+    #[tokio::test]
+    async fn router_clones_share_state() {
+        // Dispatcher task and handler task each hold a clone of
+        // the same `OutputRouter`. Operations on one must be
+        // visible on the other.
+        let r1 = OutputRouter::new();
+        let r2 = r1.clone();
+        let mut rx = r1.subscribe(0).unwrap();
+        r2.dispatch(0, "cross");
+        let got = rx.recv().await.unwrap();
+        assert_eq!(got, b"cross");
+    }
+
+    #[tokio::test]
+    async fn carry_only_output_does_not_dispatch_empty() {
+        // A chunk that is entirely absorbed into the carry
+        // (single `\`) must NOT send an empty Vec to the
+        // subscriber — we'd be telling the client "here's output"
+        // when really we're still waiting for the tail. Silence
+        // is the correct signal.
+        let r = OutputRouter::new();
+        let mut rx = r.subscribe(0).unwrap();
+        r.dispatch(0, r"\");
+        // Nothing should be receivable yet.
+        let got = rx.try_recv();
+        assert!(
+            got.is_err(),
+            "dispatch that absorbed entirely into carry must send nothing; got {got:?}"
+        );
+        // Completing the escape delivers bytes.
+        r.dispatch(0, "033");
+        let bytes = rx.recv().await.unwrap();
+        assert_eq!(bytes, &[0x1B]);
+    }
+}

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -7,7 +7,7 @@
 //! their own mutexes. `AppState` itself is just a bundle of references.
 
 use crate::revocation::RevocationPublisher;
-use crate::session::SessionManager;
+use crate::session::{OutputRouter, SessionManager};
 use katulong_auth::{AuthStore, WebAuthnService};
 use std::sync::Arc;
 use tokio::sync::broadcast::Receiver;
@@ -55,6 +55,19 @@ pub struct AppState {
     /// the field `Option` rather than `Arc<SessionManager>` avoids
     /// forcing every auth integration test to stand up tmux.
     pub sessions: Option<Arc<SessionManager>>,
+    /// Output-fan-out router. Always present (it's cheap — an
+    /// `Arc<Mutex<HashMap>>` behind the clone) so handlers can
+    /// always call `subscribe`. In `None`-sessions test builds
+    /// it has no dispatcher populating it and every subscribe
+    /// yields an empty stream; in production the dispatcher task
+    /// spawned in `main.rs` feeds decoded tmux `%output` through
+    /// it. Kept outside the `Option<SessionManager>` field
+    /// deliberately: slice 9h's ring-buffer + reconnect-replay
+    /// will want the router alive across session-manager
+    /// restarts (if that ever becomes possible), and coupling
+    /// the two by wrapping them in one `Option` would force a
+    /// lifetime they don't share.
+    pub output_router: OutputRouter,
 }
 
 impl AppState {
@@ -68,6 +81,7 @@ impl AppState {
             config: Arc::new(config),
             revocations: RevocationPublisher::new(),
             sessions: None,
+            output_router: OutputRouter::new(),
         }
     }
 

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -94,6 +94,24 @@ impl AppState {
         self
     }
 
+    /// Override the default-constructed `OutputRouter` with the
+    /// one fed by the tmux dispatcher task. `AppState::new`
+    /// constructs an empty router so tests that never wire tmux
+    /// can still call `.subscribe` on it (and get an empty
+    /// stream); production startup replaces it with the router
+    /// whose clone is handed to the dispatcher task.
+    ///
+    /// The two-step "default + override" shape matches
+    /// `with_sessions`; using struct-update syntax at the call
+    /// site works but silently throws away the default router
+    /// allocation, which an architecture review round flagged
+    /// as a latent surprise ("new() promises a valid state
+    /// then callers stomp one field").
+    pub fn with_output_router(mut self, router: OutputRouter) -> Self {
+        self.output_router = router;
+        self
+    }
+
     /// Subscribe to credential-revocation events. Transport-agnostic
     /// — the returned receiver delivers the same events to a WS
     /// handler or a future WebRTC peer connection. Subscribers

--- a/crates/server/src/transport/message.rs
+++ b/crates/server/src/transport/message.rs
@@ -172,9 +172,17 @@ pub enum ServerMessage {
     },
     /// PTY output chunk. `seq` is a monotonic counter per
     /// connection that lets clients detect gaps after a reconnect
-    /// (Node scar `da6907f`). Slice 9e defines the variant; slice
+    /// (Node scar `da6907f`). Slice 9e defined the variant; slice
     /// 9f populates it from the tmux `%output` notification stream
     /// with coalescing (`d311168`/`066dab2`).
+    ///
+    /// **Seq contract: 1-based.** The first `Output` message on
+    /// a connection carries `seq = 1`; seq = 0 is reserved to
+    /// mean "no output produced yet" so a future reconnect
+    /// (slice 9g) can send `Attach { resume_from_seq: 0 }` to
+    /// request the full ring. Clients counting gaps should never
+    /// see a decrease; any decrease means the server restarted
+    /// (seq resets) and they must treat it as a hard reconnect.
     Output {
         #[serde(with = "serde_bytes")]
         data: Vec<u8>,


### PR DESCRIPTION
## Summary

Wire the tmux I/O pipe between the session layer and the per-WebSocket handler. After slice 9e's handshake gate, an `Attach` now actually produces terminal output and accepts input.

- **`session::output`** — `Coalescer` (2 ms idle + 16 ms cap per Node `d311168`/`066dab2`) and `OctalDecoder` (tmux `\NNN`/`\\` decoding with carry buffer for wrap-boundary splits per `4dffb9f`).
- **`session::router`** — `OutputRouter` fans tmux `%output` out to per-pane mpsc subscribers. Single-subscriber-per-pane for 9f; 9h lifts that for multi-device.
- **`SessionManager::{query_default_pane, send_input}`** — pane discovery via `list-panes -F '#{pane_id}'`; keystroke forwarding via `send-keys -t %<pane> -H <hex>` (binary-safe).
- **`main.rs`** — dispatcher task replaces the slice-9e drop-all drain; routes `%output` → router, logs `%exit`, traces the rest.
- **`session::handler`** — new `AttachedState` with output receiver, seq counter, coalescer, resize gate state. Enlarged `tokio::select!` with output/flush/resize-flush branches. Cleanup path unsubscribes from the router.

## Scar alignment

- `d311168`/`066dab2` — 2 ms idle + 16 ms cap coalesce; fixing only one dimension (output OR resize) doesn't work.
- `4dffb9f` — octal escape split mid-wrap needs carry buffer, same shape as UTF-8 StringDecoder.
- `09c0542` — resize must use `refresh-client -C` (synchronous in control mode), not `resize-window` (async race).
- `da6907f` — `ServerMessage::Output { seq }` monotonic for reconnect-gap detection.

## Resize gate

`RESIZE_GATE = 50ms` (idle after last output) + `RESIZE_MAX_DEFER = 500ms` (cap, prevents `tail -f` from starving resize forever). On overlapping resize attempts, latest dims win but oldest `queued_at` persists.

## Not in this slice

- **Ring buffer / reconnect replay** — `seq` is emitted but no history kept (slice 9g).
- **Multi-device output fan-out** — router rejects second subscriber per pane with `SESSION_BUSY` (slice 9h).
- **UTF-8 byte-boundary split fix** — Node `f57dc76`. `BufReader::lines()` errors on mid-UTF-8 wrap. Separate slice; unlikely to bite ASCII-heavy output in the short term.

## Test plan

- [x] `cargo test --workspace` — 121 server tests passing (up from 90), 1 ignored (`tmux_roundtrip`, pre-existing failure unrelated to this slice).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] Pre-push Node test suite — unit + integration + smoke E2E passed (no node code changed).

## Gotchas

- Router drops bytes (with `warn!`) when a subscriber's channel is full — visible as terminal glitch, not a crash. Ring buffer in 9g is the proper fix.
- Dispatcher task MUST keep up: if it stalls, the unbounded `notifs` receiver grows toward OOM. `router.dispatch` is non-blocking (try_send drops on full), so one slow client doesn't starve the whole stream.