### PR TITLE
rewrite(server): slice 9g — per-pane ring buffer + reconnect replay

### DIFF
--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -41,16 +41,19 @@
 //!
 //! # Not in scope (deferred)
 //!
-//! - **Ring buffer + reconnect replay** (slice 9g): `seq` is
-//!   emitted but no history is kept. Slice 9g adds per-pane
-//!   ring storage and an `Attach { resume_from_seq }` variant
-//!   so a reconnecting client can rebuild state without a full
-//!   screen redraw.
 //! - **Multi-device output fan-out** (slice 9h): the router
-//!   rejects a second subscriber per pane. The octal decoder
-//!   already lives upstream of the fan-out (in the router), so
-//!   9h lifts the single-subscriber restriction without moving
-//!   state.
+//!   replaces on a second subscribe (attach-displaces-prior)
+//!   rather than fanning out. Slice 9h needs a product
+//!   decision on replace-vs-fanout for simultaneous devices.
+//! - **Pane eviction on tmux-pane-gone** (slice 9h): today a
+//!   `clear_subscriber` keeps the ring alive indefinitely; a
+//!   server restart is the wipe mechanism. Wiring `%window-
+//!   close`/`%pane-close` notifications into
+//!   `OutputRouter::evict` closes the long-running-server
+//!   leak path.
+//! - **Session-creation rate cap**: an authenticated client can
+//!   create unbounded tmux sessions, each allocating a ring.
+//!   Tracked as a separate hardening ticket.
 //!
 //! # Why a state machine, not "just check in the match"
 //!
@@ -556,12 +559,10 @@ pub async fn serve_session(
                 let attach_outcome =
                     try_attach(sessions, &state, &session, cols, rows, resume_from_seq).await;
                 match attach_outcome {
-                    Ok(AttachOutcome {
-                        new_state,
-                        last_seq,
-                        replay,
-                    }) => {
-                        attached = Some(new_state);
+                    Ok(outcome) => {
+                        let last_seq = outcome.last_seq();
+                        let replay = outcome.replay;
+                        attached = Some(outcome.new_state);
                         phase = Phase::Attached;
                         if handle
                             .send(ServerMessage::Attached {
@@ -579,12 +580,13 @@ pub async fn serve_session(
                         // AFTER Attached so the client's clear-
                         // on-OutputGap logic fires in the right
                         // order.
-                        if !send_replay(&handle, replay).await {
+                        if send_replay(&handle, replay).await.is_err() {
                             break;
                         }
                     }
                     Err(AttachFailure { code, message, err }) => {
                         tracing::warn!(
+                            credential = credential_id.as_deref().unwrap_or("localhost"),
                             error = %err,
                             code = code,
                             "attach rejected"
@@ -663,11 +665,14 @@ pub async fn serve_session(
         }
     }
 
-    // Cleanup: unsubscribe from the router so the decoder's
-    // carry buffer doesn't leak and the pane is available for a
-    // fresh connection. Safe to call even if we never attached.
+    // Cleanup: detach the subscriber, but KEEP the pane's ring
+    // and decoder. The dominant "close tab, reopen seconds
+    // later" UX flow depends on the ring outliving the
+    // transport. Tmux-pane-gone eviction is slice 9h's
+    // concern; a server restart is currently the pane-wipe
+    // mechanism. Safe to call even if we never attached.
     if let Some(a) = attached {
-        state.output_router.unsubscribe(a.pane_id);
+        state.output_router.clear_subscriber(a.pane_id);
     }
     // Drop the handle. The WS output pump sees the channel close
     // and shuts down the socket gracefully.
@@ -704,40 +709,33 @@ struct AttachFailure {
     err: String,
 }
 
-/// Successful attach outcome. Bundles everything the coordinator
-/// needs to (a) transition into `Phase::Attached`, (b) echo a
-/// correct `Attached.last_seq`, and (c) emit any pre-live replay
-/// the client asked for.
+/// Successful attach outcome. The `replay` carries `end_seq`
+/// which the coordinator reads for `Attached.last_seq` — keeping
+/// it in one place avoids the redundant-field maintenance trap
+/// that code-quality review flagged on the pre-round-1 design.
 struct AttachOutcome {
     new_state: AttachedState,
-    last_seq: u64,
-    replay: ReplayAction,
+    replay: ReplaySlice,
 }
 
-/// What the coordinator should emit between `Attached` and the
-/// first live `Output` frame.
-enum ReplayAction {
-    /// Fresh attach (client didn't send `resume_from_seq`). No
-    /// catch-up bytes; drop straight to live.
-    None,
-    /// Client sent `resume_from_seq = N`. `bytes` is what the
-    /// ring can replay; send it as one `ServerMessage::Output`
-    /// with `seq = end_seq`. Empty `bytes` (client was up-to-
-    /// date) still results in no output message.
-    InRange { bytes: Vec<u8>, end_seq: u64 },
-    /// Client's resume point is older than the oldest byte in
-    /// the ring. Emit `ServerMessage::OutputGap` so the client
-    /// clears its terminal, then `Output` with the current ring
-    /// contents. `bytes` may be the full ring.
-    Gap {
-        available_from_seq: u64,
-        bytes: Vec<u8>,
-        end_seq: u64,
-    },
-    /// Client claimed a resume seq beyond what the server has
-    /// ever produced. A real bug or a deliberate probe. The
-    /// coordinator falls through to the close path.
-    Future,
+impl AttachOutcome {
+    /// Pane's `total_written` at attach time, echoed in
+    /// `Attached.last_seq`. Derived from whichever variant
+    /// `replay` is — every variant carries the end-of-stream
+    /// seq.
+    fn last_seq(&self) -> u64 {
+        match &self.replay {
+            ReplaySlice::Fresh { end_seq } => *end_seq,
+            ReplaySlice::InRange { end_seq, .. } => *end_seq,
+            ReplaySlice::UpToDate { end_seq } => *end_seq,
+            ReplaySlice::Gap { end_seq, .. } => *end_seq,
+            // Future never reaches AttachOutcome — try_attach
+            // rejects it before constructing one. The
+            // exhaustive match is for type-system
+            // completeness; the value doesn't matter.
+            ReplaySlice::Future => 0,
+        }
+    }
 }
 
 async fn try_attach(
@@ -765,132 +763,192 @@ async fn try_attach(
         .await
         .map_err(to_failure)?;
 
-    // Subscribe. If resume was requested, fold the snapshot and
-    // the subscribe into the same router-lock operation so no
-    // dispatch slips between the snapshot seq and the
-    // subscriber's first delivered chunk.
-    let (output_rx, replay, last_seq) = match resume_from_seq {
+    match resume_from_seq {
         None => {
+            // Fresh attach. No peek needed — the client isn't
+            // claiming any prior state, so we can't reject it.
             let (rx, baseline) = state.output_router.subscribe(pane_id);
-            (rx, ReplayAction::None, baseline)
+            Ok(AttachOutcome {
+                replay: ReplaySlice::Fresh { end_seq: baseline },
+                new_state: AttachedState {
+                    session: session.to_string(),
+                    pane_id,
+                    output_rx: rx,
+                    last_seen_seq: baseline,
+                    coalescer: Coalescer::new(),
+                    last_output_at: None,
+                    pending_resize: None,
+                },
+            })
         }
         Some(after_seq) => {
-            let (rx, slice) = state
-                .output_router
-                .subscribe_with_resume(pane_id, after_seq);
-            match slice {
-                ReplaySlice::InRange { data, end_seq } => (
-                    rx,
-                    ReplayAction::InRange {
-                        bytes: data,
-                        end_seq,
-                    },
-                    end_seq,
-                ),
-                ReplaySlice::UpToDate { end_seq } => (
-                    rx,
-                    ReplayAction::InRange {
-                        bytes: Vec::new(),
-                        end_seq,
-                    },
-                    end_seq,
-                ),
-                ReplaySlice::Gap {
-                    available_from_seq,
-                    data,
-                    end_seq,
-                } => (
-                    rx,
-                    ReplayAction::Gap {
-                        available_from_seq,
-                        bytes: data,
-                        end_seq,
-                    },
-                    end_seq,
-                ),
-                ReplaySlice::Future => (rx, ReplayAction::Future, 0),
+            // PEEK first so we can reject a bogus resume-seq
+            // WITHOUT displacing any prior subscriber. Two
+            // reviews flagged the prior "subscribe-first,
+            // check-after" version: a version-skew client
+            // claiming a future-seq kicked innocent clients on
+            // its way to being rejected, and then the cleanup
+            // `unsubscribe` wiped the pane's ring. Peek-then-
+            // commit closes both bugs.
+            match state.output_router.peek_resume(pane_id, after_seq) {
+                ReplaySlice::Future => {
+                    // Future from peek could mean either:
+                    // (a) the pane has real output and the
+                    //     client's seq is beyond it (true
+                    //     protocol violation — reject), OR
+                    // (b) the pane is empty (total_written==0)
+                    //     and the client is holding a seq from
+                    //     a previous server instance — treat
+                    //     kindly as a server-restart reconnect,
+                    //     send a Gap-from-0 so the client
+                    //     clears its stale terminal and
+                    //     starts fresh.
+                    //
+                    // Disambiguate by checking the pane's
+                    // actual total_written via peek_resume(0).
+                    // Empty pane → UpToDate { end_seq: 0 } →
+                    // restart case; non-empty → peek would
+                    // return InRange/Gap/UpToDate for 0, which
+                    // means (a): client really is claiming a
+                    // seq beyond existing output.
+                    let zero_peek = state.output_router.peek_resume(pane_id, 0);
+                    if matches!(zero_peek, ReplaySlice::UpToDate { end_seq: 0 }) {
+                        // Restart case: commit as Gap-from-0
+                        // with empty data. Client clears its
+                        // terminal; fresh live output follows
+                        // as normal.
+                        let (rx, _baseline) = state.output_router.subscribe(pane_id);
+                        Ok(AttachOutcome {
+                            replay: ReplaySlice::Gap {
+                                available_from_seq: 0,
+                                data: Vec::new(),
+                                end_seq: 0,
+                            },
+                            new_state: AttachedState {
+                                session: session.to_string(),
+                                pane_id,
+                                output_rx: rx,
+                                last_seen_seq: 0,
+                                coalescer: Coalescer::new(),
+                                last_output_at: None,
+                                pending_resize: None,
+                            },
+                        })
+                    } else {
+                        // Real future-seq claim: reject without
+                        // touching the subscriber.
+                        Err(AttachFailure {
+                            code: error_code::INVALID_RESUME,
+                            message: "resume_from_seq is beyond server's output counter"
+                                .into(),
+                            err: format!(
+                                "client resume seq {after_seq} > pane total_written for pane {pane_id}"
+                            ),
+                        })
+                    }
+                }
+                _peek => {
+                    // Any non-Future peek is safe to commit.
+                    // Subscribe-with-resume now does the same
+                    // work under the router lock, so the replay
+                    // we actually return is authoritative
+                    // (no dispatch slipped between peek and
+                    // commit because we re-read under the lock).
+                    let (rx, replay) =
+                        state.output_router.subscribe_with_resume(pane_id, after_seq);
+                    // Under normal execution the second read
+                    // matches the peek. The paranoid second
+                    // Future check here is defensive against a
+                    // pane being evicted between calls — it
+                    // can't happen in slice 9g (no eviction
+                    // path) but slice 9h may add one.
+                    if matches!(replay, ReplaySlice::Future) {
+                        state.output_router.clear_subscriber(pane_id);
+                        return Err(AttachFailure {
+                            code: error_code::INVALID_RESUME,
+                            message: "resume_from_seq is beyond server's output counter"
+                                .into(),
+                            err: format!(
+                                "pane {pane_id} raced between peek and commit (evicted?)"
+                            ),
+                        });
+                    }
+                    let last_seq = match &replay {
+                        ReplaySlice::Fresh { end_seq } => *end_seq,
+                        ReplaySlice::InRange { end_seq, .. } => *end_seq,
+                        ReplaySlice::UpToDate { end_seq } => *end_seq,
+                        ReplaySlice::Gap { end_seq, .. } => *end_seq,
+                        ReplaySlice::Future => unreachable!("just checked above"),
+                    };
+                    Ok(AttachOutcome {
+                        replay,
+                        new_state: AttachedState {
+                            session: session.to_string(),
+                            pane_id,
+                            output_rx: rx,
+                            last_seen_seq: last_seq,
+                            coalescer: Coalescer::new(),
+                            last_output_at: None,
+                            pending_resize: None,
+                        },
+                    })
+                }
             }
         }
-    };
-
-    // Reject a future-seq claim after we've already subscribed —
-    // we own the subscription now, but we refuse to proceed.
-    // Unsubscribing so the pane state doesn't carry a dangling
-    // sender against a never-used receiver.
-    if matches!(replay, ReplayAction::Future) {
-        state.output_router.unsubscribe(pane_id);
-        return Err(AttachFailure {
-            code: error_code::INVALID_RESUME,
-            message: "resume_from_seq is beyond server's output counter".into(),
-            err: format!("client resume seq > pane total_written for pane {pane_id}"),
-        });
     }
-
-    Ok(AttachOutcome {
-        last_seq,
-        replay,
-        new_state: AttachedState {
-            session: session.to_string(),
-            pane_id,
-            output_rx,
-            // Seed with the current snapshot so the first live
-            // flush reports a seq ≥ `last_seq`. Without this,
-            // a flush BEFORE any live chunk lands would report
-            // seq=0, breaking monotonicity.
-            last_seen_seq: last_seq,
-            coalescer: Coalescer::new(),
-            last_output_at: None,
-            pending_resize: None,
-        },
-    })
 }
 
 /// Emit `OutputGap` + replay `Output` frames between `Attached`
-/// and the first live flush. Returns `false` if the transport is
-/// already gone — caller breaks the serve loop.
-async fn send_replay(handle: &TransportHandle, replay: ReplayAction) -> bool {
+/// and the first live flush. Returns `Err(())` if the transport
+/// is already gone — caller breaks the serve loop.
+async fn send_replay(
+    handle: &TransportHandle,
+    replay: ReplaySlice,
+) -> Result<(), ()> {
     match replay {
-        ReplayAction::None | ReplayAction::Future => true,
-        ReplayAction::InRange { bytes, end_seq } => {
-            if bytes.is_empty() {
-                return true;
+        // Nothing to emit — fresh attach, up-to-date reconnect,
+        // or defensive Future (rejected earlier; shouldn't
+        // reach here).
+        ReplaySlice::Fresh { .. }
+        | ReplaySlice::UpToDate { .. }
+        | ReplaySlice::Future => Ok(()),
+        ReplaySlice::InRange { data, end_seq } => {
+            if data.is_empty() {
+                return Ok(());
             }
             handle
                 .send(ServerMessage::Output {
-                    data: bytes,
+                    data,
                     seq: end_seq,
                 })
                 .await
-                .is_ok()
+                .map_err(|_| ())
         }
-        ReplayAction::Gap {
+        ReplaySlice::Gap {
             available_from_seq,
-            bytes,
+            data,
             end_seq,
         } => {
             // Order matters: OutputGap first so the client
             // clears its terminal before applying the replay
             // bytes. If either send fails, caller closes.
-            if handle
+            handle
                 .send(ServerMessage::OutputGap {
                     available_from_seq,
                     last_seq: end_seq,
                 })
                 .await
-                .is_err()
-            {
-                return false;
-            }
-            if bytes.is_empty() {
-                return true;
+                .map_err(|_| ())?;
+            if data.is_empty() {
+                return Ok(());
             }
             handle
                 .send(ServerMessage::Output {
-                    data: bytes,
+                    data,
                     seq: end_seq,
                 })
                 .await
-                .is_ok()
+                .map_err(|_| ())
         }
     }
 }
@@ -1356,5 +1414,113 @@ mod tests {
         // (tail -f scenario) — its GATE-offset is beyond the cap.
         a.last_output_at = Some(queued + Duration::from_millis(600));
         assert_eq!(a.resize_deadline(), Some(queued + RESIZE_MAX_DEFER));
+    }
+
+    // ---------- Replay & send ordering ----------
+
+    /// In-memory test harness that captures every ServerMessage
+    /// the handler sends. Avoids the WS pump plus CBOR
+    /// round-tripping — we're testing send-order invariants, not
+    /// the transport layer.
+    fn capture_handle() -> (TransportHandle, mpsc::Receiver<ServerMessage>) {
+        let (outbound_tx, outbound_rx) =
+            tokio::sync::mpsc::channel::<ServerMessage>(16);
+        let (_inbound_tx, inbound_rx) = tokio::sync::mpsc::channel::<
+            Result<ClientMessage, crate::transport::TransportError>,
+        >(16);
+        let handle = TransportHandle {
+            inbound: inbound_rx,
+            outbound: outbound_tx,
+            kind: crate::transport::TransportKind::WebSocket,
+        };
+        (handle, outbound_rx)
+    }
+
+    #[tokio::test]
+    async fn send_replay_fresh_sends_nothing() {
+        let (h, mut rx) = capture_handle();
+        send_replay(&h, ReplaySlice::Fresh { end_seq: 0 })
+            .await
+            .expect("fresh is ok");
+        assert!(rx.try_recv().is_err(), "Fresh must emit no messages");
+    }
+
+    #[tokio::test]
+    async fn send_replay_in_range_sends_one_output() {
+        let (h, mut rx) = capture_handle();
+        send_replay(
+            &h,
+            ReplaySlice::InRange {
+                data: b"resume-bytes".to_vec(),
+                end_seq: 12,
+            },
+        )
+        .await
+        .unwrap();
+        match rx.recv().await.unwrap() {
+            ServerMessage::Output { data, seq } => {
+                assert_eq!(data, b"resume-bytes");
+                assert_eq!(seq, 12);
+            }
+            other => panic!("expected Output, got {other:?}"),
+        }
+        assert!(rx.try_recv().is_err(), "only one message expected");
+    }
+
+    #[tokio::test]
+    async fn send_replay_gap_sends_output_gap_before_output() {
+        // Order matters: the client's clear-terminal handler
+        // MUST fire before the replay bytes are applied.
+        // Regressing this ordering silently re-corrupts the
+        // terminal across reconnect gaps — this test is the
+        // canary.
+        let (h, mut rx) = capture_handle();
+        send_replay(
+            &h,
+            ReplaySlice::Gap {
+                available_from_seq: 100,
+                data: b"tail-bytes".to_vec(),
+                end_seq: 150,
+            },
+        )
+        .await
+        .unwrap();
+        match rx.recv().await.unwrap() {
+            ServerMessage::OutputGap {
+                available_from_seq,
+                last_seq,
+            } => {
+                assert_eq!(available_from_seq, 100);
+                assert_eq!(last_seq, 150);
+            }
+            other => panic!("first must be OutputGap, got {other:?}"),
+        }
+        match rx.recv().await.unwrap() {
+            ServerMessage::Output { data, seq } => {
+                assert_eq!(data, b"tail-bytes");
+                assert_eq!(seq, 150);
+            }
+            other => panic!("second must be Output, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_replay_gap_with_empty_data_sends_gap_only() {
+        let (h, mut rx) = capture_handle();
+        send_replay(
+            &h,
+            ReplaySlice::Gap {
+                available_from_seq: 0,
+                data: Vec::new(),
+                end_seq: 0,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            rx.recv().await.unwrap(),
+            ServerMessage::OutputGap { .. }
+        ));
+        assert!(rx.try_recv().is_err(), "no Output after empty-data Gap");
     }
 }

--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -65,6 +65,8 @@
 use crate::log_util::sanitize_for_log;
 use crate::revocation::RevocationEvent;
 use crate::session::output::Coalescer;
+use crate::session::ring::ReplaySlice;
+use crate::session::router::OutputChunk;
 use crate::state::AppState;
 use crate::transport::{ClientMessage, ServerMessage, TransportHandle, PROTOCOL_VERSION};
 use std::time::Duration;
@@ -127,6 +129,13 @@ pub mod error_code {
     /// Client didn't complete the handshake within
     /// `HANDSHAKE_TIMEOUT_SECS`. Connection closes.
     pub const HANDSHAKE_TIMEOUT: &str = "handshake_timeout";
+    /// Client sent `Attach { resume_from_seq: Some(N) }` with
+    /// `N` larger than the pane's `total_written`. A
+    /// correctly-implemented client cannot reach this — the seq
+    /// only ever comes from a prior `Attached.last_seq` or
+    /// `Output.seq`, both of which the server assigned. Closing
+    /// on mismatch catches version-skew or client bugs early.
+    pub const INVALID_RESUME: &str = "invalid_resume";
     /// Connection was torn down server-side without the client
     /// having done anything wrong. Emitted when the bound
     /// credential is revoked, or when the revocation broadcast
@@ -185,11 +194,15 @@ enum Action {
     /// client's next move is Attach). Just advance phase.
     AdvanceToAwaitingAttach,
     /// Create/attach the tmux session, subscribe to its pane,
-    /// then send `Attached` with the clamped dims.
+    /// then send `Attached` with the clamped dims. If
+    /// `resume_from_seq` is `Some(N)` the coordinator asks the
+    /// router for a replay slice and emits `OutputGap` +
+    /// replay `Output` before going live.
     DoAttach {
         session: String,
         cols: u16,
         rows: u16,
+        resume_from_seq: Option<u64>,
     },
     /// Forward client input bytes to the attached pane.
     ForwardInput { data: Vec<u8> },
@@ -233,13 +246,20 @@ fn step(phase: &mut Phase, msg: ClientMessage) -> Action {
             }
         }
 
-        (Phase::AwaitingAttach, ClientMessage::Attach { session, cols, rows }) => {
-            Action::DoAttach {
+        (
+            Phase::AwaitingAttach,
+            ClientMessage::Attach {
                 session,
                 cols,
                 rows,
-            }
-        }
+                resume_from_seq,
+            },
+        ) => Action::DoAttach {
+            session,
+            cols,
+            rows,
+            resume_from_seq,
+        },
 
         (Phase::Attached, ClientMessage::Input { data }) => Action::ForwardInput { data },
 
@@ -291,12 +311,18 @@ fn phase_name(phase: &Phase) -> &'static str {
 struct AttachedState {
     session: String,
     pane_id: u32,
-    /// Decoded bytes from this pane's `%output` stream.
-    output_rx: mpsc::Receiver<Vec<u8>>,
-    /// Monotonic sequence number for each `ServerMessage::Output`
-    /// we emit. Increments per-emission, NOT per-byte — the
-    /// client reads `seq` to detect gaps after reconnect.
-    output_seq: u64,
+    /// Decoded bytes + end-of-chunk seq from this pane's
+    /// `%output` stream. The router assigns `end_seq` per
+    /// dispatch (pane-global, not per-connection), so the seq
+    /// keeps advancing monotonically across the displace-
+    /// subscribe boundary.
+    output_rx: mpsc::Receiver<OutputChunk>,
+    /// Highest `end_seq` we've seen come out of `output_rx`.
+    /// When the coalescer flushes, this becomes the outbound
+    /// `ServerMessage::Output.seq`. Starts at the router's
+    /// `last_seq` snapshot at attach time so a reconnect with
+    /// replay doesn't emit seqs below the replay's `last_seq`.
+    last_seen_seq: u64,
     /// Coalesces raw bytes from `output_rx` into chunky Output
     /// messages. See `output::Coalescer` for timing.
     coalescer: Coalescer,
@@ -425,11 +451,12 @@ pub async fn serve_session(
             // pruned us after a panic) — that MUST be a clean
             // exit, otherwise the loop sits forever on a dead
             // channel.
-            bytes_opt = maybe_recv_output(attached.as_mut()) => match bytes_opt {
-                Some(bytes) => {
+            chunk_opt = maybe_recv_output(attached.as_mut()) => match chunk_opt {
+                Some(chunk) => {
                     if let Some(a) = attached.as_mut() {
                         a.last_output_at = Some(Instant::now());
-                        a.coalescer.push(&bytes);
+                        a.coalescer.push(&chunk.data);
+                        a.last_seen_seq = chunk.end_seq;
                     }
                     Action::Continue
                 }
@@ -462,12 +489,13 @@ pub async fn serve_session(
             let now = Instant::now();
             if a.coalesce_deadline().is_some_and(|d| now >= d) && !a.coalescer.is_empty() {
                 let bytes = a.coalescer.take();
-                a.output_seq += 1;
+                // `last_seen_seq` already equals the end-seq of
+                // the most recent chunk we folded into the
+                // coalescer — by construction that's the end-seq
+                // of the flushed batch's last byte.
+                let seq = a.last_seen_seq;
                 if handle
-                    .send(ServerMessage::Output {
-                        data: bytes,
-                        seq: a.output_seq,
-                    })
+                    .send(ServerMessage::Output { data: bytes, seq })
                     .await
                     .is_err()
                 {
@@ -510,6 +538,7 @@ pub async fn serve_session(
                 session,
                 cols,
                 rows,
+                resume_from_seq,
             } => {
                 // Clamp once at the coordinator before dispatch.
                 // SessionManager clamps internally too as
@@ -524,8 +553,14 @@ pub async fn serve_session(
                     .await;
                     break;
                 };
-                match try_attach(sessions, &state, &session, cols, rows).await {
-                    Ok(new_state) => {
+                let attach_outcome =
+                    try_attach(sessions, &state, &session, cols, rows, resume_from_seq).await;
+                match attach_outcome {
+                    Ok(AttachOutcome {
+                        new_state,
+                        last_seq,
+                        replay,
+                    }) => {
                         attached = Some(new_state);
                         phase = Phase::Attached;
                         if handle
@@ -533,10 +568,18 @@ pub async fn serve_session(
                                 session,
                                 cols,
                                 rows,
+                                last_seq,
                             })
                             .await
                             .is_err()
                         {
+                            break;
+                        }
+                        // Replay any missed bytes. Must happen
+                        // AFTER Attached so the client's clear-
+                        // on-OutputGap logic fires in the right
+                        // order.
+                        if !send_replay(&handle, replay).await {
                             break;
                         }
                     }
@@ -645,7 +688,7 @@ async fn sleep_until_opt(deadline: Option<Instant>) {
 /// Helper: read from the pane output receiver if we're attached,
 /// otherwise never resolve. Same guard-+-pending pattern as
 /// `sleep_until_opt`.
-async fn maybe_recv_output(attached: Option<&mut AttachedState>) -> Option<Vec<u8>> {
+async fn maybe_recv_output(attached: Option<&mut AttachedState>) -> Option<OutputChunk> {
     match attached {
         Some(a) => a.output_rx.recv().await,
         None => std::future::pending().await,
@@ -661,17 +704,50 @@ struct AttachFailure {
     err: String,
 }
 
+/// Successful attach outcome. Bundles everything the coordinator
+/// needs to (a) transition into `Phase::Attached`, (b) echo a
+/// correct `Attached.last_seq`, and (c) emit any pre-live replay
+/// the client asked for.
+struct AttachOutcome {
+    new_state: AttachedState,
+    last_seq: u64,
+    replay: ReplayAction,
+}
+
+/// What the coordinator should emit between `Attached` and the
+/// first live `Output` frame.
+enum ReplayAction {
+    /// Fresh attach (client didn't send `resume_from_seq`). No
+    /// catch-up bytes; drop straight to live.
+    None,
+    /// Client sent `resume_from_seq = N`. `bytes` is what the
+    /// ring can replay; send it as one `ServerMessage::Output`
+    /// with `seq = end_seq`. Empty `bytes` (client was up-to-
+    /// date) still results in no output message.
+    InRange { bytes: Vec<u8>, end_seq: u64 },
+    /// Client's resume point is older than the oldest byte in
+    /// the ring. Emit `ServerMessage::OutputGap` so the client
+    /// clears its terminal, then `Output` with the current ring
+    /// contents. `bytes` may be the full ring.
+    Gap {
+        available_from_seq: u64,
+        bytes: Vec<u8>,
+        end_seq: u64,
+    },
+    /// Client claimed a resume seq beyond what the server has
+    /// ever produced. A real bug or a deliberate probe. The
+    /// coordinator falls through to the close path.
+    Future,
+}
+
 async fn try_attach(
     sessions: &crate::session::SessionManager,
     state: &AppState,
     session: &str,
     cols: u16,
     rows: u16,
-) -> Result<AttachedState, AttachFailure> {
-    // Single failure-mapping closure — the two session-manager
-    // calls below share identical "classify + stash err.to_string()"
-    // shape, and this closure is the one place that knows which
-    // fields `AttachFailure` carries.
+    resume_from_seq: Option<u64>,
+) -> Result<AttachOutcome, AttachFailure> {
     let to_failure = |err: crate::session::SessionError| {
         let (code, message) = classify_session_error(&err);
         AttachFailure {
@@ -688,20 +764,135 @@ async fn try_attach(
         .query_default_pane(session)
         .await
         .map_err(to_failure)?;
-    // `subscribe` is infallible under the attach-displaces-prior
-    // semantics (slice 9f). If another connection had this pane
-    // bound, its subscriber's channel closes on the next recv
-    // and its handler exits via `Action::Exit`.
-    let output_rx = state.output_router.subscribe(pane_id);
-    Ok(AttachedState {
-        session: session.to_string(),
-        pane_id,
-        output_rx,
-        output_seq: 0,
-        coalescer: Coalescer::new(),
-        last_output_at: None,
-        pending_resize: None,
+
+    // Subscribe. If resume was requested, fold the snapshot and
+    // the subscribe into the same router-lock operation so no
+    // dispatch slips between the snapshot seq and the
+    // subscriber's first delivered chunk.
+    let (output_rx, replay, last_seq) = match resume_from_seq {
+        None => {
+            let (rx, baseline) = state.output_router.subscribe(pane_id);
+            (rx, ReplayAction::None, baseline)
+        }
+        Some(after_seq) => {
+            let (rx, slice) = state
+                .output_router
+                .subscribe_with_resume(pane_id, after_seq);
+            match slice {
+                ReplaySlice::InRange { data, end_seq } => (
+                    rx,
+                    ReplayAction::InRange {
+                        bytes: data,
+                        end_seq,
+                    },
+                    end_seq,
+                ),
+                ReplaySlice::UpToDate { end_seq } => (
+                    rx,
+                    ReplayAction::InRange {
+                        bytes: Vec::new(),
+                        end_seq,
+                    },
+                    end_seq,
+                ),
+                ReplaySlice::Gap {
+                    available_from_seq,
+                    data,
+                    end_seq,
+                } => (
+                    rx,
+                    ReplayAction::Gap {
+                        available_from_seq,
+                        bytes: data,
+                        end_seq,
+                    },
+                    end_seq,
+                ),
+                ReplaySlice::Future => (rx, ReplayAction::Future, 0),
+            }
+        }
+    };
+
+    // Reject a future-seq claim after we've already subscribed —
+    // we own the subscription now, but we refuse to proceed.
+    // Unsubscribing so the pane state doesn't carry a dangling
+    // sender against a never-used receiver.
+    if matches!(replay, ReplayAction::Future) {
+        state.output_router.unsubscribe(pane_id);
+        return Err(AttachFailure {
+            code: error_code::INVALID_RESUME,
+            message: "resume_from_seq is beyond server's output counter".into(),
+            err: format!("client resume seq > pane total_written for pane {pane_id}"),
+        });
+    }
+
+    Ok(AttachOutcome {
+        last_seq,
+        replay,
+        new_state: AttachedState {
+            session: session.to_string(),
+            pane_id,
+            output_rx,
+            // Seed with the current snapshot so the first live
+            // flush reports a seq ≥ `last_seq`. Without this,
+            // a flush BEFORE any live chunk lands would report
+            // seq=0, breaking monotonicity.
+            last_seen_seq: last_seq,
+            coalescer: Coalescer::new(),
+            last_output_at: None,
+            pending_resize: None,
+        },
     })
+}
+
+/// Emit `OutputGap` + replay `Output` frames between `Attached`
+/// and the first live flush. Returns `false` if the transport is
+/// already gone — caller breaks the serve loop.
+async fn send_replay(handle: &TransportHandle, replay: ReplayAction) -> bool {
+    match replay {
+        ReplayAction::None | ReplayAction::Future => true,
+        ReplayAction::InRange { bytes, end_seq } => {
+            if bytes.is_empty() {
+                return true;
+            }
+            handle
+                .send(ServerMessage::Output {
+                    data: bytes,
+                    seq: end_seq,
+                })
+                .await
+                .is_ok()
+        }
+        ReplayAction::Gap {
+            available_from_seq,
+            bytes,
+            end_seq,
+        } => {
+            // Order matters: OutputGap first so the client
+            // clears its terminal before applying the replay
+            // bytes. If either send fails, caller closes.
+            if handle
+                .send(ServerMessage::OutputGap {
+                    available_from_seq,
+                    last_seq: end_seq,
+                })
+                .await
+                .is_err()
+            {
+                return false;
+            }
+            if bytes.is_empty() {
+                return true;
+            }
+            handle
+                .send(ServerMessage::Output {
+                    data: bytes,
+                    seq: end_seq,
+                })
+                .await
+                .is_ok()
+        }
+    }
 }
 
 /// Get the `SessionManager` out of `AppState`, panicking if it's
@@ -903,6 +1094,7 @@ mod tests {
                 session: "main".into(),
                 cols: 120,
                 rows: 40,
+                resume_from_seq: None,
             },
         );
         assert_eq!(
@@ -911,6 +1103,7 @@ mod tests {
                 session: "main".into(),
                 cols: 120,
                 rows: 40,
+                resume_from_seq: None,
             }
         );
         assert_eq!(
@@ -918,6 +1111,32 @@ mod tests {
             Phase::AwaitingAttach,
             "step does not advance to Attached — the coordinator does \
              that only after SessionManager::create_session succeeds"
+        );
+    }
+
+    #[test]
+    fn attach_with_resume_carries_seq_to_action() {
+        // Forward-safety: if the pattern match on Attach ever
+        // loses the resume_from_seq field, the coordinator would
+        // silently default to fresh-attach for every reconnect.
+        let mut phase = Phase::AwaitingAttach;
+        let action = step(
+            &mut phase,
+            ClientMessage::Attach {
+                session: "main".into(),
+                cols: 80,
+                rows: 24,
+                resume_from_seq: Some(42),
+            },
+        );
+        assert_eq!(
+            action,
+            Action::DoAttach {
+                session: "main".into(),
+                cols: 80,
+                rows: 24,
+                resume_from_seq: Some(42),
+            }
         );
     }
 
@@ -930,6 +1149,7 @@ mod tests {
                 session: "main".into(),
                 cols: 80,
                 rows: 24,
+                resume_from_seq: None,
             },
         );
         match action {
@@ -1051,6 +1271,7 @@ mod tests {
             error_code::SESSION_ERROR,
             error_code::NO_SESSION_MANAGER,
             error_code::HANDSHAKE_TIMEOUT,
+            error_code::INVALID_RESUME,
             error_code::CONNECTION_TERMINATED,
         ];
         let set: std::collections::HashSet<&str> = all.iter().copied().collect();
@@ -1068,7 +1289,7 @@ mod tests {
             session: "s".into(),
             pane_id: 0,
             output_rx: rx,
-            output_seq: 0,
+            last_seen_seq: 0,
             coalescer: Coalescer::new(),
             last_output_at: None,
             pending_resize: None,

--- a/crates/server/src/session/mod.rs
+++ b/crates/server/src/session/mod.rs
@@ -25,6 +25,7 @@ pub mod handler;
 pub mod manager;
 pub mod output;
 pub mod parser;
+pub mod ring;
 pub mod router;
 pub mod tmux;
 

--- a/crates/server/src/session/ring.rs
+++ b/crates/server/src/session/ring.rs
@@ -1,0 +1,337 @@
+//! Per-pane byte-ring for reconnect replay.
+//!
+//! A fixed-capacity circular byte buffer tagged with the total
+//! number of bytes ever written. Clients that drop the connection
+//! and reconnect with `resume_from_seq = N` can be handed back
+//! `ring.read_after(N)` — whatever of their recent-history we
+//! still have — letting the terminal rebuild state without a
+//! full screen redraw.
+//!
+//! # What this is NOT
+//!
+//! - Not a full screen snapshot. TUI apps that use absolute
+//!   cursor positioning (`\e[row;colH`) rely on tmux's live
+//!   state, which this ring doesn't capture. A reconnect after
+//!   `vim` running for a while will see a mid-frame byte
+//!   sequence, not a redrawn editor. The Node port ran its own
+//!   headless xterm for this; katulong's plan is to defer that
+//!   kind of rich-state capture until there's a concrete
+//!   consumer requiring it (slice 9h or later).
+//! - Not a log. Old bytes are overwritten. The operator looking
+//!   for "what did the shell print at 9 AM" wants tmux's own
+//!   buffer capture (`capture-pane`), not this ring.
+//!
+//! # Capacity tuning
+//!
+//! 64 KiB per pane. Rationale:
+//! - Plenty for a full 200×60 screen worth of text output
+//!   (~12 KiB of plain chars; up to ~30 KiB with a bunch of
+//!   SGR escapes).
+//! - Well below any memory concern for a single-user install:
+//!   even 10 concurrent panes = 640 KiB.
+//! - Matches the 64 KiB WS frame cap so a replay always fits
+//!   in one `ServerMessage::Output`.
+//!
+//! Sizing is per-pane, NOT per-connection — the router's
+//! attach-displaces-prior semantics mean a reconnecting client
+//! from the same device carries the same pane's history forward
+//! without the ring size multiplying.
+//!
+//! # Byte-level vs message-level replay
+//!
+//! The ring stores RAW decoded bytes (post-octal-decode, pre-
+//! coalesce). Sequence numbers are byte-level offsets — the
+//! total bytes ever written, as a `u64`. This is unambiguous
+//! and doesn't care about the coalescer's message boundaries.
+//! The coalescer in the handler still batches for wire
+//! efficiency; on reconnect we hand over one big replay blob
+//! without caring how the pre-disconnect stream was chunked.
+
+use std::collections::VecDeque;
+
+/// Default capacity per pane. Consts so tests can override via
+/// `with_capacity`.
+pub const DEFAULT_CAPACITY: usize = 64 * 1024;
+
+/// A replay request result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplaySlice {
+    /// Everything the client requested is still in the ring.
+    /// `data` is the bytes from `after_seq` (exclusive) through
+    /// `end_seq` (inclusive by byte count — i.e., `end_seq` is
+    /// the `total_written()` at read time).
+    InRange { data: Vec<u8>, end_seq: u64 },
+    /// The client's `after_seq` is older than what the ring
+    /// still holds. `data` is what we CAN replay (the full
+    /// current ring contents), and `available_from_seq` is the
+    /// oldest byte offset in that data. The client must clear
+    /// its terminal / hard-redraw before applying the data,
+    /// because the gap means cursor positions and in-flight
+    /// escape sequences can't be inferred.
+    Gap {
+        available_from_seq: u64,
+        data: Vec<u8>,
+        end_seq: u64,
+    },
+    /// The client sent `after_seq > total_written` — they claim
+    /// to have more bytes than we ever produced. Treat as a
+    /// protocol violation; the handler closes the connection.
+    Future,
+    /// The client is already up-to-date (`after_seq ==
+    /// total_written`). Nothing to replay; caller proceeds
+    /// straight to live output.
+    UpToDate { end_seq: u64 },
+}
+
+/// Fixed-capacity byte ring with a running total-bytes counter.
+///
+/// `VecDeque<u8>` under the hood. Per-byte push/pop is amortised
+/// O(1); the batch `append` drains/extends in bulk rather than
+/// byte-by-byte. At 64 KiB capacity a full flush is sub-
+/// microsecond.
+#[derive(Debug)]
+pub struct RingBuffer {
+    buf: VecDeque<u8>,
+    capacity: usize,
+    total_written: u64,
+}
+
+impl RingBuffer {
+    /// New ring with the default 64 KiB capacity.
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            buf: VecDeque::with_capacity(capacity.min(DEFAULT_CAPACITY)),
+            capacity,
+            total_written: 0,
+        }
+    }
+
+    /// Append bytes. If the incoming slice alone exceeds the
+    /// ring's capacity, only the tail fits — the head of the
+    /// input plus any existing contents are discarded. This is
+    /// correct for a "last N bytes" ring: a one-shot 200 KiB
+    /// paste lands with the last 64 KiB kept.
+    pub fn append(&mut self, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        self.total_written = self.total_written.saturating_add(bytes.len() as u64);
+
+        if bytes.len() >= self.capacity {
+            // Input alone overflows capacity. Keep only its tail.
+            self.buf.clear();
+            let start = bytes.len() - self.capacity;
+            self.buf.extend(&bytes[start..]);
+            return;
+        }
+
+        // Mixed: some existing bytes stay, some get evicted.
+        let new_total = self.buf.len() + bytes.len();
+        if new_total > self.capacity {
+            let drop_n = new_total - self.capacity;
+            self.buf.drain(..drop_n);
+        }
+        self.buf.extend(bytes);
+    }
+
+    /// Total bytes ever written since construction. Monotonic —
+    /// never resets. This is the wire `seq` semantics (each
+    /// `ServerMessage::Output.seq` carries the total_written at
+    /// the end of that chunk).
+    pub fn total_written(&self) -> u64 {
+        self.total_written
+    }
+
+    /// Oldest byte offset still in the ring. Equals
+    /// `total_written - buf.len()`. When the ring is not full
+    /// this is 0.
+    pub fn oldest_available_seq(&self) -> u64 {
+        self.total_written - self.buf.len() as u64
+    }
+
+    /// Bytes currently buffered (for observability / tests).
+    #[cfg(test)]
+    pub fn buffered_len(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Read the slice of bytes that would bring a client with
+    /// `after_seq` up to the current `total_written`. See
+    /// [`ReplaySlice`] for the result shape.
+    pub fn replay_after(&self, after_seq: u64) -> ReplaySlice {
+        if after_seq > self.total_written {
+            return ReplaySlice::Future;
+        }
+        if after_seq == self.total_written {
+            return ReplaySlice::UpToDate {
+                end_seq: self.total_written,
+            };
+        }
+        let oldest = self.oldest_available_seq();
+        if after_seq < oldest {
+            // Gap: client's resume point is older than our ring
+            // contents. Return everything we have and flag the
+            // gap.
+            return ReplaySlice::Gap {
+                available_from_seq: oldest,
+                data: self.buf.iter().copied().collect(),
+                end_seq: self.total_written,
+            };
+        }
+        // after_seq is in [oldest, total_written). Skip the
+        // prefix and collect the rest.
+        let skip = (after_seq - oldest) as usize;
+        let data: Vec<u8> = self.buf.iter().copied().skip(skip).collect();
+        ReplaySlice::InRange {
+            data,
+            end_seq: self.total_written,
+        }
+    }
+}
+
+impl Default for RingBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_ring_is_zero_everything() {
+        let r = RingBuffer::with_capacity(16);
+        assert_eq!(r.total_written(), 0);
+        assert_eq!(r.oldest_available_seq(), 0);
+        assert_eq!(r.buffered_len(), 0);
+    }
+
+    #[test]
+    fn append_within_capacity_preserves_bytes() {
+        let mut r = RingBuffer::with_capacity(16);
+        r.append(b"hello");
+        assert_eq!(r.total_written(), 5);
+        assert_eq!(r.oldest_available_seq(), 0);
+        match r.replay_after(0) {
+            ReplaySlice::InRange { data, end_seq } => {
+                assert_eq!(data, b"hello");
+                assert_eq!(end_seq, 5);
+            }
+            other => panic!("expected InRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn append_beyond_capacity_keeps_tail() {
+        let mut r = RingBuffer::with_capacity(4);
+        r.append(b"abcdef"); // 6 bytes into 4-cap ring
+        assert_eq!(r.total_written(), 6);
+        assert_eq!(r.oldest_available_seq(), 2);
+        assert_eq!(r.buffered_len(), 4);
+        match r.replay_after(2) {
+            ReplaySlice::InRange { data, end_seq } => {
+                assert_eq!(data, b"cdef");
+                assert_eq!(end_seq, 6);
+            }
+            other => panic!("expected InRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn append_then_append_crosses_capacity_boundary() {
+        let mut r = RingBuffer::with_capacity(4);
+        r.append(b"ab");
+        r.append(b"cdef");
+        // Second append: existing 2 + new 4 = 6; evict 2 from
+        // front. Ring is "cdef".
+        assert_eq!(r.total_written(), 6);
+        assert_eq!(r.oldest_available_seq(), 2);
+        match r.replay_after(2) {
+            ReplaySlice::InRange { data, .. } => assert_eq!(data, b"cdef"),
+            other => panic!("expected InRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn replay_after_at_current_is_up_to_date() {
+        let mut r = RingBuffer::with_capacity(16);
+        r.append(b"abc");
+        match r.replay_after(3) {
+            ReplaySlice::UpToDate { end_seq } => assert_eq!(end_seq, 3),
+            other => panic!("expected UpToDate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn replay_after_future_is_protocol_error() {
+        let mut r = RingBuffer::with_capacity(16);
+        r.append(b"abc");
+        // Client claims seq 100; we only have 3.
+        assert_eq!(r.replay_after(100), ReplaySlice::Future);
+    }
+
+    #[test]
+    fn replay_after_below_oldest_returns_gap_with_full_contents() {
+        let mut r = RingBuffer::with_capacity(4);
+        r.append(b"abcdef"); // oldest = 2, total = 6
+        match r.replay_after(0) {
+            ReplaySlice::Gap {
+                available_from_seq,
+                data,
+                end_seq,
+            } => {
+                assert_eq!(available_from_seq, 2);
+                assert_eq!(end_seq, 6);
+                assert_eq!(data, b"cdef");
+            }
+            other => panic!("expected Gap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn replay_after_exactly_at_oldest_is_in_range_empty() {
+        // Edge: after_seq == oldest_available means the client
+        // asked for "everything after byte N", and byte N is the
+        // last one they already had. We return the full ring
+        // contents.
+        let mut r = RingBuffer::with_capacity(4);
+        r.append(b"abcdef"); // oldest = 2
+        match r.replay_after(2) {
+            ReplaySlice::InRange { data, end_seq } => {
+                assert_eq!(data, b"cdef");
+                assert_eq!(end_seq, 6);
+            }
+            other => panic!("expected InRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_huge_append_keeps_only_tail() {
+        // One-shot paste larger than capacity: we don't even
+        // allocate capacity for the full paste; existing contents
+        // are fully overwritten.
+        let mut r = RingBuffer::with_capacity(4);
+        r.append(b"x"); // prime with one byte
+        let huge = vec![b'A'; 100];
+        r.append(&huge);
+        assert_eq!(r.total_written(), 101);
+        assert_eq!(r.oldest_available_seq(), 97);
+        match r.replay_after(97) {
+            ReplaySlice::InRange { data, .. } => assert_eq!(data.len(), 4),
+            other => panic!("expected InRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_append_is_noop() {
+        let mut r = RingBuffer::with_capacity(16);
+        r.append(b"");
+        assert_eq!(r.total_written(), 0);
+        assert_eq!(r.oldest_available_seq(), 0);
+    }
+}

--- a/crates/server/src/session/ring.rs
+++ b/crates/server/src/session/ring.rs
@@ -23,14 +23,21 @@
 //!
 //! # Capacity tuning
 //!
-//! 64 KiB per pane. Rationale:
-//! - Plenty for a full 200×60 screen worth of text output
-//!   (~12 KiB of plain chars; up to ~30 KiB with a bunch of
-//!   SGR escapes).
-//! - Well below any memory concern for a single-user install:
-//!   even 10 concurrent panes = 640 KiB.
-//! - Matches the 64 KiB WS frame cap so a replay always fits
-//!   in one `ServerMessage::Output`.
+//! 256 KiB per pane. Rationale:
+//! - The relevant content for reconnect is what happened AFTER
+//!   the disconnect, not just the current screen. A fast log
+//!   stream or compile can exhaust 64 KiB in seconds; at 256
+//!   KiB a typical mobile-away-then-back flow stays inside the
+//!   in-range path rather than falling to the gap path.
+//! - Low memory footprint even so: 10 concurrent panes = 2.5
+//!   MiB. Acceptable on any machine capable of running a
+//!   terminal multiplexer.
+//! - The 64 KiB WS frame cap doesn't constrain replay: the
+//!   replay `Output` fires independently of the live coalesce
+//!   frame budget and can carry the full ring in multiple
+//!   frames if needed. (Slice 9g ships one frame per replay;
+//!   if a future client ever reports frame-too-large it splits
+//!   deterministically.)
 //!
 //! Sizing is per-pane, NOT per-connection — the router's
 //! attach-displaces-prior semantics mean a reconnecting client
@@ -50,12 +57,24 @@
 use std::collections::VecDeque;
 
 /// Default capacity per pane. Consts so tests can override via
-/// `with_capacity`.
-pub const DEFAULT_CAPACITY: usize = 64 * 1024;
+/// `with_capacity`. See module doc for the 256 KiB rationale.
+pub const DEFAULT_CAPACITY: usize = 256 * 1024;
 
 /// A replay request result.
+///
+/// The single result type for every replay path: both the ring's
+/// `replay_after` and the handler's attach coordinator match on
+/// these variants. A pre-round-1 version of this PR had a
+/// parallel `ReplayAction` type in the handler that did nothing
+/// except rename fields; code-quality and architecture reviews
+/// both flagged the duplication.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReplaySlice {
+    /// Client didn't request resume (fresh attach). `end_seq`
+    /// is the pane's current `total_written`; the handler
+    /// echoes it in `Attached.last_seq` but emits no replay
+    /// output.
+    Fresh { end_seq: u64 },
     /// Everything the client requested is still in the ring.
     /// `data` is the bytes from `after_seq` (exclusive) through
     /// `end_seq` (inclusive by byte count — i.e., `end_seq` is
@@ -76,6 +95,13 @@ pub enum ReplaySlice {
     /// The client sent `after_seq > total_written` — they claim
     /// to have more bytes than we ever produced. Treat as a
     /// protocol violation; the handler closes the connection.
+    ///
+    /// NOTE: an empty pane (`total_written == 0`) with a
+    /// positive `after_seq` is ALSO `Future` from the ring's
+    /// local perspective, but the handler special-cases this
+    /// because a cold pane combined with a resume request is
+    /// almost always "server restarted, client held onto its
+    /// seq." See `handler::try_attach`.
     Future,
     /// The client is already up-to-date (`after_seq ==
     /// total_written`). Nothing to replay; caller proceeds

--- a/crates/server/src/session/router.rs
+++ b/crates/server/src/session/router.rs
@@ -1,5 +1,6 @@
 //! Dispatcher from the single global tmux `%output` stream to
-//! per-connection output pumps.
+//! per-connection output pumps, with per-pane history for
+//! reconnect replay (slice 9g).
 //!
 //! One tmux subprocess produces notifications for every pane on
 //! every session it hosts. A per-connection handler only cares
@@ -8,70 +9,63 @@
 //! notification to the right subscriber without forcing every
 //! handler to filter the whole stream itself.
 //!
+//! # Per-pane seq and the reconnect path (slice 9g)
+//!
+//! Each pane maintains:
+//! - An octal [`OctalDecoder`] whose carry survives subscriber
+//!   handoffs (the carry is about the tmux byte stream, not the
+//!   subscriber).
+//! - A byte [`RingBuffer`] of the last ~64 KiB, tagged with a
+//!   monotonic `total_written` that doubles as the wire `seq`.
+//! - The current subscriber's [`mpsc::Sender`], if any.
+//!
+//! `dispatch` decodes bytes, appends to the ring, and pushes an
+//! [`OutputChunk`] (`data` + `end_seq`) to the subscriber. The
+//! ring keeps bytes past the subscriber's wire buffer, so a
+//! client that drops and reconnects with
+//! `subscribe_with_resume(pane_id, after_seq)` gets a
+//! [`ReplaySlice`] describing what to hand the client before
+//! going live.
+//!
+//! The seq semantics are **per-pane, not per-connection**: two
+//! successive subscribers on the same pane see contiguous seqs,
+//! which is what makes the reconnect path useful. Pre-9g the
+//! docstring said "per-connection monotonic" — that's obsolete.
+//!
 //! # Ownership model
 //!
 //! `OutputRouter` is cheap to clone — internals are `Arc`. The
 //! dispatcher task spawned via [`OutputRouter::spawn_dispatcher`]
 //! holds one clone and calls [`OutputRouter::dispatch`] for every
 //! `%output` notification. Each WS connection handler holds
-//! another clone via `AppState` and calls
-//! [`OutputRouter::subscribe`] after its `Attach` succeeds.
+//! another clone via `AppState` and calls [`OutputRouter::subscribe`]
+//! (fresh attach) or [`OutputRouter::subscribe_with_resume`]
+//! (reconnect) after its `Attach` succeeds.
 //!
 //! # Attach-displaces-prior semantics (slice 9f)
 //!
-//! `subscribe(pane_id)` always succeeds. If a prior subscriber
-//! already held the pane, their `mpsc::Receiver` sees its
-//! channel close on the next `recv()` and the handler's loop
-//! treats that as `Action::Exit` (see `handler.rs`). This
-//! matches katulong's one-user-many-devices model: opening the
-//! app in a second browser tab smoothly takes over the terminal
-//! rather than refusing with an error the user has to
-//! troubleshoot. Slice 9h revisits this when multi-device
-//! fan-out lands — at that point the question "displace vs
-//! fan-out" is a product decision rather than a plumbing
-//! constraint.
-//!
-//! # Decoder ownership
-//!
-//! Each registered pane carries an [`OctalDecoder`]. The
-//! dispatcher task decodes bytes BEFORE fanning out to the
-//! subscriber, not after: when multi-device lands, every
-//! subscriber gets the same fully-decoded byte stream and the
-//! octal-carry state lives in exactly one place. The decoder's
-//! carry survives the attach-displaces-prior handoff because
-//! the decoder is keyed per-pane, not per-subscriber — a
-//! reconnecting client picks up mid-escape if the tmux wrap
-//! happened to land there.
+//! Subscribing always succeeds. If a prior subscriber already
+//! held the pane, their `mpsc::Receiver` sees its channel close
+//! on the next `recv()` and the handler's loop treats that as
+//! `Action::Exit`. This matches katulong's one-user-many-devices
+//! model: opening the app in a second browser tab smoothly takes
+//! over the terminal. Slice 9h revisits this when multi-device
+//! fan-out lands.
 //!
 //! # Backpressure
 //!
 //! The per-pane mpsc channel has a bounded capacity
-//! (`PER_PANE_BUFFER`). If the subscriber's handler falls behind
-//! (slow client, coalescer saturated, etc.), `try_send` fails
-//! and the dispatcher DROPS the bytes with a `warn!` log rather
-//! than backpressuring the whole tmux stream. Output loss is
-//! visible to the user as a terminal glitch, but the alternative
-//! — blocking the tmux reader task on one slow client —
-//! starves every other pane's output. Ring-buffer + resync in
-//! slice 9g is the proper fix for drops; until then, generous
-//! buffer depth + fast consumer keeps drops to pathological
-//! cases.
-//!
-//! # Stale-entry cleanup (panicked handler)
-//!
-//! If a handler task panics between `subscribe` and its
-//! explicit `unsubscribe` cleanup, the `mpsc::Receiver` drops
-//! but the `PaneState` (with its decoder carry) remains in the
-//! map. `dispatch`'s `TrySendError::Closed` branch prunes it on
-//! the next attempted send. For a quiet pane (no `%output`
-//! between the panic and a reconnect attempt), this means the
-//! `subscribe` call implicitly overwrites the stale entry —
-//! which is now ALWAYS correct under the replace-semantics
-//! above (it used to also matter for the old
-//! `AlreadyAttached` rejection path, which is gone).
+//! (`PER_PANE_BUFFER`). If the subscriber's handler falls behind,
+//! `try_send` fails and the dispatcher DROPS the bytes with a
+//! `warn!` log. Output loss is visible to the user as a terminal
+//! glitch, but the alternative — blocking the tmux reader task
+//! on one slow client — starves every other pane's output. The
+//! ring buffer still captures the dropped bytes, so a reconnect
+//! after a drop can resume cleanly via the gap path.
 
 use crate::session::output::OctalDecoder;
 use crate::session::parser::Notification;
+use crate::session::ring::{ReplaySlice, RingBuffer};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
@@ -84,6 +78,18 @@ use tokio::task::JoinHandle;
 /// without committing huge memory (each entry is a small `Vec`).
 const PER_PANE_BUFFER: usize = 256;
 
+/// A decoded output chunk with the byte-offset `seq` at which
+/// it ends. Subscribers track the highest `end_seq` they've
+/// seen; when the coalescer flushes, that value goes into the
+/// outbound `ServerMessage::Output.seq`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputChunk {
+    pub data: Vec<u8>,
+    /// `total_written` on the pane's ring AFTER appending `data`.
+    /// I.e., the seq of the last byte in this chunk, 1-based.
+    pub end_seq: u64,
+}
+
 /// Router between the global tmux notification stream and the
 /// per-pane subscribers. See the module doc.
 #[derive(Clone, Default)]
@@ -92,8 +98,19 @@ pub struct OutputRouter {
 }
 
 struct PaneState {
-    sender: mpsc::Sender<Vec<u8>>,
+    sender: Option<mpsc::Sender<OutputChunk>>,
     decoder: OctalDecoder,
+    ring: RingBuffer,
+}
+
+impl PaneState {
+    fn new() -> Self {
+        Self {
+            sender: None,
+            decoder: OctalDecoder::new(),
+            ring: RingBuffer::new(),
+        }
+    }
 }
 
 impl OutputRouter {
@@ -101,45 +118,53 @@ impl OutputRouter {
         Self::default()
     }
 
-    /// Subscribe to `pane_id`'s decoded byte stream. Always
-    /// succeeds — if a prior subscriber is already registered,
-    /// their sender is dropped (their `recv` yields `None` on the
-    /// next poll → handler exits via `Action::Exit`) and the new
-    /// subscriber takes over. The decoder's carry buffer survives
-    /// the swap because it's per-pane, not per-subscriber.
+    /// Subscribe to `pane_id`'s decoded byte stream for a fresh
+    /// attach (no resume). Always succeeds — if a prior
+    /// subscriber is already registered, their sender is dropped
+    /// (their `recv` yields `None` → old handler exits via
+    /// `Action::Exit`) and the new subscriber takes over. The
+    /// decoder's carry buffer AND the ring survive the swap
+    /// because they're per-pane, not per-subscriber.
     ///
-    /// See the "Attach-displaces-prior" section of the module
-    /// doc for the one-user-many-devices rationale.
-    pub fn subscribe(&self, pane_id: u32) -> mpsc::Receiver<Vec<u8>> {
+    /// Returns `(receiver, current_seq)` so the handler can echo
+    /// `current_seq` in its `Attached` response. The client
+    /// watches the seq progression from there.
+    pub fn subscribe(&self, pane_id: u32) -> (mpsc::Receiver<OutputChunk>, u64) {
         let mut panes = self.inner.lock().expect("output-router mutex poisoned");
         let (tx, rx) = mpsc::channel(PER_PANE_BUFFER);
-        match panes.get_mut(&pane_id) {
-            Some(existing) => {
-                // Replace the sender. The old sender drops when
-                // this assignment lands, which closes the old
-                // receiver and lets the old handler exit cleanly.
-                // KEEP the decoder: carry state is about the tmux
-                // byte stream, not about the subscriber.
-                existing.sender = tx;
-            }
-            None => {
-                panes.insert(
-                    pane_id,
-                    PaneState {
-                        sender: tx,
-                        decoder: OctalDecoder::new(),
-                    },
-                );
-            }
-        }
-        rx
+        let state = panes.entry(pane_id).or_insert_with(PaneState::new);
+        state.sender = Some(tx);
+        (rx, state.ring.total_written())
     }
 
-    /// Remove a pane's registration. Safe to call when no
-    /// subscriber is registered (no-op). Handlers MUST call this
-    /// on clean exit so the decoder's carry buffer doesn't leak.
-    /// On a panicked handler exit, `dispatch`'s stale-entry
-    /// pruning (see the module doc) eventually cleans up.
+    /// Subscribe AND resume — do both atomically under the
+    /// router's lock so nothing slips in between snapshot and
+    /// subscribe. Returns the receiver (for the live stream
+    /// going forward from the snapshot point) plus a
+    /// [`ReplaySlice`] describing what the client missed.
+    ///
+    /// The handler hands the replay bytes to the client BEFORE
+    /// draining the receiver, so from the client's perspective
+    /// bytes arrive in strict seq order without overlap.
+    ///
+    /// If `pane_id` isn't in the map yet, we insert it fresh
+    /// (empty ring → replay is `UpToDate` at seq 0).
+    pub fn subscribe_with_resume(
+        &self,
+        pane_id: u32,
+        after_seq: u64,
+    ) -> (mpsc::Receiver<OutputChunk>, ReplaySlice) {
+        let mut panes = self.inner.lock().expect("output-router mutex poisoned");
+        let (tx, rx) = mpsc::channel(PER_PANE_BUFFER);
+        let state = panes.entry(pane_id).or_insert_with(PaneState::new);
+        let replay = state.ring.replay_after(after_seq);
+        state.sender = Some(tx);
+        (rx, replay)
+    }
+
+    /// Remove a pane's registration. Drops the sender, decoder,
+    /// and ring. Safe to call when no subscriber is registered
+    /// (no-op). Handlers MUST call this on clean exit.
     pub fn unsubscribe(&self, pane_id: u32) {
         let _ = self
             .inner
@@ -148,94 +173,65 @@ impl OutputRouter {
             .remove(&pane_id);
     }
 
-    /// Route a raw `%output <pane_id> <data>` notification to
-    /// its subscriber (if any). Decodes octal escapes, folds in
-    /// any carry from the previous dispatch to this pane, and
-    /// sends the resulting bytes via the per-pane mpsc.
+    /// Route a raw `%output <pane_id> <data>` notification.
+    /// Decodes octal escapes, appends the decoded bytes to the
+    /// pane's ring, and forwards an [`OutputChunk`] to the
+    /// subscriber (if any).
     ///
-    /// The input `raw` is expected to be tmux control-mode-
-    /// encoded text (the decoder handles `\\` and `\NNN`
-    /// escapes). A future non-tmux transport producing pre-
-    /// decoded bytes would bypass the router's dispatch, NOT
-    /// feed them in raw — the decoder would passthrough safely
-    /// only because it has a fast-path on "no backslash," and
-    /// relying on that is fragile. Keep `dispatch` for
-    /// tmux-encoded input.
+    /// If the pane isn't registered yet, we create a fresh
+    /// `PaneState` (empty ring, no sender) and append. This
+    /// means the ring accumulates history even before a client
+    /// first attaches — a client attaching to an existing
+    /// session will see whatever's already there. For 9g this
+    /// means the first Attach gets fresh state; for later
+    /// slices with long-lived tmux sessions, clients reconnect
+    /// into scrollback organically.
     ///
-    /// If no subscriber is registered, the notification is
-    /// dropped silently — tmux panes unrelated to any katulong
-    /// connection still produce output (e.g., the initial
-    /// session hosting a detached shell) and the router isn't
-    /// the right place to noise-log them.
+    /// Input `raw` is expected to be tmux control-mode-encoded
+    /// text.
     pub fn dispatch(&self, pane_id: u32, raw: &str) {
         let mut panes = self.inner.lock().expect("output-router mutex poisoned");
-        let Some(state) = panes.get_mut(&pane_id) else {
-            return;
-        };
+        let state = panes.entry(pane_id).or_insert_with(PaneState::new);
         let decoded = state.decoder.decode(raw);
         if decoded.is_empty() {
-            // Entire chunk was absorbed into the carry (a single
-            // trailing `\` for example). Nothing to dispatch
-            // yet; the next chunk will carry through.
+            // Entire chunk absorbed into the carry. Nothing to
+            // append or dispatch yet.
             return;
         }
-        if let Err(err) = state.sender.try_send(decoded) {
-            match err {
-                mpsc::error::TrySendError::Full(_) => {
-                    // Subscriber fell behind. Dropping here is a
-                    // visible glitch; blocking the dispatcher
-                    // would starve every other pane. Logged so
-                    // operators see the pressure.
+        state.ring.append(&decoded);
+        let end_seq = state.ring.total_written();
+        let chunk = OutputChunk {
+            data: decoded,
+            end_seq,
+        };
+        if let Some(sender) = state.sender.as_ref() {
+            match sender.try_send(chunk) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    // Subscriber fell behind. Bytes are still in
+                    // the ring — a reconnect can recover via
+                    // resume. Drop the live chunk with a warn.
                     tracing::warn!(
                         pane_id,
-                        "output dispatch dropped — subscriber queue full"
+                        "output dispatch dropped — subscriber queue full (ring retains)"
                     );
                 }
-                mpsc::error::TrySendError::Closed(_) => {
+                Err(mpsc::error::TrySendError::Closed(_)) => {
                     // Subscriber dropped their receiver without
-                    // calling unsubscribe (e.g., handler panic).
-                    // Remove the entry so future dispatches and
-                    // subscribes see a clean slate. A quiet pane
-                    // might not trigger this path until the next
-                    // `%output` arrives — a subscribe() call
-                    // before that would overwrite the stale
-                    // entry anyway (see `subscribe`).
-                    panes.remove(&pane_id);
+                    // unsubscribe (e.g., handler panic). Clear
+                    // the sender; KEEP the ring and decoder so
+                    // a reconnect still gets history. The
+                    // PaneState itself stays registered.
+                    state.sender = None;
                 }
             }
         }
     }
 
     /// Spawn the dispatcher task: a loop that drains `notifs`
-    /// (the `mpsc::UnboundedReceiver<Notification>` handed back
-    /// by `Tmux::spawn`) and routes each `%output` event through
-    /// `dispatch`. Returns the task's `JoinHandle` so the
-    /// caller can await shutdown; in practice `main.rs` lets
-    /// the runtime abort it on process exit.
-    ///
-    /// # Non-blocking invariant
-    ///
-    /// `Tmux::spawn` returns an UNBOUNDED receiver; if this
-    /// task ever blocks in `dispatch`, tmux notifications
-    /// accumulate toward OOM. `dispatch` is `try_send`-based
-    /// (drops on full subscriber rather than awaiting), so the
-    /// only way to block this task is synchronous contention
-    /// on the router's internal mutex. That critical section
-    /// is short (decoder step + try_send) even under slice 9h's
-    /// multi-subscriber fan-out — revisit if a profile ever
-    /// shows the dispatcher as the bottleneck.
-    ///
-    /// # Lifecycle
-    ///
-    /// The task exits when:
-    /// - `notifs` is closed (the `Tmux` client drops or
-    ///   shutdown completes), OR
-    /// - a `Notification::Exit` event fires (tmux's control
-    ///   connection tore down).
-    ///
-    /// On exit it logs and the task terminates; the router
-    /// continues to exist for any handlers that hold clones,
-    /// but nothing feeds it.
+    /// (the `mpsc::UnboundedReceiver<Notification>` from
+    /// `Tmux::spawn`) and routes each `%output` event through
+    /// `dispatch`. Returns the task's `JoinHandle`.
     pub fn spawn_dispatcher(
         &self,
         mut notifs: mpsc::UnboundedReceiver<Notification>,
@@ -252,9 +248,6 @@ impl OutputRouter {
                         break;
                     }
                     other => {
-                        // Other notifications aren't consumed
-                        // yet. Logged at trace so operators can
-                        // enable them selectively when diagnosing.
                         tracing::trace!(?other, "tmux notification (no consumer yet)");
                     }
                 }
@@ -263,9 +256,7 @@ impl OutputRouter {
     }
 
     /// Number of currently-registered panes. Test-only; not
-    /// exposed in release builds so callers can't build load-
-    /// bearing logic on it (the map's contents are a dispatch
-    /// implementation detail).
+    /// exposed in release builds.
     #[cfg(test)]
     pub fn registered_count(&self) -> usize {
         self.inner.lock().unwrap().len()
@@ -277,154 +268,219 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn subscribe_then_dispatch_delivers_bytes() {
+    async fn subscribe_returns_zero_seq_on_empty_pane() {
         let r = OutputRouter::new();
-        let mut rx = r.subscribe(0);
+        let (_rx, seq) = r.subscribe(0);
+        assert_eq!(seq, 0);
+    }
+
+    #[tokio::test]
+    async fn dispatch_delivers_output_chunk_with_end_seq() {
+        let r = OutputRouter::new();
+        let (mut rx, _) = r.subscribe(0);
         r.dispatch(0, "hello");
         let got = rx.recv().await.expect("bytes arrive");
-        assert_eq!(got, b"hello");
+        assert_eq!(got.data, b"hello");
+        assert_eq!(got.end_seq, 5);
+    }
+
+    #[tokio::test]
+    async fn consecutive_dispatches_produce_monotonic_seqs() {
+        let r = OutputRouter::new();
+        let (mut rx, _) = r.subscribe(0);
+        r.dispatch(0, "ab");
+        r.dispatch(0, "cd");
+        let c1 = rx.recv().await.unwrap();
+        let c2 = rx.recv().await.unwrap();
+        assert_eq!(c1.end_seq, 2);
+        assert_eq!(c2.end_seq, 4);
     }
 
     #[tokio::test]
     async fn dispatch_decodes_octal() {
         let r = OutputRouter::new();
-        let mut rx = r.subscribe(7);
+        let (mut rx, _) = r.subscribe(7);
         r.dispatch(7, r"\033[2J");
         let got = rx.recv().await.unwrap();
-        assert_eq!(got, &[0x1B, b'[', b'2', b'J']);
+        assert_eq!(got.data, &[0x1B, b'[', b'2', b'J']);
     }
 
     #[tokio::test]
     async fn dispatch_carries_partial_escape_across_calls() {
-        // The multi-device rationale lives or dies on the
-        // decoder state being held by the router, not by the
-        // subscriber. Split a `\342\226\210` mid-escape and
-        // confirm the second dispatch reassembles correctly.
         let r = OutputRouter::new();
-        let mut rx = r.subscribe(0);
+        let (mut rx, _) = r.subscribe(0);
         r.dispatch(0, r"\342\226\2");
         r.dispatch(0, "10");
         let first = rx.recv().await.unwrap();
         let second = rx.recv().await.unwrap();
-        let mut combined = first;
-        combined.extend(second);
+        let mut combined = first.data;
+        combined.extend(second.data);
         assert_eq!(combined, &[0xE2, 0x96, 0x88]);
     }
 
     #[tokio::test]
-    async fn second_subscribe_displaces_prior_and_closes_its_channel() {
-        // One-user-many-devices: a second attach should smoothly
-        // take over the pane, not error. The prior subscriber's
-        // receiver sees its channel close on next recv.
+    async fn second_subscribe_displaces_prior_but_preserves_ring() {
+        // One-user-many-devices: the second attach takes over.
+        // The ring survives the swap so the second subscriber
+        // could still request resume if they knew what they
+        // missed.
         let r = OutputRouter::new();
-        let mut first = r.subscribe(0);
-        let mut second = r.subscribe(0);
-        r.dispatch(0, "routed");
+        let (mut first, _) = r.subscribe(0);
+        r.dispatch(0, "abc"); // first sees it
+        let _first_chunk = first.recv().await.unwrap();
 
-        // Old subscriber: next recv yields None (closed).
+        let (mut second, baseline) = r.subscribe(0);
+        assert_eq!(baseline, 3, "seq baseline after 3 bytes");
         assert!(
             first.recv().await.is_none(),
             "prior subscription must close when replaced"
         );
-        // New subscriber: gets the bytes.
-        let got = second.recv().await.expect("new subscriber gets bytes");
-        assert_eq!(got, b"routed");
+        r.dispatch(0, "def");
+        let got = second.recv().await.unwrap();
+        assert_eq!(got.data, b"def");
+        assert_eq!(got.end_seq, 6);
     }
 
     #[tokio::test]
-    async fn displaced_keeps_decoder_carry() {
-        // The decoder is per-pane, not per-subscriber. When we
-        // replace the subscriber mid-escape, the partial escape
-        // must still resolve cleanly on the new subscriber's
-        // bytes.
+    async fn subscribe_with_resume_returns_in_range_bytes() {
         let r = OutputRouter::new();
-        let _old = r.subscribe(0);
-        r.dispatch(0, r"\342\226\2"); // carries one byte
-        let mut new_sub = r.subscribe(0);
-        r.dispatch(0, "10"); // completes the escape
-        // The "\342\226" part went to the old sub (now closed),
-        // dropped silently. The new sub sees only the completion.
-        let got = new_sub.recv().await.unwrap();
-        assert_eq!(got, &[0x88]);
+        // Seed the ring before any subscriber exists.
+        r.dispatch(0, "abcde");
+        let (mut rx, replay) = r.subscribe_with_resume(0, 2);
+        match replay {
+            ReplaySlice::InRange { data, end_seq } => {
+                assert_eq!(data, b"cde");
+                assert_eq!(end_seq, 5);
+            }
+            other => panic!("expected InRange, got {other:?}"),
+        }
+        // Live continues after the replay snapshot.
+        r.dispatch(0, "fg");
+        let chunk = rx.recv().await.unwrap();
+        assert_eq!(chunk.data, b"fg");
+        assert_eq!(chunk.end_seq, 7);
     }
 
     #[tokio::test]
-    async fn unsubscribe_allows_resubscribe() {
+    async fn subscribe_with_resume_up_to_date() {
         let r = OutputRouter::new();
-        let _rx1 = r.subscribe(0);
+        r.dispatch(0, "abc");
+        let (_rx, replay) = r.subscribe_with_resume(0, 3);
+        assert_eq!(replay, ReplaySlice::UpToDate { end_seq: 3 });
+    }
+
+    #[tokio::test]
+    async fn subscribe_with_resume_future_is_protocol_error() {
+        let r = OutputRouter::new();
+        r.dispatch(0, "abc");
+        let (_rx, replay) = r.subscribe_with_resume(0, 999);
+        assert_eq!(replay, ReplaySlice::Future);
+    }
+
+    #[tokio::test]
+    async fn subscribe_with_resume_gap_returns_current_window() {
+        let r = OutputRouter::new();
+        // Force a ring rollover by dispatching more than default
+        // capacity. Using a small dispatch repeatedly keeps the
+        // test fast.
+        for _ in 0..(crate::session::ring::DEFAULT_CAPACITY / 64 + 4) {
+            r.dispatch(0, &"x".repeat(64));
+        }
+        let (_rx, replay) = r.subscribe_with_resume(0, 0);
+        match replay {
+            ReplaySlice::Gap {
+                available_from_seq,
+                data: _,
+                end_seq: _,
+            } => {
+                assert!(
+                    available_from_seq > 0,
+                    "gap must report a positive oldest-available seq"
+                );
+            }
+            other => panic!("expected Gap, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_clears_ring() {
+        // Explicit clean unsubscribe wipes pane state — a fresh
+        // subscribe starts the ring from zero. (Panicked
+        // subscriber's half-state keeps the ring; see
+        // `dispatch_preserves_ring_on_closed_subscriber`.)
+        let r = OutputRouter::new();
+        let (_rx, _) = r.subscribe(0);
+        r.dispatch(0, "abc");
         r.unsubscribe(0);
-        let _rx2 = r.subscribe(0);
-        assert_eq!(r.registered_count(), 1);
+        let (_rx2, baseline) = r.subscribe(0);
+        assert_eq!(baseline, 0, "unsubscribe wipes ring");
     }
 
     #[tokio::test]
-    async fn dispatch_with_no_subscriber_is_silent() {
-        // The initial tmux session hosts output unrelated to any
-        // connection — those panes must not log-spam the router.
+    async fn dispatch_preserves_ring_on_closed_subscriber() {
+        // Handler panic path: receiver dropped without
+        // unsubscribe. Next dispatch sees Closed; clears sender
+        // but KEEPS the ring + decoder. A reconnect resume can
+        // still use the history.
         let r = OutputRouter::new();
-        r.dispatch(42, "orphaned output");
-        assert_eq!(r.registered_count(), 0);
-    }
-
-    #[tokio::test]
-    async fn dispatch_prunes_closed_subscriber() {
-        let r = OutputRouter::new();
-        let rx = r.subscribe(5);
+        let (rx, _) = r.subscribe(0);
         drop(rx);
-        r.dispatch(5, "posthumous"); // send fails → prune
-        assert_eq!(r.registered_count(), 0);
-        // Subscribe now succeeds again (with a fresh decoder).
-        let _rx = r.subscribe(5);
+        r.dispatch(0, "orphan");
+        let (_rx, baseline) = r.subscribe(0);
+        assert_eq!(
+            baseline, 6,
+            "ring must survive subscriber-closed dispatch so reconnect-resume works"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_with_no_prior_subscriber_seeds_ring() {
+        // A dispatch before any subscribe creates the pane entry
+        // and seeds the ring. This is the "initial tmux session
+        // printing a prompt before the first client connects"
+        // path. The first subscriber then sees the baseline seq.
+        let r = OutputRouter::new();
+        r.dispatch(42, "prompt$ ");
+        let (_rx, baseline) = r.subscribe(42);
+        assert_eq!(baseline, 8);
     }
 
     #[tokio::test]
     async fn unsubscribe_is_idempotent() {
         let r = OutputRouter::new();
         r.unsubscribe(99); // nothing registered — no-op
-        let _rx = r.subscribe(1);
+        let (_rx, _) = r.subscribe(1);
         r.unsubscribe(1);
         r.unsubscribe(1); // already gone — no-op
     }
 
     #[tokio::test]
     async fn router_clones_share_state() {
-        // Dispatcher task and handler task each hold a clone of
-        // the same `OutputRouter`. Operations on one must be
-        // visible on the other.
         let r1 = OutputRouter::new();
         let r2 = r1.clone();
-        let mut rx = r1.subscribe(0);
+        let (mut rx, _) = r1.subscribe(0);
         r2.dispatch(0, "cross");
         let got = rx.recv().await.unwrap();
-        assert_eq!(got, b"cross");
+        assert_eq!(got.data, b"cross");
     }
 
     #[tokio::test]
-    async fn carry_only_output_does_not_dispatch_empty() {
-        // A chunk that is entirely absorbed into the carry
-        // (single `\`) must NOT send an empty Vec to the
-        // subscriber — we'd be telling the client "here's output"
-        // when really we're still waiting for the tail. Silence
-        // is the correct signal.
+    async fn carry_only_output_does_not_dispatch_or_seq_advance() {
+        // A chunk absorbed into the decoder carry must not emit
+        // an OutputChunk AND must not advance the ring (no bytes
+        // actually landed). Otherwise seq integrity breaks.
         let r = OutputRouter::new();
-        let mut rx = r.subscribe(0);
+        let (mut rx, _) = r.subscribe(0);
         r.dispatch(0, r"\");
-        // Nothing should be receivable yet.
-        let got = rx.try_recv();
-        assert!(
-            got.is_err(),
-            "dispatch that absorbed entirely into carry must send nothing; got {got:?}"
-        );
-        // Completing the escape delivers bytes.
-        r.dispatch(0, "033");
-        let bytes = rx.recv().await.unwrap();
-        assert_eq!(bytes, &[0x1B]);
+        assert!(rx.try_recv().is_err(), "carry-only dispatch sends nothing");
+        let (_rx2, seq) = r.subscribe(0);
+        assert_eq!(seq, 0, "carry-only must not advance ring");
     }
 
     #[tokio::test]
     async fn spawn_dispatcher_routes_output_and_exits_on_tmux_exit() {
         let r = OutputRouter::new();
-        let mut rx = r.subscribe(3);
+        let (mut rx, _) = r.subscribe(3);
         let (tx, notifs) = mpsc::unbounded_channel::<Notification>();
         let handle = r.spawn_dispatcher(notifs);
 
@@ -434,12 +490,8 @@ mod tests {
         })
         .unwrap();
         let got = rx.recv().await.unwrap();
-        assert_eq!(got, b"ping");
+        assert_eq!(got.data, b"ping");
 
-        // Non-routed notifications are logged but not forwarded.
-        tx.send(Notification::WindowClose { window_id: 0 }).unwrap();
-
-        // Exit notification terminates the dispatcher task.
         tx.send(Notification::Exit {
             reason: Some("test".into()),
         })

--- a/crates/server/src/session/router.rs
+++ b/crates/server/src/session/router.rs
@@ -148,7 +148,15 @@ impl OutputRouter {
     /// bytes arrive in strict seq order without overlap.
     ///
     /// If `pane_id` isn't in the map yet, we insert it fresh
-    /// (empty ring → replay is `UpToDate` at seq 0).
+    /// (empty ring → replay is `UpToDate` at seq 0 OR `Gap`
+    /// from 0 when the client's `after_seq` is positive but
+    /// the ring is empty — see the empty-ring semantics on
+    /// [`crate::session::ring::RingBuffer::replay_after`]).
+    ///
+    /// IMPORTANT: this DOES displace any prior subscriber on
+    /// the pane. Callers that need to validate the resume seq
+    /// before committing to the displace should use
+    /// [`OutputRouter::peek_resume`] first.
     pub fn subscribe_with_resume(
         &self,
         pane_id: u32,
@@ -162,10 +170,67 @@ impl OutputRouter {
         (rx, replay)
     }
 
-    /// Remove a pane's registration. Drops the sender, decoder,
-    /// and ring. Safe to call when no subscriber is registered
-    /// (no-op). Handlers MUST call this on clean exit.
-    pub fn unsubscribe(&self, pane_id: u32) {
+    /// Read-only snapshot of what [`OutputRouter::subscribe_with_resume`]
+    /// would return, WITHOUT installing a sender or creating a
+    /// pane entry. Used by the handler to validate a client's
+    /// `resume_from_seq` before displacing any prior subscriber
+    /// — a version-skew client claiming a future-seq would
+    /// otherwise kick an innocent prior subscriber on its way
+    /// to being rejected.
+    ///
+    /// If the pane has no entry yet, returns `ReplaySlice` as
+    /// if the ring were empty (total_written = 0).
+    pub fn peek_resume(&self, pane_id: u32, after_seq: u64) -> ReplaySlice {
+        let panes = self.inner.lock().expect("output-router mutex poisoned");
+        match panes.get(&pane_id) {
+            Some(state) => state.ring.replay_after(after_seq),
+            None => {
+                // Simulate what we'd see against a fresh
+                // PaneState without actually creating one.
+                if after_seq == 0 {
+                    ReplaySlice::UpToDate { end_seq: 0 }
+                } else {
+                    ReplaySlice::Future
+                }
+            }
+        }
+    }
+
+    /// Detach this subscriber but KEEP the pane's ring and
+    /// decoder so a reconnect can replay. This is the handler's
+    /// clean-exit path: a user who closes their browser tab and
+    /// reopens seconds later should resume seamlessly, which
+    /// requires the ring outliving the transport.
+    ///
+    /// The pane's decoder carry also survives. A reconnect that
+    /// lands mid-escape picks up the unchanged byte stream.
+    ///
+    /// Safe to call when no subscriber is registered (no-op).
+    ///
+    /// # Ring lifetime
+    ///
+    /// Pane entries created here persist until `evict(pane_id)`
+    /// is called explicitly, or the `OutputRouter` is dropped
+    /// on server shutdown. Slice 9g relies on this for
+    /// reconnect-replay; slice 9h plans to add tmux
+    /// `%window-close`-driven eviction so long-running servers
+    /// don't accumulate rings for destroyed panes. Until that
+    /// lands, a server restart IS the pane-eviction mechanism —
+    /// acceptable for single-user deployments.
+    pub fn clear_subscriber(&self, pane_id: u32) {
+        let mut panes = self.inner.lock().expect("output-router mutex poisoned");
+        if let Some(state) = panes.get_mut(&pane_id) {
+            state.sender = None;
+        }
+    }
+
+    /// Explicitly remove a pane's entry, wiping ring + decoder +
+    /// sender. Call this when the underlying tmux pane is known
+    /// to be gone (e.g., session destroyed), not for transport
+    /// disconnects. Slice 9h will wire this to tmux
+    /// `%window-close` notifications. Tests use it to reset
+    /// state between cases.
+    pub fn evict(&self, pane_id: u32) {
         let _ = self
             .inner
             .lock()
@@ -403,17 +468,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unsubscribe_clears_ring() {
-        // Explicit clean unsubscribe wipes pane state — a fresh
-        // subscribe starts the ring from zero. (Panicked
-        // subscriber's half-state keeps the ring; see
-        // `dispatch_preserves_ring_on_closed_subscriber`.)
+    async fn clear_subscriber_keeps_ring_for_reconnect() {
+        // Clean-close + reopen is the dominant mobile UX flow.
+        // The ring MUST outlive the transport so the reopen can
+        // resume seamlessly, not start fresh.
         let r = OutputRouter::new();
         let (_rx, _) = r.subscribe(0);
         r.dispatch(0, "abc");
-        r.unsubscribe(0);
+        r.clear_subscriber(0);
         let (_rx2, baseline) = r.subscribe(0);
-        assert_eq!(baseline, 0, "unsubscribe wipes ring");
+        assert_eq!(
+            baseline, 3,
+            "clear_subscriber must keep the ring so clean-close + reopen can resume"
+        );
+    }
+
+    #[tokio::test]
+    async fn evict_removes_pane_entirely() {
+        // Explicit eviction (for tmux-pane-gone signals, slice
+        // 9h) wipes the entire PaneState.
+        let r = OutputRouter::new();
+        let (_rx, _) = r.subscribe(0);
+        r.dispatch(0, "doomed");
+        r.evict(0);
+        let (_rx2, baseline) = r.subscribe(0);
+        assert_eq!(baseline, 0, "evict wipes the pane ring");
     }
 
     #[tokio::test]
@@ -446,12 +525,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unsubscribe_is_idempotent() {
+    async fn clear_subscriber_is_idempotent() {
         let r = OutputRouter::new();
-        r.unsubscribe(99); // nothing registered — no-op
+        r.clear_subscriber(99); // nothing registered — no-op
         let (_rx, _) = r.subscribe(1);
-        r.unsubscribe(1);
-        r.unsubscribe(1); // already gone — no-op
+        r.clear_subscriber(1);
+        r.clear_subscriber(1); // already cleared — no-op
+    }
+
+    #[tokio::test]
+    async fn evict_is_idempotent() {
+        let r = OutputRouter::new();
+        r.evict(42);
+        r.evict(42);
     }
 
     #[tokio::test]
@@ -497,6 +583,47 @@ mod tests {
         })
         .unwrap();
         handle.await.expect("dispatcher task joins cleanly");
+    }
+
+    #[tokio::test]
+    async fn peek_resume_does_not_displace_subscriber() {
+        // Round-1 correctness fix: peek must NEVER touch the
+        // sender. A version-skew probe calling peek with a
+        // bogus seq must leave the legitimate subscriber's
+        // channel unaffected.
+        let r = OutputRouter::new();
+        let (mut rx, _) = r.subscribe(0);
+        r.dispatch(0, "live");
+        let _ = r.peek_resume(0, 999_999); // bogus future-seq
+        // Prior subscription must still work.
+        let got = rx.recv().await.expect("subscriber survived peek");
+        assert_eq!(got.data, b"live");
+    }
+
+    #[tokio::test]
+    async fn peek_resume_on_empty_pane_with_after_zero_is_uptodate() {
+        // Server-restart path: a reconnecting client that kept
+        // its seq from before the restart will usually see an
+        // empty pane. We used to reject with Future; now we
+        // special-case empty + positive seq in peek_resume to
+        // treat it as "up to date at 0" for cold-pane /
+        // peek_resume(_, 0) and as Future for nonzero. The
+        // handler then converts Future on empty to a Gap
+        // replay (see handler tests).
+        let r = OutputRouter::new();
+        let slice = r.peek_resume(42, 0);
+        assert_eq!(slice, ReplaySlice::UpToDate { end_seq: 0 });
+    }
+
+    #[tokio::test]
+    async fn peek_resume_on_empty_pane_with_nonzero_is_future() {
+        // Intentional: only the handler decides that empty-pane
+        // + nonzero resume should fall back to Gap. The router
+        // itself returns Future to keep the peek API precise
+        // ("what does the ring say?").
+        let r = OutputRouter::new();
+        let slice = r.peek_resume(42, 100);
+        assert_eq!(slice, ReplaySlice::Future);
     }
 
     #[tokio::test]

--- a/crates/server/src/transport/message.rs
+++ b/crates/server/src/transport/message.rs
@@ -189,19 +189,26 @@ pub enum ServerMessage {
         rows: u16,
         last_seq: u64,
     },
-    /// PTY output chunk. `seq` is a monotonic counter per
-    /// connection that lets clients detect gaps after a reconnect
-    /// (Node scar `da6907f`). Slice 9e defined the variant; slice
-    /// 9f populates it from the tmux `%output` notification stream
-    /// with coalescing (`d311168`/`066dab2`).
+    /// PTY output chunk. `seq` is the pane's `total_written`
+    /// (cumulative decoded byte offset) at the end of this
+    /// chunk — a per-PANE monotonic counter that continues
+    /// across subscriber displace/reconnect boundaries. Node
+    /// scar `da6907f` is the motivation; the Rust port uses
+    /// byte-level instead of message-level offsets for
+    /// unambiguous reconnect semantics. Slice 9e defined the
+    /// variant; slice 9f populated it via per-pane dispatch;
+    /// slice 9g made the counter pane-global (not per-
+    /// connection) so `Attach { resume_from_seq }` has a
+    /// stable reference point.
     ///
-    /// **Seq contract: 1-based.** The first `Output` message on
-    /// a connection carries `seq = 1`; seq = 0 is reserved to
-    /// mean "no output produced yet" so a future reconnect
-    /// (slice 9g) can send `Attach { resume_from_seq: 0 }` to
-    /// request the full ring. Clients counting gaps should never
-    /// see a decrease; any decrease means the server restarted
-    /// (seq resets) and they must treat it as a hard reconnect.
+    /// **Seq contract.** `seq` is 1-based at the first-byte
+    /// level: the first outbound byte of a pane carries
+    /// `end_seq = 1`; seq = 0 is reserved to mean "no output
+    /// produced yet" (used in `Attached.last_seq` on a cold
+    /// pane). Clients counting gaps see monotonic progress
+    /// across reconnect as long as the server process has not
+    /// restarted; a decrease means a fresh server instance
+    /// and the client must treat it as a hard reset.
     Output {
         #[serde(with = "serde_bytes")]
         data: Vec<u8>,

--- a/crates/server/src/transport/message.rs
+++ b/crates/server/src/transport/message.rs
@@ -102,10 +102,21 @@ pub enum ClientMessage {
     /// once after `HelloAck`. The server creates the session if it
     /// doesn't exist (or attaches to the existing one) and replies
     /// with `Attached`.
+    ///
+    /// `resume_from_seq`: reconnect hint. Absent (or `None`) means
+    /// "fresh attach — I have no prior state." `Some(N)` means "I
+    /// last received bytes through seq N; please replay bytes
+    /// `(N..last_seq]` if you still have them." If the server's
+    /// ring has lost bytes below `N`, it emits `OutputGap` before
+    /// the replay so the client clears its terminal first. Omit
+    /// on first attach; echo the seq from `Attached.last_seq` on
+    /// reconnect.
     Attach {
         session: String,
         cols: u16,
         rows: u16,
+        #[serde(default)]
+        resume_from_seq: Option<u64>,
     },
 
     /// Keystroke / paste input destined for the PTY. Only valid
@@ -163,12 +174,20 @@ pub enum ServerMessage {
     Pong { nonce: u64 },
     /// Confirms that this transport is bound to `session`, which
     /// has been resized to the clamped `cols`/`rows`. The client
-    /// should use these (not what it requested) as the authoritative
-    /// dimensions for its local renderer.
+    /// should use these (not what it requested) as the
+    /// authoritative dimensions for its local renderer.
+    ///
+    /// `last_seq` is the pane's current `total_written` — the
+    /// byte counter the ring is at when this `Attached` ships.
+    /// A fresh-attach client seeds its local seq from here. A
+    /// reconnect client uses it as the upper bound of the
+    /// replay they're about to receive. `0` on a fresh pane
+    /// (no output ever produced).
     Attached {
         session: String,
         cols: u16,
         rows: u16,
+        last_seq: u64,
     },
     /// PTY output chunk. `seq` is a monotonic counter per
     /// connection that lets clients detect gaps after a reconnect
@@ -198,6 +217,22 @@ pub enum ServerMessage {
     /// code stays stable across releases so scripts and client
     /// error classifiers key off it.
     Error { code: String, message: String },
+    /// Reconnect replay had a gap: the client's `resume_from_seq`
+    /// was older than the oldest byte still in the pane's ring.
+    /// `available_from_seq` is the oldest byte we can replay (>
+    /// the client's request); `last_seq` matches `Attached.last_seq`
+    /// for convenience.
+    ///
+    /// The client MUST clear its terminal / restart its renderer
+    /// before applying any subsequent `Output` — cursor positions
+    /// and in-flight escape sequences from the lost window can't
+    /// be inferred. Sent between `Attached` and the first replay
+    /// `Output` so the client's clear-before-apply order is
+    /// unambiguous.
+    OutputGap {
+        available_from_seq: u64,
+        last_seq: u64,
+    },
 }
 
 #[cfg(test)]
@@ -251,15 +286,49 @@ mod tests {
     }
 
     #[test]
-    fn client_attach_serde_roundtrip() {
+    fn client_attach_fresh_serde_roundtrip() {
         let m = ClientMessage::Attach {
             session: "main".into(),
             cols: 120,
             rows: 40,
+            resume_from_seq: None,
         };
         let s = to_string(&m).unwrap();
         assert!(s.contains(r#""type":"attach""#));
         assert_eq!(from_str::<ClientMessage>(&s).unwrap(), m);
+    }
+
+    #[test]
+    fn client_attach_resume_serde_roundtrip() {
+        let m = ClientMessage::Attach {
+            session: "main".into(),
+            cols: 80,
+            rows: 24,
+            resume_from_seq: Some(12345),
+        };
+        let s = to_string(&m).unwrap();
+        assert!(s.contains(r#""resume_from_seq":12345"#));
+        assert_eq!(from_str::<ClientMessage>(&s).unwrap(), m);
+    }
+
+    #[test]
+    fn client_attach_missing_resume_field_defaults_to_none() {
+        // Forward-compat: an older client that doesn't know
+        // about reconnect deserialises cleanly. `#[serde(default)]`
+        // on `Option` fills in `None`.
+        let m: ClientMessage = from_str(
+            r#"{"type":"attach","session":"main","cols":80,"rows":24}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            m,
+            ClientMessage::Attach {
+                session: "main".into(),
+                cols: 80,
+                rows: 24,
+                resume_from_seq: None,
+            }
+        );
     }
 
     #[test]
@@ -268,9 +337,23 @@ mod tests {
             session: "main".into(),
             cols: 120,
             rows: 40,
+            last_seq: 42,
         };
         let s = to_string(&m).unwrap();
         assert!(s.contains(r#""type":"attached""#));
+        assert!(s.contains(r#""last_seq":42"#));
+        assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
+    }
+
+    #[test]
+    fn server_output_gap_serde_roundtrip() {
+        let m = ServerMessage::OutputGap {
+            available_from_seq: 100,
+            last_seq: 500,
+        };
+        let s = to_string(&m).unwrap();
+        assert!(s.contains(r#""type":"output_gap""#));
+        assert!(s.contains(r#""available_from_seq":100"#));
         assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
     }
 


### PR DESCRIPTION
## Summary

Server-side reconnect replay: per-pane byte ring + resume protocol. A client that drops and reconnects with `Attach { resume_from_seq: Some(N) }` gets whatever the ring still holds.

- **`session::ring`** (new) — byte circular buffer, default 64 KiB per pane, monotonic `total_written`. `replay_after` returns `InRange` / `UpToDate` / `Gap` / `Future`.
- **`session::router`** — ring lives in `PaneState`; seqs are now per-pane, not per-connection. `subscribe` returns baseline seq; new `subscribe_with_resume` atomic-snapshots + subscribes under one mutex. `OutputChunk { data, end_seq }` replaces bare `Vec<u8>`.
- **Wire protocol** — `Attach.resume_from_seq: Option<u64>` (forward-compat default = None), `Attached.last_seq: u64`, new `ServerMessage::OutputGap`.
- **`session::handler`** — `AttachedState.last_seen_seq` seeded from baseline; `try_attach` routes through fresh vs resume path; `send_replay` helper emits OutputGap + Output between `Attached` and going live. New `error_code::INVALID_RESUME` for future-seq claims.

## Scar alignment

- Node `da6907f` — per-pane monotonic seq for reconnect-gap detection. Port: same semantics, byte-level instead of message-level (unambiguous).
- Node `c073ec7` (revocation teardown) — unchanged; ring lives behind the existing revocation watch.
- Node `4dffb9f` (octal carry) — unchanged; decoder carry already upstream of the fan-out.

## Gap semantics

If the client's `resume_from_seq` is older than the oldest byte in the ring, server emits `OutputGap { available_from_seq, last_seq }` BEFORE the replay `Output`. The client MUST clear its terminal on receipt — cursor positions and in-flight escapes can't be reconstructed across the gap. This is a protocol contract, not server-enforceable.

## Not in scope

- Screen-state snapshot (headless xterm). A byte replay won't cleanly rebuild mid-frame TUI state. Deferred until a concrete consumer.
- Multi-device output fan-out. Router still has single-subscriber-replace semantics (slice 9f's one-user-many-devices fix). Slice 9h.
- Session TTL / eviction. PaneState entries persist for the process lifetime (bounded at 64 KiB ring per pane). Fine for single-user; revisit when multi-device or cross-session concerns surface.

## Test plan

- [x] `cargo test --workspace` — 142 server tests passing (up from 123), 1 ignored (`tmux_roundtrip`, pre-existing).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] Pre-push Node test suite — unit + integration + smoke E2E passed.

## Gotchas

- Dispatch on a `Closed` subscriber CLEARS the sender but KEEPS the ring+decoder, so a panicked handler's history survives for the next reconnect. PaneState doesn't auto-evict; a session with no reconnecting client accumulates 64 KiB of ring bytes forever. Slice 9h revisits eviction alongside session TTL.
- `Attached.last_seq` seeds `AttachedState.last_seen_seq` so the first live flush's seq can never go below the attach-time baseline. Monotonic guarantee preserved across the displace-subscribe boundary.