### PR TITLE
fix(terminal): stop status pill bar from covering the prompt cursor

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -51,7 +51,9 @@
       "Bash(dig +short katulong-git-info.felixflor.es @1.1.1.1)",
       "Bash(cp /Users/felixflores/Projects/dorky_robot/katulong/.claude/commands/token.md /Users/felixflores/Projects/dorky_robot/katulong-git-info/.claude/commands/token.md)",
       "Bash(cp /Users/felixflores/Projects/dorky_robot/katulong/.claude/commands/stage.md /Users/felixflores/Projects/dorky_robot/katulong-git-info/.claude/commands/stage.md)",
-      "Bash(rm /Users/felixflores/Projects/dorky_robot/katulong/.claude/commands/token.md)"
+      "Bash(rm /Users/felixflores/Projects/dorky_robot/katulong/.claude/commands/token.md)",
+      "Bash(/Users/felixflores/Projects/dorky_robot/katulong/bin/katulong-stage start *)",
+      "Bash(tunnels routes *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -53,7 +53,9 @@
       "Bash(cp /Users/felixflores/Projects/dorky_robot/katulong/.claude/commands/stage.md /Users/felixflores/Projects/dorky_robot/katulong-git-info/.claude/commands/stage.md)",
       "Bash(rm /Users/felixflores/Projects/dorky_robot/katulong/.claude/commands/token.md)",
       "Bash(/Users/felixflores/Projects/dorky_robot/katulong/bin/katulong-stage start *)",
-      "Bash(tunnels routes *)"
+      "Bash(tunnels routes *)",
+      "Bash(gh pr *)",
+      "Read(//private/tmp/**)"
     ]
   }
 }

--- a/public/design-tokens.css
+++ b/public/design-tokens.css
@@ -27,7 +27,7 @@
   --height-btn-md: 2.75rem;   /* 44px - primary buttons, iOS touch target */
   --height-input: 2.75rem;    /* 44px - match primary buttons */
   --height-bar: 2.75rem;      /* 44px - shortcut bar height (matches iOS touch target) */
-  --term-status-bar-height: 30px; /* 30px - reserved bottom strip on terminal panes for the Warp-style status pill bar; xterm renders fewer rows so the cursor stays clear */
+  --height-term-status-bar: 30px; /* 30px - reserved bottom strip on terminal panes for the Warp-style status pill bar; xterm renders fewer rows so the cursor stays clear */
 
   /* ===== Border Radius (3 consistent values) ===== */
   --radius-sm: 0.375rem;  /* 6px - tags, badges, small elements */

--- a/public/design-tokens.css
+++ b/public/design-tokens.css
@@ -27,6 +27,7 @@
   --height-btn-md: 2.75rem;   /* 44px - primary buttons, iOS touch target */
   --height-input: 2.75rem;    /* 44px - match primary buttons */
   --height-bar: 2.75rem;      /* 44px - shortcut bar height (matches iOS touch target) */
+  --term-status-bar-height: 30px; /* 30px - reserved bottom strip on terminal panes for the Warp-style status pill bar; xterm renders fewer rows so the cursor stays clear */
 
   /* ===== Border Radius (3 consistent values) ===== */
   --radius-sm: 0.375rem;  /* 6px - tags, badges, small elements */

--- a/public/index.html
+++ b/public/index.html
@@ -188,9 +188,9 @@
     #terminal-container { flex: 1; min-width: 0; position: relative; z-index: 1; background: var(--bg); }
     /* terminal-pane: stacking + containment — contain:paint clips all child
        rendering (including system carets) to the pane boundary. */
-    .terminal-pane { position: absolute; inset: 0; display: none; contain: paint; overflow: hidden; padding: 4px 0; }
+    .terminal-pane { position: absolute; inset: 0; display: none; contain: paint; overflow: hidden; padding: 4px 0 var(--term-status-bar-height, 30px) 0; }
     .terminal-pane.active { display: block; }
-    @media (max-width: 600px) { .terminal-pane { padding: 2px 0; } }
+    @media (max-width: 600px) { .terminal-pane { padding: 2px 0 var(--term-status-bar-height, 30px) 0; } }
 
     /* In carousel mode, all terminal panes stay visible — each one lives
        inside its own card wrapper so they don't overlap. Without this,
@@ -442,7 +442,8 @@
       flex-wrap: wrap;
       gap: var(--space-xs, 4px);
       padding: 6px 10px;
-      background: linear-gradient(to top, rgba(17, 17, 27, 0.88), rgba(17, 17, 27, 0.72) 70%, rgba(17, 17, 27, 0));
+      background: var(--bg);
+      border-top: 1px solid var(--border);
       pointer-events: none;
       z-index: 5;
       font-size: var(--text-xs, 12px);
@@ -453,7 +454,7 @@
       align-items: center;
       gap: 5px;
       padding: 3px 8px;
-      border-radius: 999px;
+      border-radius: 4px;
       background: rgba(49, 50, 68, 0.85);
       border: 1px solid rgba(255, 255, 255, 0.06);
       color: var(--text, #cdd6f4);

--- a/public/index.html
+++ b/public/index.html
@@ -192,7 +192,7 @@
       position: absolute; inset: 0; display: none; contain: paint; overflow: hidden;
       /* Bottom padding reserves a strip for the .term-status-bar so xterm
          renders fewer rows instead of having the cursor row covered. */
-      padding: 4px 0 var(--term-status-bar-height) 0;
+      padding: 4px 0 var(--height-term-status-bar) 0;
     }
     .terminal-pane.active { display: block; }
     /* Mobile only narrows the top padding (2px vs 4px). Bottom strip is the

--- a/public/index.html
+++ b/public/index.html
@@ -188,9 +188,16 @@
     #terminal-container { flex: 1; min-width: 0; position: relative; z-index: 1; background: var(--bg); }
     /* terminal-pane: stacking + containment — contain:paint clips all child
        rendering (including system carets) to the pane boundary. */
-    .terminal-pane { position: absolute; inset: 0; display: none; contain: paint; overflow: hidden; padding: 4px 0 var(--term-status-bar-height, 30px) 0; }
+    .terminal-pane {
+      position: absolute; inset: 0; display: none; contain: paint; overflow: hidden;
+      /* Bottom padding reserves a strip for the .term-status-bar so xterm
+         renders fewer rows instead of having the cursor row covered. */
+      padding: 4px 0 var(--term-status-bar-height) 0;
+    }
     .terminal-pane.active { display: block; }
-    @media (max-width: 600px) { .terminal-pane { padding: 2px 0 var(--term-status-bar-height, 30px) 0; } }
+    /* Mobile only narrows the top padding (2px vs 4px). Bottom strip is the
+       same — the status bar height does not change on phones. */
+    @media (max-width: 600px) { .terminal-pane { padding-top: 2px; } }
 
     /* In carousel mode, all terminal panes stay visible — each one lives
        inside its own card wrapper so they don't overlap. Without this,
@@ -442,7 +449,11 @@
       flex-wrap: wrap;
       gap: var(--space-xs, 4px);
       padding: 6px 10px;
-      background: var(--bg);
+      /* Transparent so the strip inherits whatever the host surface uses
+         (var(--bg) under the main #terminal-container, var(--bg-surface)
+         inside a carousel .card-face). The 1px top border is the visual
+         separator between terminal output and the pills. */
+      background: transparent;
       border-top: 1px solid var(--border);
       pointer-events: none;
       z-index: 5;

--- a/public/lib/tiles/terminal-status-bar.js
+++ b/public/lib/tiles/terminal-status-bar.js
@@ -12,9 +12,12 @@
  * watcher and `meta.pane` rides along on that response, so the status bar
  * subscribes to the same watcher — no extra poller.
  *
- * The bar is absolutely positioned over the xterm viewport. We accept
- * that it covers the bottom ~1 row of terminal output; keeping layout
- * flat avoids a structural refactor of the terminalPool container.
+ * The bar is absolutely positioned at the bottom of the tile body. The
+ * `.terminal-pane` reserves equivalent bottom padding (--term-status-bar-height
+ * in index.html) so xterm renders fewer rows instead of having its bottom
+ * row hidden behind the pills. `scaleToFit` in terminal-pool.js already
+ * subtracts paddingBottom when computing rows, so the carve-out flows
+ * through automatically.
  */
 
 import { escapeHtml } from "/lib/utils.js";

--- a/public/lib/tiles/terminal-status-bar.js
+++ b/public/lib/tiles/terminal-status-bar.js
@@ -13,7 +13,7 @@
  * subscribes to the same watcher — no extra poller.
  *
  * The bar is absolutely positioned at the bottom of the tile body. The
- * `.terminal-pane` reserves equivalent bottom padding (--term-status-bar-height
+ * `.terminal-pane` reserves equivalent bottom padding (--height-term-status-bar
  * in index.html) so xterm renders fewer rows instead of having its bottom
  * row hidden behind the pills. `scaleToFit` in terminal-pool.js already
  * subtracts paddingBottom when computing rows, so the carve-out flows


### PR DESCRIPTION
## Summary

- Reserve 30px of bottom padding on `.terminal-pane` so the Warp-style status pill bar lives in a true carve-out instead of covering the bottom row of terminal output (where the cursor lands on phones / small iPad windows).
- Replace the gradient fade-out on `.term-status-bar` with a flat `var(--bg)` background and a 1px `var(--border)` top divider — clean line of separation now that there's an actual gap.
- Drop `.term-status-pill` from full-pill (`border-radius: 999px`) to soft 4px corners — reads better against the divider line.

## Why

The file header comment in `terminal-status-bar.js` previously conceded that the bar covered ~1 row of output, citing "keeping layout flat avoids a structural refactor of the terminalPool container." That row is exactly where the prompt cursor sits on mobile — users couldn't see what they were typing.

Turns out no refactor was needed: `scaleToFit()` in `terminal-pool.js` already subtracts `paddingBottom` when computing rows, so a single CSS change (pane bottom padding) flows through to xterm row count automatically.

## Caveats

- 30px is a fixed reservation. If a tile accumulates enough pills to wrap the bar to two lines, the second line starts covering the bottom row again. Tunable via `--term-status-bar-height` in `index.html` if it ever matters.

## Test plan

- [x] `npm test` (pre-push hook ran unit + integration)
- [x] Manual: prompt cursor visible on iPad in portrait/landscape, no overlap with `~/Projects/...` or branch pills
- [ ] Visual check on a tile with enough pills to wrap (worktree + agent + branch + cwd)