### PR TITLE
rewrite(server): slice 9l — Tmux::attach + clean shutdown + attach_tile

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -44,7 +44,7 @@ async fn main() {
         Tmux::spawn(&socket_name, &keepalive_session, DEFAULT_COLS, DEFAULT_ROWS)
             .await
             .expect("spawn tmux control-mode subprocess");
-    let sessions = SessionManager::new(tmux);
+    let sessions = SessionManager::new(tmux, socket_name.clone());
     let output_router = OutputRouter::new();
 
     // The dispatcher task drains the (unbounded per `Tmux::spawn`

--- a/crates/server/src/session/manager.rs
+++ b/crates/server/src/session/manager.rs
@@ -93,6 +93,20 @@ impl SessionManager {
         );
         let reply = self.tmux.send_command(&cmd).await?;
         if !reply.ok {
+            // tmux's "duplicate session" error is what we want to
+            // treat as idempotent success: it means a concurrent
+            // caller (or a prior aborted attempt) already created
+            // this session. Mirrors the symmetric idempotency in
+            // `destroy_session` (treats "can't find session" as
+            // ok). Closes the ensure_session TOCTOU race PR #656
+            // correctness review flagged HIGH.
+            if reply.output.contains("duplicate session") {
+                tracing::info!(
+                    session = %name,
+                    "session already exists; create_session is idempotent"
+                );
+                return Ok(());
+            }
             return Err(SessionError::TmuxRejected(reply.output));
         }
         tracing::info!(session = %name, cols, rows, "session created");
@@ -132,10 +146,17 @@ impl SessionManager {
     /// tile session. Ensures the session exists first.
     ///
     /// Returns the `Tmux` handle and its notification receiver.
+    /// The returned `Tmux` owns a live CM subprocess (despite
+    /// the method name — `attach` here means "attach a CM
+    /// client to an existing tmux session," and that always
+    /// involves spawning a subprocess).
+    ///
     /// **Ownership transfers to the caller** — typically a WS
     /// handler. The caller is responsible for:
-    /// - draining the notification receiver (per the
-    ///   backpressure contract on [`Tmux::spawn`]),
+    /// - draining the notification receiver (the unbounded-
+    ///   channel backpressure contract documented on
+    ///   [`Tmux::spawn`] applies equally to receivers from
+    ///   [`Tmux::attach`]),
     /// - calling [`Tmux::shutdown`] when the WS connection
     ///   tears down (clean detach avoids the tmux 3.6a UAF).
     ///
@@ -683,7 +704,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "requires tmux binary + dedicated socket; run with: cargo test -- --ignored"]
-    async fn ensure_session_is_idempotent() {
+    async fn ensure_session_second_call_is_noop() {
         // Calling ensure_session twice for the same name must
         // succeed both times. Second call hits the has-session
         // pre-check and no-ops.
@@ -746,7 +767,34 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "requires tmux binary + dedicated socket; run with: cargo test -- --ignored"]
-    async fn shutdown_uses_in_band_detach_client() {
+    async fn create_session_treats_duplicate_as_idempotent() {
+        // PR #656 round-1 HIGH fix: a concurrent attach race
+        // where two callers both try to create the same session
+        // must not surface tmux's "duplicate session" error to
+        // the second caller. Repeat create_session twice and
+        // expect both Ok.
+        use super::super::tmux::Tmux;
+
+        let socket = format!("katulong-dup-{}", std::process::id());
+        let (tmux, _notifs) = Tmux::spawn(&socket, "main", 80, 24)
+            .await
+            .expect("spawn tmux");
+        let manager = SessionManager::new(tmux.clone(), socket.clone());
+
+        manager.create_session("tile-z", 80, 24).await.unwrap();
+        // Second call must succeed (the "duplicate session" tmux
+        // error is caught and treated as Ok).
+        manager
+            .create_session("tile-z", 80, 24)
+            .await
+            .expect("second create_session must be idempotent");
+
+        tmux.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires tmux binary + dedicated socket; run with: cargo test -- --ignored"]
+    async fn shutdown_exits_cleanly_within_grace_period() {
         // Verifies the slice 9l shutdown path: send detach-client,
         // wait for clean exit, no SIGKILL fallback in the happy
         // path. The watchdog warning from `apply_note` style would

--- a/crates/server/src/session/manager.rs
+++ b/crates/server/src/session/manager.rs
@@ -25,18 +25,37 @@ use super::dims::{clamp_dims, DEFAULT_COLS, DEFAULT_ROWS};
 use super::router::OutputRouter;
 use super::tmux::{Tmux, TmuxError};
 use std::collections::HashSet;
+use tokio::sync::mpsc;
+
+use super::parser::Notification;
 
 /// Public handle to the session layer. Construct with `new` at
 /// server startup; clone into every handler that needs to touch
 /// sessions.
+///
+/// SessionManager holds the **command CM** — the long-lived
+/// control-mode client used for global queries
+/// (`list-panes -a`, `list-sessions`, `kill-session`, etc.) and
+/// for issuing `new-session` commands when tiles are created.
+/// It is intentionally NOT a registry of per-tile state; each
+/// per-tile `Tmux` instance is owned by the WS handler that
+/// attached it. Lifecycle of per-tile CMs is tied to the
+/// handler's task, not to this struct.
 #[derive(Clone)]
 pub struct SessionManager {
     tmux: Tmux,
+    socket_name: String,
 }
 
 impl SessionManager {
-    pub fn new(tmux: Tmux) -> Self {
-        Self { tmux }
+    pub fn new(tmux: Tmux, socket_name: String) -> Self {
+        Self { tmux, socket_name }
+    }
+
+    /// Tmux socket this manager talks to. Per-tile `Tmux::attach`
+    /// callers need it; exposed read-only.
+    pub fn socket_name(&self) -> &str {
+        &self.socket_name
     }
 
     /// Create a new tmux session with the given name and initial
@@ -78,6 +97,62 @@ impl SessionManager {
         }
         tracing::info!(session = %name, cols, rows, "session created");
         Ok(())
+    }
+
+    /// Idempotent variant of [`SessionManager::create_session`].
+    /// Creates the session if it doesn't exist; no-op if it does.
+    /// Used by [`SessionManager::attach_tile`] so a WS handler
+    /// can ensure-and-attach in one call without coupling to
+    /// who-creates-it ordering.
+    ///
+    /// Implementation is a `has-session` probe + conditional
+    /// `new-session`. tmux's `new-session -A` flag advertises
+    /// idempotency, but its semantics (attach the calling client
+    /// if the session exists) don't match our use case — the
+    /// command CM should NOT attach to user-tile sessions.
+    pub async fn ensure_session(
+        &self,
+        name: &str,
+        cols: u16,
+        rows: u16,
+    ) -> Result<(), SessionError> {
+        validate_session_name(name)?;
+        let has = self
+            .tmux
+            .send_command(&format!("has-session -t {name}"))
+            .await?;
+        if has.ok {
+            tracing::trace!(session = %name, "ensure_session: already exists");
+            return Ok(());
+        }
+        self.create_session(name, cols, rows).await
+    }
+
+    /// Spawn a per-tile control-mode client attached to the named
+    /// tile session. Ensures the session exists first.
+    ///
+    /// Returns the `Tmux` handle and its notification receiver.
+    /// **Ownership transfers to the caller** — typically a WS
+    /// handler. The caller is responsible for:
+    /// - draining the notification receiver (per the
+    ///   backpressure contract on [`Tmux::spawn`]),
+    /// - calling [`Tmux::shutdown`] when the WS connection
+    ///   tears down (clean detach avoids the tmux 3.6a UAF).
+    ///
+    /// `SessionManager` holds NO per-tile state. The tile's
+    /// underlying tmux session persists across CM disconnects
+    /// (a re-attach gets the same session); only the per-tile
+    /// CM client lifetime is tied to the handler.
+    pub async fn attach_tile(
+        &self,
+        name: &str,
+        cols: u16,
+        rows: u16,
+    ) -> Result<(Tmux, mpsc::UnboundedReceiver<Notification>), SessionError> {
+        self.ensure_session(name, cols, rows).await?;
+        Tmux::attach(&self.socket_name, name)
+            .await
+            .map_err(SessionError::Tmux)
     }
 
     /// List session names currently running on tmux. Returns them in
@@ -578,7 +653,7 @@ mod tests {
         let (tmux, _notifs) = Tmux::spawn(&socket, "main", 80, 24)
             .await
             .expect("spawn tmux");
-        let manager = SessionManager::new(tmux.clone());
+        let manager = SessionManager::new(tmux.clone(), socket.clone());
         let router = OutputRouter::new();
 
         manager.create_session("alpha", 80, 24).await.unwrap();
@@ -604,5 +679,95 @@ mod tests {
         assert_eq!(router.subscriber_count(alpha_pane), 0);
 
         tmux.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires tmux binary + dedicated socket; run with: cargo test -- --ignored"]
+    async fn ensure_session_is_idempotent() {
+        // Calling ensure_session twice for the same name must
+        // succeed both times. Second call hits the has-session
+        // pre-check and no-ops.
+        use super::super::tmux::Tmux;
+
+        let socket = format!("katulong-ensure-{}", std::process::id());
+        let (tmux, _notifs) = Tmux::spawn(&socket, "main", 80, 24)
+            .await
+            .expect("spawn tmux");
+        let manager = SessionManager::new(tmux.clone(), socket.clone());
+
+        manager.ensure_session("tile-x", 80, 24).await.unwrap();
+        manager
+            .ensure_session("tile-x", 80, 24)
+            .await
+            .expect("second ensure must be a no-op");
+
+        // Verify the session actually exists.
+        let sessions = manager.list_sessions().await.unwrap();
+        assert!(sessions.iter().any(|s| s == "tile-x"));
+
+        tmux.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires tmux binary + dedicated socket; run with: cargo test -- --ignored"]
+    async fn attach_tile_returns_live_cm_for_existing_session() {
+        // attach_tile must produce a Tmux whose CM is attached to
+        // the named session. Verified by issuing a list-sessions
+        // command through the per-tile CM and seeing the tile's
+        // session in the reply.
+        use super::super::tmux::Tmux;
+
+        let socket = format!("katulong-attach-{}", std::process::id());
+        let (cmd_tmux, _notifs) = Tmux::spawn(&socket, "main", 80, 24)
+            .await
+            .expect("spawn cmd-tmux");
+        let manager = SessionManager::new(cmd_tmux.clone(), socket.clone());
+
+        let (tile_tmux, _tile_notifs) = manager
+            .attach_tile("tile-y", 80, 24)
+            .await
+            .expect("attach_tile");
+
+        let reply = tile_tmux
+            .send_command("list-sessions -F '#{session_name}'")
+            .await
+            .expect("list-sessions through tile CM");
+        assert!(reply.ok);
+        assert!(
+            reply.output.contains("tile-y"),
+            "tile-y session should appear in list-sessions: {}",
+            reply.output
+        );
+
+        // Clean shutdown via in-band detach.
+        tile_tmux.shutdown().await;
+        cmd_tmux.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires tmux binary + dedicated socket; run with: cargo test -- --ignored"]
+    async fn shutdown_uses_in_band_detach_client() {
+        // Verifies the slice 9l shutdown path: send detach-client,
+        // wait for clean exit, no SIGKILL fallback in the happy
+        // path. The watchdog warning from `apply_note` style would
+        // not fire on a healthy tmux.
+        use super::super::tmux::Tmux;
+
+        let socket = format!("katulong-detach-{}", std::process::id());
+        let (tmux, _notifs) = Tmux::spawn(&socket, "main", 80, 24)
+            .await
+            .expect("spawn tmux");
+
+        // shutdown should return well within the SHUTDOWN_GRACE
+        // budget (2s). If it took longer, the watchdog tripped
+        // and we'd see a warn — but here the clean path should
+        // be sub-100ms.
+        let start = std::time::Instant::now();
+        tmux.shutdown().await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_secs(1),
+            "clean detach should be quick; took {elapsed:?}"
+        );
     }
 }

--- a/crates/server/src/session/router.rs
+++ b/crates/server/src/session/router.rs
@@ -594,7 +594,7 @@ mod tests {
     /// reconcile path logs the error and moves on, so these
     /// tests still observe the loop's behavior correctly.
     fn dead_sessions() -> SessionManager {
-        SessionManager::new(Tmux::dead_for_tests())
+        SessionManager::new(Tmux::dead_for_tests(), "dead-test-socket".to_string())
     }
 
     // ---------- Single-subscriber core behaviour ----------

--- a/crates/server/src/session/tmux.rs
+++ b/crates/server/src/session/tmux.rs
@@ -261,7 +261,7 @@ impl Tmux {
         // the tmux server we created in step 1 — otherwise a
         // failed spawn leaves the server running with an
         // orphaned keepalive session.
-        match Self::cm_attach_raw(socket_name, initial_session).await {
+        match Self::cm_attach_inner(socket_name, initial_session).await {
             Ok(handle) => Ok(handle),
             Err(e) => {
                 kill_orphan_server(socket_name).await;
@@ -287,7 +287,7 @@ impl Tmux {
     ) -> Result<(Self, mpsc::UnboundedReceiver<Notification>), TmuxError> {
         validate_socket_name(socket_name)?;
         validate_session_name_for_tmux(session)?;
-        Self::cm_attach_raw(socket_name, session).await
+        Self::cm_attach_inner(socket_name, session).await
     }
 
     /// Shared body of [`Tmux::spawn`] and [`Tmux::attach`]: spawn
@@ -296,7 +296,7 @@ impl Tmux {
     /// terminate the child (if it spawned) but do NOT kill the
     /// tmux server — that's `spawn`'s responsibility because only
     /// `spawn` created it.
-    async fn cm_attach_raw(
+    async fn cm_attach_inner(
         socket_name: &str,
         session: &str,
     ) -> Result<(Self, mpsc::UnboundedReceiver<Notification>), TmuxError> {
@@ -408,7 +408,9 @@ impl Tmux {
     }
 
     /// Cleanly tear down this CM client. Idempotent — calling
-    /// twice is safe; the second call no-ops.
+    /// twice is safe; the second call no-ops. The inline step
+    /// labels in the body narrate the sequence; the prose here
+    /// covers only the rationale.
     ///
     /// # tmux 3.6a UAF avoidance (Node scar `33feed2`)
     ///
@@ -417,19 +419,11 @@ impl Tmux {
     /// `tmux -C` child dies abruptly (e.g. SIGTERM/SIGKILL),
     /// causing the tmux server to segfault and take EVERY
     /// session with it. The Node implementation captured this
-    /// scar tissue: walk tmux's normal detach path by writing
-    /// `detach-client\n` on stdin first, wait for the CM to
-    /// close cleanly, then SIGKILL only as a watchdog fallback
-    /// if it didn't exit on its own.
-    ///
-    /// Sequence:
-    /// 1. Send `detach-client` via the CM's command channel
-    ///    (best-effort — if the channel is already torn down,
-    ///    proceed to step 3).
-    /// 2. Wait up to [`SHUTDOWN_GRACE`] for the child process
-    ///    to exit on its own.
-    /// 3. If still alive, SIGKILL as a last resort.
-    /// 4. Abort the reader/writer/stderr tasks and await them.
+    /// scar tissue: walk tmux's normal detach path with
+    /// `detach-client` first, wait for the CM to close cleanly,
+    /// SIGKILL only as a watchdog fallback. This Rust port
+    /// matches that pattern with [`SHUTDOWN_GRACE`] as the
+    /// watchdog budget.
     pub async fn shutdown(&self) {
         // Step 1: ask the CM client to detach in-band. We don't
         // care about the reply — tmux closes the connection
@@ -437,7 +431,15 @@ impl Tmux {
         // typically resolves with `Disconnected`. The point is
         // that tmux saw the request and walked its normal
         // detach path before the child exits.
-        let _ = self.send_command("detach-client").await;
+        //
+        // The send_command is timeout-bounded: if tmux is alive
+        // but frozen (SIGSTOP'd, OOM-suspended, blocked on a
+        // full pipe), the reader task can't resolve the oneshot
+        // and a bare await would hang forever — step 2's
+        // `child.wait()` watchdog would never start. PR #656
+        // correctness review HIGH.
+        let _ =
+            tokio::time::timeout(SHUTDOWN_GRACE, self.send_command("detach-client")).await;
 
         // Step 2 + 3: drain the child handle. If detach-client
         // worked, `child.wait()` returns quickly. If not (channel

--- a/crates/server/src/session/tmux.rs
+++ b/crates/server/src/session/tmux.rs
@@ -105,10 +105,19 @@ use super::parser::{parse, Notification, ParseError};
 use std::collections::VecDeque;
 use std::process::Stdio;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio::task::JoinHandle;
+
+/// How long [`Tmux::shutdown`] waits for the CM child to exit
+/// cleanly after sending `detach-client` before falling back to
+/// SIGKILL. Two seconds matches the Node implementation's
+/// watchdog (Node scar `33feed2`) — long enough that a healthy
+/// tmux always exits well within budget, short enough that a
+/// genuinely stuck process doesn't block server shutdown.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
 
 /// Result of executing one command against tmux.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -247,19 +256,63 @@ impl Tmux {
             )));
         }
 
-        // Step 2: spawn the long-lived CM client attached to the
-        // keepalive session. `-C attach-session` is the pattern
-        // that keeps the CM alive: the client stays connected as
-        // long as the attached session exists. `cat` in the
-        // keepalive session never exits, so the CM never gets a
-        // `%session-changed`/`%exit` from session death.
+        // Step 2: spawn the long-lived CM child attached to the
+        // keepalive session. If this fails we have to tear down
+        // the tmux server we created in step 1 — otherwise a
+        // failed spawn leaves the server running with an
+        // orphaned keepalive session.
+        match Self::cm_attach_raw(socket_name, initial_session).await {
+            Ok(handle) => Ok(handle),
+            Err(e) => {
+                kill_orphan_server(socket_name).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Attach a control-mode client to an EXISTING tmux session.
+    /// Pairs with [`Tmux::spawn`] (which creates a new session and
+    /// attaches): use `attach` when the session is already
+    /// running on the given socket, e.g. when a katulong tile's
+    /// session was created earlier and a new WS handler is now
+    /// hooking up its own per-tile CM client.
+    ///
+    /// The session must already exist on `socket_name`. Failures
+    /// from this path do NOT touch the tmux server itself —
+    /// callers other than `Tmux::spawn` are not the server's
+    /// owner.
+    pub async fn attach(
+        socket_name: &str,
+        session: &str,
+    ) -> Result<(Self, mpsc::UnboundedReceiver<Notification>), TmuxError> {
+        validate_socket_name(socket_name)?;
+        validate_session_name_for_tmux(session)?;
+        Self::cm_attach_raw(socket_name, session).await
+    }
+
+    /// Shared body of [`Tmux::spawn`] and [`Tmux::attach`]: spawn
+    /// a `tmux -C attach-session -t <session>` child and hook its
+    /// pipes to the reader/writer/stderr-drain tasks. Errors
+    /// terminate the child (if it spawned) but do NOT kill the
+    /// tmux server — that's `spawn`'s responsibility because only
+    /// `spawn` created it.
+    async fn cm_attach_raw(
+        socket_name: &str,
+        session: &str,
+    ) -> Result<(Self, mpsc::UnboundedReceiver<Notification>), TmuxError> {
+        // `-C attach-session` is the pattern that keeps the CM
+        // client alive: the client stays connected as long as the
+        // attached session exists. The session's pane behavior
+        // determines CM lifetime — for the keepalive session that
+        // pane runs `cat` (never exits), for a user-tile session
+        // it's the user's shell.
         let mut cmd = Command::new("tmux");
         cmd.arg("-L")
             .arg(socket_name)
             .arg("-C")
             .arg("attach-session")
             .arg("-t")
-            .arg(initial_session);
+            .arg(session);
         cmd.stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -268,23 +321,11 @@ impl Tmux {
             // escape sequences into tmux on terminal resizes.
             .kill_on_drop(true);
 
-        // From here on, any error must clean up the tmux server
-        // we created in step 1 — otherwise a failed spawn leaves
-        // the server running with an orphaned keepalive session,
-        // and the next `Tmux::spawn` against the same socket
-        // hits `new-session: session already exists`.
-        let mut child = match cmd.spawn() {
-            Ok(c) => c,
-            Err(e) => {
-                kill_orphan_server(socket_name).await;
-                return Err(TmuxError::Io(e));
-            }
-        };
+        let mut child = cmd.spawn().map_err(TmuxError::Io)?;
         let stdin = match child.stdin.take() {
             Some(s) => s,
             None => {
                 let _ = child.start_kill();
-                kill_orphan_server(socket_name).await;
                 return Err(TmuxError::Disconnected);
             }
         };
@@ -292,7 +333,6 @@ impl Tmux {
             Some(s) => s,
             None => {
                 let _ = child.start_kill();
-                kill_orphan_server(socket_name).await;
                 return Err(TmuxError::Disconnected);
             }
         };
@@ -367,35 +407,61 @@ impl Tmux {
         rx.await.map_err(|_| TmuxError::Disconnected)?
     }
 
-    // TODO(shutdown-safety): add in-band detach-client dance
-    // before kill to avoid the tmux 3.6a UAF; see KNOWN GAP in
-    // the doc below.
-    /// Kill the tmux subprocess and wait for the reader/writer
-    /// tasks to finish. Idempotent — calling twice is safe; the
-    /// second call no-ops.
+    /// Cleanly tear down this CM client. Idempotent — calling
+    /// twice is safe; the second call no-ops.
     ///
-    /// # KNOWN GAP — tmux 3.6a UAF on abrupt CM child kill
+    /// # tmux 3.6a UAF avoidance (Node scar `33feed2`)
     ///
-    /// Per Node scar `33feed2`: tmux 3.6a has a use-after-free
-    /// in `control_notify_client_detached` that triggers when a
+    /// tmux 3.6a has a use-after-free in
+    /// `control_notify_client_detached` that triggers when a
     /// `tmux -C` child dies abruptly (e.g. SIGTERM/SIGKILL),
     /// causing the tmux server to segfault and take EVERY
-    /// session with it. The fix walks tmux's normal detach path
-    /// by writing `detach-client\n` on stdin first, waiting for
-    /// the CM to close cleanly, THEN running `kill-session`.
-    /// An unref'd 2-second watchdog SIGKILLs as last resort.
+    /// session with it. The Node implementation captured this
+    /// scar tissue: walk tmux's normal detach path by writing
+    /// `detach-client\n` on stdin first, wait for the CM to
+    /// close cleanly, then SIGKILL only as a watchdog fallback
+    /// if it didn't exit on its own.
     ///
-    /// The current code uses `start_kill` directly. That's the
-    /// abrupt path. Today this only fires in test cleanup and
-    /// process-shutdown paths where tmux dying is acceptable;
-    /// production code never calls `shutdown` on a still-live
-    /// instance. Track adding the in-band `detach-client` dance
-    /// before this becomes user-visible.
+    /// Sequence:
+    /// 1. Send `detach-client` via the CM's command channel
+    ///    (best-effort — if the channel is already torn down,
+    ///    proceed to step 3).
+    /// 2. Wait up to [`SHUTDOWN_GRACE`] for the child process
+    ///    to exit on its own.
+    /// 3. If still alive, SIGKILL as a last resort.
+    /// 4. Abort the reader/writer/stderr tasks and await them.
     pub async fn shutdown(&self) {
+        // Step 1: ask the CM client to detach in-band. We don't
+        // care about the reply — tmux closes the connection
+        // immediately after acking the detach, so the oneshot
+        // typically resolves with `Disconnected`. The point is
+        // that tmux saw the request and walked its normal
+        // detach path before the child exits.
+        let _ = self.send_command("detach-client").await;
+
+        // Step 2 + 3: drain the child handle. If detach-client
+        // worked, `child.wait()` returns quickly. If not (channel
+        // dead, tmux misbehaving), the watchdog SIGKILLs.
         if let Some(mut child) = self.child.lock().await.take() {
-            let _ = child.start_kill();
-            let _ = child.wait().await;
+            match tokio::time::timeout(SHUTDOWN_GRACE, child.wait()).await {
+                Ok(_) => { /* clean exit */ }
+                Err(_) => {
+                    // Watchdog tripped — fall back to abrupt
+                    // kill. This may still trigger the UAF, but
+                    // we tried the clean path first.
+                    tracing::warn!(
+                        "tmux CM did not exit within {}s of detach-client; SIGKILL fallback",
+                        SHUTDOWN_GRACE.as_secs()
+                    );
+                    let _ = child.start_kill();
+                    let _ = child.wait().await;
+                }
+            }
         }
+
+        // Step 4: tear down the reader/writer/stderr tasks. They
+        // would exit on their own once stdout/stdin close, but
+        // aborting + awaiting makes shutdown deterministic.
         let handles = std::mem::take(&mut *self.tasks.lock().await);
         for h in handles {
             h.abort();


### PR DESCRIPTION
## Summary

Foundation for **Path 1** (per-session CM clients). This slice ships the per-tile attach machinery and closes the documented tmux 3.6a UAF; the `handler.rs` wiring that consumes it is slice 9m.

## What changed

- **`Tmux::attach(socket, session)`** — new constructor; `-C attach-session -t <session>` against an existing tmux session. Pairs with `Tmux::spawn` (create + attach) via a shared `cm_attach_raw` private helper.
- **`Tmux::shutdown` does in-band `detach-client`** — closes the tmux 3.6a UAF (Node scar `33feed2`). 2s `SHUTDOWN_GRACE` watchdog; SIGKILL only as fallback.
- **`SessionManager::ensure_session`** — idempotent `has-session` probe + conditional `new-session`.
- **`SessionManager::attach_tile`** — returns `(Tmux, NotifReceiver)`; ownership transfers to caller.
- **`SessionManager` gains `socket_name`** — needed for `Tmux::attach` calls. Constructor sig changed; main.rs + 2 test sites updated.

## Why no per-tile HashMap on SessionManager

Per the FP-leaning direction memory: shared interior mutability for task-scoped state is an antipattern. Per-tile lifetime maps to the WS handler that owns it; the underlying tmux session persists across CM disconnects (re-attach gets the same session). `SessionManager` holds no per-tile state.

## Coverage

3 new ignored integration tests against real tmux:
- `ensure_session_is_idempotent`
- `attach_tile_returns_live_cm_for_existing_session`
- `shutdown_uses_in_band_detach_client`

188 unit tests pass; **5 ignored integration tests all pass** under `--ignored`. Clippy clean.

## Deferred to slice 9m

- Wiring per-tile attach into `handler.rs::serve_session`. The current handler uses the global `OutputRouter::dispatch` driven by the keepalive CM; with `attach_tile` available, the handler should spawn its own dispatcher per WS connection that routes the per-tile CM's `%output` to the router.

## Test plan

- [x] `cargo test --lib` — 188 passing, 5 ignored
- [x] `cargo test --lib -- --ignored` — all 5 pass against real tmux 3.6a
- [x] `cargo clippy --all-targets -- -D warnings` — clean