### PR TITLE
rewrite(server): slice 9i — pane eviction on tmux window-close

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -48,7 +48,7 @@ async fn main() {
     // the method and enforced by `dispatch`'s `try_send` path.
     // Letting the tokio runtime abort the task on process exit
     // is fine; we ignore the `JoinHandle`.
-    let _dispatcher = output_router.spawn_dispatcher(notifs);
+    let _dispatcher = output_router.spawn_dispatcher(notifs, sessions.clone());
 
     let state = AppState::new(auth_store, webauthn, config)
         .with_sessions(sessions)

--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -1107,10 +1107,13 @@ fn classify_session_error(err: &crate::session::SessionError) -> (&'static str, 
             error_code::INVALID_SESSION,
             "invalid session name".into(),
         ),
-        SessionError::TmuxRejected(_) | SessionError::Tmux(_) => (
+        SessionError::TmuxRejected(_)
+        | SessionError::MalformedReply(_)
+        | SessionError::Tmux(_) => (
             error_code::SESSION_ERROR,
             // Do NOT embed raw tmux output in the client message.
             // The `SessionManager` doc calls this out explicitly
+            // for both `TmuxRejected` and `MalformedReply`
             // (socket paths, other session names, internal
             // diagnostics). A generic client-facing string is
             // enough; operators have the tracing field.

--- a/crates/server/src/session/manager.rs
+++ b/crates/server/src/session/manager.rs
@@ -22,7 +22,9 @@
 //! onto the subprocess's stdin. There's no in-memory cache to race.
 
 use super::dims::{clamp_dims, DEFAULT_COLS, DEFAULT_ROWS};
+use super::router::OutputRouter;
 use super::tmux::{Tmux, TmuxError};
+use std::collections::HashSet;
 
 /// Public handle to the session layer. Construct with `new` at
 /// server startup; clone into every handler that needs to touch
@@ -161,26 +163,26 @@ impl SessionManager {
 
     /// Look up the default pane id for `session`. Returns the
     /// numeric pane id (tmux's `%N` with the `%` stripped) that
-    /// the output router keys off. For a session freshly created
-    /// by `create_session`, the first `list-panes` result IS the
-    /// default pane, because tmux creates the session with a
-    /// single window hosting a single pane.
+    /// the output router keys off.
     ///
-    /// **Single-pane assumption, load-bearing for slice 9f.**
-    /// This function calls `list-panes -t <session> -F
-    /// '#{pane_id}'` and takes the FIRST line of output as the
-    /// canonical pane. That's correct for a freshly-created
-    /// session with one pane, and for reconnects to an existing
-    /// single-pane session. It is SILENTLY WRONG if a user has
-    /// run `split-window` or `new-window` — the first pane tmux
-    /// lists is not necessarily the one the user is typing in.
-    /// Slice 9h is the right place to decide the product
-    /// semantics here (follow active pane? let the client pick?
-    /// expose multiple pane streams?); until then, multi-pane
-    /// tmux sessions under katulong will show output from the
-    /// wrong pane. If this is ever surfaced to the UI it should
-    /// be a conscious choice, not an accidental artifact of
-    /// `lines().next()`.
+    /// # Product invariant: one pane per tile, always
+    ///
+    /// Katulong's tile model is 1:1:1:1 — one tile = one tmux
+    /// session = one tmux window = one tmux pane. Splits inside
+    /// a tile are not a feature; the tile manager handles
+    /// side-by-side layout by composing independent tiles, each
+    /// with its own tmux session. A user who runs `split-window`
+    /// or `new-window` from inside their katulong shell creates
+    /// panes tmux can see but the router doesn't — those panes
+    /// receive no I/O from katulong.
+    ///
+    /// So "the default pane" is just "the one pane this session
+    /// has." We run `list-panes -t <session> -F '#{pane_id}'`
+    /// and take the first line because under the invariant
+    /// there's only one line. If tmux ever reports multiple,
+    /// that's a bug state (e.g., a user-run `split-window`);
+    /// handling it is out of scope — the katulong UX should
+    /// prevent or reset that state, not patch around it here.
     pub async fn query_default_pane(&self, session: &str) -> Result<u32, SessionError> {
         validate_session_name(session)?;
         let cmd = format!("list-panes -t {session} -F '#{{pane_id}}'");
@@ -239,6 +241,62 @@ impl SessionManager {
         Ok(())
     }
 
+    /// Query tmux for the set of currently-live pane ids across
+    /// every session it hosts. Runs `list-panes -a -F '#{pane_id}'`
+    /// and parses the `%N` replies into a `HashSet<u32>`.
+    ///
+    /// Slice 9i uses this to reconcile the output router against
+    /// tmux's view of reality. Tmux doesn't emit a per-pane close
+    /// notification — only `%window-close @N` — and from window-
+    /// id alone the router can't tell which panes were in that
+    /// window. Re-querying the live set sidesteps the mapping
+    /// problem: anything the router has that tmux no longer
+    /// reports is a zombie.
+    pub async fn list_live_panes(&self) -> Result<HashSet<u32>, SessionError> {
+        let reply = self
+            .tmux
+            .send_command("list-panes -a -F '#{pane_id}'")
+            .await?;
+        if !reply.ok {
+            return Err(SessionError::TmuxRejected(reply.output));
+        }
+        parse_pane_id_list(&reply.output)
+    }
+
+    /// Reconcile `router` against tmux's current set of live
+    /// panes. Any pane registered on the router that tmux no
+    /// longer reports gets evicted — its ring dropped, its
+    /// subscribers' receivers closed, its handlers woken to
+    /// `Action::Exit`. Returns the number of panes evicted.
+    ///
+    /// **Eviction driver (slice 9i).** The dispatcher calls this
+    /// on `%window-close` / `%unlinked-window-close`
+    /// notifications. Tmux emits window-level closures only
+    /// (there's no `%pane-close`), so the pane→window mapping
+    /// is reconstructed by querying tmux rather than tracked
+    /// in Rust memory — consistent with the SessionManager's
+    /// stateless design ("tmux is the source of truth").
+    ///
+    /// Fire-and-forget semantics from the dispatcher: on Err we
+    /// log and move on. The next window-close event will try
+    /// again; the router's `MAX_PANES` cap bounds the memory
+    /// cost of any individual stale entry in the meantime.
+    pub async fn reconcile_router(
+        &self,
+        router: &OutputRouter,
+    ) -> Result<usize, SessionError> {
+        let live = self.list_live_panes().await?;
+        let evicted = router.retain_panes(&live);
+        if evicted > 0 {
+            tracing::info!(
+                evicted,
+                live_panes = live.len(),
+                "reconciled output router against tmux live panes"
+            );
+        }
+        Ok(evicted)
+    }
+
     /// Default dimensions the session manager uses for new sessions
     /// when the client hasn't reported a real window size yet.
     pub fn default_dims() -> (u16, u16) {
@@ -291,6 +349,31 @@ const MAX_SESSION_NAME_LEN: usize = 64;
 ///
 /// **Length cap.** Names over `MAX_SESSION_NAME_LEN` bytes fail
 /// validation — see the constant's doc for the rationale.
+/// Parse a `%N\n%M\n...` block (tmux's `list-panes -F '#{pane_id}'`
+/// output shape) into a set of numeric pane ids. Blank lines are
+/// tolerated (trailing newline); anything else that doesn't start
+/// with `%` or fails to parse as u32 is rejected with
+/// `SessionError::TmuxRejected` — we don't silently skip
+/// malformed lines because that could mask a parser bug that
+/// leaves the router out of sync with tmux.
+fn parse_pane_id_list(raw: &str) -> Result<HashSet<u32>, SessionError> {
+    let mut out = HashSet::new();
+    for line in raw.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let rest = line.strip_prefix('%').ok_or_else(|| {
+            SessionError::TmuxRejected(format!("unexpected pane-id reply: {line:?}"))
+        })?;
+        let id = rest.parse::<u32>().map_err(|_| {
+            SessionError::TmuxRejected(format!("invalid pane-id in reply: {line:?}"))
+        })?;
+        out.insert(id);
+    }
+    Ok(out)
+}
+
 fn validate_session_name(name: &str) -> Result<(), SessionError> {
     if name.is_empty() || name.starts_with('-') || name.len() > MAX_SESSION_NAME_LEN {
         return Err(SessionError::InvalidName(name.to_string()));
@@ -380,4 +463,69 @@ mod tests {
             (DEFAULT_COLS, DEFAULT_ROWS)
         );
     }
+
+    // ---------- parse_pane_id_list (slice 9i) ----------
+
+    #[test]
+    fn parse_pane_id_list_accepts_single_line() {
+        let got = parse_pane_id_list("%3").unwrap();
+        assert_eq!(got, [3].into_iter().collect());
+    }
+
+    #[test]
+    fn parse_pane_id_list_accepts_multi_line() {
+        let got = parse_pane_id_list("%1\n%5\n%42").unwrap();
+        assert_eq!(got, [1, 5, 42].into_iter().collect());
+    }
+
+    #[test]
+    fn parse_pane_id_list_tolerates_trailing_newline() {
+        // tmux replies typically end with a newline. Skipping
+        // empty lines prevents a spurious TmuxRejected on that.
+        let got = parse_pane_id_list("%7\n").unwrap();
+        assert_eq!(got, [7].into_iter().collect());
+    }
+
+    #[test]
+    fn parse_pane_id_list_deduplicates() {
+        // tmux shouldn't emit duplicates, but HashSet dedup means
+        // we don't have to think about it.
+        let got = parse_pane_id_list("%1\n%1\n%2").unwrap();
+        assert_eq!(got, [1, 2].into_iter().collect());
+    }
+
+    #[test]
+    fn parse_pane_id_list_empty_input_is_empty_set() {
+        // If tmux reports no panes (server restart, all sessions
+        // dead mid-reconcile), retain_panes(&empty) evicts every
+        // zombie — exactly what we want.
+        assert!(parse_pane_id_list("").unwrap().is_empty());
+        assert!(parse_pane_id_list("\n").unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_pane_id_list_rejects_missing_percent_prefix() {
+        // Don't silently skip malformed lines — that could mask a
+        // parser bug that leaves zombies in the router.
+        let err = parse_pane_id_list("3\n%5").unwrap_err();
+        assert!(matches!(err, SessionError::TmuxRejected(_)));
+    }
+
+    #[test]
+    fn parse_pane_id_list_rejects_non_numeric_id() {
+        let err = parse_pane_id_list("%abc").unwrap_err();
+        assert!(matches!(err, SessionError::TmuxRejected(_)));
+    }
+
+    // Live-tmux integration coverage is deferred: `Tmux::spawn`
+    // uses `tmux -C new-session -d` which exits the CM client
+    // immediately after creating the session (empirically
+    // reproduced on tmux 3.6a — see the existing
+    // `tmux_roundtrip` ignored test with the same limitation).
+    // Wiring an `attach -t` style CM that stays alive is a
+    // separate, broader concern; the unit coverage here
+    // (`retain_panes`, `parse_pane_id_list`, dispatcher-wiring
+    // tests in router.rs) exercises every decision slice 9i
+    // makes. An end-to-end test lands when the tmux spawn
+    // lifetime issue is fixed in its own slice.
 }

--- a/crates/server/src/session/manager.rs
+++ b/crates/server/src/session/manager.rs
@@ -285,6 +285,17 @@ impl SessionManager {
         &self,
         router: &OutputRouter,
     ) -> Result<usize, SessionError> {
+        // TOCTOU note: `list_live_panes` is an async tmux round-
+        // trip; `retain_panes` runs later under the router lock.
+        // A handler that calls `router.subscribe(P)` for a pane P
+        // created between the query and the retain will see its
+        // subscriber evicted immediately if P wasn't in `live`.
+        // The subscriber's `output_rx` closes and the handler
+        // wakes to `Action::Exit`; the client reconnects and the
+        // pane is alive on the reconnect path. At katulong scale
+        // (one or a few concurrent connections) the window is
+        // narrow and the failure is self-healing — the pane is
+        // still live in tmux, so the reconnect succeeds cleanly.
         let live = self.list_live_panes().await?;
         let evicted = router.retain_panes(&live);
         if evicted > 0 {
@@ -306,18 +317,32 @@ impl SessionManager {
 
 /// Errors returned by `SessionManager` operations.
 ///
-/// **HTTP caller obligation.** `TmuxRejected` wraps tmux's raw
-/// stderr/stdout output. Do NOT forward that to an HTTP response
-/// body — it may contain socket paths, other session names, or
-/// internal tmux details. Log the content server-side and render
-/// a generic "session operation failed" to the client. Same shape
-/// as the `AuthError::Io` obligation from slice 1+2.
+/// **HTTP caller obligation.** `TmuxRejected` and `MalformedReply`
+/// both wrap raw tmux output. Do NOT forward either to an HTTP
+/// response body — they may contain socket paths, other session
+/// names, or internal tmux details. Log the content server-side
+/// and render a generic "session operation failed" to the
+/// client. Same shape as the `AuthError::Io` obligation from
+/// slice 1+2.
 #[derive(Debug, thiserror::Error)]
 pub enum SessionError {
     #[error("invalid session name: {0:?}")]
     InvalidName(String),
+    /// tmux acknowledged the command but reported an error
+    /// (`%error` or `reply.ok == false`). Wraps the stderr/stdout
+    /// payload. This is the "tmux said no" path.
     #[error("tmux rejected command: {0}")]
     TmuxRejected(String),
+    /// tmux acknowledged the command successfully but the reply
+    /// payload didn't match the format we asked for (e.g., a
+    /// line in `list-panes -F '#{pane_id}'` output that's not a
+    /// `%N` value). Distinct from `TmuxRejected` so callers and
+    /// log scanners can tell "tmux said no" apart from "we
+    /// couldn't parse tmux's answer." The latter usually
+    /// indicates a tmux version or locale change on the host —
+    /// actionable differently from a command rejection.
+    #[error("tmux reply did not match expected format: {0}")]
+    MalformedReply(String),
     #[error("tmux error: {0}")]
     Tmux(#[from] TmuxError),
 }
@@ -349,31 +374,6 @@ const MAX_SESSION_NAME_LEN: usize = 64;
 ///
 /// **Length cap.** Names over `MAX_SESSION_NAME_LEN` bytes fail
 /// validation — see the constant's doc for the rationale.
-/// Parse a `%N\n%M\n...` block (tmux's `list-panes -F '#{pane_id}'`
-/// output shape) into a set of numeric pane ids. Blank lines are
-/// tolerated (trailing newline); anything else that doesn't start
-/// with `%` or fails to parse as u32 is rejected with
-/// `SessionError::TmuxRejected` — we don't silently skip
-/// malformed lines because that could mask a parser bug that
-/// leaves the router out of sync with tmux.
-fn parse_pane_id_list(raw: &str) -> Result<HashSet<u32>, SessionError> {
-    let mut out = HashSet::new();
-    for line in raw.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let rest = line.strip_prefix('%').ok_or_else(|| {
-            SessionError::TmuxRejected(format!("unexpected pane-id reply: {line:?}"))
-        })?;
-        let id = rest.parse::<u32>().map_err(|_| {
-            SessionError::TmuxRejected(format!("invalid pane-id in reply: {line:?}"))
-        })?;
-        out.insert(id);
-    }
-    Ok(out)
-}
-
 fn validate_session_name(name: &str) -> Result<(), SessionError> {
     if name.is_empty() || name.starts_with('-') || name.len() > MAX_SESSION_NAME_LEN {
         return Err(SessionError::InvalidName(name.to_string()));
@@ -385,6 +385,37 @@ fn validate_session_name(name: &str) -> Result<(), SessionError> {
         }
     }
     Ok(())
+}
+
+/// Parse a `%N\n%M\n...` block (tmux's `list-panes -F '#{pane_id}'`
+/// output shape) into a set of numeric pane ids. Blank lines are
+/// tolerated (trailing newline). Anything else that doesn't start
+/// with `%` or fails to parse as u32 is rejected with
+/// `SessionError::MalformedReply` — the command succeeded, but the
+/// reply shape is wrong. Distinct from `TmuxRejected` (which means
+/// tmux said no to the command itself).
+///
+/// We don't silently skip malformed lines because that could mask
+/// a parser bug that leaves the router out of sync with tmux.
+/// The hard-fail blast radius is one reconcile pass skipped: the
+/// next `%window-close` / `%sessions-changed` event re-runs the
+/// reconcile, and `MAX_PANES` bounds the interim memory cost.
+fn parse_pane_id_list(raw: &str) -> Result<HashSet<u32>, SessionError> {
+    let mut out = HashSet::new();
+    for line in raw.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let rest = line.strip_prefix('%').ok_or_else(|| {
+            SessionError::MalformedReply(format!("expected %N pane-id, got: {line:?}"))
+        })?;
+        let id = rest.parse::<u32>().map_err(|_| {
+            SessionError::MalformedReply(format!("pane-id not numeric: {line:?}"))
+        })?;
+        out.insert(id);
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -464,7 +495,7 @@ mod tests {
         );
     }
 
-    // ---------- parse_pane_id_list (slice 9i) ----------
+    // ---------- pane-id list parser ----------
 
     #[test]
     fn parse_pane_id_list_accepts_single_line() {
@@ -506,15 +537,21 @@ mod tests {
     #[test]
     fn parse_pane_id_list_rejects_missing_percent_prefix() {
         // Don't silently skip malformed lines — that could mask a
-        // parser bug that leaves zombies in the router.
+        // parser bug that leaves zombies in the router. Distinct
+        // variant from TmuxRejected so log scanners can tell
+        // "tmux said no" apart from "we failed to parse tmux's
+        // reply."
         let err = parse_pane_id_list("3\n%5").unwrap_err();
-        assert!(matches!(err, SessionError::TmuxRejected(_)));
+        assert!(
+            matches!(err, SessionError::MalformedReply(_)),
+            "malformed reply must be MalformedReply, not TmuxRejected: {err:?}"
+        );
     }
 
     #[test]
     fn parse_pane_id_list_rejects_non_numeric_id() {
         let err = parse_pane_id_list("%abc").unwrap_err();
-        assert!(matches!(err, SessionError::TmuxRejected(_)));
+        assert!(matches!(err, SessionError::MalformedReply(_)));
     }
 
     // Live-tmux integration coverage is deferred: `Tmux::spawn`

--- a/crates/server/src/session/router.rs
+++ b/crates/server/src/session/router.rs
@@ -524,19 +524,32 @@ impl OutputRouter {
                         // path. Reconcile is idempotent, so a
                         // cascade of events (close → sessions-
                         // changed) just does the same work twice.
+                        //
+                        // Known debt: each event fires its own
+                        // `tokio::spawn`. Under a pathological
+                        // event storm (e.g., a user-run script
+                        // opening + closing many sessions in a
+                        // tight loop), this produces one spawn
+                        // per event with no coalescing. Future
+                        // fix: a single-buffer `tokio::sync::Notify`
+                        // drained by a dedicated worker task.
+                        // Acceptable for single-user scale since
+                        // each task is a lightweight tmux round-
+                        // trip and idempotent under concurrency.
+                        //
+                        // Logging: `reconcile_router` owns the
+                        // success info! (it has access to the
+                        // `live_panes` count). We only log failures
+                        // here — the failure message names this
+                        // notification arm as context.
                         let sessions = sessions.clone();
                         let router = router.clone();
                         tokio::spawn(async move {
-                            match sessions.reconcile_router(&router).await {
-                                Ok(0) => {}
-                                Ok(n) => tracing::info!(
-                                    evicted = n,
-                                    "reconciled router after tmux lifecycle event"
-                                ),
-                                Err(e) => tracing::warn!(
+                            if let Err(e) = sessions.reconcile_router(&router).await {
+                                tracing::warn!(
                                     error = %e,
                                     "reconcile_router failed; next event will retry"
-                                ),
+                                );
                             }
                         });
                     }
@@ -584,7 +597,7 @@ mod tests {
         SessionManager::new(Tmux::dead_for_tests())
     }
 
-    // ---------- Single-subscriber parity (carried forward from 9g) ----------
+    // ---------- Single-subscriber core behaviour ----------
 
     #[tokio::test]
     async fn subscribe_returns_zero_seq_on_empty_pane() {
@@ -775,7 +788,7 @@ mod tests {
         assert_eq!(r.peek_resume(42, 100), ReplaySlice::Future);
     }
 
-    // ---------- Multi-device fan-out (slice 9h) ----------
+    // ---------- Multi-device fan-out ----------
 
     #[tokio::test]
     async fn two_subscribers_both_receive_the_same_bytes() {
@@ -948,7 +961,7 @@ mod tests {
         handle.await.expect("dispatcher exits on sender drop");
     }
 
-    // ---------- Shutdown propagation (slice 9h round-1) ----------
+    // ---------- Dispatcher-exit shutdown propagation ----------
 
     #[tokio::test]
     async fn evict_all_closes_every_subscriber_receiver() {
@@ -990,7 +1003,7 @@ mod tests {
         );
     }
 
-    // ---------- Retain-panes / reconcile (slice 9i) ----------
+    // ---------- Pane eviction / reconcile ----------
 
     #[tokio::test]
     async fn retain_panes_evicts_panes_not_in_keep_set() {

--- a/crates/server/src/session/router.rs
+++ b/crates/server/src/session/router.rs
@@ -87,7 +87,7 @@
 use crate::session::output::OctalDecoder;
 use crate::session::parser::Notification;
 use crate::session::ring::{ReplaySlice, RingBuffer};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
@@ -345,8 +345,10 @@ impl OutputRouter {
     /// Explicitly remove a pane's entry, wiping ring + decoder
     /// plus all subscribers. Call when the underlying tmux pane
     /// is known to be gone (e.g., session destroyed), not for
-    /// transport disconnects. Slice 9h+ will wire this to
-    /// tmux-pane-close notifications.
+    /// transport disconnects. Slice 9i reaches this path via
+    /// [`OutputRouter::retain_panes`] driven by
+    /// `SessionManager::reconcile_router` on tmux
+    /// `%window-close` / `%unlinked-window-close` notifications.
     pub fn evict(&self, pane_id: u32) {
         let _ = self
             .inner
@@ -375,6 +377,29 @@ impl OutputRouter {
         if count > 0 {
             tracing::info!(panes = count, "output router evicted all panes");
         }
+    }
+
+    /// Retain only the panes whose id is in `keep`; evict the
+    /// rest. Returns how many panes were evicted so the caller
+    /// can log a single summary line per reconcile pass.
+    ///
+    /// Intended caller: `SessionManager::reconcile_router`, which
+    /// queries tmux for the current set of live pane ids and
+    /// hands that set here. Any router-registered pane that tmux
+    /// no longer reports is a zombie (its underlying window
+    /// closed) and its ring is safe to drop.
+    ///
+    /// Eviction is the same drop-all-subscribers +
+    /// drop-ring-and-decoder path as [`OutputRouter::evict`]:
+    /// every subscriber's receiver closes on its next `recv()`,
+    /// and their handlers exit via `Action::Exit`. Safe to call
+    /// with a `keep` set that contains pane ids the router never
+    /// registered — extras are ignored.
+    pub fn retain_panes(&self, keep: &HashSet<u32>) -> usize {
+        let mut panes = self.inner.lock().expect("output-router mutex poisoned");
+        let before = panes.len();
+        panes.retain(|pane_id, _| keep.contains(pane_id));
+        before - panes.len()
     }
 
     /// Route a raw `%output <pane_id> <data>` notification.
@@ -449,9 +474,27 @@ impl OutputRouter {
     /// `output_rx.recv()` waiting for bytes that will never
     /// arrive. A correctness reviewer called this out as a HIGH
     /// bug on the first round of slice 9h; this is the fix.
+    ///
+    /// # Slice 9i: reconcile on window-close
+    ///
+    /// On `%window-close` / `%unlinked-window-close`, the
+    /// dispatcher fires off `sessions.reconcile_router(&router)`
+    /// as a detached tokio task. The reconcile queries tmux for
+    /// its current set of live pane ids and evicts any router-
+    /// registered pane tmux no longer reports — closing the
+    /// long-running-server ring leak path.
+    ///
+    /// Fire-and-forget is deliberate: reconcile makes a tmux
+    /// round-trip, and blocking the notification loop on it
+    /// would back-pressure `%output` events behind cleanup
+    /// work. A failed reconcile logs and moves on; the next
+    /// close event will try again. Multiple reconciles
+    /// queueing up is self-compensating — each one is
+    /// idempotent (it sets the keep-set, doesn't append to it).
     pub fn spawn_dispatcher(
         &self,
         mut notifs: mpsc::UnboundedReceiver<Notification>,
+        sessions: crate::session::SessionManager,
     ) -> JoinHandle<()> {
         let router = self.clone();
         tokio::spawn(async move {
@@ -463,6 +506,39 @@ impl OutputRouter {
                     Notification::Exit { reason } => {
                         tracing::warn!(?reason, "tmux control-mode exited");
                         break;
+                    }
+                    Notification::WindowClose { .. }
+                    | Notification::UnlinkedWindowClose { .. }
+                    | Notification::SessionsChanged => {
+                        // Any of these can signal that a pane the
+                        // router is tracking has gone away. We
+                        // don't trust the specific event — some
+                        // versions of tmux prefer one code path
+                        // over another depending on whether the
+                        // CM client was attached to the dying
+                        // session. SessionsChanged fires on every
+                        // session add/remove and is the most
+                        // reliable "something changed, re-check"
+                        // signal; window-close variants are
+                        // kept for faster reaction on the hot
+                        // path. Reconcile is idempotent, so a
+                        // cascade of events (close → sessions-
+                        // changed) just does the same work twice.
+                        let sessions = sessions.clone();
+                        let router = router.clone();
+                        tokio::spawn(async move {
+                            match sessions.reconcile_router(&router).await {
+                                Ok(0) => {}
+                                Ok(n) => tracing::info!(
+                                    evicted = n,
+                                    "reconciled router after tmux lifecycle event"
+                                ),
+                                Err(e) => tracing::warn!(
+                                    error = %e,
+                                    "reconcile_router failed; next event will retry"
+                                ),
+                            }
+                        });
                     }
                     other => {
                         tracing::trace!(?other, "tmux notification (no consumer yet)");
@@ -495,6 +571,18 @@ impl OutputRouter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::{SessionManager, Tmux};
+
+    /// A `SessionManager` backed by a dead Tmux channel. Calls
+    /// to `reconcile_router` will fail with `TmuxError::Disconnected`
+    /// — which is exactly what we want for tests that exercise
+    /// the dispatcher's notification loop without pulling in a
+    /// real tmux subprocess. The dispatcher's fire-and-forget
+    /// reconcile path logs the error and moves on, so these
+    /// tests still observe the loop's behavior correctly.
+    fn dead_sessions() -> SessionManager {
+        SessionManager::new(Tmux::dead_for_tests())
+    }
 
     // ---------- Single-subscriber parity (carried forward from 9g) ----------
 
@@ -834,7 +922,7 @@ mod tests {
         let r = OutputRouter::new();
         let (mut rx, _id, _) = r.subscribe(3).unwrap();
         let (tx, notifs) = mpsc::unbounded_channel::<Notification>();
-        let handle = r.spawn_dispatcher(notifs);
+        let handle = r.spawn_dispatcher(notifs, dead_sessions());
 
         tx.send(Notification::Output {
             pane_id: 3,
@@ -855,7 +943,7 @@ mod tests {
     async fn spawn_dispatcher_exits_when_notifs_closes() {
         let r = OutputRouter::new();
         let (tx, notifs) = mpsc::unbounded_channel::<Notification>();
-        let handle = r.spawn_dispatcher(notifs);
+        let handle = r.spawn_dispatcher(notifs, dead_sessions());
         drop(tx);
         handle.await.expect("dispatcher exits on sender drop");
     }
@@ -890,7 +978,7 @@ mod tests {
         let r = OutputRouter::new();
         let (mut rx, _id, _) = r.subscribe(0).unwrap();
         let (tx, notifs) = mpsc::unbounded_channel::<Notification>();
-        let handle = r.spawn_dispatcher(notifs);
+        let handle = r.spawn_dispatcher(notifs, dead_sessions());
         tx.send(Notification::Exit {
             reason: Some("tmux died".into()),
         })
@@ -900,6 +988,162 @@ mod tests {
             rx.recv().await.is_none(),
             "subscriber's recv must yield None after dispatcher-driven evict_all"
         );
+    }
+
+    // ---------- Retain-panes / reconcile (slice 9i) ----------
+
+    #[tokio::test]
+    async fn retain_panes_evicts_panes_not_in_keep_set() {
+        // Core claim: panes absent from `keep` are evicted
+        // (subscribers' recv yields None), panes present stay
+        // live. This is the mechanism SessionManager uses on
+        // %window-close to prune zombie panes against tmux's
+        // current set of live panes.
+        let r = OutputRouter::new();
+        let (mut live, _id_l, _) = r.subscribe(1).unwrap();
+        let (mut zombie, _id_z, _) = r.subscribe(2).unwrap();
+        let keep: HashSet<u32> = [1].into_iter().collect();
+
+        let evicted = r.retain_panes(&keep);
+        assert_eq!(evicted, 1);
+        assert_eq!(r.registered_count(), 1);
+        assert!(zombie.recv().await.is_none(), "zombie pane closed");
+        // Live pane still receives.
+        r.dispatch(1, "alive");
+        let got = live.recv().await.expect("live pane still flows");
+        assert_eq!(got.data, b"alive");
+    }
+
+    #[tokio::test]
+    async fn retain_panes_with_empty_keep_set_evicts_everything() {
+        // Equivalent to evict_all but takes the explicit-set
+        // path. Verifies that an edge-case reconcile against a
+        // tmux reporting zero panes does the right thing.
+        let r = OutputRouter::new();
+        let (mut a, _id_a, _) = r.subscribe(1).unwrap();
+        let (mut b, _id_b, _) = r.subscribe(2).unwrap();
+
+        let evicted = r.retain_panes(&HashSet::new());
+        assert_eq!(evicted, 2);
+        assert!(a.recv().await.is_none());
+        assert!(b.recv().await.is_none());
+        assert_eq!(r.registered_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn retain_panes_keeps_all_when_superset() {
+        // A `keep` set larger than what's registered must not
+        // evict anything. Covers the common case where tmux
+        // reports more live panes than the router is tracking
+        // (other sessions nobody's attached to).
+        let r = OutputRouter::new();
+        let (mut rx, _id, _) = r.subscribe(5).unwrap();
+        let keep: HashSet<u32> = [1, 2, 5, 7, 99].into_iter().collect();
+
+        let evicted = r.retain_panes(&keep);
+        assert_eq!(evicted, 0);
+        assert_eq!(r.registered_count(), 1);
+        r.dispatch(5, "still-here");
+        assert_eq!(rx.recv().await.unwrap().data, b"still-here");
+    }
+
+    #[tokio::test]
+    async fn retain_panes_on_empty_router_is_noop() {
+        let r = OutputRouter::new();
+        let keep: HashSet<u32> = [1, 2, 3].into_iter().collect();
+        assert_eq!(r.retain_panes(&keep), 0);
+        assert_eq!(r.registered_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn retain_panes_closes_all_subscribers_on_evicted_pane() {
+        // Fan-out interaction: when a pane has multiple
+        // subscribers (phone + laptop attached to the same
+        // session), eviction must close ALL of them. Otherwise
+        // one device would silently freeze while the other
+        // continues — worse UX than a clean disconnect.
+        let r = OutputRouter::new();
+        let (mut phone, _ip, _) = r.subscribe(7).unwrap();
+        let (mut laptop, _il, _) = r.subscribe(7).unwrap();
+
+        r.retain_panes(&HashSet::new());
+        assert!(phone.recv().await.is_none());
+        assert!(laptop.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn dispatcher_handles_window_close_without_wedging() {
+        // Slice 9i wiring: the WindowClose arm fires a detached
+        // reconcile task. With a dead SessionManager the reconcile
+        // fails (logged + dropped), and the dispatcher loop MUST
+        // continue processing subsequent Output. Regression guard
+        // against accidentally awaiting the reconcile on the hot
+        // path, which would make a flaky tmux freeze all output.
+        let r = OutputRouter::new();
+        let (mut rx, _id, _) = r.subscribe(7).unwrap();
+        let (tx, notifs) = mpsc::unbounded_channel::<Notification>();
+        let handle = r.spawn_dispatcher(notifs, dead_sessions());
+
+        tx.send(Notification::WindowClose { window_id: 42 })
+            .unwrap();
+        tx.send(Notification::Output {
+            pane_id: 7,
+            data: "alive".into(),
+        })
+        .unwrap();
+        let got = rx.recv().await.expect("output still flows after WindowClose");
+        assert_eq!(got.data, b"alive");
+
+        drop(tx);
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dispatcher_handles_sessions_changed_without_wedging() {
+        // SessionsChanged is the catch-all reconcile trigger —
+        // fires on add AND remove, so it costs a tmux round-trip
+        // even when a session was just created. Verify the
+        // dispatcher loop survives the spawned reconcile on this
+        // arm the same way it does for window-close.
+        let r = OutputRouter::new();
+        let (mut rx, _id, _) = r.subscribe(11).unwrap();
+        let (tx, notifs) = mpsc::unbounded_channel::<Notification>();
+        let handle = r.spawn_dispatcher(notifs, dead_sessions());
+
+        tx.send(Notification::SessionsChanged).unwrap();
+        tx.send(Notification::Output {
+            pane_id: 11,
+            data: "ok".into(),
+        })
+        .unwrap();
+        let got = rx.recv().await.unwrap();
+        assert_eq!(got.data, b"ok");
+
+        drop(tx);
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dispatcher_handles_unlinked_window_close_without_wedging() {
+        // Same contract for the tmux 3.3+ alternate notification
+        // shape. Both arms route to the same reconcile path.
+        let r = OutputRouter::new();
+        let (mut rx, _id, _) = r.subscribe(3).unwrap();
+        let (tx, notifs) = mpsc::unbounded_channel::<Notification>();
+        let handle = r.spawn_dispatcher(notifs, dead_sessions());
+
+        tx.send(Notification::UnlinkedWindowClose { window_id: 9 })
+            .unwrap();
+        tx.send(Notification::Output {
+            pane_id: 3,
+            data: "still-here".into(),
+        })
+        .unwrap();
+        let got = rx.recv().await.unwrap();
+        assert_eq!(got.data, b"still-here");
+
+        drop(tx);
+        handle.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/server/src/session/tmux.rs
+++ b/crates/server/src/session/tmux.rs
@@ -205,6 +205,22 @@ impl Tmux {
         ))
     }
 
+    /// Construct a `Tmux` handle with no live subprocess behind
+    /// it — every `send_command` immediately fails with
+    /// `TmuxError::Disconnected`. Exposed so tests in adjacent
+    /// modules (router, manager) can build a `SessionManager`
+    /// for wiring tests without spawning a real tmux binary.
+    #[cfg(test)]
+    pub fn dead_for_tests() -> Self {
+        let (cmd_tx, _rx) = mpsc::unbounded_channel::<OutgoingCommand>();
+        drop(_rx);
+        Self {
+            cmd_tx,
+            child: Arc::new(Mutex::new(None)),
+            tasks: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
     /// Send one command to tmux and await the reply. `line` must
     /// not contain a newline or carriage return — the writer
     /// appends `\n` itself, and injecting either would let the


### PR DESCRIPTION
## Summary

Closes the long-running-server ring leak path: zombie panes (tmux windows that closed while the router was still tracking them) now get evicted automatically.

- **New**: `OutputRouter::retain_panes(keep: &HashSet<u32>) -> usize` evicts panes not in the keep-set.
- **New**: `SessionManager::list_live_panes` + `reconcile_router` compose into "make the router agree with tmux's current reality."
- **Wired**: dispatcher now handles `%window-close`, `%unlinked-window-close`, and `%sessions-changed` — each fires a detached reconcile. Fire-and-forget to avoid blocking `%output` behind tmux round-trips.
- **Boy Scout**: rewrote stale `query_default_pane` doc to state the one-pane-per-tile product invariant flatly (was hedging a multi-pane future that the tile-system design has decided against).

## Design note: why reconcile instead of window→pane tracking

`SessionManager` is stateless by design. Adding a `HashMap<session, window_id>` to support window-keyed eviction would have broken that invariant. Re-querying `list-panes -a` on each event keeps tmux as the single source of truth and self-corrects against any drift (parser bugs, manual kills, etc.).

## Deferred

- **Live-tmux integration test**: `Tmux::spawn` uses `tmux -C new-session -d`, which exits the CM client immediately after session creation (empirically reproduced on tmux 3.6a). The existing `tmux_roundtrip` ignored test has the same limitation. Fixing the spawn model is a separate slice.

## Test plan

- [x] `cargo test --workspace` — 272 passing, 1 ignored (pre-existing), 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] 5 `retain_panes` unit tests (empty keep, superset, nothing-to-evict, fan-out closes all subs, noop on empty router)
- [x] 3 dispatcher-wiring tests (all three reconcile-trigger arms non-fatal to the loop under a dead tmux)
- [x] 7 `parse_pane_id_list` parser tests (edge cases + malformed-input rejection)