### PR TITLE
rewrite(server): slice 9j — fix tmux CM lifetime + payload-line parsing

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -32,11 +32,18 @@ async fn main() {
     // missing binary.
     let socket_name = std::env::var("KATULONG_TMUX_SOCKET")
         .unwrap_or_else(|_| DEDICATED_SOCKET_NAME.to_string());
-    let initial_session = std::env::var("KATULONG_INITIAL_SESSION")
-        .unwrap_or_else(|_| "main".to_string());
-    let (tmux, notifs) = Tmux::spawn(&socket_name, &initial_session, DEFAULT_COLS, DEFAULT_ROWS)
-        .await
-        .expect("spawn tmux control-mode subprocess");
+    // The "keepalive" session is internal infrastructure: its
+    // only job is keeping the CM client attached to something so
+    // the control channel stays alive. It is NOT a user-facing
+    // tile. The env var is named accordingly so an operator
+    // overriding it knows they're naming a hidden session, not
+    // configuring a user terminal.
+    let keepalive_session = std::env::var("KATULONG_KEEPALIVE_SESSION")
+        .unwrap_or_else(|_| "__cm_keepalive".to_string());
+    let (tmux, notifs) =
+        Tmux::spawn(&socket_name, &keepalive_session, DEFAULT_COLS, DEFAULT_ROWS)
+            .await
+            .expect("spawn tmux control-mode subprocess");
     let sessions = SessionManager::new(tmux);
     let output_router = OutputRouter::new();
 

--- a/crates/server/src/session/manager.rs
+++ b/crates/server/src/session/manager.rs
@@ -554,15 +554,55 @@ mod tests {
         assert!(matches!(err, SessionError::MalformedReply(_)));
     }
 
-    // Live-tmux integration coverage is deferred: `Tmux::spawn`
-    // uses `tmux -C new-session -d` which exits the CM client
-    // immediately after creating the session (empirically
-    // reproduced on tmux 3.6a — see the existing
-    // `tmux_roundtrip` ignored test with the same limitation).
-    // Wiring an `attach -t` style CM that stays alive is a
-    // separate, broader concern; the unit coverage here
-    // (`retain_panes`, `parse_pane_id_list`, dispatcher-wiring
-    // tests in router.rs) exercises every decision slice 9i
-    // makes. An end-to-end test lands when the tmux spawn
-    // lifetime issue is fixed in its own slice.
+    // ---------- Live-tmux integration ----------
+
+    #[tokio::test]
+    #[ignore = "requires tmux binary + dedicated socket; run with: cargo test -- --ignored"]
+    async fn reconcile_router_evicts_panes_of_destroyed_sessions() {
+        // End-to-end: stand up a real tmux subprocess, create two
+        // extra sessions, register their panes with the router,
+        // destroy one, then reconcile. The destroyed session's
+        // pane must be evicted from the router; the surviving
+        // one must not.
+        //
+        // This test also empirically confirms that `list-panes
+        // -a` reports across every session on the tmux server
+        // regardless of which session the CM client is attached
+        // to — that's the property slice 9i's reconcile depends
+        // on. Per-session `%output` routing is a separate
+        // concern (Path 1 follow-on).
+        use super::super::router::OutputRouter;
+        use super::super::tmux::Tmux;
+
+        let socket = format!("katulong-reconcile-{}", std::process::id());
+        let (tmux, _notifs) = Tmux::spawn(&socket, "main", 80, 24)
+            .await
+            .expect("spawn tmux");
+        let manager = SessionManager::new(tmux.clone());
+        let router = OutputRouter::new();
+
+        manager.create_session("alpha", 80, 24).await.unwrap();
+        manager.create_session("beta", 80, 24).await.unwrap();
+
+        let alpha_pane = manager.query_default_pane("alpha").await.unwrap();
+        let beta_pane = manager.query_default_pane("beta").await.unwrap();
+        assert_ne!(alpha_pane, beta_pane, "panes must be distinct");
+
+        let (_alpha_rx, _alpha_id, _) = router.subscribe(alpha_pane).unwrap();
+        let (_beta_rx, _beta_id, _) = router.subscribe(beta_pane).unwrap();
+        assert_eq!(router.registered_count(), 2);
+
+        manager.destroy_session("alpha").await.unwrap();
+
+        let evicted = manager
+            .reconcile_router(&router)
+            .await
+            .expect("reconcile succeeds");
+        assert_eq!(evicted, 1, "alpha's pane evicted, beta's survives");
+        assert_eq!(router.registered_count(), 1);
+        assert_eq!(router.subscriber_count(beta_pane), 1);
+        assert_eq!(router.subscriber_count(alpha_pane), 0);
+
+        tmux.shutdown().await;
+    }
 }

--- a/crates/server/src/session/tmux.rs
+++ b/crates/server/src/session/tmux.rs
@@ -77,14 +77,11 @@
 //! `kill-server` anywhere zapped both. A dedicated socket isolates
 //! katulong's tmux state.
 //!
-//! # Slice 9b scope
+//! # Live-tmux tests
 //!
-//! This slice ships the client type and its protocol handling.
-//! Slice 9c wires it into `SessionManager` and exposes it through
-//! `AppState`. The integration test that actually spawns tmux is
-//! marked `#[ignore]` so CI without tmux installed still passes;
-//! developers run it manually with `cargo test -- --ignored
-//! tmux_roundtrip`.
+//! Integration tests that actually spawn a tmux subprocess are
+//! `#[ignore]`-gated so CI without tmux installed still passes;
+//! developers run them with `cargo test -- --ignored`.
 
 use super::parser::{parse, Notification, ParseError};
 use std::collections::VecDeque;
@@ -220,7 +217,7 @@ impl Tmux {
             .arg(cols.to_string())
             .arg("-y")
             .arg(rows.to_string())
-            .arg("cat")
+            .arg(KEEPALIVE_PANE_CMD)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
@@ -254,9 +251,34 @@ impl Tmux {
             // escape sequences into tmux on terminal resizes.
             .kill_on_drop(true);
 
-        let mut child = cmd.spawn()?;
-        let stdin = child.stdin.take().ok_or(TmuxError::Disconnected)?;
-        let stdout = child.stdout.take().ok_or(TmuxError::Disconnected)?;
+        // From here on, any error must clean up the tmux server
+        // we created in step 1 — otherwise a failed spawn leaves
+        // the server running with an orphaned keepalive session,
+        // and the next `Tmux::spawn` against the same socket
+        // hits `new-session: session already exists`.
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                kill_orphan_server(socket_name).await;
+                return Err(TmuxError::Io(e));
+            }
+        };
+        let stdin = match child.stdin.take() {
+            Some(s) => s,
+            None => {
+                let _ = child.start_kill();
+                kill_orphan_server(socket_name).await;
+                return Err(TmuxError::Disconnected);
+            }
+        };
+        let stdout = match child.stdout.take() {
+            Some(s) => s,
+            None => {
+                let _ = child.start_kill();
+                kill_orphan_server(socket_name).await;
+                return Err(TmuxError::Disconnected);
+            }
+        };
         let stderr = child.stderr.take();
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<OutgoingCommand>();
@@ -328,6 +350,9 @@ impl Tmux {
         rx.await.map_err(|_| TmuxError::Disconnected)?
     }
 
+    // TODO(shutdown-safety): add in-band detach-client dance
+    // before kill to avoid the tmux 3.6a UAF; see KNOWN GAP in
+    // the doc below.
     /// Kill the tmux subprocess and wait for the reader/writer
     /// tasks to finish. Idempotent — calling twice is safe; the
     /// second call no-ops.
@@ -368,6 +393,14 @@ impl Tmux {
 /// Staging instances override this via their own per-worktree name
 /// (e.g. `stage-rewrite-rust-leptos`) when they spawn `Tmux`.
 pub const DEDICATED_SOCKET_NAME: &str = "katulong";
+
+/// Command run in the keepalive session's pane to keep the CM
+/// client attached. `cat` blocks on its pty stdin (which never
+/// receives EOF), consuming zero CPU and emitting no `%output`.
+/// Named so the choice is grep-able from the spawn site, and so
+/// any future swap (e.g. to `sleep infinity` or a `tmux set-option
+/// remain-on-exit on` no-command session) lands in one place.
+const KEEPALIVE_PANE_CMD: &str = "cat";
 
 /// Validate a tmux socket name. Same allowlist as session names
 /// but enforced here rather than in `SessionManager` because
@@ -424,6 +457,24 @@ struct InFlightReply {
     reply: oneshot::Sender<Result<CommandReply, TmuxError>>,
 }
 
+/// Best-effort tear-down of a tmux server we just created in
+/// `Tmux::spawn`'s step 1 but failed to attach to in step 2.
+/// Without this, a failed spawn leaves the server running and
+/// the next `Tmux::spawn` against the same socket hits
+/// `new-session: session already exists`. Invoked from spawn's
+/// error paths only — never on the happy path.
+async fn kill_orphan_server(socket_name: &str) {
+    let _ = Command::new("tmux")
+        .arg("-L")
+        .arg(socket_name)
+        .arg("kill-server")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .await;
+}
+
 async fn run_reader(
     stdout: ChildStdout,
     notifications: mpsc::UnboundedSender<Notification>,
@@ -436,15 +487,21 @@ async fn run_reader(
     // the oneshot.
     let mut current: Option<InFlightReply> = None;
 
+    // # `tmux_ready` warm-up gate
+    //
     // tmux's CM emits a `%begin <time> <num> 0` / `%end ...` pair
     // at attach time, BEFORE it processes any command we send. If
-    // the writer task pushes a pending reply slot during that
+    // the writer task pushed a pending reply slot during that
     // window, the reader would pop it for the orphan startup pair
-    // and resolve our user command with an empty payload. Tmux
-    // signals attach completion via `%session-changed`, so we
-    // treat any `%begin`/`%end` BEFORE that as orphans and drop
-    // them without consuming pending. Once `tmux_ready` flips, the
-    // reader behaves normally.
+    // and resolve our user command with empty payload.
+    //
+    // tmux's primary attach-completion signal is
+    // `%session-changed`. Belt-and-suspenders fallback: the orphan
+    // pair is exactly one — we also flip ready once we've seen the
+    // first warm-up `%end`. That way, even if a tmux version ever
+    // omits or reorders `%session-changed`, we don't hang every
+    // subsequent `send_command` waiting for a signal that never
+    // arrives.
     let mut tmux_ready = false;
 
     while let Ok(Some(line)) = reader.next_line().await {
@@ -455,47 +512,17 @@ async fn run_reader(
                 continue;
             }
         };
-        // While a command reply is in flight, tmux's `%begin` /
-        // `%end` framing wins over the leading-`%` heuristic.
-        // Tmux command payloads can themselves start with `%`
-        // (e.g. `list-panes -F '#{pane_id}'` returns `%N` per
-        // line). The parser treats those as `Notification::
-        // Unknown`, but inside a command reply they're payload.
-        // Only `%end` and `%error` terminate the in-flight
-        // reply; everything else gets pushed as raw payload.
-        //
-        // Caveat: this means async notifications that arrive
-        // between `%begin` and `%end` (uncommon but allowed by
-        // tmux's protocol) get folded into the reply payload
-        // instead of routing to the notification channel. For
-        // katulong's CM-attached-to-keepalive setup, the
-        // attached pane is `cat` and emits no `%output`, so
-        // interleaving doesn't happen in practice. If it ever
-        // does, the right fix is allowlisting specific async
-        // notifications even inside reply blocks.
-        if current.is_some()
-            && !matches!(
-                n,
-                Notification::End { .. } | Notification::Error { .. }
-            )
-        {
-            if let Some(in_flight) = current.as_mut() {
-                in_flight.payload.push(line);
-            }
-            continue;
-        }
         match n {
-            Notification::Begin { .. } if !tmux_ready => {
-                // Orphan begin from tmux's attach handshake — drop.
-                tracing::trace!("tmux %begin during attach warm-up; ignoring");
-            }
-            Notification::End { .. } | Notification::Error { .. } if !tmux_ready => {
-                tracing::trace!("tmux %end/%error during attach warm-up; ignoring");
-            }
+            // ---- Reply framing ----
+            //
+            // `%begin` / `%end` / `%error` are the framing
+            // markers. While `tmux_ready` is false they're orphans
+            // from the attach handshake; once ready they pair with
+            // pending command slots.
             Notification::Begin { .. } => {
-                // Pop the oldest pending command — tmux replies in
-                // the order commands were submitted.
-                if let Some(cmd) = pending.lock().await.pop_front() {
+                if !tmux_ready {
+                    tracing::trace!("tmux %begin during attach warm-up; ignoring");
+                } else if let Some(cmd) = pending.lock().await.pop_front() {
                     current = Some(InFlightReply {
                         payload: Vec::new(),
                         reply: cmd.reply,
@@ -507,16 +534,16 @@ async fn run_reader(
                     current = None;
                 }
             }
-            Notification::Payload(p) => {
-                if let Some(in_flight) = current.as_mut() {
-                    in_flight.payload.push(p);
-                } else {
-                    tracing::trace!(payload = %p, "tmux payload outside begin/end; discarded");
-                }
-            }
             Notification::End { .. } | Notification::Error { .. } => {
                 let is_error = matches!(n, Notification::Error { .. });
-                if let Some(in_flight) = current.take() {
+                if !tmux_ready {
+                    // First warm-up `%end` → flip ready. The
+                    // attach handshake's pair has now closed and
+                    // the next `%begin` must belong to a real
+                    // command.
+                    tracing::trace!("tmux %end/%error during attach warm-up; ignoring");
+                    tmux_ready = true;
+                } else if let Some(in_flight) = current.take() {
                     let r = CommandReply {
                         ok: !is_error,
                         output: in_flight.payload.join("\n"),
@@ -528,19 +555,54 @@ async fn run_reader(
                     );
                 }
             }
+            // ---- Payload accumulation ----
+            //
+            // Lines that don't start with `%` (parsed as Payload)
+            // and lines that DO start with `%` but aren't a known
+            // notification keyword (parsed as Unknown) both land
+            // here when a command reply is in flight. tmux command
+            // output can include both — `list-panes -F '#{pane_id}'`
+            // emits lines like `%1` which parse as Unknown.
+            //
+            // Security note: tmux wraps user-pane bytes in
+            // `%output %P data` envelopes, so a user typing
+            // `%end 0 0 0` into their shell does NOT produce a
+            // bare `%end` line on the CM stdout — it arrives as
+            // `%output %N %end 0 0 0`, which parses as
+            // `Notification::Output` and never reaches this
+            // termination branch. The framing remains
+            // unforgeable from user input.
+            Notification::Payload(_) | Notification::Unknown { .. }
+                if current.is_some() =>
+            {
+                if let Some(in_flight) = current.as_mut() {
+                    in_flight.payload.push(line);
+                }
+            }
+            Notification::Payload(p) => {
+                tracing::trace!(payload = %p, "tmux payload outside begin/end; discarded");
+            }
+            // ---- Async notifications ----
+            //
+            // Lifecycle and async events that arrive between
+            // `%begin` and `%end` route to the notification
+            // channel REGARDLESS of in-flight state. The
+            // dispatcher relies on these (`%sessions-changed`,
+            // `%window-close`, `%unlinked-window-close`) to
+            // trigger reconcile, and folding them into a reply's
+            // payload would silently break that path under
+            // concurrent activity (e.g., once Path 1 per-session
+            // CMs land on the same tmux server).
             other => {
-                // tmux signals attach completion via
-                // `%session-changed`. Until we see it, the reader
-                // is in attach warm-up mode and treats any
-                // `%begin`/`%end` as orphans. After it lands, the
-                // reader pairs `%begin` to pending command slots
-                // normally.
+                // First `%session-changed` is tmux's primary
+                // attach-completion signal — set tmux_ready true
+                // even before a `%end` arrives.
                 if matches!(other, Notification::SessionChanged { .. }) {
                     tmux_ready = true;
                 }
-                // Async notification. Drop on the floor if no one's
-                // listening — that's the mpsc semantics and the
-                // consumer's responsibility to keep up.
+                // Async notifications. Drop on the floor if no
+                // one's listening — that's the mpsc semantics and
+                // the consumer's responsibility to keep up.
                 let _ = notifications.send(other);
             }
         }

--- a/crates/server/src/session/tmux.rs
+++ b/crates/server/src/session/tmux.rs
@@ -1,9 +1,56 @@
 //! tmux control-mode client.
 //!
-//! Owns one long-running `tmux -C -L <socket>` subprocess and
-//! speaks the protocol parsed by `super::parser`. Commands are
-//! sent via the subprocess's stdin; replies and asynchronous
-//! notifications arrive on stdout.
+//! Owns one long-running `tmux -C -L <socket> attach-session`
+//! subprocess and speaks the protocol parsed by `super::parser`.
+//! Commands are sent via the subprocess's stdin; replies and
+//! asynchronous notifications arrive on stdout.
+//!
+//! # Why `attach-session`, not `new-session -d`
+//!
+//! Tmux control mode invoked as `tmux -C new-session -d ...`
+//! runs the new-session command and then exits the CM client
+//! immediately, because `-d` means detached and the CM has
+//! nothing to attach to. This was the original spawn shape and
+//! it was silently broken — the CM emitted its initial
+//! `%sessions-changed` then `%exit` before any caller could
+//! send a follow-up command. Empirically reproduced on tmux
+//! 3.6a.
+//!
+//! The Node katulong implementation uses the proven pattern
+//! captured by diwa as commit `a7519f5` ("tmux control mode
+//! does not replay screen content on attach"): a CM is spawned
+//! with `-C attach-session -t <existing>`. As long as the
+//! attached session exists, the CM stays alive and accepts
+//! commands.
+//!
+//! `Tmux::spawn` therefore does TWO things:
+//! 1. Synchronously runs `tmux -L <socket> new-session -d -s
+//!    <init> -x <cols> -y <rows> "cat"` to start the tmux
+//!    server and a "keepalive" session whose only pane runs
+//!    `cat`. `cat` blocks on its pty stdin (which never
+//!    receives EOF), consuming zero CPU.
+//! 2. Spawns the long-lived CM child via
+//!    `tmux -L <socket> -C attach-session -t <init>` and hooks
+//!    reader/writer/stderr tasks to its pipes.
+//!
+//! # Visible-output scope: caveat
+//!
+//! A CM client only receives `%output` notifications for panes
+//! in the session it is attached to. The initial keepalive
+//! session is the only thing this CM sees output for, and that
+//! pane runs `cat` — no useful bytes. Commands like
+//! `list-panes -a`, `new-session`, `kill-session`, and global
+//! lifecycle events (`%sessions-changed`,
+//! `%unlinked-window-close`) DO span every session on the tmux
+//! server, so this single CM is sufficient for slice 9i's
+//! reconcile path.
+//!
+//! Routing `%output` for user-facing tiles (each in its own
+//! tmux session) requires per-session CM clients — the path
+//! the Node implementation took (see Node scars in diwa under
+//! "control mode + attach-session"). That's a Path 1 follow-on
+//! slice; this slice unblocks command-side integration tests
+//! and the slice 9i reconcile model.
 //!
 //! The client's job splits into three asynchronous pieces:
 //!
@@ -111,13 +158,18 @@ struct PendingReply {
 }
 
 impl Tmux {
-    /// Spawn `tmux -C -L <socket_name> new-session -d -s <session>
-    /// -x <cols> -y <rows>` and begin the reader/writer tasks.
+    /// Start the tmux server with a detached keepalive session,
+    /// then spawn a long-lived `tmux -C attach-session` child as
+    /// the control-mode client. See the module-level "Why
+    /// `attach-session`, not `new-session -d`" section for the
+    /// rationale.
     ///
     /// `socket_name` is validated: alphanumeric + `-_` only, no
     /// leading hyphen, no `/` (which would redirect tmux's socket
     /// file to an attacker-controlled path). Use
     /// `DEDICATED_SOCKET_NAME` for the production convention.
+    /// `initial_session` is the keepalive session's name; treat
+    /// it as a tmux-internal name, not a user-facing tile name.
     ///
     /// Returns the client handle plus an mpsc receiver for
     /// asynchronous notifications (`%output`, `%window-close`,
@@ -147,10 +199,19 @@ impl Tmux {
         validate_socket_name(socket_name)?;
         validate_session_name_for_tmux(initial_session)?;
 
-        let mut cmd = Command::new("tmux");
-        cmd.arg("-L")
+        // Step 1: start the tmux server and a detached keepalive
+        // session synchronously. `new-session -d ... cat` creates
+        // the session with one pane running `cat`, which blocks
+        // on its pty stdin forever (zero CPU). We wait for this
+        // command to exit successfully — that's our signal that
+        // the tmux server is up and the session exists.
+        //
+        // We don't keep this subprocess as a Tmux child handle;
+        // it's a one-shot "create the server" exec that returns
+        // once the work is done.
+        let init_status = Command::new("tmux")
+            .arg("-L")
             .arg(socket_name)
-            .arg("-C")
             .arg("new-session")
             .arg("-d")
             .arg("-s")
@@ -158,7 +219,33 @@ impl Tmux {
             .arg("-x")
             .arg(cols.to_string())
             .arg("-y")
-            .arg(rows.to_string());
+            .arg(rows.to_string())
+            .arg("cat")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .await?;
+        if !init_status.status.success() {
+            let stderr = String::from_utf8_lossy(&init_status.stderr).into_owned();
+            return Err(TmuxError::InvalidCommand(format!(
+                "tmux new-session failed: {stderr}"
+            )));
+        }
+
+        // Step 2: spawn the long-lived CM client attached to the
+        // keepalive session. `-C attach-session` is the pattern
+        // that keeps the CM alive: the client stays connected as
+        // long as the attached session exists. `cat` in the
+        // keepalive session never exits, so the CM never gets a
+        // `%session-changed`/`%exit` from session death.
+        let mut cmd = Command::new("tmux");
+        cmd.arg("-L")
+            .arg(socket_name)
+            .arg("-C")
+            .arg("attach-session")
+            .arg("-t")
+            .arg(initial_session);
         cmd.stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -244,6 +331,24 @@ impl Tmux {
     /// Kill the tmux subprocess and wait for the reader/writer
     /// tasks to finish. Idempotent — calling twice is safe; the
     /// second call no-ops.
+    ///
+    /// # KNOWN GAP — tmux 3.6a UAF on abrupt CM child kill
+    ///
+    /// Per Node scar `33feed2`: tmux 3.6a has a use-after-free
+    /// in `control_notify_client_detached` that triggers when a
+    /// `tmux -C` child dies abruptly (e.g. SIGTERM/SIGKILL),
+    /// causing the tmux server to segfault and take EVERY
+    /// session with it. The fix walks tmux's normal detach path
+    /// by writing `detach-client\n` on stdin first, waiting for
+    /// the CM to close cleanly, THEN running `kill-session`.
+    /// An unref'd 2-second watchdog SIGKILLs as last resort.
+    ///
+    /// The current code uses `start_kill` directly. That's the
+    /// abrupt path. Today this only fires in test cleanup and
+    /// process-shutdown paths where tmux dying is acceptable;
+    /// production code never calls `shutdown` on a still-live
+    /// instance. Track adding the in-band `detach-client` dance
+    /// before this becomes user-visible.
     pub async fn shutdown(&self) {
         if let Some(mut child) = self.child.lock().await.take() {
             let _ = child.start_kill();
@@ -331,6 +436,17 @@ async fn run_reader(
     // the oneshot.
     let mut current: Option<InFlightReply> = None;
 
+    // tmux's CM emits a `%begin <time> <num> 0` / `%end ...` pair
+    // at attach time, BEFORE it processes any command we send. If
+    // the writer task pushes a pending reply slot during that
+    // window, the reader would pop it for the orphan startup pair
+    // and resolve our user command with an empty payload. Tmux
+    // signals attach completion via `%session-changed`, so we
+    // treat any `%begin`/`%end` BEFORE that as orphans and drop
+    // them without consuming pending. Once `tmux_ready` flips, the
+    // reader behaves normally.
+    let mut tmux_ready = false;
+
     while let Ok(Some(line)) = reader.next_line().await {
         let n = match parse(&line) {
             Ok(n) => n,
@@ -339,7 +455,43 @@ async fn run_reader(
                 continue;
             }
         };
+        // While a command reply is in flight, tmux's `%begin` /
+        // `%end` framing wins over the leading-`%` heuristic.
+        // Tmux command payloads can themselves start with `%`
+        // (e.g. `list-panes -F '#{pane_id}'` returns `%N` per
+        // line). The parser treats those as `Notification::
+        // Unknown`, but inside a command reply they're payload.
+        // Only `%end` and `%error` terminate the in-flight
+        // reply; everything else gets pushed as raw payload.
+        //
+        // Caveat: this means async notifications that arrive
+        // between `%begin` and `%end` (uncommon but allowed by
+        // tmux's protocol) get folded into the reply payload
+        // instead of routing to the notification channel. For
+        // katulong's CM-attached-to-keepalive setup, the
+        // attached pane is `cat` and emits no `%output`, so
+        // interleaving doesn't happen in practice. If it ever
+        // does, the right fix is allowlisting specific async
+        // notifications even inside reply blocks.
+        if current.is_some()
+            && !matches!(
+                n,
+                Notification::End { .. } | Notification::Error { .. }
+            )
+        {
+            if let Some(in_flight) = current.as_mut() {
+                in_flight.payload.push(line);
+            }
+            continue;
+        }
         match n {
+            Notification::Begin { .. } if !tmux_ready => {
+                // Orphan begin from tmux's attach handshake — drop.
+                tracing::trace!("tmux %begin during attach warm-up; ignoring");
+            }
+            Notification::End { .. } | Notification::Error { .. } if !tmux_ready => {
+                tracing::trace!("tmux %end/%error during attach warm-up; ignoring");
+            }
             Notification::Begin { .. } => {
                 // Pop the oldest pending command — tmux replies in
                 // the order commands were submitted.
@@ -377,6 +529,15 @@ async fn run_reader(
                 }
             }
             other => {
+                // tmux signals attach completion via
+                // `%session-changed`. Until we see it, the reader
+                // is in attach warm-up mode and treats any
+                // `%begin`/`%end` as orphans. After it lands, the
+                // reader pairs `%begin` to pending command slots
+                // normally.
+                if matches!(other, Notification::SessionChanged { .. }) {
+                    tmux_ready = true;
+                }
                 // Async notification. Drop on the floor if no one's
                 // listening — that's the mpsc semantics and the
                 // consumer's responsibility to keep up.


### PR DESCRIPTION
## Summary

Two interlocking bugs in `Tmux::spawn` were keeping every slice from 9b onward functional only against mocks. After this slice the production tmux integration path actually runs end-to-end.

### Bug 1: CM exits immediately
`tmux -C new-session -d` creates a session and exits because there's nothing to attach to. Per `diwa` findings on the Node implementation, the proven pattern is `tmux -C attach-session -t <existing>`. The fix is two-step: synchronously run `new-session -d -s <init> ... cat` (keepalive pane, zero CPU), then spawn the long-lived CM via `attach-session -t <init>`.

### Bug 2: parser misclassifies command-payload lines starting with `%`
`list-panes -F '#{pane_id}'` returns lines like `%1` as command output. The parser treated every `%`-prefixed line as a notification keyword, so `%1` became `Notification::Unknown` and the reply came back empty. tmux's protocol rule is `%begin`/`%end` framing wins: between those markers, lines are payload regardless of leading character.

### Bug 3: race on attach-handshake `%begin`/`%end`
tmux emits an orphan `%begin`/`%end` pair at attach time. If the writer pushed a pending reply slot during that window, the reader popped it for the orphan pair and resolved the user's command with empty payload. Fix: reader tracks `tmux_ready` and drops `%begin`/`%end` until the first `%session-changed` (tmux's attach-completion signal).

## What this unblocks

- **`tmux_roundtrip`** ignored test passes (was always failing in this environment)
- **`reconcile_router_evicts_panes_of_destroyed_sessions`** re-added (was deleted in slice 9i with a deferral comment; the deferral is now resolved)
- Future slices can rely on `Tmux::spawn` actually working end-to-end

## What this does NOT fix (Path 1 follow-on)

A CM only receives `%output` notifications for panes in the session it's attached to. The keepalive `cat` pane emits nothing, so this single CM sees no `%output` events. Routing `%output` for user-facing tiles (each in its own tmux session) requires per-session CM clients — a separate architectural slice. Documented in the module-level doc.

## Known gaps documented in code

- `Tmux::shutdown` calls `child.start_kill()` directly. Per Node scar `33feed2`, tmux 3.6a has a UAF when a CM child dies abruptly. Clean path is in-band `detach-client` then `kill-session`. Only fires on explicit shutdown today, not in any user-driven path.

## Test plan

- [x] `cargo test --lib session` — 122 passing, 2 ignored
- [x] `cargo test --lib -- --ignored` — both ignored tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean