### PR TITLE
fix(summarizer): activity + volume gates to stop polling streaming sessions

### DIFF
--- a/lib/session-summarizer.js
+++ b/lib/session-summarizer.js
@@ -149,7 +149,9 @@ export function parseSummaryResponse(raw) {
  * @param {function} opts.callOllama    - async (userPrompt, { systemPrompt }) => string
  * @param {number} [opts.pollIntervalMs=30000]
  * @param {number} [opts.windowBytes=8000] - max tail bytes fed into the hash + prompt
+ * @param {number} [opts.scrollbackLines=500] - tmux scrollback lines for `captureScrollback`
  * @param {number} [opts.minContentChars=400] - below this, skip the session entirely
+ * @param {number} [opts.minNewBytesPerSummary=200] - cursor advance required for a re-summary
  */
 export function createSessionSummarizer({
   sessionManager,
@@ -193,6 +195,13 @@ export function createSessionSummarizer({
     return "";
   }
 
+  // Helper: read session.cursor, returning null for fakes/sources that
+  // don't expose the getter. Used both for gate input and to refresh
+  // state after async waits where bytes may have arrived.
+  function readCursor(session) {
+    return typeof session.cursor === "number" ? session.cursor : null;
+  }
+
   async function summarizeOne(session) {
     const name = session.name;
     let st = state.get(name);
@@ -202,8 +211,11 @@ export function createSessionSummarizer({
         inFlight: false,
         // null = never observed. Distinct from 0 (observed at start).
         lastCursor: null,
-        // Cursor at the time of the last successful summary. New bytes
-        // since this point determine whether a re-summary is worthwhile.
+        // Cursor at the last summary attempt (successful or failed).
+        // New bytes since this point determine whether a re-attempt is
+        // worthwhile — failed attempts also bump this so transient
+        // Ollama errors don't trigger a tight retry loop on every
+        // settled tick.
         lastSummarizedCursor: 0,
       };
       state.set(name, st);
@@ -213,44 +225,41 @@ export function createSessionSummarizer({
     // session.cursor is the monotonic total-bytes counter (lib/session.js).
     // Fakes/legacy sessions without it bypass the cursor-based gates and
     // fall back to the hash gate alone — preserves prior behaviour.
-    const cursor = typeof session.cursor === "number" ? session.cursor : null;
+    const cursor = readCursor(session);
+    const previousCursor = st.lastCursor;
+    // Update lastCursor unconditionally and once: every subsequent
+    // early-return path inherits it without each having to remember to
+    // copy the value through. The next tick's activity gate compares
+    // against this single point of truth.
+    if (cursor !== null) st.lastCursor = cursor;
 
-    if (cursor !== null) {
+    if (cursor !== null && previousCursor !== null) {
       // Activity gate: cursor moved between ticks → terminal is still
       // streaming → wait for it to settle. First observation
-      // (lastCursor === null) is exempt: a fresh session shouldn't sit
-      // titleless waiting an extra poll interval just to confirm it's
-      // settled.
-      if (st.lastCursor !== null && cursor !== st.lastCursor) {
-        st.lastCursor = cursor;
-        return;
-      }
-      // Volume gate: require enough new bytes since the last summary
-      // for a fresh model call to be worth the cost.
-      if (cursor - st.lastSummarizedCursor < minNewBytesPerSummary) {
-        st.lastCursor = cursor;
-        return;
-      }
+      // (previousCursor === null) is exempt: a fresh session shouldn't
+      // sit titleless waiting an extra poll interval just to confirm
+      // it's quiet.
+      if (cursor !== previousCursor) return;
+      // Volume gate: require enough new bytes since the last attempt
+      // for a fresh model call to be worth the cost. Also exempt on
+      // first observation — same reasoning as the activity gate.
+      if (cursor - st.lastSummarizedCursor < minNewBytesPerSummary) return;
     }
 
-    const window = await extractWindow(session);
-    if (window.length < minContentChars) {
-      if (cursor !== null) st.lastCursor = cursor;
-      return;
-    }
+    const windowText = await extractWindow(session);
+    if (windowText.length < minContentChars) return;
 
-    const hash = hashWindow(window);
-    if (hash === st.lastHash) {
-      if (cursor !== null) st.lastCursor = cursor;
-      return;
-    }
+    const hash = hashWindow(windowText);
+    if (hash === st.lastHash) return;
 
     st.inFlight = true;
     try {
-      const raw = await callOllama(window, { systemPrompt: SYSTEM_PROMPT });
+      const raw = await callOllama(windowText, { systemPrompt: SYSTEM_PROMPT });
       const parsed = parseSummaryResponse(raw);
       if (!parsed) {
         log.warn("session-summarizer: unparseable response", { session: name });
+        // Fall through to finally so lastSummarizedCursor advances —
+        // see the cursor refresh below.
         return;
       }
 
@@ -285,16 +294,24 @@ export function createSessionSummarizer({
         live.setMeta("summaryHistory", next);
       }
       st.lastHash = hash;
-      if (cursor !== null) {
-        st.lastSummarizedCursor = cursor;
-        st.lastCursor = cursor;
-      }
       log.info("session-summarizer: summary updated", {
         session: name, title: parsed.title,
       });
     } catch (err) {
       log.warn("session-summarizer: cycle failed", { session: name, error: err.message });
+      // Fall through to finally — failed attempts still advance
+      // lastSummarizedCursor to suppress immediate retries.
     } finally {
+      // Re-read cursor: bytes may have arrived during the await chain.
+      // Always advance lastSummarizedCursor on any path that called
+      // Ollama (success, parse-failure, or thrown error) so a transient
+      // failure waits out another minNewBytesPerSummary of activity
+      // before retrying — same backoff as a successful summary.
+      const cursorAfter = readCursor(session);
+      if (cursorAfter !== null) {
+        st.lastSummarizedCursor = cursorAfter;
+        st.lastCursor = cursorAfter;
+      }
       st.inFlight = false;
     }
   }

--- a/lib/session-summarizer.js
+++ b/lib/session-summarizer.js
@@ -27,10 +27,28 @@
  * changes over time (edit → run server → debug → …). Older context
  * ages out naturally as the PTY emits new bytes.
  *
- * Change detection: hashes the stripped window and skips Ollama when
- * the hash is unchanged. An idle tab costs one SHA-1 per cycle and
- * nothing else. The hash is kept in memory, so a server restart
- * forces one "first" summary on each session — which is the
+ * Change detection runs three gates before paying for an Ollama call:
+ *
+ *   1. Activity gate — if `session.cursor` (monotonic total-bytes)
+ *      moved between this tick and the previous one, the terminal is
+ *      still streaming. Skip and wait for it to settle. Without this,
+ *      a long-running streaming session (Claude agent, build, tail -f)
+ *      bills a fresh model call every poll interval even though the
+ *      gist hasn't moved.
+ *   2. Volume gate — require at least `minNewBytesPerSummary` of new
+ *      cursor advance since the last summary. Tiny incremental output
+ *      (a single command echo) shouldn't churn the title.
+ *   3. Hash gate — even after the cursor gates pass, the stripped
+ *      window may be byte-identical to last time (e.g. the buffer
+ *      rolled over identical text). Skip Ollama in that case.
+ *
+ * The first observation of a session is exempt from the activity gate
+ * (we have no prior cursor to compare to), so freshly-restored or
+ * newly-created sessions still get a first summary as soon as they
+ * have enough buffered output.
+ *
+ * Per-session state is kept in memory; a server restart re-arms the
+ * gates and forces one "first" summary on each session — which is the
  * behaviour we want: after restart, the tooltip repopulates as soon
  * as each session has enough buffered output.
  *
@@ -52,6 +70,12 @@ const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const DEFAULT_WINDOW_BYTES = 8000;
 const DEFAULT_SCROLLBACK_LINES = 500;
 const DEFAULT_MIN_CONTENT_CHARS = 400;
+// Minimum cursor advance (in bytes) required to consider re-summarizing
+// a session that has already been summarized. Set high enough that a
+// single command echo or one-line status update doesn't churn the
+// title; low enough that real activity (a fresh build log, a Claude
+// turn, a `git log` dump) still triggers an update.
+const DEFAULT_MIN_NEW_BYTES_PER_SUMMARY = 200;
 const MAX_TITLE_LEN = 60;
 const MAX_SUMMARY_LEN = 300;
 // Cap the ring so an always-on session doesn't grow meta.summaryHistory
@@ -134,6 +158,7 @@ export function createSessionSummarizer({
   windowBytes = DEFAULT_WINDOW_BYTES,
   scrollbackLines = DEFAULT_SCROLLBACK_LINES,
   minContentChars = DEFAULT_MIN_CONTENT_CHARS,
+  minNewBytesPerSummary = DEFAULT_MIN_NEW_BYTES_PER_SUMMARY,
 }) {
   if (!sessionManager) {
     throw new Error("createSessionSummarizer: sessionManager is required");
@@ -142,9 +167,10 @@ export function createSessionSummarizer({
     throw new Error("createSessionSummarizer: callOllama is required");
   }
 
-  // Per-session state: { lastHash, inFlight }. Keyed by session name
-  // (unique within a manager). Cleared on stop() and on session
-  // removal (garbage-collected when listSessions stops reporting it).
+  // Per-session state: { lastHash, inFlight, lastCursor,
+  // lastSummarizedCursor }. Keyed by session name (unique within a
+  // manager). Cleared on stop() and on session removal
+  // (garbage-collected when listSessions stops reporting it).
   const state = new Map();
   let timer = null;
   let stopped = false;
@@ -171,16 +197,53 @@ export function createSessionSummarizer({
     const name = session.name;
     let st = state.get(name);
     if (!st) {
-      st = { lastHash: null, inFlight: false };
+      st = {
+        lastHash: null,
+        inFlight: false,
+        // null = never observed. Distinct from 0 (observed at start).
+        lastCursor: null,
+        // Cursor at the time of the last successful summary. New bytes
+        // since this point determine whether a re-summary is worthwhile.
+        lastSummarizedCursor: 0,
+      };
       state.set(name, st);
     }
     if (st.inFlight) return;
 
+    // session.cursor is the monotonic total-bytes counter (lib/session.js).
+    // Fakes/legacy sessions without it bypass the cursor-based gates and
+    // fall back to the hash gate alone — preserves prior behaviour.
+    const cursor = typeof session.cursor === "number" ? session.cursor : null;
+
+    if (cursor !== null) {
+      // Activity gate: cursor moved between ticks → terminal is still
+      // streaming → wait for it to settle. First observation
+      // (lastCursor === null) is exempt: a fresh session shouldn't sit
+      // titleless waiting an extra poll interval just to confirm it's
+      // settled.
+      if (st.lastCursor !== null && cursor !== st.lastCursor) {
+        st.lastCursor = cursor;
+        return;
+      }
+      // Volume gate: require enough new bytes since the last summary
+      // for a fresh model call to be worth the cost.
+      if (cursor - st.lastSummarizedCursor < minNewBytesPerSummary) {
+        st.lastCursor = cursor;
+        return;
+      }
+    }
+
     const window = await extractWindow(session);
-    if (window.length < minContentChars) return;
+    if (window.length < minContentChars) {
+      if (cursor !== null) st.lastCursor = cursor;
+      return;
+    }
 
     const hash = hashWindow(window);
-    if (hash === st.lastHash) return;
+    if (hash === st.lastHash) {
+      if (cursor !== null) st.lastCursor = cursor;
+      return;
+    }
 
     st.inFlight = true;
     try {
@@ -222,6 +285,10 @@ export function createSessionSummarizer({
         live.setMeta("summaryHistory", next);
       }
       st.lastHash = hash;
+      if (cursor !== null) {
+        st.lastSummarizedCursor = cursor;
+        st.lastCursor = cursor;
+      }
       log.info("session-summarizer: summary updated", {
         session: name, title: parsed.title,
       });

--- a/test/session-summarizer.test.js
+++ b/test/session-summarizer.test.js
@@ -443,6 +443,109 @@ describe("createSessionSummarizer", () => {
     s.stop();
   });
 
+  it("volume gate alone: settled session with no new bytes blocks a second Ollama call", async () => {
+    // Isolates the volume gate from the activity gate. After a first
+    // summary, the cursor is unchanged on the next tick — activity gate
+    // passes — and `cursor - lastSummarizedCursor === 0`, so the volume
+    // gate must block on its own.
+    const session = makeFakeSessionWithCursor({
+      name: "kat_settled_only",
+      buffer: "ample initial content\n".repeat(40),
+    });
+    const mgr = makeFakeManager([session]);
+    const callOllama = okOllama();
+
+    const s = createSessionSummarizer({
+      sessionManager: mgr,
+      callOllama,
+      minContentChars: 100,
+      minNewBytesPerSummary: 500,
+    });
+
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(callOllama.calls.length, 1);
+
+    // Same cursor on the next tick. Activity gate is satisfied (no
+    // movement); volume gate must reject the call by itself.
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(callOllama.calls.length, 1);
+
+    s.stop();
+  });
+
+  it("unparseable response advances lastSummarizedCursor to suppress retry storm", async () => {
+    const session = makeFakeSessionWithCursor({
+      name: "kat_garbage_retry",
+      buffer: "meaningful content\n".repeat(40),
+    });
+    const mgr = makeFakeManager([session]);
+    const callOllama = okOllama("not json at all");
+
+    const s = createSessionSummarizer({
+      sessionManager: mgr,
+      callOllama,
+      minContentChars: 100,
+      minNewBytesPerSummary: 500,
+    });
+
+    // First tick: gates exempt, Ollama called, parse fails.
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(callOllama.calls.length, 1);
+
+    // Settled tick: without the failure-path cursor advance, the volume
+    // gate (delta=0) would block — but the bug we're guarding against
+    // is the previous version not advancing lastSummarizedCursor on
+    // parse failure, which left delta=cursor (well above the threshold)
+    // and triggered Ollama on every settled tick. Asserts the fix.
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(
+      callOllama.calls.length, 1,
+      "settled session must not retry Ollama after a parse failure",
+    );
+
+    s.stop();
+  });
+
+  it("thrown Ollama error advances lastSummarizedCursor to suppress retry storm", async () => {
+    const session = makeFakeSessionWithCursor({
+      name: "kat_throw_retry",
+      buffer: "meaningful content\n".repeat(40),
+    });
+    const mgr = makeFakeManager([session]);
+    let attempts = 0;
+    const callOllama = async () => {
+      attempts += 1;
+      throw new Error("network down");
+    };
+
+    const s = createSessionSummarizer({
+      sessionManager: mgr,
+      callOllama,
+      minContentChars: 100,
+      minNewBytesPerSummary: 500,
+    });
+
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(attempts, 1);
+
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(
+      attempts, 1,
+      "settled session must not retry Ollama after a thrown error",
+    );
+
+    s.stop();
+  });
+
   it("first observation is exempt from the activity gate", async () => {
     const session = makeFakeSessionWithCursor({
       name: "kat_fresh",

--- a/test/session-summarizer.test.js
+++ b/test/session-summarizer.test.js
@@ -32,6 +32,36 @@ function makeFakeSession({ name, buffer, alive = true }) {
   };
 }
 
+// Variant that exposes `session.cursor` (real Session does) so the
+// activity- and volume-gate paths in the summarizer are exercised.
+// `appendBytes` simulates new PTY output: it grows the buffer (so
+// pullTail returns updated content) and advances the cursor.
+function makeFakeSessionWithCursor({ name, buffer, alive = true }) {
+  const meta = {};
+  let _buffer = buffer;
+  let _cursor = buffer.length;
+  return {
+    name,
+    alive,
+    meta,
+    get cursor() {
+      return _cursor;
+    },
+    appendBytes(text) {
+      _buffer += text;
+      _cursor += text.length;
+    },
+    pullTail(maxBytes) {
+      const slice = _buffer.slice(Math.max(0, _buffer.length - maxBytes));
+      return { data: slice, cursor: _cursor };
+    },
+    setMeta(ns, value) {
+      if (value === null || value === undefined) delete meta[ns];
+      else meta[ns] = value;
+    },
+  };
+}
+
 function makeFakeManager(sessions) {
   const byName = new Map(sessions.map((s) => [s.name, s]));
   return {
@@ -318,6 +348,124 @@ describe("createSessionSummarizer", () => {
 
     assert.strictEqual(session.meta.autoTitle, undefined);
     assert.strictEqual(session.meta.summary, undefined);
+    s.stop();
+  });
+
+  it("activity gate: skips Ollama when cursor moved between ticks (still streaming)", async () => {
+    const session = makeFakeSessionWithCursor({
+      name: "kat_streaming",
+      buffer: "first burst of output\n".repeat(30),
+    });
+    const mgr = makeFakeManager([session]);
+    const callOllama = okOllama();
+
+    const s = createSessionSummarizer({
+      sessionManager: mgr,
+      callOllama,
+      minContentChars: 100,
+      minNewBytesPerSummary: 50,
+    });
+
+    // First cycle: no prior cursor observation, gate is exempt → fires.
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(callOllama.calls.length, 1);
+
+    // Simulate continuous streaming between ticks: cursor moves before
+    // the next cycle. Gate must skip without paying for Ollama.
+    session.appendBytes("more streaming output\n".repeat(30));
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(callOllama.calls.length, 1, "streaming session must not trigger Ollama");
+
+    // Streaming continues — still skipped.
+    session.appendBytes("even more output\n".repeat(30));
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(callOllama.calls.length, 1);
+
+    // Settle: no new bytes between ticks → cursor unchanged → gate
+    // passes and Ollama is called.
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(callOllama.calls.length, 2, "settled session must trigger Ollama");
+
+    s.stop();
+  });
+
+  it("volume gate: skips Ollama when too few new bytes since last summary", async () => {
+    const session = makeFakeSessionWithCursor({
+      name: "kat_low_volume",
+      buffer: "initial burst of meaningful content\n".repeat(30),
+    });
+    const mgr = makeFakeManager([session]);
+    const callOllama = okOllama();
+
+    const s = createSessionSummarizer({
+      sessionManager: mgr,
+      callOllama,
+      minContentChars: 100,
+      minNewBytesPerSummary: 500,
+    });
+
+    // First cycle fires: lastSummarizedCursor=0, cursor>=500, gate exempt.
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(callOllama.calls.length, 1);
+
+    // Trickle: append a tiny chunk, then run two ticks. The first tick
+    // sees cursor moved (activity gate); the second tick sees cursor
+    // settled but new bytes (5) below the 500 threshold (volume gate).
+    session.appendBytes("$ ls\n");
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(
+      callOllama.calls.length, 1,
+      "trickle below the volume threshold must not trigger Ollama even after settling",
+    );
+
+    // Cross the threshold: append a substantial chunk. Same two-tick
+    // pattern — activity gate absorbs the cursor move, volume gate
+    // passes on the settled tick.
+    session.appendBytes("substantial new chunk of output\n".repeat(30));
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(callOllama.calls.length, 2);
+
+    s.stop();
+  });
+
+  it("first observation is exempt from the activity gate", async () => {
+    const session = makeFakeSessionWithCursor({
+      name: "kat_fresh",
+      buffer: "fresh session content\n".repeat(30),
+    });
+    const mgr = makeFakeManager([session]);
+    const callOllama = okOllama();
+
+    const s = createSessionSummarizer({
+      sessionManager: mgr,
+      callOllama,
+      minContentChars: 100,
+      minNewBytesPerSummary: 100,
+    });
+
+    // First tick: lastCursor is null → activity gate exempt → fires
+    // without needing a "settled" cycle first.
+    await s.runOnce();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(callOllama.calls.length, 1);
+    assert.strictEqual(session.meta.autoTitle, "Editing Auth Module");
+
     s.stop();
   });
 


### PR DESCRIPTION
## Summary
- Streaming sessions (Claude agent, build, `tail -f`) used to bill an Ollama call every poll interval because their byte windows changed every 30s — even when the gist hadn't moved. The History tile filled with near-duplicates.
- Add an **activity gate** that compares `session.cursor` between ticks: if the cursor moved, the terminal is still streaming → skip and wait for it to settle.
- Add a **volume gate** that requires ≥ `minNewBytesPerSummary` (default 200) of new cursor advance since the last summary, so a single `ls` echo doesn't churn the title.
- First observation of a session is exempt from the activity gate so a fresh session still gets a title in the first poll interval.
- Sessions whose `cursor` getter is missing (test fakes, non-`Session` sources) bypass the cursor gates and fall back to the existing hash gate.

## What changes for the user
- A continuously-streaming session no longer produces a fresh History entry every 30s. It produces one when output pauses for a full poll interval.
- Idle sessions still cost nothing.
- Single short commands no longer trigger a re-summary.

## Test plan
- [x] `node --test test/session-summarizer.test.js` — 19 pass (16 existing + 3 new gate tests)
- [x] `npm run test:unit` — 2577 pass, 0 fail
- [ ] Smoke against a live katulong: open a streaming session, watch the History tile stop accumulating near-duplicates while still updating after the stream settles.