### PR TITLE
rewrite(server): slice 9m — handler ensure_session + socket_name dedup

### DIFF
--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -44,7 +44,7 @@ async fn main() {
         Tmux::spawn(&socket_name, &keepalive_session, DEFAULT_COLS, DEFAULT_ROWS)
             .await
             .expect("spawn tmux control-mode subprocess");
-    let sessions = SessionManager::new(tmux, socket_name.clone());
+    let sessions = SessionManager::new(tmux);
     let output_router = OutputRouter::new();
 
     // The dispatcher task drains the (unbounded per `Tmux::spawn`

--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -786,8 +786,14 @@ async fn try_attach(
             err: err.to_string(),
         }
     };
+    // ensure_session is idempotent: existing session → no-op,
+    // missing session → create. The non-idempotent
+    // `create_session` would surface a spurious "duplicate
+    // session" error to a client whose tile already exists
+    // (e.g., a reconnect to a session created by an earlier
+    // WS connection). Architecture HIGH from PR #656 review.
     sessions
-        .create_session(session, cols, rows)
+        .ensure_session(session, cols, rows)
         .await
         .map_err(to_failure)?;
     let pane_id = sessions

--- a/crates/server/src/session/manager.rs
+++ b/crates/server/src/session/manager.rs
@@ -44,18 +44,19 @@ use super::parser::Notification;
 #[derive(Clone)]
 pub struct SessionManager {
     tmux: Tmux,
-    socket_name: String,
 }
 
 impl SessionManager {
-    pub fn new(tmux: Tmux, socket_name: String) -> Self {
-        Self { tmux, socket_name }
+    pub fn new(tmux: Tmux) -> Self {
+        Self { tmux }
     }
 
-    /// Tmux socket this manager talks to. Per-tile `Tmux::attach`
-    /// callers need it; exposed read-only.
+    /// Tmux socket this manager talks to. Delegates to the
+    /// embedded `Tmux` (which owns the canonical
+    /// `socket_name`). Per-tile `Tmux::attach` callers need it;
+    /// exposed read-only.
     pub fn socket_name(&self) -> &str {
-        &self.socket_name
+        self.tmux.socket_name()
     }
 
     /// Create a new tmux session with the given name and initial
@@ -171,7 +172,7 @@ impl SessionManager {
         rows: u16,
     ) -> Result<(Tmux, mpsc::UnboundedReceiver<Notification>), SessionError> {
         self.ensure_session(name, cols, rows).await?;
-        Tmux::attach(&self.socket_name, name)
+        Tmux::attach(self.socket_name(), name)
             .await
             .map_err(SessionError::Tmux)
     }
@@ -674,7 +675,7 @@ mod tests {
         let (tmux, _notifs) = Tmux::spawn(&socket, "main", 80, 24)
             .await
             .expect("spawn tmux");
-        let manager = SessionManager::new(tmux.clone(), socket.clone());
+        let manager = SessionManager::new(tmux.clone());
         let router = OutputRouter::new();
 
         manager.create_session("alpha", 80, 24).await.unwrap();
@@ -714,7 +715,7 @@ mod tests {
         let (tmux, _notifs) = Tmux::spawn(&socket, "main", 80, 24)
             .await
             .expect("spawn tmux");
-        let manager = SessionManager::new(tmux.clone(), socket.clone());
+        let manager = SessionManager::new(tmux.clone());
 
         manager.ensure_session("tile-x", 80, 24).await.unwrap();
         manager
@@ -742,7 +743,7 @@ mod tests {
         let (cmd_tmux, _notifs) = Tmux::spawn(&socket, "main", 80, 24)
             .await
             .expect("spawn cmd-tmux");
-        let manager = SessionManager::new(cmd_tmux.clone(), socket.clone());
+        let manager = SessionManager::new(cmd_tmux.clone());
 
         let (tile_tmux, _tile_notifs) = manager
             .attach_tile("tile-y", 80, 24)
@@ -779,7 +780,7 @@ mod tests {
         let (tmux, _notifs) = Tmux::spawn(&socket, "main", 80, 24)
             .await
             .expect("spawn tmux");
-        let manager = SessionManager::new(tmux.clone(), socket.clone());
+        let manager = SessionManager::new(tmux.clone());
 
         manager.create_session("tile-z", 80, 24).await.unwrap();
         // Second call must succeed (the "duplicate session" tmux

--- a/crates/server/src/session/router.rs
+++ b/crates/server/src/session/router.rs
@@ -594,7 +594,7 @@ mod tests {
     /// reconcile path logs the error and moves on, so these
     /// tests still observe the loop's behavior correctly.
     fn dead_sessions() -> SessionManager {
-        SessionManager::new(Tmux::dead_for_tests(), "dead-test-socket".to_string())
+        SessionManager::new(Tmux::dead_for_tests())
     }
 
     // ---------- Single-subscriber core behaviour ----------

--- a/crates/server/src/session/tmux.rs
+++ b/crates/server/src/session/tmux.rs
@@ -163,6 +163,12 @@ pub struct Tmux {
     /// The reader/writer tasks' join handles. Same reason: exactly
     /// one shutdown path should await them.
     tasks: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    /// The `-L <socket_name>` this CM was spawned against. Held
+    /// here (not just via `SessionManager`) so any caller with
+    /// a `Tmux` handle can spawn additional CMs against the
+    /// same socket — e.g. `SessionManager::attach_tile` calling
+    /// `Tmux::attach` for a per-tile CM.
+    socket_name: Arc<str>,
 }
 
 /// Sent over the command mpsc. Carries both what to write to
@@ -366,9 +372,18 @@ impl Tmux {
                 cmd_tx,
                 child: Arc::new(Mutex::new(Some(child))),
                 tasks: Arc::new(Mutex::new(tasks)),
+                socket_name: Arc::from(socket_name),
             },
             notif_rx,
         ))
+    }
+
+    /// Tmux socket name (`-L <name>`) this CM was spawned
+    /// against. Cheap to call (returns a `&str` borrow into the
+    /// `Arc<str>` field). `Tmux::attach` callers need it to
+    /// spawn additional CMs against the same server.
+    pub fn socket_name(&self) -> &str {
+        &self.socket_name
     }
 
     /// Construct a `Tmux` handle with no live subprocess behind
@@ -384,6 +399,7 @@ impl Tmux {
             cmd_tx,
             child: Arc::new(Mutex::new(None)),
             tasks: Arc::new(Mutex::new(Vec::new())),
+            socket_name: Arc::from("dead-test-socket"),
         }
     }
 
@@ -1167,6 +1183,7 @@ mod tests {
             cmd_tx: tx.clone(),
             child: Arc::new(Mutex::new(None)),
             tasks: Arc::new(Mutex::new(vec![])),
+            socket_name: Arc::from("test-direct-socket"),
         };
         drop(tx);
         drop(rx);
@@ -1184,6 +1201,7 @@ mod tests {
             cmd_tx: tx,
             child: Arc::new(Mutex::new(None)),
             tasks: Arc::new(Mutex::new(vec![])),
+            socket_name: Arc::from("test-direct-socket"),
         };
         let err = t
             .send_command("list-sessions\nkill-server")
@@ -1201,6 +1219,7 @@ mod tests {
             cmd_tx: tx,
             child: Arc::new(Mutex::new(None)),
             tasks: Arc::new(Mutex::new(vec![])),
+            socket_name: Arc::from("test-direct-socket"),
         };
         let err = t
             .send_command("list-sessions\rkill-server")


### PR DESCRIPTION
## Summary

Closes the two architecture findings deferred from PR #656's review.

- **`Tmux::socket_name()` accessor** — `Tmux` now owns its `-L <name>` as `Arc<str>` and exposes a borrow. `SessionManager::socket_name()` delegates instead of holding a duplicate field.
- **`SessionManager::new` reverts to single-arg** — no separate `socket_name` parameter. Constructor sigs in main.rs + tests updated.
- **`try_attach` uses `ensure_session`** instead of `create_session` — closes the architecture HIGH (contingent) flagged in PR #656's review. Reconnects to existing tile sessions no longer fail with "duplicate session"; they succeed and pick up live state.

## What this does NOT do

Slice 9m is structural cleanup — no behavior change in non-error paths. The actual Path 1 wiring (per-tile CM in `AttachedState`, dispatcher per WS connection feeding `OutputRouter`) lands in slice 9n. Today the handler still subscribes to a router fed by the keepalive CM, which doesn't see user-tile `%output`.

## Test plan

- [x] `cargo test --lib` — 188 passing, 6 ignored
- [x] `cargo test --lib -- --ignored` — all 6 pass against real tmux 3.6a
- [x] `cargo clippy --all-targets -- -D warnings` — clean