### PR TITLE
fix(mobile): hide terminal status bar on phone-class screens

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -488,6 +488,13 @@
       color: #89b4fa;
     }
     .term-status-agent i { color: #89b4fa; }
+    /* Phones don't have the vertical real estate to overlay the status
+       bar on the xterm viewport without burying the last line of output
+       (e.g. an active Claude session). The cwd/branch info is still
+       reachable via the History tile and the terminal title, so we just
+       hide the floating bar on phone-class screens. iPad and desktop
+       keep it — they have the height to spare. */
+    body[data-platform="phone"] .term-status-bar { display: none; }
 
     /* ── History tile ───────────────────────────────────────────── */
     .history-tile-root {


### PR DESCRIPTION
## Summary
- The Warp-style terminal status bar from PR #649 is `position: absolute; bottom: 0` over the xterm viewport. On phones it lands on top of the last line of terminal output — the cwd chip overlaps a live Claude session's footer.
- One-line CSS rule keyed off `body[data-platform=\"phone\"]` (set by `shortcut-bar.js:262`) hides the bar on phone-class screens. iPad and desktop are unchanged.

## Why CSS, not JS
The renderer mounts a single absolutely-positioned element per tile. Hiding it costs nothing; short-circuiting in JS would add branches and a phone-detection import to the renderer for a purely cosmetic change.

## Test plan
- [ ] Reload the mobile PWA: confirm the cwd chip is gone and the terminal's last line is no longer obscured
- [ ] iPad: confirm the chip still renders
- [ ] Desktop: confirm the chip still renders