### PR TITLE
chore: persist permission allowlist additions from session work

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -57,8 +57,7 @@
       "Bash(gh pr *)",
       "Read(//private/tmp/**)",
       "Bash(/Users/felixflores/Projects/dorky_robot/katulong/bin/katulong-stage stop *)",
-      "Bash(/Users/felixflores/Projects/dorky_robot/katulong/bin/katulong-stage list *)",
-      "Read(//Users/felixflores/.claude/**)"
+      "Bash(/Users/felixflores/Projects/dorky_robot/katulong/bin/katulong-stage list *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -55,7 +55,10 @@
       "Bash(/Users/felixflores/Projects/dorky_robot/katulong/bin/katulong-stage start *)",
       "Bash(tunnels routes *)",
       "Bash(gh pr *)",
-      "Read(//private/tmp/**)"
+      "Read(//private/tmp/**)",
+      "Bash(/Users/felixflores/Projects/dorky_robot/katulong/bin/katulong-stage stop *)",
+      "Bash(/Users/felixflores/Projects/dorky_robot/katulong/bin/katulong-stage list *)",
+      "Read(//Users/felixflores/.claude/**)"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Persists three permission allowlist additions approved during the PR #658 / #657 cleanup session:

- `Bash(/Users/felixflores/Projects/dorky_robot/katulong/bin/katulong-stage stop *)`
- `Bash(/Users/felixflores/Projects/dorky_robot/katulong/bin/katulong-stage list *)`
- `Read(//Users/felixflores/.claude/**)` (verifying `katulong setup claude-hooks` writes to the global Claude config, not the project-local one)

Same pattern as commit `5009f61` — `.claude/settings.local.json` is committed in this repo so the agent allowlist is shared across contributors and future runs.

## Test plan

- [x] No runtime impact — pure Claude Code agent allowlist.