### PR TITLE
fix(update): keep smoke-test child in parent's process group

### DIFF
--- a/lib/cli/commands/_finish-upgrade.js
+++ b/lib/cli/commands/_finish-upgrade.js
@@ -108,8 +108,12 @@ export default async function finishUpgrade(args) {
   );
 
   const logPath = join(DATA_DIR, "smoke-test.log");
+  // Smoke-test child stays in this process's process group on purpose.
+  // If the upgrade is interrupted (ssh drop → SIGHUP, ^C → SIGINT), the
+  // signal is delivered to the whole pgrp and the child dies with us —
+  // no orphan smoke-test server holding an ephemeral port. The explicit
+  // SIGKILL below still handles the happy path.
   const testProc = spawn(process.execPath, [join(ROOT, "server.js")], {
-    detached: true,
     stdio: ["ignore", openSync(logPath, "w"), openSync(logPath, "w")],
     env: {
       ...process.env,

--- a/lib/cli/commands/update.js
+++ b/lib/cli/commands/update.js
@@ -252,10 +252,13 @@ export default async function update(args) {
         console.error("  Recovery options:");
         console.error("    1. File an issue with the smoke test output above:");
         console.error("       https://github.com/Dorky-Robot/katulong/issues");
-        console.error("    2. Reinstall a known-good version from the tap, e.g.:");
+        console.error(`    2. Downgrade to v${currentVersion}: pin the tap formula to its prior`);
+        console.error("       commit, then reinstall:");
+        console.error('         cd "$(brew --repo dorky-robot/tap)"');
+        console.error(`         git log -- Formula/katulong.rb       # find a v${currentVersion} commit`);
+        console.error("         git checkout <commit> -- Formula/katulong.rb");
         console.error("         brew uninstall katulong");
-        console.error("         brew install dorky-robot/tap/katulong  # at a known-good tag");
-        console.error(`       (you were on v${currentVersion} before this upgrade.)`);
+        console.error("         brew install dorky-robot/tap/katulong");
       }
       console.error("");
       process.exit(1);

--- a/lib/cli/commands/update.js
+++ b/lib/cli/commands/update.js
@@ -63,6 +63,33 @@ function cleanupSentinel() {
   try { unlinkSync(SENTINEL_PATH); } catch {}
 }
 
+/**
+ * Probe the old server to find out if it's actually still serving.
+ *
+ * Important: post `brew upgrade`, the old Cellar's `libexec/public/`
+ * directory is gone. The old server PID is still alive but its
+ * `readFileSync` on static assets now hits ENOENT — every request
+ * 500s. So "old PID is alive" does NOT imply "old server is healthy".
+ * This probe is what lets the catch block report truth instead of
+ * the misleading "old server should still be serving" line.
+ */
+async function probeOldServer(port) {
+  if (!port) return { ok: false, reason: "no port" };
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return { ok: false, reason: `HTTP ${res.status}` };
+    const data = await res.json().catch(() => null);
+    if (data?.status !== "ok") {
+      return { ok: false, reason: `health status "${data?.status ?? "unparseable"}"` };
+    }
+    return { ok: true, version: data.version };
+  } catch (err) {
+    return { ok: false, reason: err.cause?.code || err.code || err.message };
+  }
+}
+
 export default async function update(args) {
   // Reject unexpected positional arguments
   const positional = args.find((arg) => !arg.startsWith("--"));
@@ -94,6 +121,7 @@ export default async function update(args) {
   // Capture old server state before upgrading
   const oldServer = isServerRunning();
   const oldPid = oldServer.running ? oldServer.pid : null;
+  const oldPort = oldServer.running ? oldServer.port : null;
 
   // Create sentinel so brew post_install skips its own restart —
   // we'll handle it ourselves via _finish-upgrade after brew is done.
@@ -182,15 +210,17 @@ export default async function update(args) {
     } catch {
       cleanupSentinel();
       // By the time we reach this catch, `brew upgrade` has already
-      // replaced the on-disk binary with v${newVersion}. _finish-upgrade
-      // then ran its smoke battery and failed. It exits 1 BEFORE touching
-      // the old server (see lib/cli/commands/_finish-upgrade.js), so in
-      // the common case the old v${currentVersion} process is still alive
-      // and serving requests — the user's terminal is not broken.
+      // replaced the on-disk binary with v${newVersion} AND has typically
+      // removed the old Cellar's libexec contents (including public/).
+      // _finish-upgrade then ran its smoke battery and failed, exiting 1
+      // BEFORE touching the old server.
       //
-      // The dangerous advice here would be "Try: katulong start" — that
-      // would start the BROKEN new binary and leave the user without a
-      // working terminal. We give safe recovery guidance instead.
+      // Critical nuance: the old server PID is alive, but if brew has
+      // removed its public/ assets, every static read now 500s. So
+      // "process is running" does not imply "server is healthy". We
+      // probe before deciding what to tell the user.
+      const probe = await probeOldServer(oldPort);
+
       console.error("");
       console.error("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
       console.error(`✗ Post-upgrade smoke test failed for v${newVersion}`);
@@ -199,21 +229,34 @@ export default async function update(args) {
       console.error(`  The new v${newVersion} binary is installed on disk but failed its`);
       console.error("  smoke test. See the errors above for the specific failures.");
       console.error("");
-      console.error(`  Your old v${currentVersion} server should still be running and serving`);
-      console.error("  requests — the upgrade flow leaves it untouched on smoke failure.");
-      console.error("");
-      console.error("  ⚠  DO NOT run 'katulong start' or 'katulong restart' right now.");
-      console.error(`     Those commands would launch the broken v${newVersion} binary and`);
-      console.error("     leave you without a working terminal.");
-      console.error("");
-      console.error("  To verify the old server is still alive:");
-      console.error("    katulong status");
-      console.error("");
-      console.error("  Recovery options:");
-      console.error("    1. Keep using the old server — it's safe, no action needed.");
-      console.error("    2. File an issue with the smoke test output above:");
-      console.error("       https://github.com/Dorky-Robot/katulong/issues");
-      console.error(`    3. Downgrade to a known-good tag when a fix is released.`);
+
+      if (probe.ok) {
+        console.error(`  Your old v${currentVersion} server is still healthy on port ${oldPort}`);
+        console.error("  (just probed). The upgrade flow left it untouched on smoke failure.");
+        console.error("");
+        console.error("  ⚠  DO NOT run 'katulong start' or 'katulong restart' right now.");
+        console.error(`     Those commands would launch the broken v${newVersion} binary and`);
+        console.error("     leave you without a working terminal.");
+        console.error("");
+        console.error("  Recovery options:");
+        console.error("    1. Keep using the old server — it's safe, no action needed.");
+        console.error("    2. File an issue with the smoke test output above:");
+        console.error("       https://github.com/Dorky-Robot/katulong/issues");
+        console.error("    3. Downgrade to a known-good tag when a fix is released.");
+      } else {
+        console.error(`  Your old v${currentVersion} server is ALSO unhealthy: ${probe.reason}.`);
+        console.error("  Most likely brew has removed the old Cellar's static assets, so the");
+        console.error("  still-running process now 500s on every static read. Both versions");
+        console.error("  are broken — there is no safe fallback on this host.");
+        console.error("");
+        console.error("  Recovery options:");
+        console.error("    1. File an issue with the smoke test output above:");
+        console.error("       https://github.com/Dorky-Robot/katulong/issues");
+        console.error("    2. Reinstall a known-good version from the tap, e.g.:");
+        console.error("         brew uninstall katulong");
+        console.error("         brew install dorky-robot/tap/katulong  # at a known-good tag");
+        console.error(`       (you were on v${currentVersion} before this upgrade.)`);
+      }
       console.error("");
       process.exit(1);
     }

--- a/test/finish-upgrade-pgrp.test.js
+++ b/test/finish-upgrade-pgrp.test.js
@@ -1,0 +1,60 @@
+/**
+ * Regression test for the orphan-smoke-test bug fixed in PR #655.
+ *
+ * `_finish-upgrade.js` spawns a smoke-test server on a temp port. Before
+ * the fix it used `detached: true`, which puts the child in its own
+ * process group — when the orchestrator received SIGHUP from an ssh
+ * disconnect (or SIGINT from ^C), the child was NOT in the foreground
+ * pgrp and survived as an orphan, holding the ephemeral port and
+ * occasionally serving stale state.
+ *
+ * The fix: keep the child in the parent's pgrp by NOT detaching. Then
+ * a terminal-disconnect SIGHUP propagates to the whole pgrp and the
+ * child dies with the orchestrator — for free, via OS primitives.
+ *
+ * This test guards against accidental re-introduction of `detached: true`
+ * on the smoke-test spawn. We don't try to exercise the SIGHUP path at
+ * runtime — that would be testing kernel/Node behavior, not our code.
+ * The thing that can actually regress is the spawn options literal.
+ */
+
+import { test } from "node:test";
+import { ok } from "node:assert";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SOURCE_PATH = join(
+  __dirname,
+  "..",
+  "lib",
+  "cli",
+  "commands",
+  "_finish-upgrade.js",
+);
+
+test("smoke-test spawn must not use detached:true (orphan-on-SIGHUP regression)", () => {
+  const src = readFileSync(SOURCE_PATH, "utf-8");
+
+  // The smoke-test child is the FIRST `spawn(process.execPath` call in
+  // the file. The second one (production server post-swap) is allowed
+  // and required to be `detached: true` — it must outlive its parent.
+  const firstSpawnIdx = src.indexOf("spawn(process.execPath");
+  ok(
+    firstSpawnIdx !== -1,
+    "expected spawn(process.execPath, ...) call in _finish-upgrade.js",
+  );
+  const blockEnd = src.indexOf("});", firstSpawnIdx);
+  ok(
+    blockEnd > firstSpawnIdx,
+    "could not locate end of smoke-test spawn options block",
+  );
+  const block = src.slice(firstSpawnIdx, blockEnd);
+
+  ok(
+    !/\bdetached\s*:\s*true\b/.test(block),
+    "smoke-test spawn must not set detached:true — it puts the child in its own " +
+      "process group and orphans it on ssh-drop SIGHUP. See PR #655.",
+  );
+});


### PR DESCRIPTION
## Summary

`katulong update` over `ssh mini` left an orphan smoke-test `server.js` holding an ephemeral port, while `brew upgrade` had already deleted the old Cellar's `public/` assets. The launchd-managed old server kept running but began 500'ing on every static read — production returned `{"error":"Internal server error"}`.

This PR addresses the bug at two levels:

1. **Don't orphan the smoke-test child.** `_finish-upgrade.js`'s smoke-test spawn used `detached: true`, putting the child in its own process group — when the orchestrator received SIGHUP from an ssh disconnect, the child wasn't in the foreground pgrp and survived. Drop `detached: true` and the OS handles cleanup via process-group signal delivery. The other two `detached: true` spawns in the codebase (production server post-swap, `restart.js:75`) are correct as-is — those processes are SUPPOSED to outlive their parent.

2. **Don't lie to the user when the upgrade fails.** `update.js`'s catch block previously told the user *"Your old v\${currentVersion} server should still be running and serving requests."* That's false post-`brew upgrade`: brew has already torn out the old Cellar's `public/` directory, so the still-running PID 500s on every static read. Now we probe `http://127.0.0.1:<oldPort>/health` before reporting and branch the message:
   - **Old server healthy** → keep the original "still serving, safe to keep using" guidance.
   - **Old server broken** → tell the user BOTH versions are broken on this host, point at `brew install dorky-robot/tap/katulong` at a known-good tag as recovery.

## Why these over more elaborate fixes

Considered but rejected:
- Sentinel-based resume on next CLI invocation
- End-of-flow probe + force `launchctl kickstart -k`
- Trapping signals inside `_finish-upgrade` to explicitly kill the child
- Wrapping spawn → SIGKILL in try/finally — read `runSmokeTest` and `waitForHealth`; both wrap every external call in try/catch and return result objects rather than throwing. The defended-against path can't fire, so the guard would be dead code.

All of those reinvent cleanup logic the OS already provides via process groups. Don't fight the OS.

## Test coverage

- New `test/finish-upgrade-pgrp.test.js` — structural regression test that asserts the smoke-test spawn does NOT use `detached: true`. Guards against accidental re-introduction. We don't exercise the actual SIGHUP path because that would test kernel/Node behavior, not our code; the thing that *can* regress is the spawn options literal.
- All 2581 unit + integration tests pass (was 2580, +1 for the new regression test).
- Smoke E2E pass via pre-push hook.

## Test plan

- [x] Unit + integration pass locally
- [x] Smoke E2E pass via pre-push hook
- [x] Review agents pass via pre-push hook
- [x] New regression test prevents accidental re-add of `detached: true`
- [ ] Manual: drop ssh mid-upgrade and confirm no orphan via `ssh mini "lsof -nP -iTCP -sTCP:LISTEN | grep node"` — actionable on the next real version bump
- [ ] Manual: trigger smoke-test failure on a host with brew-cleaned old Cellar assets and confirm the catch block now reports the broken state accurately — actionable on the next real version bump