### PR TITLE
rewrite(server): slice 9h — multi-device output fan-out

### DIFF
--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -69,9 +69,10 @@ use crate::log_util::sanitize_for_log;
 use crate::revocation::RevocationEvent;
 use crate::session::output::Coalescer;
 use crate::session::ring::ReplaySlice;
-use crate::session::router::OutputChunk;
+use crate::session::router::{OutputChunk, SubscribeError, SubscriberId};
 use crate::state::AppState;
 use crate::transport::{ClientMessage, ServerMessage, TransportHandle, PROTOCOL_VERSION};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::mpsc;
@@ -139,6 +140,12 @@ pub mod error_code {
     /// `Output.seq`, both of which the server assigned. Closing
     /// on mismatch catches version-skew or client bugs early.
     pub const INVALID_RESUME: &str = "invalid_resume";
+    /// Attach rejected because the pane already has the maximum
+    /// number of concurrent subscribers (slice 9h multi-device
+    /// fan-out cap). Clients should close the connection and
+    /// prompt the user if they want to disconnect one of their
+    /// other devices.
+    pub const SESSION_OVERSUBSCRIBED: &str = "session_oversubscribed";
     /// Connection was torn down server-side without the client
     /// having done anything wrong. Emitted when the bound
     /// credential is revoked, or when the revocation broadcast
@@ -314,12 +321,17 @@ fn phase_name(phase: &Phase) -> &'static str {
 struct AttachedState {
     session: String,
     pane_id: u32,
+    /// This subscriber's id, handed back by the router on
+    /// subscribe. Used at cleanup to remove ONLY this
+    /// connection's sender from the pane's fan-out list,
+    /// leaving sibling subscribers (multi-device) untouched.
+    subscriber_id: SubscriberId,
     /// Decoded bytes + end-of-chunk seq from this pane's
-    /// `%output` stream. The router assigns `end_seq` per
-    /// dispatch (pane-global, not per-connection), so the seq
-    /// keeps advancing monotonically across the displace-
-    /// subscribe boundary.
-    output_rx: mpsc::Receiver<OutputChunk>,
+    /// `%output` stream. The router fans out an `Arc<OutputChunk>`
+    /// per dispatch so every subscriber gets the same bytes
+    /// without per-subscriber allocation; the handler only
+    /// reads through the Arc, never mutates.
+    output_rx: mpsc::Receiver<Arc<OutputChunk>>,
     /// Highest `end_seq` we've seen come out of `output_rx`.
     /// When the coalescer flushes, this becomes the outbound
     /// `ServerMessage::Output.seq`. Starts at the router's
@@ -665,14 +677,16 @@ pub async fn serve_session(
         }
     }
 
-    // Cleanup: detach the subscriber, but KEEP the pane's ring
-    // and decoder. The dominant "close tab, reopen seconds
-    // later" UX flow depends on the ring outliving the
-    // transport. Tmux-pane-gone eviction is slice 9h's
-    // concern; a server restart is currently the pane-wipe
-    // mechanism. Safe to call even if we never attached.
+    // Cleanup: detach THIS subscriber, but keep the pane's
+    // ring, decoder, and sibling subscribers alive. Slice 9h:
+    // `clear_subscriber` takes the SubscriberId so only this
+    // connection's sender is removed. Multi-device sessions
+    // (phone + laptop) keep flowing for the other devices
+    // when one closes its transport.
     if let Some(a) = attached {
-        state.output_router.clear_subscriber(a.pane_id);
+        state
+            .output_router
+            .clear_subscriber(a.pane_id, a.subscriber_id);
     }
     // Drop the handle. The WS output pump sees the channel close
     // and shuts down the socket gracefully.
@@ -693,7 +707,9 @@ async fn sleep_until_opt(deadline: Option<Instant>) {
 /// Helper: read from the pane output receiver if we're attached,
 /// otherwise never resolve. Same guard-+-pending pattern as
 /// `sleep_until_opt`.
-async fn maybe_recv_output(attached: Option<&mut AttachedState>) -> Option<OutputChunk> {
+async fn maybe_recv_output(
+    attached: Option<&mut AttachedState>,
+) -> Option<Arc<OutputChunk>> {
     match attached {
         Some(a) => a.output_rx.recv().await,
         None => std::future::pending().await,
@@ -767,12 +783,16 @@ async fn try_attach(
         None => {
             // Fresh attach. No peek needed — the client isn't
             // claiming any prior state, so we can't reject it.
-            let (rx, baseline) = state.output_router.subscribe(pane_id);
+            let (rx, subscriber_id, baseline) = state
+                .output_router
+                .subscribe(pane_id)
+                .map_err(to_subscribe_failure)?;
             Ok(AttachOutcome {
                 replay: ReplaySlice::Fresh { end_seq: baseline },
                 new_state: AttachedState {
                     session: session.to_string(),
                     pane_id,
+                    subscriber_id,
                     output_rx: rx,
                     last_seen_seq: baseline,
                     coalescer: Coalescer::new(),
@@ -817,7 +837,10 @@ async fn try_attach(
                         // with empty data. Client clears its
                         // terminal; fresh live output follows
                         // as normal.
-                        let (rx, _baseline) = state.output_router.subscribe(pane_id);
+                        let (rx, subscriber_id, _baseline) = state
+                            .output_router
+                            .subscribe(pane_id)
+                            .map_err(to_subscribe_failure)?;
                         Ok(AttachOutcome {
                             replay: ReplaySlice::Gap {
                                 available_from_seq: 0,
@@ -827,6 +850,7 @@ async fn try_attach(
                             new_state: AttachedState {
                                 session: session.to_string(),
                                 pane_id,
+                                subscriber_id,
                                 output_rx: rx,
                                 last_seen_seq: 0,
                                 coalescer: Coalescer::new(),
@@ -849,21 +873,23 @@ async fn try_attach(
                 }
                 _peek => {
                     // Any non-Future peek is safe to commit.
-                    // Subscribe-with-resume now does the same
-                    // work under the router lock, so the replay
-                    // we actually return is authoritative
-                    // (no dispatch slipped between peek and
-                    // commit because we re-read under the lock).
-                    let (rx, replay) =
-                        state.output_router.subscribe_with_resume(pane_id, after_seq);
-                    // Under normal execution the second read
-                    // matches the peek. The paranoid second
-                    // Future check here is defensive against a
-                    // pane being evicted between calls — it
-                    // can't happen in slice 9g (no eviction
-                    // path) but slice 9h may add one.
+                    // Subscribe-with-resume does the same work
+                    // under the router lock, so the replay we
+                    // actually return is authoritative (no
+                    // dispatch slipped between peek and commit
+                    // because we re-read under the lock).
+                    let (rx, subscriber_id, replay) = state
+                        .output_router
+                        .subscribe_with_resume(pane_id, after_seq)
+                        .map_err(to_subscribe_failure)?;
+                    // Paranoid second Future check — defensive
+                    // against a pane being evicted between
+                    // peek and commit. Can't happen in 9g/9h
+                    // yet (no live eviction path), but the
+                    // subscribe already succeeded so we must
+                    // clean up this subscriber before rejecting.
                     if matches!(replay, ReplaySlice::Future) {
-                        state.output_router.clear_subscriber(pane_id);
+                        state.output_router.clear_subscriber(pane_id, subscriber_id);
                         return Err(AttachFailure {
                             code: error_code::INVALID_RESUME,
                             message: "resume_from_seq is beyond server's output counter"
@@ -885,6 +911,7 @@ async fn try_attach(
                         new_state: AttachedState {
                             session: session.to_string(),
                             pane_id,
+                            subscriber_id,
                             output_rx: rx,
                             last_seen_seq: last_seq,
                             coalescer: Coalescer::new(),
@@ -1019,6 +1046,27 @@ async fn send_error_and_close(handle: &TransportHandle, code: &str, message: Str
             message,
         })
         .await;
+}
+
+/// Map a router `SubscribeError` into a handler `AttachFailure`
+/// with the matching wire error code. Only one variant today
+/// (`Oversubscribed`); kept in a dedicated helper so adding
+/// future subscribe error variants doesn't scatter mapping
+/// logic across the attach arms.
+fn to_subscribe_failure(err: SubscribeError) -> AttachFailure {
+    match err {
+        SubscribeError::Oversubscribed {
+            pane_id,
+            active,
+            max,
+        } => AttachFailure {
+            code: error_code::SESSION_OVERSUBSCRIBED,
+            message: "too many devices attached to this session".into(),
+            err: format!(
+                "pane {pane_id} has {active}/{max} subscribers"
+            ),
+        },
+    }
 }
 
 fn classify_session_error(err: &crate::session::SessionError) -> (&'static str, String) {
@@ -1330,6 +1378,7 @@ mod tests {
             error_code::NO_SESSION_MANAGER,
             error_code::HANDSHAKE_TIMEOUT,
             error_code::INVALID_RESUME,
+            error_code::SESSION_OVERSUBSCRIBED,
             error_code::CONNECTION_TERMINATED,
         ];
         let set: std::collections::HashSet<&str> = all.iter().copied().collect();
@@ -1339,13 +1388,14 @@ mod tests {
     // ---------- Resize gate deadline math (pure, no runtime) ----------
 
     fn attached_state_for_gate_tests() -> AttachedState {
-        // Build a minimal AttachedState by hand — output_rx is
-        // required by the struct but the gate-math helpers don't
-        // touch it.
+        // Build a minimal AttachedState by hand — output_rx +
+        // subscriber_id are required by the struct but the
+        // gate-math helpers don't touch them.
         let (_tx, rx) = mpsc::channel(1);
         AttachedState {
             session: "s".into(),
             pane_id: 0,
+            subscriber_id: SubscriberId::testing(0),
             output_rx: rx,
             last_seen_seq: 0,
             coalescer: Coalescer::new(),

--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -41,16 +41,23 @@
 //!
 //! # Not in scope (deferred)
 //!
-//! - **Multi-device output fan-out** (slice 9h): the router
-//!   replaces on a second subscribe (attach-displaces-prior)
-//!   rather than fanning out. Slice 9h needs a product
-//!   decision on replace-vs-fanout for simultaneous devices.
-//! - **Pane eviction on tmux-pane-gone** (slice 9h): today a
+//! - **Pane eviction on tmux-pane-gone**: today a
 //!   `clear_subscriber` keeps the ring alive indefinitely; a
-//!   server restart is the wipe mechanism. Wiring `%window-
-//!   close`/`%pane-close` notifications into
-//!   `OutputRouter::evict` closes the long-running-server
-//!   leak path.
+//!   server restart or the dispatcher's `evict_all` on tmux
+//!   exit is the wipe mechanism. Wiring `%window-close`/
+//!   `%pane-close` notifications into `OutputRouter::evict`
+//!   closes the long-running-server leak path. **Fan-out
+//!   amplifies urgency**: a zombie pane now occupies one of
+//!   the 16 subscriber slots per pane (actually, it occupies
+//!   zero slots after `clear_subscriber` runs — but the ring
+//!   sits at 256 KiB, and with `MAX_PANES = 128` unevicted
+//!   zombies could in theory reach the pane-namespace cap
+//!   and block new attaches).
+//! - **Per-credential subscriber cap**: the 16-subscriber cap
+//!   is per-pane, not per-credential. One stolen cookie with
+//!   16 concurrent WS connections can block any new attach
+//!   on a pane until it disconnects. Low priority for a
+//!   single-user install; required before multi-credential.
 //! - **Session-creation rate cap**: an authenticated client can
 //!   create unbounded tmux sessions, each allocating a ring.
 //!   Tracked as a separate hardening ticket.
@@ -146,6 +153,15 @@ pub mod error_code {
     /// prompt the user if they want to disconnect one of their
     /// other devices.
     pub const SESSION_OVERSUBSCRIBED: &str = "session_oversubscribed";
+    /// Attach rejected because the router is tracking as many
+    /// distinct panes as its defense-in-depth cap allows (see
+    /// `router::MAX_PANES`). A conforming client can't
+    /// naturally reach this — it fires only if tmux has been
+    /// wildly churning panes or a parser bug is creating
+    /// phantom pane ids. Exposed as a wire code so operators
+    /// see it in logs and clients surface a clear message
+    /// rather than a generic "session failed."
+    pub const ROUTER_AT_CAPACITY: &str = "router_at_capacity";
     /// Connection was torn down server-side without the client
     /// having done anything wrong. Emitted when the bound
     /// credential is revoked, or when the revocation broadcast
@@ -871,8 +887,12 @@ async fn try_attach(
                         })
                     }
                 }
-                _peek => {
-                    // Any non-Future peek is safe to commit.
+                // InRange | UpToDate | Gap — safe to commit.
+                // `Fresh` never comes back from `peek_resume`
+                // with `after_seq > 0` (that path goes to
+                // `Future` against empty panes and is caught
+                // above).
+                _ => {
                     // Subscribe-with-resume does the same work
                     // under the router lock, so the replay we
                     // actually return is authoritative (no
@@ -899,25 +919,31 @@ async fn try_attach(
                             ),
                         });
                     }
-                    let last_seq = match &replay {
-                        ReplaySlice::Fresh { end_seq } => *end_seq,
-                        ReplaySlice::InRange { end_seq, .. } => *end_seq,
-                        ReplaySlice::UpToDate { end_seq } => *end_seq,
-                        ReplaySlice::Gap { end_seq, .. } => *end_seq,
-                        ReplaySlice::Future => unreachable!("just checked above"),
-                    };
-                    Ok(AttachOutcome {
+                    let outcome = AttachOutcome {
                         replay,
                         new_state: AttachedState {
                             session: session.to_string(),
                             pane_id,
                             subscriber_id,
                             output_rx: rx,
-                            last_seen_seq: last_seq,
+                            // Seeded below after construction so
+                            // `outcome.last_seq()` is the single
+                            // source of truth (accessor reads
+                            // the end_seq from the `replay`
+                            // variant).
+                            last_seen_seq: 0,
                             coalescer: Coalescer::new(),
                             last_output_at: None,
                             pending_resize: None,
                         },
+                    };
+                    let baseline = outcome.last_seq();
+                    Ok(AttachOutcome {
+                        new_state: AttachedState {
+                            last_seen_seq: baseline,
+                            ..outcome.new_state
+                        },
+                        ..outcome
                     })
                 }
             }
@@ -1065,6 +1091,11 @@ fn to_subscribe_failure(err: SubscribeError) -> AttachFailure {
             err: format!(
                 "pane {pane_id} has {active}/{max} subscribers"
             ),
+        },
+        SubscribeError::RouterAtCapacity { pane_id } => AttachFailure {
+            code: error_code::ROUTER_AT_CAPACITY,
+            message: "server at pane capacity; try again later".into(),
+            err: format!("cannot register new pane {pane_id}: router at MAX_PANES"),
         },
     }
 }
@@ -1379,6 +1410,7 @@ mod tests {
             error_code::HANDSHAKE_TIMEOUT,
             error_code::INVALID_RESUME,
             error_code::SESSION_OVERSUBSCRIBED,
+            error_code::ROUTER_AT_CAPACITY,
             error_code::CONNECTION_TERMINATED,
         ];
         let set: std::collections::HashSet<&str> = all.iter().copied().collect();

--- a/crates/server/src/session/router.rs
+++ b/crates/server/src/session/router.rs
@@ -1,12 +1,13 @@
 //! Dispatcher from the single global tmux `%output` stream to
 //! per-connection output pumps, with per-pane history for
-//! reconnect replay (slice 9g).
+//! reconnect replay (slice 9g) and multi-device fan-out (slice
+//! 9h).
 //!
 //! One tmux subprocess produces notifications for every pane on
 //! every session it hosts. A per-connection handler only cares
 //! about ONE pane (the one its `Attach` bound). The router is
 //! the thin indirection that routes a `%output <pane_id> <data>`
-//! notification to the right subscriber without forcing every
+//! notification to the right subscribers without forcing each
 //! handler to filter the whole stream itself.
 //!
 //! # Per-pane seq and the reconnect path (slice 9g)
@@ -15,22 +16,63 @@
 //! - An octal [`OctalDecoder`] whose carry survives subscriber
 //!   handoffs (the carry is about the tmux byte stream, not the
 //!   subscriber).
-//! - A byte [`RingBuffer`] of the last ~64 KiB, tagged with a
+//! - A byte [`RingBuffer`] (default 256 KiB), tagged with a
 //!   monotonic `total_written` that doubles as the wire `seq`.
-//! - The current subscriber's [`mpsc::Sender`], if any.
+//! - Zero-or-more active subscriber senders.
 //!
-//! `dispatch` decodes bytes, appends to the ring, and pushes an
-//! [`OutputChunk`] (`data` + `end_seq`) to the subscriber. The
-//! ring keeps bytes past the subscriber's wire buffer, so a
-//! client that drops and reconnects with
-//! `subscribe_with_resume(pane_id, after_seq)` gets a
-//! [`ReplaySlice`] describing what to hand the client before
-//! going live.
+//! `dispatch` decodes bytes, appends to the ring, wraps the
+//! result in `Arc<OutputChunk>`, and fans it out to every
+//! registered subscriber. The ring keeps bytes past each
+//! subscriber's wire buffer, so a client that drops and
+//! reconnects with `subscribe_with_resume(pane_id, after_seq)`
+//! gets a [`ReplaySlice`] describing what to hand the client
+//! before going live.
 //!
-//! The seq semantics are **per-pane, not per-connection**: two
-//! successive subscribers on the same pane see contiguous seqs,
-//! which is what makes the reconnect path useful. Pre-9g the
-//! docstring said "per-connection monotonic" — that's obsolete.
+//! Seq is **per-pane, not per-subscriber or per-connection**:
+//! two subscribers on the same pane see the same seq sequence
+//! at the same time, and a reconnecting client picks up the
+//! same counter the prior subscriber was tracking.
+//!
+//! # Multi-device fan-out (slice 9h)
+//!
+//! Pre-9h the router allowed at most one subscriber per pane:
+//! a second subscribe would DISPLACE the first, matching the
+//! "attach-displaces-prior" UX. That got the common "close tab,
+//! reopen" flow right but made the genuine multi-device case
+//! (phone + laptop connected simultaneously) unworkable — one
+//! device would silently kick the other.
+//!
+//! Slice 9h lifts that restriction: a pane can hold up to
+//! [`MAX_SUBSCRIBERS_PER_PANE`] concurrent subscribers. Each
+//! gets a [`SubscriberId`] returned from `subscribe` so the
+//! handler can later clean itself up without affecting the
+//! others. Dispatch fans out the same byte stream to every
+//! subscriber via `Arc<OutputChunk>` (one allocation per
+//! dispatch regardless of subscriber count).
+//!
+//! Decisions made explicit:
+//! - **Input from multiple devices is serialised by tmux.** Two
+//!   clients typing at the same time both forward their bytes
+//!   via `SessionManager::send_input`, which writes to tmux's
+//!   stdin one command at a time. Interleaving is at the
+//!   tmux-command level, which for keystrokes is the correct
+//!   granularity (a multi-byte paste on one device doesn't get
+//!   split by another device's Ctrl-C).
+//! - **Resize still last-writer-wins on the tmux-one-size
+//!   constraint.** `CLAUDE.md` is explicit: "A tmux pane has
+//!   exactly one terminal size." Two devices with different
+//!   window sizes will fight; this is a PTY-structural
+//!   limitation and not something we can solve at the
+//!   router layer. Users with different sizes should use
+//!   separate tmux sessions.
+//! - **Backpressure is per-subscriber.** When one subscriber's
+//!   queue fills, we drop THAT subscriber's bytes only; other
+//!   subscribers on the same pane keep receiving. The dropped
+//!   subscriber can still reconnect with resume_from_seq and
+//!   pull the missed bytes from the ring.
+//! - **Closed-receiver pruning happens during dispatch.**
+//!   Subscribers whose receiver got dropped without calling
+//!   `clear_subscriber` are pruned on the next fan-out.
 //!
 //! # Ownership model
 //!
@@ -41,47 +83,74 @@
 //! another clone via `AppState` and calls [`OutputRouter::subscribe`]
 //! (fresh attach) or [`OutputRouter::subscribe_with_resume`]
 //! (reconnect) after its `Attach` succeeds.
-//!
-//! # Attach-displaces-prior semantics (slice 9f)
-//!
-//! Subscribing always succeeds. If a prior subscriber already
-//! held the pane, their `mpsc::Receiver` sees its channel close
-//! on the next `recv()` and the handler's loop treats that as
-//! `Action::Exit`. This matches katulong's one-user-many-devices
-//! model: opening the app in a second browser tab smoothly takes
-//! over the terminal. Slice 9h revisits this when multi-device
-//! fan-out lands.
-//!
-//! # Backpressure
-//!
-//! The per-pane mpsc channel has a bounded capacity
-//! (`PER_PANE_BUFFER`). If the subscriber's handler falls behind,
-//! `try_send` fails and the dispatcher DROPS the bytes with a
-//! `warn!` log. Output loss is visible to the user as a terminal
-//! glitch, but the alternative — blocking the tmux reader task
-//! on one slow client — starves every other pane's output. The
-//! ring buffer still captures the dropped bytes, so a reconnect
-//! after a drop can resume cleanly via the gap path.
 
 use crate::session::output::OctalDecoder;
 use crate::session::parser::Notification;
 use crate::session::ring::{ReplaySlice, RingBuffer};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-/// Per-pane queue capacity. Tmux emits one `%output` per I/O
-/// boundary; a single TUI frame is typically 1–10 chunks, and
-/// the handler drains each chunk into a coalescer in constant
-/// time. 256 gives a generous headroom above any realistic burst
-/// without committing huge memory (each entry is a small `Vec`).
+/// Per-pane queue capacity for each subscriber. Tmux emits one
+/// `%output` per I/O boundary; a single TUI frame is typically
+/// 1–10 chunks, and the handler drains each chunk into a
+/// coalescer in constant time. 256 gives generous headroom
+/// above any realistic burst without committing huge memory
+/// per subscriber.
 const PER_PANE_BUFFER: usize = 256;
+
+/// Cap on concurrent subscribers per pane. A single user
+/// opening the terminal on phone + laptop + tablet + a few
+/// browser tabs shouldn't get anywhere near this. Higher
+/// numbers are almost certainly a bug or a deliberate probe;
+/// rejecting them keeps memory bounded under misuse.
+pub const MAX_SUBSCRIBERS_PER_PANE: usize = 16;
+
+/// Identifier for a registered subscriber. Monotonically
+/// increasing per-router; overflow is not a practical concern
+/// at single-user scale. Returned from `subscribe` so the
+/// handler can `clear_subscriber(pane_id, id)` specifically
+/// its own sender without touching siblings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SubscriberId(u64);
+
+impl SubscriberId {
+    /// Exposed for the test harness; not intended for
+    /// production callers, who should only ever use IDs they
+    /// received from `subscribe` / `subscribe_with_resume`.
+    #[cfg(test)]
+    pub fn testing(raw: u64) -> Self {
+        Self(raw)
+    }
+}
+
+/// Error from [`OutputRouter::subscribe`] /
+/// [`OutputRouter::subscribe_with_resume`] when the pane
+/// already has `MAX_SUBSCRIBERS_PER_PANE` active subscribers.
+/// Callers should surface this to the client as
+/// `session_oversubscribed` and close the new connection.
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum SubscribeError {
+    #[error(
+        "pane %{pane_id} already has {active} subscribers; \
+         maximum is {max}"
+    )]
+    Oversubscribed {
+        pane_id: u32,
+        active: usize,
+        max: usize,
+    },
+}
 
 /// A decoded output chunk with the byte-offset `seq` at which
 /// it ends. Subscribers track the highest `end_seq` they've
 /// seen; when the coalescer flushes, that value goes into the
 /// outbound `ServerMessage::Output.seq`.
+///
+/// Wrapped in `Arc` for fan-out: one allocation per dispatch
+/// is shared across all subscribers regardless of count.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OutputChunk {
     pub data: Vec<u8>,
@@ -95,10 +164,16 @@ pub struct OutputChunk {
 #[derive(Clone, Default)]
 pub struct OutputRouter {
     inner: Arc<Mutex<HashMap<u32, PaneState>>>,
+    next_subscriber_id: Arc<AtomicU64>,
+}
+
+struct Subscriber {
+    id: SubscriberId,
+    sender: mpsc::Sender<Arc<OutputChunk>>,
 }
 
 struct PaneState {
-    sender: Option<mpsc::Sender<OutputChunk>>,
+    subscribers: Vec<Subscriber>,
     decoder: OctalDecoder,
     ring: RingBuffer,
 }
@@ -106,7 +181,7 @@ struct PaneState {
 impl PaneState {
     fn new() -> Self {
         Self {
-            sender: None,
+            subscribers: Vec::new(),
             decoder: OctalDecoder::new(),
             ring: RingBuffer::new(),
         }
@@ -118,75 +193,82 @@ impl OutputRouter {
         Self::default()
     }
 
-    /// Subscribe to `pane_id`'s decoded byte stream for a fresh
-    /// attach (no resume). Always succeeds — if a prior
-    /// subscriber is already registered, their sender is dropped
-    /// (their `recv` yields `None` → old handler exits via
-    /// `Action::Exit`) and the new subscriber takes over. The
-    /// decoder's carry buffer AND the ring survive the swap
-    /// because they're per-pane, not per-subscriber.
-    ///
-    /// Returns `(receiver, current_seq)` so the handler can echo
-    /// `current_seq` in its `Attached` response. The client
-    /// watches the seq progression from there.
-    pub fn subscribe(&self, pane_id: u32) -> (mpsc::Receiver<OutputChunk>, u64) {
-        let mut panes = self.inner.lock().expect("output-router mutex poisoned");
-        let (tx, rx) = mpsc::channel(PER_PANE_BUFFER);
-        let state = panes.entry(pane_id).or_insert_with(PaneState::new);
-        state.sender = Some(tx);
-        (rx, state.ring.total_written())
+    fn mint_id(&self) -> SubscriberId {
+        SubscriberId(self.next_subscriber_id.fetch_add(1, Ordering::Relaxed))
     }
 
-    /// Subscribe AND resume — do both atomically under the
-    /// router's lock so nothing slips in between snapshot and
-    /// subscribe. Returns the receiver (for the live stream
-    /// going forward from the snapshot point) plus a
-    /// [`ReplaySlice`] describing what the client missed.
+    /// Subscribe to `pane_id`'s decoded byte stream for a fresh
+    /// attach (no resume). Returns `(receiver, subscriber_id,
+    /// baseline_seq)` so the handler can (a) hand its
+    /// `subscriber_id` to `clear_subscriber` at cleanup, (b)
+    /// echo `baseline_seq` in `Attached.last_seq`.
     ///
-    /// The handler hands the replay bytes to the client BEFORE
-    /// draining the receiver, so from the client's perspective
-    /// bytes arrive in strict seq order without overlap.
+    /// Fails if the pane already has [`MAX_SUBSCRIBERS_PER_PANE`]
+    /// active subscribers. Returns `SubscribeError::Oversubscribed`;
+    /// caller closes the connection with `session_oversubscribed`.
+    pub fn subscribe(
+        &self,
+        pane_id: u32,
+    ) -> Result<(mpsc::Receiver<Arc<OutputChunk>>, SubscriberId, u64), SubscribeError> {
+        let mut panes = self.inner.lock().expect("output-router mutex poisoned");
+        let state = panes.entry(pane_id).or_insert_with(PaneState::new);
+        if state.subscribers.len() >= MAX_SUBSCRIBERS_PER_PANE {
+            return Err(SubscribeError::Oversubscribed {
+                pane_id,
+                active: state.subscribers.len(),
+                max: MAX_SUBSCRIBERS_PER_PANE,
+            });
+        }
+        let (tx, rx) = mpsc::channel(PER_PANE_BUFFER);
+        let id = self.mint_id();
+        state.subscribers.push(Subscriber { id, sender: tx });
+        Ok((rx, id, state.ring.total_written()))
+    }
+
+    /// Subscribe AND resume — atomic snapshot + append under
+    /// the router lock. Returns the receiver, subscriber id, and
+    /// the [`ReplaySlice`] describing what was missed.
     ///
-    /// If `pane_id` isn't in the map yet, we insert it fresh
-    /// (empty ring → replay is `UpToDate` at seq 0 OR `Gap`
-    /// from 0 when the client's `after_seq` is positive but
-    /// the ring is empty — see the empty-ring semantics on
-    /// [`crate::session::ring::RingBuffer::replay_after`]).
-    ///
-    /// IMPORTANT: this DOES displace any prior subscriber on
-    /// the pane. Callers that need to validate the resume seq
-    /// before committing to the displace should use
-    /// [`OutputRouter::peek_resume`] first.
+    /// Oversubscribed panes reject the same way as `subscribe`.
     pub fn subscribe_with_resume(
         &self,
         pane_id: u32,
         after_seq: u64,
-    ) -> (mpsc::Receiver<OutputChunk>, ReplaySlice) {
+    ) -> Result<
+        (mpsc::Receiver<Arc<OutputChunk>>, SubscriberId, ReplaySlice),
+        SubscribeError,
+    > {
         let mut panes = self.inner.lock().expect("output-router mutex poisoned");
-        let (tx, rx) = mpsc::channel(PER_PANE_BUFFER);
         let state = panes.entry(pane_id).or_insert_with(PaneState::new);
+        if state.subscribers.len() >= MAX_SUBSCRIBERS_PER_PANE {
+            return Err(SubscribeError::Oversubscribed {
+                pane_id,
+                active: state.subscribers.len(),
+                max: MAX_SUBSCRIBERS_PER_PANE,
+            });
+        }
+        let (tx, rx) = mpsc::channel(PER_PANE_BUFFER);
+        let id = self.mint_id();
         let replay = state.ring.replay_after(after_seq);
-        state.sender = Some(tx);
-        (rx, replay)
+        state.subscribers.push(Subscriber { id, sender: tx });
+        Ok((rx, id, replay))
     }
 
     /// Read-only snapshot of what [`OutputRouter::subscribe_with_resume`]
-    /// would return, WITHOUT installing a sender or creating a
-    /// pane entry. Used by the handler to validate a client's
-    /// `resume_from_seq` before displacing any prior subscriber
-    /// — a version-skew client claiming a future-seq would
-    /// otherwise kick an innocent prior subscriber on its way
+    /// would return, WITHOUT installing a subscriber or creating
+    /// a pane entry. Used by the handler to validate a client's
+    /// `resume_from_seq` before committing the new subscriber —
+    /// a version-skew client claiming a future-seq would
+    /// otherwise consume one of the subscriber slots on its way
     /// to being rejected.
     ///
     /// If the pane has no entry yet, returns `ReplaySlice` as
-    /// if the ring were empty (total_written = 0).
+    /// if the ring were empty (`total_written == 0`).
     pub fn peek_resume(&self, pane_id: u32, after_seq: u64) -> ReplaySlice {
         let panes = self.inner.lock().expect("output-router mutex poisoned");
         match panes.get(&pane_id) {
             Some(state) => state.ring.replay_after(after_seq),
             None => {
-                // Simulate what we'd see against a fresh
-                // PaneState without actually creating one.
                 if after_seq == 0 {
                     ReplaySlice::UpToDate { end_seq: 0 }
                 } else {
@@ -196,40 +278,28 @@ impl OutputRouter {
         }
     }
 
-    /// Detach this subscriber but KEEP the pane's ring and
-    /// decoder so a reconnect can replay. This is the handler's
-    /// clean-exit path: a user who closes their browser tab and
-    /// reopens seconds later should resume seamlessly, which
-    /// requires the ring outliving the transport.
+    /// Remove THIS subscriber's sender from the pane's
+    /// fan-out list. Other subscribers on the same pane keep
+    /// receiving. The pane's ring and decoder survive too —
+    /// they're per-pane, not per-subscriber, and a future
+    /// reconnect (same or different device) gets the
+    /// accumulated history via resume.
     ///
-    /// The pane's decoder carry also survives. A reconnect that
-    /// lands mid-escape picks up the unchanged byte stream.
-    ///
-    /// Safe to call when no subscriber is registered (no-op).
-    ///
-    /// # Ring lifetime
-    ///
-    /// Pane entries created here persist until `evict(pane_id)`
-    /// is called explicitly, or the `OutputRouter` is dropped
-    /// on server shutdown. Slice 9g relies on this for
-    /// reconnect-replay; slice 9h plans to add tmux
-    /// `%window-close`-driven eviction so long-running servers
-    /// don't accumulate rings for destroyed panes. Until that
-    /// lands, a server restart IS the pane-eviction mechanism —
-    /// acceptable for single-user deployments.
-    pub fn clear_subscriber(&self, pane_id: u32) {
+    /// Safe to call when the `SubscriberId` is no longer
+    /// registered (already pruned by a dispatch after the
+    /// receiver was dropped; already cleared by a prior call).
+    pub fn clear_subscriber(&self, pane_id: u32, id: SubscriberId) {
         let mut panes = self.inner.lock().expect("output-router mutex poisoned");
         if let Some(state) = panes.get_mut(&pane_id) {
-            state.sender = None;
+            state.subscribers.retain(|s| s.id != id);
         }
     }
 
-    /// Explicitly remove a pane's entry, wiping ring + decoder +
-    /// sender. Call this when the underlying tmux pane is known
-    /// to be gone (e.g., session destroyed), not for transport
-    /// disconnects. Slice 9h will wire this to tmux
-    /// `%window-close` notifications. Tests use it to reset
-    /// state between cases.
+    /// Explicitly remove a pane's entry, wiping ring + decoder
+    /// plus all subscribers. Call when the underlying tmux pane
+    /// is known to be gone (e.g., session destroyed), not for
+    /// transport disconnects. Slice 9h+ will wire this to
+    /// tmux-pane-close notifications.
     pub fn evict(&self, pane_id: u32) {
         let _ = self
             .inner
@@ -239,64 +309,52 @@ impl OutputRouter {
     }
 
     /// Route a raw `%output <pane_id> <data>` notification.
-    /// Decodes octal escapes, appends the decoded bytes to the
-    /// pane's ring, and forwards an [`OutputChunk`] to the
-    /// subscriber (if any).
+    /// Decodes octal escapes, appends to the pane's ring, and
+    /// fans the decoded bytes out to every registered
+    /// subscriber. Subscribers whose receiver was dropped
+    /// without `clear_subscriber` are pruned on the way; those
+    /// whose queue is full drop the chunk but stay subscribed
+    /// (they can catch up via resume later).
     ///
-    /// If the pane isn't registered yet, we create a fresh
-    /// `PaneState` (empty ring, no sender) and append. This
-    /// means the ring accumulates history even before a client
-    /// first attaches — a client attaching to an existing
-    /// session will see whatever's already there. For 9g this
-    /// means the first Attach gets fresh state; for later
-    /// slices with long-lived tmux sessions, clients reconnect
-    /// into scrollback organically.
-    ///
-    /// Input `raw` is expected to be tmux control-mode-encoded
-    /// text.
+    /// One allocation per dispatch regardless of subscriber
+    /// count — `OutputChunk` wraps in `Arc` for the fan-out.
     pub fn dispatch(&self, pane_id: u32, raw: &str) {
         let mut panes = self.inner.lock().expect("output-router mutex poisoned");
         let state = panes.entry(pane_id).or_insert_with(PaneState::new);
         let decoded = state.decoder.decode(raw);
         if decoded.is_empty() {
-            // Entire chunk absorbed into the carry. Nothing to
-            // append or dispatch yet.
             return;
         }
         state.ring.append(&decoded);
         let end_seq = state.ring.total_written();
-        let chunk = OutputChunk {
+        let chunk = Arc::new(OutputChunk {
             data: decoded,
             end_seq,
-        };
-        if let Some(sender) = state.sender.as_ref() {
-            match sender.try_send(chunk) {
-                Ok(()) => {}
+        });
+        state.subscribers.retain(|sub| {
+            match sub.sender.try_send(Arc::clone(&chunk)) {
+                Ok(()) => true,
                 Err(mpsc::error::TrySendError::Full(_)) => {
-                    // Subscriber fell behind. Bytes are still in
-                    // the ring — a reconnect can recover via
-                    // resume. Drop the live chunk with a warn.
                     tracing::warn!(
                         pane_id,
+                        subscriber = ?sub.id,
                         "output dispatch dropped — subscriber queue full (ring retains)"
                     );
+                    true
                 }
                 Err(mpsc::error::TrySendError::Closed(_)) => {
-                    // Subscriber dropped their receiver without
-                    // unsubscribe (e.g., handler panic). Clear
-                    // the sender; KEEP the ring and decoder so
-                    // a reconnect still gets history. The
-                    // PaneState itself stays registered.
-                    state.sender = None;
+                    tracing::trace!(
+                        pane_id,
+                        subscriber = ?sub.id,
+                        "pruning subscriber whose receiver was dropped"
+                    );
+                    false
                 }
             }
-        }
+        });
     }
 
-    /// Spawn the dispatcher task: a loop that drains `notifs`
-    /// (the `mpsc::UnboundedReceiver<Notification>` from
-    /// `Tmux::spawn`) and routes each `%output` event through
-    /// `dispatch`. Returns the task's `JoinHandle`.
+    /// Spawn the dispatcher task. See module doc.
     pub fn spawn_dispatcher(
         &self,
         mut notifs: mpsc::UnboundedReceiver<Notification>,
@@ -320,11 +378,20 @@ impl OutputRouter {
         })
     }
 
-    /// Number of currently-registered panes. Test-only; not
-    /// exposed in release builds.
+    /// Number of currently-registered panes. Test-only.
     #[cfg(test)]
     pub fn registered_count(&self) -> usize {
         self.inner.lock().unwrap().len()
+    }
+
+    /// Number of active subscribers on a pane. Test-only.
+    #[cfg(test)]
+    pub fn subscriber_count(&self, pane_id: u32) -> usize {
+        self.inner
+            .lock()
+            .unwrap()
+            .get(&pane_id)
+            .map_or(0, |s| s.subscribers.len())
     }
 }
 
@@ -332,17 +399,19 @@ impl OutputRouter {
 mod tests {
     use super::*;
 
+    // ---------- Single-subscriber parity (carried forward from 9g) ----------
+
     #[tokio::test]
     async fn subscribe_returns_zero_seq_on_empty_pane() {
         let r = OutputRouter::new();
-        let (_rx, seq) = r.subscribe(0);
+        let (_rx, _id, seq) = r.subscribe(0).unwrap();
         assert_eq!(seq, 0);
     }
 
     #[tokio::test]
     async fn dispatch_delivers_output_chunk_with_end_seq() {
         let r = OutputRouter::new();
-        let (mut rx, _) = r.subscribe(0);
+        let (mut rx, _id, _) = r.subscribe(0).unwrap();
         r.dispatch(0, "hello");
         let got = rx.recv().await.expect("bytes arrive");
         assert_eq!(got.data, b"hello");
@@ -352,7 +421,7 @@ mod tests {
     #[tokio::test]
     async fn consecutive_dispatches_produce_monotonic_seqs() {
         let r = OutputRouter::new();
-        let (mut rx, _) = r.subscribe(0);
+        let (mut rx, _id, _) = r.subscribe(0).unwrap();
         r.dispatch(0, "ab");
         r.dispatch(0, "cd");
         let c1 = rx.recv().await.unwrap();
@@ -364,7 +433,7 @@ mod tests {
     #[tokio::test]
     async fn dispatch_decodes_octal() {
         let r = OutputRouter::new();
-        let (mut rx, _) = r.subscribe(7);
+        let (mut rx, _id, _) = r.subscribe(7).unwrap();
         r.dispatch(7, r"\033[2J");
         let got = rx.recv().await.unwrap();
         assert_eq!(got.data, &[0x1B, b'[', b'2', b'J']);
@@ -373,45 +442,21 @@ mod tests {
     #[tokio::test]
     async fn dispatch_carries_partial_escape_across_calls() {
         let r = OutputRouter::new();
-        let (mut rx, _) = r.subscribe(0);
+        let (mut rx, _id, _) = r.subscribe(0).unwrap();
         r.dispatch(0, r"\342\226\2");
         r.dispatch(0, "10");
         let first = rx.recv().await.unwrap();
         let second = rx.recv().await.unwrap();
-        let mut combined = first.data;
-        combined.extend(second.data);
+        let mut combined = first.data.clone();
+        combined.extend(&second.data);
         assert_eq!(combined, &[0xE2, 0x96, 0x88]);
-    }
-
-    #[tokio::test]
-    async fn second_subscribe_displaces_prior_but_preserves_ring() {
-        // One-user-many-devices: the second attach takes over.
-        // The ring survives the swap so the second subscriber
-        // could still request resume if they knew what they
-        // missed.
-        let r = OutputRouter::new();
-        let (mut first, _) = r.subscribe(0);
-        r.dispatch(0, "abc"); // first sees it
-        let _first_chunk = first.recv().await.unwrap();
-
-        let (mut second, baseline) = r.subscribe(0);
-        assert_eq!(baseline, 3, "seq baseline after 3 bytes");
-        assert!(
-            first.recv().await.is_none(),
-            "prior subscription must close when replaced"
-        );
-        r.dispatch(0, "def");
-        let got = second.recv().await.unwrap();
-        assert_eq!(got.data, b"def");
-        assert_eq!(got.end_seq, 6);
     }
 
     #[tokio::test]
     async fn subscribe_with_resume_returns_in_range_bytes() {
         let r = OutputRouter::new();
-        // Seed the ring before any subscriber exists.
         r.dispatch(0, "abcde");
-        let (mut rx, replay) = r.subscribe_with_resume(0, 2);
+        let (mut rx, _id, replay) = r.subscribe_with_resume(0, 2).unwrap();
         match replay {
             ReplaySlice::InRange { data, end_seq } => {
                 assert_eq!(data, b"cde");
@@ -419,7 +464,6 @@ mod tests {
             }
             other => panic!("expected InRange, got {other:?}"),
         }
-        // Live continues after the replay snapshot.
         r.dispatch(0, "fg");
         let chunk = rx.recv().await.unwrap();
         assert_eq!(chunk.data, b"fg");
@@ -430,121 +474,82 @@ mod tests {
     async fn subscribe_with_resume_up_to_date() {
         let r = OutputRouter::new();
         r.dispatch(0, "abc");
-        let (_rx, replay) = r.subscribe_with_resume(0, 3);
+        let (_rx, _id, replay) = r.subscribe_with_resume(0, 3).unwrap();
         assert_eq!(replay, ReplaySlice::UpToDate { end_seq: 3 });
     }
 
     #[tokio::test]
-    async fn subscribe_with_resume_future_is_protocol_error() {
+    async fn subscribe_with_resume_future_is_protocol_error_slice() {
         let r = OutputRouter::new();
         r.dispatch(0, "abc");
-        let (_rx, replay) = r.subscribe_with_resume(0, 999);
+        let (_rx, _id, replay) = r.subscribe_with_resume(0, 999).unwrap();
         assert_eq!(replay, ReplaySlice::Future);
     }
 
     #[tokio::test]
     async fn subscribe_with_resume_gap_returns_current_window() {
         let r = OutputRouter::new();
-        // Force a ring rollover by dispatching more than default
-        // capacity. Using a small dispatch repeatedly keeps the
-        // test fast.
         for _ in 0..(crate::session::ring::DEFAULT_CAPACITY / 64 + 4) {
             r.dispatch(0, &"x".repeat(64));
         }
-        let (_rx, replay) = r.subscribe_with_resume(0, 0);
+        let (_rx, _id, replay) = r.subscribe_with_resume(0, 0).unwrap();
         match replay {
             ReplaySlice::Gap {
                 available_from_seq,
                 data: _,
                 end_seq: _,
-            } => {
-                assert!(
-                    available_from_seq > 0,
-                    "gap must report a positive oldest-available seq"
-                );
-            }
+            } => assert!(available_from_seq > 0),
             other => panic!("expected Gap, got {other:?}"),
         }
     }
 
     #[tokio::test]
     async fn clear_subscriber_keeps_ring_for_reconnect() {
-        // Clean-close + reopen is the dominant mobile UX flow.
-        // The ring MUST outlive the transport so the reopen can
-        // resume seamlessly, not start fresh.
         let r = OutputRouter::new();
-        let (_rx, _) = r.subscribe(0);
+        let (_rx, id, _) = r.subscribe(0).unwrap();
         r.dispatch(0, "abc");
-        r.clear_subscriber(0);
-        let (_rx2, baseline) = r.subscribe(0);
+        r.clear_subscriber(0, id);
+        let (_rx2, _id2, baseline) = r.subscribe(0).unwrap();
         assert_eq!(
             baseline, 3,
-            "clear_subscriber must keep the ring so clean-close + reopen can resume"
+            "clear_subscriber keeps ring for reconnect-replay"
         );
     }
 
     #[tokio::test]
     async fn evict_removes_pane_entirely() {
-        // Explicit eviction (for tmux-pane-gone signals, slice
-        // 9h) wipes the entire PaneState.
         let r = OutputRouter::new();
-        let (_rx, _) = r.subscribe(0);
+        let (_rx, _id, _) = r.subscribe(0).unwrap();
         r.dispatch(0, "doomed");
         r.evict(0);
-        let (_rx2, baseline) = r.subscribe(0);
-        assert_eq!(baseline, 0, "evict wipes the pane ring");
+        let (_rx2, _id2, baseline) = r.subscribe(0).unwrap();
+        assert_eq!(baseline, 0);
     }
 
     #[tokio::test]
-    async fn dispatch_preserves_ring_on_closed_subscriber() {
-        // Handler panic path: receiver dropped without
-        // unsubscribe. Next dispatch sees Closed; clears sender
-        // but KEEPS the ring + decoder. A reconnect resume can
-        // still use the history.
+    async fn clear_subscriber_unknown_id_is_noop() {
+        // An already-pruned sub or a stale id from a different
+        // pane must not panic or corrupt state.
         let r = OutputRouter::new();
-        let (rx, _) = r.subscribe(0);
-        drop(rx);
-        r.dispatch(0, "orphan");
-        let (_rx, baseline) = r.subscribe(0);
-        assert_eq!(
-            baseline, 6,
-            "ring must survive subscriber-closed dispatch so reconnect-resume works"
-        );
+        r.clear_subscriber(99, SubscriberId::testing(9999));
+        let (_rx, id, _) = r.subscribe(1).unwrap();
+        r.clear_subscriber(1, id);
+        r.clear_subscriber(1, id); // second clear: no-op
     }
 
     #[tokio::test]
     async fn dispatch_with_no_prior_subscriber_seeds_ring() {
-        // A dispatch before any subscribe creates the pane entry
-        // and seeds the ring. This is the "initial tmux session
-        // printing a prompt before the first client connects"
-        // path. The first subscriber then sees the baseline seq.
         let r = OutputRouter::new();
         r.dispatch(42, "prompt$ ");
-        let (_rx, baseline) = r.subscribe(42);
+        let (_rx, _id, baseline) = r.subscribe(42).unwrap();
         assert_eq!(baseline, 8);
-    }
-
-    #[tokio::test]
-    async fn clear_subscriber_is_idempotent() {
-        let r = OutputRouter::new();
-        r.clear_subscriber(99); // nothing registered — no-op
-        let (_rx, _) = r.subscribe(1);
-        r.clear_subscriber(1);
-        r.clear_subscriber(1); // already cleared — no-op
-    }
-
-    #[tokio::test]
-    async fn evict_is_idempotent() {
-        let r = OutputRouter::new();
-        r.evict(42);
-        r.evict(42);
     }
 
     #[tokio::test]
     async fn router_clones_share_state() {
         let r1 = OutputRouter::new();
         let r2 = r1.clone();
-        let (mut rx, _) = r1.subscribe(0);
+        let (mut rx, _id, _) = r1.subscribe(0).unwrap();
         r2.dispatch(0, "cross");
         let got = rx.recv().await.unwrap();
         assert_eq!(got.data, b"cross");
@@ -552,21 +557,182 @@ mod tests {
 
     #[tokio::test]
     async fn carry_only_output_does_not_dispatch_or_seq_advance() {
-        // A chunk absorbed into the decoder carry must not emit
-        // an OutputChunk AND must not advance the ring (no bytes
-        // actually landed). Otherwise seq integrity breaks.
         let r = OutputRouter::new();
-        let (mut rx, _) = r.subscribe(0);
+        let (mut rx, _id, _) = r.subscribe(0).unwrap();
         r.dispatch(0, r"\");
-        assert!(rx.try_recv().is_err(), "carry-only dispatch sends nothing");
-        let (_rx2, seq) = r.subscribe(0);
-        assert_eq!(seq, 0, "carry-only must not advance ring");
+        assert!(rx.try_recv().is_err());
+        let (_rx2, _id2, seq) = r.subscribe(0).unwrap();
+        assert_eq!(seq, 0);
+    }
+
+    #[tokio::test]
+    async fn peek_resume_does_not_displace_subscribers() {
+        let r = OutputRouter::new();
+        let (mut rx, _id, _) = r.subscribe(0).unwrap();
+        r.dispatch(0, "live");
+        let _ = r.peek_resume(0, 999_999);
+        let got = rx.recv().await.expect("subscriber survived peek");
+        assert_eq!(got.data, b"live");
+    }
+
+    #[tokio::test]
+    async fn peek_resume_on_empty_pane_with_after_zero_is_uptodate() {
+        let r = OutputRouter::new();
+        assert_eq!(
+            r.peek_resume(42, 0),
+            ReplaySlice::UpToDate { end_seq: 0 }
+        );
+    }
+
+    #[tokio::test]
+    async fn peek_resume_on_empty_pane_with_nonzero_is_future() {
+        let r = OutputRouter::new();
+        assert_eq!(r.peek_resume(42, 100), ReplaySlice::Future);
+    }
+
+    // ---------- Multi-device fan-out (slice 9h) ----------
+
+    #[tokio::test]
+    async fn two_subscribers_both_receive_the_same_bytes() {
+        // Core claim of slice 9h: a phone and a laptop attached
+        // to the same pane each see the stream, without one
+        // kicking the other.
+        let r = OutputRouter::new();
+        let (mut phone, _p_id, _) = r.subscribe(0).unwrap();
+        let (mut laptop, _l_id, _) = r.subscribe(0).unwrap();
+        assert_eq!(r.subscriber_count(0), 2);
+
+        r.dispatch(0, "shared");
+        let pc = phone.recv().await.unwrap();
+        let lc = laptop.recv().await.unwrap();
+        assert_eq!(pc.data, b"shared");
+        assert_eq!(lc.data, b"shared");
+        // Both point at the same Arc; verify by seq
+        // (Arc::ptr_eq would also work, but seq equality is
+        // the user-facing contract that matters).
+        assert_eq!(pc.end_seq, lc.end_seq);
+    }
+
+    #[tokio::test]
+    async fn dropped_subscriber_does_not_affect_siblings() {
+        // Regression guard: dropping one subscriber's receiver
+        // must not break dispatch for the others. Prior single-
+        // subscriber design prevented this question from
+        // existing; multi-device raises it.
+        let r = OutputRouter::new();
+        let (phone, _p_id, _) = r.subscribe(0).unwrap();
+        let (mut laptop, _l_id, _) = r.subscribe(0).unwrap();
+        drop(phone); // phone tab closed without calling clear_subscriber
+
+        r.dispatch(0, "after-drop");
+        let got = laptop.recv().await.expect("laptop still receives");
+        assert_eq!(got.data, b"after-drop");
+        // Phone's sub got pruned during the dispatch.
+        assert_eq!(r.subscriber_count(0), 1);
+    }
+
+    #[tokio::test]
+    async fn clear_subscriber_removes_only_named_subscriber() {
+        let r = OutputRouter::new();
+        let (mut phone, phone_id, _) = r.subscribe(0).unwrap();
+        let (mut laptop, _l_id, _) = r.subscribe(0).unwrap();
+
+        r.clear_subscriber(0, phone_id);
+        assert_eq!(r.subscriber_count(0), 1);
+
+        r.dispatch(0, "laptop-only");
+        // Phone's mpsc closed by clear_subscriber dropping its
+        // sender.
+        assert!(phone.recv().await.is_none());
+        let got = laptop.recv().await.unwrap();
+        assert_eq!(got.data, b"laptop-only");
+    }
+
+    #[tokio::test]
+    async fn over_cap_subscribe_is_rejected() {
+        let r = OutputRouter::new();
+        let mut receivers = Vec::new();
+        for _ in 0..MAX_SUBSCRIBERS_PER_PANE {
+            let (rx, _id, _) = r.subscribe(0).unwrap();
+            receivers.push(rx);
+        }
+        let err = r.subscribe(0).unwrap_err();
+        match err {
+            SubscribeError::Oversubscribed {
+                pane_id,
+                active,
+                max,
+            } => {
+                assert_eq!(pane_id, 0);
+                assert_eq!(active, MAX_SUBSCRIBERS_PER_PANE);
+                assert_eq!(max, MAX_SUBSCRIBERS_PER_PANE);
+            }
+        }
+        // The cap must not invalidate existing subscriptions.
+        assert_eq!(r.subscriber_count(0), MAX_SUBSCRIBERS_PER_PANE);
+    }
+
+    #[tokio::test]
+    async fn over_cap_rejection_does_not_create_pane_allocation_without_room() {
+        // A caller hitting the cap must not inflate the map or
+        // mint a subscriber id — the reject path is fully
+        // read-only.
+        let r = OutputRouter::new();
+        let _keep: Vec<_> = (0..MAX_SUBSCRIBERS_PER_PANE)
+            .map(|_| r.subscribe(0).unwrap().0)
+            .collect();
+        let before = r.subscriber_count(0);
+        let _ = r.subscribe(0).unwrap_err();
+        assert_eq!(r.subscriber_count(0), before);
+    }
+
+    #[tokio::test]
+    async fn subscriber_ids_are_unique_across_panes() {
+        let r = OutputRouter::new();
+        let (_a, ida, _) = r.subscribe(0).unwrap();
+        let (_b, idb, _) = r.subscribe(1).unwrap();
+        let (_c, idc, _) = r.subscribe(0).unwrap();
+        assert_ne!(ida, idb);
+        assert_ne!(ida, idc);
+        assert_ne!(idb, idc);
+    }
+
+    #[tokio::test]
+    async fn resume_after_displacement_picks_up_from_siblings_seq() {
+        // Device A connects; dispatches happen; device A loses
+        // connection; A reconnects with its last seq; with
+        // fan-out the sibling (device B) has been receiving
+        // the same stream, so A's resume covers exactly the
+        // bytes A missed while its transport was down.
+        let r = OutputRouter::new();
+        let (mut a, a_id, _) = r.subscribe(0).unwrap();
+        let (mut b, _b_id, _) = r.subscribe(0).unwrap();
+
+        r.dispatch(0, "aa"); // both see
+        let _ = a.recv().await; // A consumed through seq 2
+        let _ = b.recv().await;
+
+        // A's "connection drops" — clear it explicitly.
+        r.clear_subscriber(0, a_id);
+
+        r.dispatch(0, "bb"); // only B sees (live)
+        let _ = b.recv().await;
+
+        // A reconnects with resume_from_seq = 2.
+        let (_a2, _id, replay) = r.subscribe_with_resume(0, 2).unwrap();
+        match replay {
+            ReplaySlice::InRange { data, end_seq } => {
+                assert_eq!(data, b"bb", "A should replay exactly what it missed");
+                assert_eq!(end_seq, 4);
+            }
+            other => panic!("expected InRange, got {other:?}"),
+        }
     }
 
     #[tokio::test]
     async fn spawn_dispatcher_routes_output_and_exits_on_tmux_exit() {
         let r = OutputRouter::new();
-        let (mut rx, _) = r.subscribe(3);
+        let (mut rx, _id, _) = r.subscribe(3).unwrap();
         let (tx, notifs) = mpsc::unbounded_channel::<Notification>();
         let handle = r.spawn_dispatcher(notifs);
 
@@ -583,47 +749,6 @@ mod tests {
         })
         .unwrap();
         handle.await.expect("dispatcher task joins cleanly");
-    }
-
-    #[tokio::test]
-    async fn peek_resume_does_not_displace_subscriber() {
-        // Round-1 correctness fix: peek must NEVER touch the
-        // sender. A version-skew probe calling peek with a
-        // bogus seq must leave the legitimate subscriber's
-        // channel unaffected.
-        let r = OutputRouter::new();
-        let (mut rx, _) = r.subscribe(0);
-        r.dispatch(0, "live");
-        let _ = r.peek_resume(0, 999_999); // bogus future-seq
-        // Prior subscription must still work.
-        let got = rx.recv().await.expect("subscriber survived peek");
-        assert_eq!(got.data, b"live");
-    }
-
-    #[tokio::test]
-    async fn peek_resume_on_empty_pane_with_after_zero_is_uptodate() {
-        // Server-restart path: a reconnecting client that kept
-        // its seq from before the restart will usually see an
-        // empty pane. We used to reject with Future; now we
-        // special-case empty + positive seq in peek_resume to
-        // treat it as "up to date at 0" for cold-pane /
-        // peek_resume(_, 0) and as Future for nonzero. The
-        // handler then converts Future on empty to a Gap
-        // replay (see handler tests).
-        let r = OutputRouter::new();
-        let slice = r.peek_resume(42, 0);
-        assert_eq!(slice, ReplaySlice::UpToDate { end_seq: 0 });
-    }
-
-    #[tokio::test]
-    async fn peek_resume_on_empty_pane_with_nonzero_is_future() {
-        // Intentional: only the handler decides that empty-pane
-        // + nonzero resume should fall back to Gap. The router
-        // itself returns Future to keep the peek API precise
-        // ("what does the ring say?").
-        let r = OutputRouter::new();
-        let slice = r.peek_resume(42, 100);
-        assert_eq!(slice, ReplaySlice::Future);
     }
 
     #[tokio::test]

--- a/crates/server/src/session/router.rs
+++ b/crates/server/src/session/router.rs
@@ -108,6 +108,19 @@ const PER_PANE_BUFFER: usize = 256;
 /// rejecting them keeps memory bounded under misuse.
 pub const MAX_SUBSCRIBERS_PER_PANE: usize = 16;
 
+/// Defense-in-depth cap on distinct panes the router will
+/// track. The router's HashMap auto-creates a `PaneState` (with
+/// a 256 KiB ring) for any `pane_id` it sees — from tmux
+/// `%output` notifications AND from handler `subscribe` /
+/// `subscribe_with_resume` calls. Neither side is supposed to
+/// produce attacker-controlled `pane_id` values, but a parser
+/// bug OR a crafted tmux escape that somehow injects a spurious
+/// `%output` line could otherwise grow the map unboundedly. At
+/// 128 panes × 256 KiB ring = 32 MiB, which is plenty of
+/// headroom for any legitimate single-user katulong workload
+/// (the 16-pane dims.rs example uses 4 MiB).
+const MAX_PANES: usize = 128;
+
 /// Identifier for a registered subscriber. Monotonically
 /// increasing per-router; overflow is not a practical concern
 /// at single-user scale. Returned from `subscribe` so the
@@ -142,6 +155,13 @@ pub enum SubscribeError {
         active: usize,
         max: usize,
     },
+    /// The router is already tracking `MAX_PANES` distinct
+    /// panes; creating a new entry for this pane would exceed
+    /// the defense-in-depth cap. Fires only for a previously-
+    /// unseen `pane_id`; existing panes still accept new
+    /// subscribers up to the per-pane cap.
+    #[error("router pane capacity reached; cannot register new pane %{pane_id}")]
+    RouterAtCapacity { pane_id: u32 },
 }
 
 /// A decoded output chunk with the byte-offset `seq` at which
@@ -197,20 +217,31 @@ impl OutputRouter {
         SubscriberId(self.next_subscriber_id.fetch_add(1, Ordering::Relaxed))
     }
 
-    /// Subscribe to `pane_id`'s decoded byte stream for a fresh
-    /// attach (no resume). Returns `(receiver, subscriber_id,
-    /// baseline_seq)` so the handler can (a) hand its
-    /// `subscriber_id` to `clear_subscriber` at cleanup, (b)
-    /// echo `baseline_seq` in `Attached.last_seq`.
+    /// Shared subscribe body. Held by the router lock, runs the
+    /// pane-cap + subscriber-cap checks, mints an id, appends a
+    /// subscriber, and reads the ring slice corresponding to
+    /// `after_seq`. Callers that don't want replay pass
+    /// `None` (and get back `ReplaySlice::Fresh`); callers that
+    /// do pass `Some(N)` and match on the slice variants.
     ///
-    /// Fails if the pane already has [`MAX_SUBSCRIBERS_PER_PANE`]
-    /// active subscribers. Returns `SubscribeError::Oversubscribed`;
-    /// caller closes the connection with `session_oversubscribed`.
-    pub fn subscribe(
+    /// Private: callers go through [`OutputRouter::subscribe`] or
+    /// [`OutputRouter::subscribe_with_resume`], which share this
+    /// body. Keeping them as distinct public methods preserves
+    /// the shape of each call at the handler site — fresh attach
+    /// vs reconnect — while the shared body catches any future
+    /// cap-check or channel-setup drift in one place.
+    fn do_subscribe(
         &self,
         pane_id: u32,
-    ) -> Result<(mpsc::Receiver<Arc<OutputChunk>>, SubscriberId, u64), SubscribeError> {
+        after_seq: Option<u64>,
+    ) -> Result<(mpsc::Receiver<Arc<OutputChunk>>, SubscriberId, ReplaySlice), SubscribeError>
+    {
         let mut panes = self.inner.lock().expect("output-router mutex poisoned");
+        // Pane-namespace cap: reject NEW panes once we're at
+        // MAX_PANES. Existing panes still accept subscribers.
+        if !panes.contains_key(&pane_id) && panes.len() >= MAX_PANES {
+            return Err(SubscribeError::RouterAtCapacity { pane_id });
+        }
         let state = panes.entry(pane_id).or_insert_with(PaneState::new);
         if state.subscribers.len() >= MAX_SUBSCRIBERS_PER_PANE {
             return Err(SubscribeError::Oversubscribed {
@@ -221,8 +252,37 @@ impl OutputRouter {
         }
         let (tx, rx) = mpsc::channel(PER_PANE_BUFFER);
         let id = self.mint_id();
+        let replay = match after_seq {
+            Some(n) => state.ring.replay_after(n),
+            None => ReplaySlice::Fresh {
+                end_seq: state.ring.total_written(),
+            },
+        };
         state.subscribers.push(Subscriber { id, sender: tx });
-        Ok((rx, id, state.ring.total_written()))
+        Ok((rx, id, replay))
+    }
+
+    /// Subscribe to `pane_id`'s decoded byte stream for a fresh
+    /// attach (no resume). Returns `(receiver, subscriber_id,
+    /// baseline_seq)` so the handler can (a) hand its
+    /// `subscriber_id` to `clear_subscriber` at cleanup, (b)
+    /// echo `baseline_seq` in `Attached.last_seq`.
+    ///
+    /// Fails if the pane already has [`MAX_SUBSCRIBERS_PER_PANE`]
+    /// active subscribers OR if registering a new pane would
+    /// exceed the router's pane-namespace cap.
+    pub fn subscribe(
+        &self,
+        pane_id: u32,
+    ) -> Result<(mpsc::Receiver<Arc<OutputChunk>>, SubscriberId, u64), SubscribeError> {
+        let (rx, id, replay) = self.do_subscribe(pane_id, None)?;
+        let baseline = match replay {
+            ReplaySlice::Fresh { end_seq } => end_seq,
+            // do_subscribe(None) only ever returns Fresh. The
+            // exhaustive match guards against future refactors.
+            _ => unreachable!("do_subscribe(None) returns ReplaySlice::Fresh"),
+        };
+        Ok((rx, id, baseline))
     }
 
     /// Subscribe AND resume — atomic snapshot + append under
@@ -238,20 +298,7 @@ impl OutputRouter {
         (mpsc::Receiver<Arc<OutputChunk>>, SubscriberId, ReplaySlice),
         SubscribeError,
     > {
-        let mut panes = self.inner.lock().expect("output-router mutex poisoned");
-        let state = panes.entry(pane_id).or_insert_with(PaneState::new);
-        if state.subscribers.len() >= MAX_SUBSCRIBERS_PER_PANE {
-            return Err(SubscribeError::Oversubscribed {
-                pane_id,
-                active: state.subscribers.len(),
-                max: MAX_SUBSCRIBERS_PER_PANE,
-            });
-        }
-        let (tx, rx) = mpsc::channel(PER_PANE_BUFFER);
-        let id = self.mint_id();
-        let replay = state.ring.replay_after(after_seq);
-        state.subscribers.push(Subscriber { id, sender: tx });
-        Ok((rx, id, replay))
+        self.do_subscribe(pane_id, Some(after_seq))
     }
 
     /// Read-only snapshot of what [`OutputRouter::subscribe_with_resume`]
@@ -308,6 +355,28 @@ impl OutputRouter {
             .remove(&pane_id);
     }
 
+    /// Evict EVERY registered pane. Called by the dispatcher
+    /// task when tmux control-mode exits, so every connected
+    /// handler sees its `output_rx` close and wakes to
+    /// `Action::Exit` instead of hanging forever on a
+    /// `recv().await` that will never resolve.
+    ///
+    /// Without this, the handlers' `output_rx` channels would
+    /// stay alive as long as any `OutputRouter` clone holds the
+    /// shared `Arc<Mutex<HashMap>>` (which every handler does
+    /// via `AppState`) — the dispatcher dropping its clone
+    /// doesn't close the per-pane senders stored inside the
+    /// map. Draining the map here drops every `Sender`, which
+    /// closes every `Receiver`.
+    pub fn evict_all(&self) {
+        let mut panes = self.inner.lock().expect("output-router mutex poisoned");
+        let count = panes.len();
+        panes.clear();
+        if count > 0 {
+            tracing::info!(panes = count, "output router evicted all panes");
+        }
+    }
+
     /// Route a raw `%output <pane_id> <data>` notification.
     /// Decodes octal escapes, appends to the pane's ring, and
     /// fans the decoded bytes out to every registered
@@ -320,6 +389,20 @@ impl OutputRouter {
     /// count — `OutputChunk` wraps in `Arc` for the fan-out.
     pub fn dispatch(&self, pane_id: u32, raw: &str) {
         let mut panes = self.inner.lock().expect("output-router mutex poisoned");
+        // Defense-in-depth: don't auto-create a PaneState for a
+        // previously-unseen pane if we're at MAX_PANES. The
+        // notification is dropped silently with a rate-limited
+        // warn; production tmux never emits pane_ids we haven't
+        // already registered via subscribe, so this branch
+        // firing is a parser-bug signal.
+        if !panes.contains_key(&pane_id) && panes.len() >= MAX_PANES {
+            tracing::warn!(
+                pane_id,
+                panes = panes.len(),
+                "dropping %output for unseen pane — router at MAX_PANES"
+            );
+            return;
+        }
         let state = panes.entry(pane_id).or_insert_with(PaneState::new);
         let decoded = state.decoder.decode(raw);
         if decoded.is_empty() {
@@ -355,6 +438,17 @@ impl OutputRouter {
     }
 
     /// Spawn the dispatcher task. See module doc.
+    ///
+    /// When the task exits (either tmux's `%exit` notification
+    /// or the notification sender being dropped), it calls
+    /// [`OutputRouter::evict_all`] so every attached handler
+    /// sees its `output_rx` close and wakes to a clean
+    /// `Action::Exit`. Without this, the per-pane senders would
+    /// stay alive as long as any handler held an `OutputRouter`
+    /// clone via `AppState` — handlers would freeze on
+    /// `output_rx.recv()` waiting for bytes that will never
+    /// arrive. A correctness reviewer called this out as a HIGH
+    /// bug on the first round of slice 9h; this is the fix.
     pub fn spawn_dispatcher(
         &self,
         mut notifs: mpsc::UnboundedReceiver<Notification>,
@@ -375,6 +469,9 @@ impl OutputRouter {
                     }
                 }
             }
+            // Dispatcher ending — propagate the shutdown signal
+            // to every attached handler by evicting every pane.
+            router.evict_all();
         })
     }
 
@@ -667,6 +764,9 @@ mod tests {
                 assert_eq!(active, MAX_SUBSCRIBERS_PER_PANE);
                 assert_eq!(max, MAX_SUBSCRIBERS_PER_PANE);
             }
+            SubscribeError::RouterAtCapacity { .. } => {
+                panic!("per-pane cap should hit before router-namespace cap in this test")
+            }
         }
         // The cap must not invalidate existing subscriptions.
         assert_eq!(r.subscriber_count(0), MAX_SUBSCRIBERS_PER_PANE);
@@ -758,5 +858,107 @@ mod tests {
         let handle = r.spawn_dispatcher(notifs);
         drop(tx);
         handle.await.expect("dispatcher exits on sender drop");
+    }
+
+    // ---------- Shutdown propagation (slice 9h round-1) ----------
+
+    #[tokio::test]
+    async fn evict_all_closes_every_subscriber_receiver() {
+        // Core claim: after evict_all, every attached handler's
+        // receiver sees its channel close on the next recv.
+        // This is the fix for the "tmux exits, handlers hang"
+        // bug — without evict_all, dispatcher dropping its
+        // clone leaves per-pane senders alive in the shared
+        // Arc<Mutex<HashMap>>.
+        let r = OutputRouter::new();
+        let (mut a, _ida, _) = r.subscribe(0).unwrap();
+        let (mut b, _idb, _) = r.subscribe(1).unwrap();
+        let (mut c, _idc, _) = r.subscribe(0).unwrap();
+
+        r.evict_all();
+        assert!(a.recv().await.is_none(), "a closed");
+        assert!(b.recv().await.is_none(), "b closed");
+        assert!(c.recv().await.is_none(), "c on shared pane closed");
+        assert_eq!(r.registered_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn dispatcher_on_notifs_close_triggers_evict_all() {
+        // End-to-end: subscribe → start dispatcher → tmux exit
+        // → subscriber sees None. Proves the wiring between
+        // spawn_dispatcher's shutdown path and evict_all.
+        let r = OutputRouter::new();
+        let (mut rx, _id, _) = r.subscribe(0).unwrap();
+        let (tx, notifs) = mpsc::unbounded_channel::<Notification>();
+        let handle = r.spawn_dispatcher(notifs);
+        tx.send(Notification::Exit {
+            reason: Some("tmux died".into()),
+        })
+        .unwrap();
+        handle.await.unwrap();
+        assert!(
+            rx.recv().await.is_none(),
+            "subscriber's recv must yield None after dispatcher-driven evict_all"
+        );
+    }
+
+    #[tokio::test]
+    async fn router_rejects_subscribe_at_max_panes() {
+        // Defense-in-depth: a fresh pane cannot register once
+        // MAX_PANES is reached. Existing panes still accept
+        // new subscribers.
+        let r = OutputRouter::new();
+        // Fill the router with MAX_PANES distinct panes.
+        let mut keep = Vec::new();
+        for pane_id in 0..(MAX_PANES as u32) {
+            let (rx, _id, _) = r.subscribe(pane_id).unwrap();
+            keep.push(rx);
+        }
+        // A new pane_id beyond the cap is rejected.
+        let err = r.subscribe(MAX_PANES as u32).unwrap_err();
+        assert!(matches!(err, SubscribeError::RouterAtCapacity { .. }));
+        // Existing panes still work.
+        let (_rx, _id, _) = r
+            .subscribe(0)
+            .expect("existing panes still accept subscribers past MAX_PANES");
+    }
+
+    #[tokio::test]
+    async fn dispatch_drops_unseen_panes_at_max_panes() {
+        // Parser-bug / phantom-pane injection: dispatch for an
+        // unseen pane_id must NOT grow the map past MAX_PANES.
+        let r = OutputRouter::new();
+        let mut keep = Vec::new();
+        for pane_id in 0..(MAX_PANES as u32) {
+            let (rx, _id, _) = r.subscribe(pane_id).unwrap();
+            keep.push(rx);
+        }
+        let before = r.registered_count();
+        r.dispatch(MAX_PANES as u32 + 500, "phantom");
+        assert_eq!(
+            r.registered_count(),
+            before,
+            "dispatch must not create a new pane past MAX_PANES"
+        );
+    }
+
+    // ---------- Subscribe-body dedup canary ----------
+
+    #[tokio::test]
+    async fn subscribe_fresh_and_resume_share_cap_logic() {
+        // Round-1 dedup: both public methods now delegate to
+        // do_subscribe and enforce the same pane-namespace cap.
+        // This test holds the contract.
+        let r = OutputRouter::new();
+        let mut keep = Vec::new();
+        for pane_id in 0..(MAX_PANES as u32) {
+            let (rx, _id, _) = r.subscribe(pane_id).unwrap();
+            keep.push(rx);
+        }
+        // Resume path also rejects a new pane past the cap.
+        let err = r
+            .subscribe_with_resume(MAX_PANES as u32, 0)
+            .unwrap_err();
+        assert!(matches!(err, SubscribeError::RouterAtCapacity { .. }));
     }
 }


### PR DESCRIPTION
## Summary

Multi-device UX arrives: a phone + laptop (or multiple browser tabs) can now attach to the same session simultaneously and each device sees the full live byte stream. Previously the second `Attach` to a pane displaced the first; slice 9h lifts that restriction.

- **`PaneState.subscribers: Vec<Subscriber>`** — up to `MAX_SUBSCRIBERS_PER_PANE = 16` concurrent subscribers per pane.
- **`subscribe` returns `(Receiver, SubscriberId, u64)`** — monotonic subscriber id minted by the router; handler uses it at cleanup to remove only its own sender.
- **`Arc<OutputChunk>` on the wire** — one allocation per dispatch, fan-out is `Arc::clone` per subscriber. `dispatch` uses `Vec::retain` to prune closed senders during fan-out.
- **New `error_code::SESSION_OVERSUBSCRIBED`** — emitted when the cap is hit; the reject path is fully read-only (no existing subscriber is touched).
- **Explicit design decisions** documented in the router module doc:
  - Input is tmux-serialised (both devices' keystrokes serialise at tmux's stdin).
  - Resize is last-writer-wins (PTY-structural limit per `CLAUDE.md`).
  - Backpressure is per-subscriber (one slow device doesn't stall siblings).

## Scar alignment

- Node scar on displace-vs-fanout decisions: Node's Session had per-client attach; our router's single-subscriber interim (slice 9f) matched the earliest Node shape; 9h's fan-out is the long-term model.
- `CLAUDE.md` "Multi-device terminal dimensions" lesson: NO attempt to reconcile different sizes at this layer. Documented inline.

## What this DOESN'T change

- Input forwarding — unchanged; each handler forwards independently.
- Resize semantics — unchanged; last write wins on tmux's one-size-per-pane.
- Ring buffer + resume — unchanged; works exactly the same, now with siblings watching the same stream.

## Test plan

- [x] `cargo test --workspace` — 155 server tests passing (up from 151), 1 ignored (pre-existing `tmux_roundtrip`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] Pre-push Node test suite passed.

### New multi-device tests

- `two_subscribers_both_receive_the_same_bytes`
- `dropped_subscriber_does_not_affect_siblings` (retain-prune canary)
- `clear_subscriber_removes_only_named_subscriber`
- `over_cap_subscribe_is_rejected`
- `over_cap_rejection_does_not_create_pane_allocation_without_room`
- `subscriber_ids_are_unique_across_panes`
- `resume_after_displacement_picks_up_from_siblings_seq` — the interesting integration: device A drops, B keeps receiving, A reconnects with resume_from_seq and gets exactly what it missed while siblings were flowing.

## Not in scope (deferred)

- Pane eviction on tmux-pane-close (needs window-id → pane-id mapping; separate slice).
- Ring-clone-under-lock optimization (sub-millisecond in practice).
- Session-creation rate cap (pre-existing hardening concern).
- Per-device window sizes (structural PTY limit).