### PR TITLE
rewrite(server): slice 9n — Path 1: per-tile CMs route user-tile %output

### DIFF
--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -344,13 +344,21 @@ struct AttachedState {
     /// tile — the keepalive CM only sees its own session's
     /// (empty) output. On cleanup, [`Tmux::shutdown`] does the
     /// in-band detach-client dance to avoid the tmux 3.6a UAF.
-    tile_tmux: crate::session::Tmux,
+    ///
+    /// Wrapped in `Option` (slice 9n round-1) so the explicit
+    /// cleanup path in [`serve_session`] can `.take()` the
+    /// value, and the [`Drop`] impl can detect "cleanup didn't
+    /// run" (Some still present) and best-effort schedule async
+    /// cleanup via `tokio::spawn`. Closes the
+    /// cancellation-driven UAF risk reviewers flagged.
+    tile_tmux: Option<crate::session::Tmux>,
     /// JoinHandle for the per-tile output dispatcher task. The
     /// dispatcher consumes `%output` notifications from
     /// `tile_tmux`'s notif stream and routes them through
     /// `OutputRouter::dispatch`. Aborted on cleanup so the
-    /// task exits before the `Tmux` is dropped.
-    tile_dispatcher: tokio::task::JoinHandle<()>,
+    /// task exits before the `Tmux` is dropped. Same
+    /// `Option<...>` + Drop pattern as `tile_tmux`.
+    tile_dispatcher: Option<tokio::task::JoinHandle<()>>,
     /// This subscriber's id, handed back by the router on
     /// subscribe. Used at cleanup to remove ONLY this
     /// connection's sender from the pane's fan-out list,
@@ -385,6 +393,57 @@ struct PendingResize {
     cols: u16,
     rows: u16,
     queued_at: Instant,
+}
+
+impl Drop for AttachedState {
+    /// Best-effort cleanup if `serve_session`'s explicit cleanup
+    /// path didn't run (axum task cancelled, panic, future
+    /// dropped abnormally). Slice 9n round-1 closes the
+    /// security/correctness MEDIUM that flagged a per-tile CM
+    /// child being SIGKILLed via `kill_on_drop` instead of
+    /// going through the in-band `detach-client` path — the
+    /// SIGKILL is the tmux 3.6a UAF trigger.
+    ///
+    /// `Drop` can't `.await`, so we schedule an async cleanup
+    /// task via `tokio::spawn` that owns the moved-out handles
+    /// and runs the full shutdown dance:
+    ///   1. `Tmux::shutdown()` (in-band detach-client, watchdog)
+    ///   2. abort + await the dispatcher
+    ///
+    /// If the explicit cleanup ran, both `Option`s are `None`
+    /// (taken by the explicit path) and this is a no-op.
+    ///
+    /// Caveat: `tokio::spawn` requires a runtime. On normal
+    /// runtime shutdown the spawned cleanup may not get to run
+    /// before the runtime stops; `kill_on_drop(true)` on the
+    /// child remains the secondary backstop in that case.
+    fn drop(&mut self) {
+        let tile_tmux = self.tile_tmux.take();
+        let tile_dispatcher = self.tile_dispatcher.take();
+        if tile_tmux.is_none() && tile_dispatcher.is_none() {
+            return;
+        }
+        // Catch the no-runtime case: try_current returns Err if
+        // we're being dropped outside a runtime context (e.g.,
+        // during a runtime shutdown's cleanup phase). Falling
+        // through to runtime-end + kill_on_drop is acceptable
+        // there — the process is going away.
+        if tokio::runtime::Handle::try_current().is_err() {
+            tracing::warn!(
+                "AttachedState dropped outside tokio runtime; falling back to kill_on_drop"
+            );
+            return;
+        }
+        tokio::spawn(async move {
+            if let Some(tmux) = tile_tmux {
+                tmux.shutdown().await;
+            }
+            if let Some(d) = tile_dispatcher {
+                d.abort();
+                let _ = d.await;
+            }
+        });
+    }
 }
 
 impl AttachedState {
@@ -721,17 +780,32 @@ pub async fn serve_session(
     //    a clean exit; SIGKILL fallback only if the child is
     //    truly stuck.
     //
-    // 3. Abort the per-tile dispatcher task. It would exit
-    //    on its own once the CM's notif channel closes
-    //    during step 2, but explicit abort keeps the cleanup
-    //    deterministic and bounded.
-    if let Some(a) = attached {
+    // 3. Abort the per-tile dispatcher LAST. The dispatcher
+    //    must outlive `shutdown()` to keep draining the CM's
+    //    unbounded notif channel during the 2s detach-client
+    //    grace window — leaving it unread would violate the
+    //    backpressure contract on `Tmux::spawn`. The
+    //    dispatcher exits naturally when the CM's notif
+    //    channel closes; `abort` makes cleanup deterministic
+    //    if the CM hung past the watchdog.
+    //
+    // `.take()` on the Option fields signals to the Drop
+    // impl that explicit cleanup ran — preventing duplicate
+    // async cleanup if AttachedState is dropped after this
+    // block (shouldn't happen on the normal path but is
+    // defensive against a future caller that splits
+    // serve_session into smaller scopes).
+    if let Some(mut a) = attached {
         state
             .output_router
             .clear_subscriber(a.pane_id, a.subscriber_id);
-        a.tile_tmux.shutdown().await;
-        a.tile_dispatcher.abort();
-        let _ = a.tile_dispatcher.await;
+        if let Some(tile_tmux) = a.tile_tmux.take() {
+            tile_tmux.shutdown().await;
+        }
+        if let Some(dispatcher) = a.tile_dispatcher.take() {
+            dispatcher.abort();
+            let _ = dispatcher.await;
+        }
     }
     // Drop the handle. The WS output pump sees the channel close
     // and shuts down the socket gracefully.
@@ -838,13 +912,29 @@ async fn try_attach(
     // own session and never sees tile panes' output). On a
     // post-subscribe failure we shut down the CM and abort the
     // dispatcher so the cleanup never leaks a child process.
-    let spawn_pipeline = || async {
-        let (tmux, notifs) = sessions
-            .attach_tile(session, cols, rows)
-            .await
-            .map_err(to_failure)?;
-        let dispatcher = state.output_router.spawn_tile_dispatcher(notifs);
-        Ok::<_, AttachFailure>((tmux, dispatcher))
+    // Spawn the per-tile pipeline and roll back the subscriber
+    // on failure. Takes the just-bound `subscriber_id` so the
+    // rollback path is encapsulated here — the three call
+    // sites just `?` the result and don't need to remember
+    // the cleanup discipline. Slice 9n round-1 (correctness
+    // LOW: three-site cleanup duplication).
+    //
+    // Audit log: tie per-tile CM lifecycle to a session name
+    // in operator logs. Slice 9n round-1 (security LOW).
+    // credential_id isn't currently threaded into try_attach;
+    // if/when that lands, include it here.
+    let spawn_pipeline_with_rollback = |subscriber_id: SubscriberId| async move {
+        match sessions.attach_tile(session, cols, rows).await {
+            Ok((tmux, notifs)) => {
+                let dispatcher = state.output_router.spawn_output_pump(notifs);
+                tracing::debug!(session, pane_id, "per-tile CM spawned");
+                Ok((tmux, dispatcher))
+            }
+            Err(err) => {
+                state.output_router.clear_subscriber(pane_id, subscriber_id);
+                Err(to_failure(err))
+            }
+        }
     };
 
     match resume_from_seq {
@@ -855,20 +945,15 @@ async fn try_attach(
                 .output_router
                 .subscribe(pane_id)
                 .map_err(to_subscribe_failure)?;
-            let (tile_tmux, tile_dispatcher) = match spawn_pipeline().await {
-                Ok(p) => p,
-                Err(err) => {
-                    state.output_router.clear_subscriber(pane_id, subscriber_id);
-                    return Err(err);
-                }
-            };
+            let (tile_tmux, tile_dispatcher) =
+                spawn_pipeline_with_rollback(subscriber_id).await?;
             Ok(AttachOutcome {
                 replay: ReplaySlice::Fresh { end_seq: baseline },
                 new_state: AttachedState {
                     session: session.to_string(),
                     pane_id,
-                    tile_tmux,
-                    tile_dispatcher,
+                    tile_tmux: Some(tile_tmux),
+                    tile_dispatcher: Some(tile_dispatcher),
                     subscriber_id,
                     output_rx: rx,
                     last_seen_seq: baseline,
@@ -918,13 +1003,8 @@ async fn try_attach(
                             .output_router
                             .subscribe(pane_id)
                             .map_err(to_subscribe_failure)?;
-                        let (tile_tmux, tile_dispatcher) = match spawn_pipeline().await {
-                            Ok(p) => p,
-                            Err(err) => {
-                                state.output_router.clear_subscriber(pane_id, subscriber_id);
-                                return Err(err);
-                            }
-                        };
+                        let (tile_tmux, tile_dispatcher) =
+                            spawn_pipeline_with_rollback(subscriber_id).await?;
                         Ok(AttachOutcome {
                             replay: ReplaySlice::Gap {
                                 available_from_seq: 0,
@@ -934,8 +1014,8 @@ async fn try_attach(
                             new_state: AttachedState {
                                 session: session.to_string(),
                                 pane_id,
-                                tile_tmux,
-                                tile_dispatcher,
+                                tile_tmux: Some(tile_tmux),
+                                tile_dispatcher: Some(tile_dispatcher),
                                 subscriber_id,
                                 output_rx: rx,
                                 last_seen_seq: 0,
@@ -989,40 +1069,36 @@ async fn try_attach(
                             ),
                         });
                     }
-                    let (tile_tmux, tile_dispatcher) = match spawn_pipeline().await {
-                        Ok(p) => p,
-                        Err(err) => {
-                            state.output_router.clear_subscriber(pane_id, subscriber_id);
-                            return Err(err);
-                        }
+                    let (tile_tmux, tile_dispatcher) =
+                        spawn_pipeline_with_rollback(subscriber_id).await?;
+                    // Compute baseline directly from the replay
+                    // variant. (Slice 9n round-1: AttachedState
+                    // now has a Drop impl, which makes the
+                    // previous struct-update pattern
+                    // `..outcome.new_state` invalid — Rust
+                    // forbids partial moves out of a Drop
+                    // type. Inline the end_seq read instead.)
+                    let baseline = match &replay {
+                        ReplaySlice::Fresh { end_seq } => *end_seq,
+                        ReplaySlice::InRange { end_seq, .. } => *end_seq,
+                        ReplaySlice::UpToDate { end_seq } => *end_seq,
+                        ReplaySlice::Gap { end_seq, .. } => *end_seq,
+                        ReplaySlice::Future => 0, // unreachable; checked above
                     };
-                    let outcome = AttachOutcome {
+                    Ok(AttachOutcome {
                         replay,
                         new_state: AttachedState {
                             session: session.to_string(),
                             pane_id,
-                            tile_tmux,
-                            tile_dispatcher,
+                            tile_tmux: Some(tile_tmux),
+                            tile_dispatcher: Some(tile_dispatcher),
                             subscriber_id,
                             output_rx: rx,
-                            // Seeded below after construction so
-                            // `outcome.last_seq()` is the single
-                            // source of truth (accessor reads
-                            // the end_seq from the `replay`
-                            // variant).
-                            last_seen_seq: 0,
+                            last_seen_seq: baseline,
                             coalescer: Coalescer::new(),
                             last_output_at: None,
                             pending_resize: None,
                         },
-                    };
-                    let baseline = outcome.last_seq();
-                    Ok(AttachOutcome {
-                        new_state: AttachedState {
-                            last_seen_seq: baseline,
-                            ..outcome.new_state
-                        },
-                        ..outcome
                     })
                 }
             }
@@ -1513,8 +1589,8 @@ mod tests {
         AttachedState {
             session: "s".into(),
             pane_id: 0,
-            tile_tmux: crate::session::Tmux::dead_for_tests(),
-            tile_dispatcher: tokio::spawn(std::future::pending()),
+            tile_tmux: Some(crate::session::Tmux::dead_for_tests()),
+            tile_dispatcher: Some(tokio::spawn(std::future::pending())),
             subscriber_id: SubscriberId::testing(0),
             output_rx: rx,
             last_seen_seq: 0,

--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -337,6 +337,20 @@ fn phase_name(phase: &Phase) -> &'static str {
 struct AttachedState {
     session: String,
     pane_id: u32,
+    /// Per-tile control-mode client attached to this WS
+    /// connection's tile session. Slice 9n (Path 1): each WS
+    /// owns its own CM child rather than sharing a global
+    /// keepalive CM. The CM is what carries `%output` for the
+    /// tile — the keepalive CM only sees its own session's
+    /// (empty) output. On cleanup, [`Tmux::shutdown`] does the
+    /// in-band detach-client dance to avoid the tmux 3.6a UAF.
+    tile_tmux: crate::session::Tmux,
+    /// JoinHandle for the per-tile output dispatcher task. The
+    /// dispatcher consumes `%output` notifications from
+    /// `tile_tmux`'s notif stream and routes them through
+    /// `OutputRouter::dispatch`. Aborted on cleanup so the
+    /// task exits before the `Tmux` is dropped.
+    tile_dispatcher: tokio::task::JoinHandle<()>,
     /// This subscriber's id, handed back by the router on
     /// subscribe. Used at cleanup to remove ONLY this
     /// connection's sender from the pane's fan-out list,
@@ -693,16 +707,31 @@ pub async fn serve_session(
         }
     }
 
-    // Cleanup: detach THIS subscriber, but keep the pane's
-    // ring, decoder, and sibling subscribers alive. Slice 9h:
-    // `clear_subscriber` takes the SubscriberId so only this
-    // connection's sender is removed. Multi-device sessions
-    // (phone + laptop) keep flowing for the other devices
-    // when one closes its transport.
+    // Cleanup, slice 9n / Path 1:
+    //
+    // 1. Detach this connection's subscriber from the router
+    //    (slice 9h fan-out: keeps the pane's ring, decoder,
+    //    and sibling subscribers alive — multi-device sessions
+    //    keep flowing for the other devices).
+    //
+    // 2. Shut down the per-tile CM client via the in-band
+    //    `detach-client` dance (slice 9l). Avoids the tmux
+    //    3.6a UAF that the abrupt-drop path would trigger.
+    //    The shutdown blocks up to `SHUTDOWN_GRACE` (2s) for
+    //    a clean exit; SIGKILL fallback only if the child is
+    //    truly stuck.
+    //
+    // 3. Abort the per-tile dispatcher task. It would exit
+    //    on its own once the CM's notif channel closes
+    //    during step 2, but explicit abort keeps the cleanup
+    //    deterministic and bounded.
     if let Some(a) = attached {
         state
             .output_router
             .clear_subscriber(a.pane_id, a.subscriber_id);
+        a.tile_tmux.shutdown().await;
+        a.tile_dispatcher.abort();
+        let _ = a.tile_dispatcher.await;
     }
     // Drop the handle. The WS output pump sees the channel close
     // and shuts down the socket gracefully.
@@ -800,6 +829,23 @@ async fn try_attach(
         .query_default_pane(session)
         .await
         .map_err(to_failure)?;
+    // Slice 9n / Path 1: per-tile CM client. Spawned AFTER all
+    // pre-checks so a rejected attach never leaks a subprocess.
+    // The CM's notif stream feeds a per-tile dispatcher that
+    // routes `%output` through `OutputRouter::dispatch`; this
+    // is the path that makes user-tile output actually reach
+    // the WS subscriber (the keepalive CM is attached to its
+    // own session and never sees tile panes' output). On a
+    // post-subscribe failure we shut down the CM and abort the
+    // dispatcher so the cleanup never leaks a child process.
+    let spawn_pipeline = || async {
+        let (tmux, notifs) = sessions
+            .attach_tile(session, cols, rows)
+            .await
+            .map_err(to_failure)?;
+        let dispatcher = state.output_router.spawn_tile_dispatcher(notifs);
+        Ok::<_, AttachFailure>((tmux, dispatcher))
+    };
 
     match resume_from_seq {
         None => {
@@ -809,11 +855,20 @@ async fn try_attach(
                 .output_router
                 .subscribe(pane_id)
                 .map_err(to_subscribe_failure)?;
+            let (tile_tmux, tile_dispatcher) = match spawn_pipeline().await {
+                Ok(p) => p,
+                Err(err) => {
+                    state.output_router.clear_subscriber(pane_id, subscriber_id);
+                    return Err(err);
+                }
+            };
             Ok(AttachOutcome {
                 replay: ReplaySlice::Fresh { end_seq: baseline },
                 new_state: AttachedState {
                     session: session.to_string(),
                     pane_id,
+                    tile_tmux,
+                    tile_dispatcher,
                     subscriber_id,
                     output_rx: rx,
                     last_seen_seq: baseline,
@@ -863,6 +918,13 @@ async fn try_attach(
                             .output_router
                             .subscribe(pane_id)
                             .map_err(to_subscribe_failure)?;
+                        let (tile_tmux, tile_dispatcher) = match spawn_pipeline().await {
+                            Ok(p) => p,
+                            Err(err) => {
+                                state.output_router.clear_subscriber(pane_id, subscriber_id);
+                                return Err(err);
+                            }
+                        };
                         Ok(AttachOutcome {
                             replay: ReplaySlice::Gap {
                                 available_from_seq: 0,
@@ -872,6 +934,8 @@ async fn try_attach(
                             new_state: AttachedState {
                                 session: session.to_string(),
                                 pane_id,
+                                tile_tmux,
+                                tile_dispatcher,
                                 subscriber_id,
                                 output_rx: rx,
                                 last_seen_seq: 0,
@@ -925,11 +989,20 @@ async fn try_attach(
                             ),
                         });
                     }
+                    let (tile_tmux, tile_dispatcher) = match spawn_pipeline().await {
+                        Ok(p) => p,
+                        Err(err) => {
+                            state.output_router.clear_subscriber(pane_id, subscriber_id);
+                            return Err(err);
+                        }
+                    };
                     let outcome = AttachOutcome {
                         replay,
                         new_state: AttachedState {
                             session: session.to_string(),
                             pane_id,
+                            tile_tmux,
+                            tile_dispatcher,
                             subscriber_id,
                             output_rx: rx,
                             // Seeded below after construction so
@@ -1429,13 +1502,19 @@ mod tests {
     // ---------- Resize gate deadline math (pure, no runtime) ----------
 
     fn attached_state_for_gate_tests() -> AttachedState {
-        // Build a minimal AttachedState by hand — output_rx +
-        // subscriber_id are required by the struct but the
-        // gate-math helpers don't touch them.
+        // Build a minimal AttachedState by hand — output_rx,
+        // subscriber_id, tile_tmux, and tile_dispatcher are
+        // required by the struct but the gate-math helpers
+        // don't touch them. Slice 9n: tile_tmux is a
+        // dead-channel test handle (any send_command would
+        // fail with Disconnected); tile_dispatcher is a
+        // never-resolving spawned future that we ignore.
         let (_tx, rx) = mpsc::channel(1);
         AttachedState {
             session: "s".into(),
             pane_id: 0,
+            tile_tmux: crate::session::Tmux::dead_for_tests(),
+            tile_dispatcher: tokio::spawn(std::future::pending()),
             subscriber_id: SubscriberId::testing(0),
             output_rx: rx,
             last_seen_seq: 0,

--- a/crates/server/src/session/manager.rs
+++ b/crates/server/src/session/manager.rs
@@ -825,7 +825,7 @@ mod tests {
     async fn tile_output_routes_through_per_tile_dispatcher() {
         // SLICE 9N END-TO-END: verifies that user-tile %output
         // actually reaches an OutputRouter subscriber via the
-        // per-tile CM + spawn_tile_dispatcher path. This is
+        // per-tile CM + spawn_output_pump path. This is
         // the architectural payoff of Path 1.
         //
         // Set up:
@@ -854,7 +854,7 @@ mod tests {
             .attach_tile("tile-out", 80, 24)
             .await
             .expect("attach_tile");
-        let tile_disp = router.spawn_tile_dispatcher(tile_notifs);
+        let tile_disp = router.spawn_output_pump(tile_notifs);
 
         // Subscribe to the tile's pane on the router.
         let pane_id = manager
@@ -865,10 +865,12 @@ mod tests {
             router.subscribe(pane_id).expect("subscribe");
 
         // The default shell prints a prompt at startup, which
-        // generates %output. Wait up to 3s for the first chunk.
-        let chunk = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+        // generates %output. 5s budget — generous on a normal
+        // dev machine, tolerant of slow shell startups (e.g.,
+        // a heavy ~/.bashrc, a loaded host).
+        let chunk = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
-            .expect("output within 3s")
+            .expect("output within 5s")
             .expect("subscriber received bytes");
         assert!(
             !chunk.data.is_empty(),

--- a/crates/server/src/session/manager.rs
+++ b/crates/server/src/session/manager.rs
@@ -819,4 +819,65 @@ mod tests {
             "clean detach should be quick; took {elapsed:?}"
         );
     }
+
+    #[tokio::test]
+    #[ignore = "requires tmux binary + dedicated socket; run with: cargo test -- --ignored"]
+    async fn tile_output_routes_through_per_tile_dispatcher() {
+        // SLICE 9N END-TO-END: verifies that user-tile %output
+        // actually reaches an OutputRouter subscriber via the
+        // per-tile CM + spawn_tile_dispatcher path. This is
+        // the architectural payoff of Path 1.
+        //
+        // Set up:
+        //   command CM ── spawn keepalive session
+        //   per-tile CM (via attach_tile) ── attached to tile
+        //                                    session, runs
+        //                                    user's default
+        //                                    shell
+        //   per-tile dispatcher ── routes %output to router
+        //   router subscriber ── receives the shell's startup
+        //                        prompt as the first chunk
+        use super::super::router::OutputRouter;
+        use super::super::tmux::Tmux;
+        use std::time::Duration;
+
+        let socket = format!("katulong-tile-output-{}", std::process::id());
+        let (cmd_tmux, _cmd_notifs) = Tmux::spawn(&socket, "main", 80, 24)
+            .await
+            .expect("spawn command CM");
+        let manager = SessionManager::new(cmd_tmux.clone());
+        let router = OutputRouter::new();
+
+        // Attach a tile + spawn its per-tile dispatcher. This
+        // is the same wiring `try_attach` does in production.
+        let (tile_tmux, tile_notifs) = manager
+            .attach_tile("tile-out", 80, 24)
+            .await
+            .expect("attach_tile");
+        let tile_disp = router.spawn_tile_dispatcher(tile_notifs);
+
+        // Subscribe to the tile's pane on the router.
+        let pane_id = manager
+            .query_default_pane("tile-out")
+            .await
+            .expect("query pane");
+        let (mut rx, _sub_id, _baseline) =
+            router.subscribe(pane_id).expect("subscribe");
+
+        // The default shell prints a prompt at startup, which
+        // generates %output. Wait up to 3s for the first chunk.
+        let chunk = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("output within 3s")
+            .expect("subscriber received bytes");
+        assert!(
+            !chunk.data.is_empty(),
+            "shell startup should produce non-empty %output via per-tile CM"
+        );
+
+        tile_disp.abort();
+        let _ = tile_disp.await;
+        tile_tmux.shutdown().await;
+        cmd_tmux.shutdown().await;
+    }
 }

--- a/crates/server/src/session/router.rs
+++ b/crates/server/src/session/router.rs
@@ -491,6 +491,39 @@ impl OutputRouter {
     /// close event will try again. Multiple reconciles
     /// queueing up is self-compensating — each one is
     /// idempotent (it sets the keep-set, doesn't append to it).
+    /// Spawn a per-tile output dispatcher (slice 9n / Path 1).
+    /// Consumes `%output` notifications from a single tile's CM
+    /// and routes them through [`OutputRouter::dispatch`].
+    /// Lifecycle and exit events are IGNORED — those are
+    /// handled by the keepalive CM's global
+    /// [`OutputRouter::spawn_dispatcher`] task. Per-pane
+    /// eviction comes from the global reconcile path; per-tile
+    /// dispatchers do not touch router state on shutdown.
+    ///
+    /// The task exits when `notifs` closes (tile CM died via
+    /// `Tmux::shutdown` or because the tile session was
+    /// killed). Caller should hold the returned `JoinHandle`
+    /// and abort it on connection cleanup so the task exits
+    /// deterministically.
+    pub fn spawn_tile_dispatcher(
+        &self,
+        mut notifs: mpsc::UnboundedReceiver<Notification>,
+    ) -> JoinHandle<()> {
+        let router = self.clone();
+        tokio::spawn(async move {
+            while let Some(notif) = notifs.recv().await {
+                if let Notification::Output { pane_id, data } = notif {
+                    router.dispatch(pane_id, &data);
+                }
+                // Other notifications (lifecycle, exit, output
+                // for other panes which can't happen since the
+                // tile's session has one pane) are intentionally
+                // discarded. The keepalive CM's dispatcher
+                // handles cross-session lifecycle reconcile.
+            }
+        })
+    }
+
     pub fn spawn_dispatcher(
         &self,
         mut notifs: mpsc::UnboundedReceiver<Notification>,

--- a/crates/server/src/session/router.rs
+++ b/crates/server/src/session/router.rs
@@ -462,7 +462,20 @@ impl OutputRouter {
         });
     }
 
-    /// Spawn the dispatcher task. See module doc.
+    /// Spawn the global dispatcher task — **keepalive CM only**.
+    /// See module doc.
+    ///
+    /// This dispatcher handles `%output`, lifecycle events
+    /// (`%sessions-changed`, `%window-close`,
+    /// `%unlinked-window-close`) that drive reconcile, and
+    /// `%exit` that drives [`OutputRouter::evict_all`]. Per-tile
+    /// CMs do NOT see lifecycle events (a CM only receives
+    /// notifications for the session it's attached to), so this
+    /// task must NOT be spawned for per-tile CMs — they'd never
+    /// trigger reconcile, and a per-tile `%exit` from a tile-
+    /// session-killed event would incorrectly `evict_all`.
+    /// Per-tile CMs use [`OutputRouter::spawn_output_pump`]
+    /// instead.
     ///
     /// When the task exits (either tmux's `%exit` notification
     /// or the notification sender being dropped), it calls
@@ -505,7 +518,7 @@ impl OutputRouter {
     /// killed). Caller should hold the returned `JoinHandle`
     /// and abort it on connection cleanup so the task exits
     /// deterministically.
-    pub fn spawn_tile_dispatcher(
+    pub fn spawn_output_pump(
         &self,
         mut notifs: mpsc::UnboundedReceiver<Notification>,
     ) -> JoinHandle<()> {


### PR DESCRIPTION
## Summary

The architectural payoff of slices 9l + 9m: per-tile CM clients are wired into the WS handler so user-tile `%output` actually reaches the OutputRouter and its subscribers. Before this, the keepalive CM saw no user-tile output and end-to-end terminal interaction would have been impossible.

## What changed

- **`AttachedState` gains `tile_tmux: Tmux` + `tile_dispatcher: JoinHandle<()>`** — each WS connection owns its per-tile CM child for its attachment lifetime.
- **`OutputRouter::spawn_tile_dispatcher`** — focused per-tile dispatcher that routes only `%output`. Lifecycle/`%exit` events are intentionally ignored — handled by the keepalive CM's global `spawn_dispatcher`. (Per-tile `%exit` from a tile session dying must NOT trigger global `evict_all`.)
- **`try_attach` spawns per-tile pipeline AFTER all pre-checks** — rejected attaches don't leak subprocesses. Three sites (fresh, Future-as-Gap restart, subscribe-with-resume) share a `spawn_pipeline` closure with consistent post-subscribe error cleanup.
- **`serve_session` cleanup** does `tile_tmux.shutdown().await` (in-band detach via slice 9l) + `tile_dispatcher.abort()`.

## Test coverage

**New ignored E2E test** `tile_output_routes_through_per_tile_dispatcher` — the first end-to-end test in the rewrite that proves user-tile output reaches a subscriber. Spawns command CM, attaches a tile, subscribes on the router, waits for the shell startup prompt to arrive through the per-tile dispatcher.

7 ignored integration tests now pass against real tmux 3.6a; 188 unit tests pass; clippy clean.

## What's next (out of scope here)

Backend session pipeline is now functionally complete. The remaining big work is the **Leptos frontend** (~0% done — the long pole), **Claude integration** (9 Node modules untouched), file browser/git-info/agent-presence, the **tile SDK**, and **cutover infrastructure**.

## Test plan

- [x] `cargo test --lib` — 188 passing
- [x] `cargo test --lib -- --ignored` — 7 pass against real tmux
- [x] `cargo clippy --all-targets -- -D warnings` — clean