### PR TITLE
fix(update): detect stale running server, restart even when on-disk is current

### DIFF
--- a/lib/cli/commands/update.js
+++ b/lib/cli/commands/update.js
@@ -90,6 +90,45 @@ async function probeOldServer(port) {
   }
 }
 
+/**
+ * Decide what `katulong update` should do once it has resolved the on-disk
+ * versions and probed the running server. Pure function so it can be tested
+ * without spinning up a server.
+ *
+ * The non-obvious case is "running server is stale": brew already has the
+ * latest binary on disk (so `brew upgrade` is a no-op), but the running
+ * process started from an earlier Cellar version that has since been pruned.
+ * Without this branch, repeated `katulong update` calls all report
+ * "Already up to date" while the user keeps hitting 500s on the still-alive
+ * stale process — its `readFileSync` of static assets fails ENOENT against
+ * the deleted Cellar dir.
+ */
+export function decideUpgradeAction({
+  currentVersion,
+  newVersion,
+  runningVersion,
+  oldServerRunning,
+  noRestart,
+}) {
+  const onDiskUpgraded = currentVersion !== newVersion;
+  const runningStale =
+    !!runningVersion && oldServerRunning && runningVersion !== newVersion;
+
+  if (!onDiskUpgraded && !runningStale) {
+    return { action: "noop", reason: "already-up-to-date" };
+  }
+  if (noRestart) {
+    return { action: "noop", reason: "no-restart" };
+  }
+  if (!oldServerRunning) {
+    return { action: "noop", reason: "no-running-server" };
+  }
+  return {
+    action: "finish-upgrade",
+    reason: onDiskUpgraded ? "binary-upgraded" : "running-server-stale",
+  };
+}
+
 export default async function update(args) {
   // Reject unexpected positional arguments
   const positional = args.find((arg) => !arg.startsWith("--"));
@@ -176,24 +215,55 @@ export default async function update(args) {
   const newRoot = method === "homebrew" ? resolveInstalledRoot() : ROOT;
   const newVersion = readVersion(newRoot);
 
-  if (currentVersion === newVersion) {
-    console.log(`\n✓ Already up to date (v${newVersion})`);
+  // Probe the running server to detect a stale process: the binary on disk
+  // is already at the latest version, but the live process started from an
+  // earlier Cellar dir that has since been pruned. Without this, repeated
+  // `katulong update` runs all bail with "Already up to date" while the
+  // user keeps seeing 500s — the running PID's `readFileSync` of static
+  // assets hits ENOENT against the deleted Cellar.
+  let runningVersion = null;
+  if (oldServer.running && oldPort) {
+    const probe = await probeOldServer(oldPort);
+    if (probe.ok) runningVersion = probe.version;
+  }
+
+  const decision = decideUpgradeAction({
+    currentVersion,
+    newVersion,
+    runningVersion,
+    oldServerRunning: oldServer.running,
+    noRestart,
+  });
+
+  if (decision.action === "noop") {
+    if (decision.reason === "already-up-to-date") {
+      console.log(`\n✓ Already up to date (v${newVersion})`);
+    } else {
+      // For no-restart and no-running-server, also surface what changed
+      // (or didn't) on disk so the message is honest.
+      if (currentVersion !== newVersion) {
+        console.log(`\n✓ Updated: v${currentVersion} -> v${newVersion}`);
+      }
+      if (decision.reason === "no-restart") {
+        console.log("Skipping restart (--no-restart)");
+      } else {
+        console.log(`\nNo running server. Start with: katulong start`);
+      }
+    }
     cleanupSentinel();
     return;
   }
 
-  console.log(`\n✓ Updated: v${currentVersion} -> v${newVersion}`);
-
-  if (noRestart) {
-    console.log("Skipping restart (--no-restart)");
-    cleanupSentinel();
-    return;
-  }
-
-  if (!oldServer.running) {
-    console.log(`\nNo running server. Start with: katulong start`);
-    cleanupSentinel();
-    return;
+  if (decision.reason === "running-server-stale") {
+    console.log(
+      `\n⚠ Binary on disk is v${newVersion}, but the running server reports v${runningVersion}.`,
+    );
+    console.log(
+      "  This usually means a previous upgrade swapped the binary but failed to",
+    );
+    console.log("  restart. Restarting now to align them.");
+  } else {
+    console.log(`\n✓ Updated: v${currentVersion} -> v${newVersion}`);
   }
 
   // Hand off to the NEW binary for the smoke-test-and-swap.

--- a/lib/cli/commands/update.js
+++ b/lib/cli/commands/update.js
@@ -111,8 +111,11 @@ export function decideUpgradeAction({
   noRestart,
 }) {
   const onDiskUpgraded = currentVersion !== newVersion;
-  const runningStale =
-    !!runningVersion && oldServerRunning && runningVersion !== newVersion;
+  // Treat a missing runningVersion (probe failed / timed out) as "unknown"
+  // rather than fabricating staleness. We only claim stale when we can
+  // actually compare two known version strings.
+  const probeSucceeded = !!runningVersion && oldServerRunning;
+  const runningStale = probeSucceeded && runningVersion !== newVersion;
 
   if (!onDiskUpgraded && !runningStale) {
     return { action: "noop", reason: "already-up-to-date" };
@@ -215,12 +218,8 @@ export default async function update(args) {
   const newRoot = method === "homebrew" ? resolveInstalledRoot() : ROOT;
   const newVersion = readVersion(newRoot);
 
-  // Probe the running server to detect a stale process: the binary on disk
-  // is already at the latest version, but the live process started from an
-  // earlier Cellar dir that has since been pruned. Without this, repeated
-  // `katulong update` runs all bail with "Already up to date" while the
-  // user keeps seeing 500s — the running PID's `readFileSync` of static
-  // assets hits ENOENT against the deleted Cellar.
+  // Probe /health so decideUpgradeAction can detect a stale running process.
+  // See the JSDoc on decideUpgradeAction for why this matters.
   let runningVersion = null;
   if (oldServer.running && oldPort) {
     const probe = await probeOldServer(oldPort);
@@ -235,35 +234,32 @@ export default async function update(args) {
     noRestart,
   });
 
+  const upgradedLine =
+    currentVersion !== newVersion
+      ? `\n✓ Updated: v${currentVersion} -> v${newVersion}`
+      : "";
+  const staleLine =
+    runningVersion && runningVersion !== newVersion
+      ? `\n⚠ Running server reports v${runningVersion} but binary on disk is v${newVersion}` +
+        "\n  (a previous upgrade swapped the binary but didn't restart)"
+      : "";
+
   if (decision.action === "noop") {
-    if (decision.reason === "already-up-to-date") {
-      console.log(`\n✓ Already up to date (v${newVersion})`);
-    } else {
-      // For no-restart and no-running-server, also surface what changed
-      // (or didn't) on disk so the message is honest.
-      if (currentVersion !== newVersion) {
-        console.log(`\n✓ Updated: v${currentVersion} -> v${newVersion}`);
-      }
-      if (decision.reason === "no-restart") {
-        console.log("Skipping restart (--no-restart)");
-      } else {
-        console.log(`\nNo running server. Start with: katulong start`);
-      }
-    }
+    const noopMessages = {
+      "already-up-to-date": `\n✓ Already up to date (v${newVersion})`,
+      "no-restart": `${upgradedLine}${staleLine}\nSkipping restart (--no-restart)`,
+      "no-running-server": `${upgradedLine}\nNo running server. Start with: katulong start`,
+    };
+    console.log(noopMessages[decision.reason]);
     cleanupSentinel();
     return;
   }
 
   if (decision.reason === "running-server-stale") {
-    console.log(
-      `\n⚠ Binary on disk is v${newVersion}, but the running server reports v${runningVersion}.`,
-    );
-    console.log(
-      "  This usually means a previous upgrade swapped the binary but failed to",
-    );
-    console.log("  restart. Restarting now to align them.");
+    console.log(staleLine);
+    console.log("  Restarting now to align them.");
   } else {
-    console.log(`\n✓ Updated: v${currentVersion} -> v${newVersion}`);
+    console.log(upgradedLine);
   }
 
   // Hand off to the NEW binary for the smoke-test-and-swap.
@@ -290,6 +286,10 @@ export default async function update(args) {
       // "process is running" does not imply "server is healthy". We
       // probe before deciding what to tell the user.
       const probe = await probeOldServer(oldPort);
+      // In the stale-server-restart case currentVersion === newVersion, so
+      // labelling the running process by currentVersion would be misleading
+      // (it's actually running an older binary). Prefer the probed version.
+      const oldLabel = probe.version || runningVersion || currentVersion;
 
       console.error("");
       console.error("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
@@ -301,7 +301,7 @@ export default async function update(args) {
       console.error("");
 
       if (probe.ok) {
-        console.error(`  Your old v${currentVersion} server is still healthy on port ${oldPort}`);
+        console.error(`  Your old v${oldLabel} server is still healthy on port ${oldPort}`);
         console.error("  (just probed). The upgrade flow left it untouched on smoke failure.");
         console.error("");
         console.error("  ⚠  DO NOT run 'katulong start' or 'katulong restart' right now.");
@@ -314,7 +314,7 @@ export default async function update(args) {
         console.error("       https://github.com/Dorky-Robot/katulong/issues");
         console.error("    3. Downgrade to a known-good tag when a fix is released.");
       } else {
-        console.error(`  Your old v${currentVersion} server is ALSO unhealthy: ${probe.reason}.`);
+        console.error(`  Your old v${oldLabel} server is ALSO unhealthy: ${probe.reason}.`);
         console.error("  Most likely brew has removed the old Cellar's static assets, so the");
         console.error("  still-running process now 500s on every static read. Both versions");
         console.error("  are broken — there is no safe fallback on this host.");
@@ -322,10 +322,10 @@ export default async function update(args) {
         console.error("  Recovery options:");
         console.error("    1. File an issue with the smoke test output above:");
         console.error("       https://github.com/Dorky-Robot/katulong/issues");
-        console.error(`    2. Downgrade to v${currentVersion}: pin the tap formula to its prior`);
+        console.error(`    2. Downgrade to v${oldLabel}: pin the tap formula to its prior`);
         console.error("       commit, then reinstall:");
         console.error('         cd "$(brew --repo dorky-robot/tap)"');
-        console.error(`         git log -- Formula/katulong.rb       # find a v${currentVersion} commit`);
+        console.error(`         git log -- Formula/katulong.rb       # find a v${oldLabel} commit`);
         console.error("         git checkout <commit> -- Formula/katulong.rb");
         console.error("         brew uninstall katulong");
         console.error("         brew install dorky-robot/tap/katulong");

--- a/test/update-command.test.js
+++ b/test/update-command.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { detectInstallMethod } from "../lib/cli/process-manager.js";
+import { decideUpgradeAction } from "../lib/cli/commands/update.js";
 
 // Helper: stub fsExists to return a fixed value
 const gitExists = () => true;
@@ -155,6 +156,81 @@ describe("detectInstallMethod", () => {
         "homebrew"
       );
     });
+  });
+});
+
+describe("decideUpgradeAction", () => {
+  const base = {
+    currentVersion: "1.0.0",
+    newVersion: "1.0.0",
+    runningVersion: "1.0.0",
+    oldServerRunning: true,
+    noRestart: false,
+  };
+
+  it("noop when on-disk and running both match latest", () => {
+    assert.deepEqual(decideUpgradeAction(base), {
+      action: "noop",
+      reason: "already-up-to-date",
+    });
+  });
+
+  it("runs finish-upgrade when on-disk binary was bumped", () => {
+    assert.deepEqual(
+      decideUpgradeAction({ ...base, currentVersion: "0.9.0" }),
+      { action: "finish-upgrade", reason: "binary-upgraded" },
+    );
+  });
+
+  it("runs finish-upgrade when running server is stale (binary already updated)", () => {
+    // The bug we just fixed: on-disk == newVersion but the running PID
+    // started from an earlier Cellar dir that has since been pruned.
+    assert.deepEqual(
+      decideUpgradeAction({ ...base, runningVersion: "0.9.0" }),
+      { action: "finish-upgrade", reason: "running-server-stale" },
+    );
+  });
+
+  it("noop with --no-restart even when an upgrade is needed", () => {
+    assert.deepEqual(
+      decideUpgradeAction({
+        ...base,
+        currentVersion: "0.9.0",
+        noRestart: true,
+      }),
+      { action: "noop", reason: "no-restart" },
+    );
+  });
+
+  it("noop with --no-restart even when running server is stale", () => {
+    assert.deepEqual(
+      decideUpgradeAction({
+        ...base,
+        runningVersion: "0.9.0",
+        noRestart: true,
+      }),
+      { action: "noop", reason: "no-restart" },
+    );
+  });
+
+  it("noop when no server is running, even on binary upgrade", () => {
+    assert.deepEqual(
+      decideUpgradeAction({
+        ...base,
+        currentVersion: "0.9.0",
+        runningVersion: null,
+        oldServerRunning: false,
+      }),
+      { action: "noop", reason: "no-running-server" },
+    );
+  });
+
+  it("ignores unprobed runningVersion (null) when versions agree", () => {
+    // /health probe failed (e.g., timeout). Don't fabricate staleness.
+    assert.deepEqual(
+      decideUpgradeAction({ ...base, runningVersion: null }),
+      { action: "noop", reason: "already-up-to-date" },
+    );
   });
 });
 

--- a/test/update-command.test.js
+++ b/test/update-command.test.js
@@ -232,6 +232,21 @@ describe("decideUpgradeAction", () => {
       { action: "noop", reason: "already-up-to-date" },
     );
   });
+
+  it("still runs finish-upgrade when probe failed but on-disk was upgraded", () => {
+    // Probe timed out (runningVersion === null), but brew DID bump the
+    // on-disk binary. We should still proceed with finish-upgrade — the
+    // probe failure is unrelated to the fact that there's something new
+    // to swap in.
+    assert.deepEqual(
+      decideUpgradeAction({
+        ...base,
+        currentVersion: "0.9.0",
+        runningVersion: null,
+      }),
+      { action: "finish-upgrade", reason: "binary-upgraded" },
+    );
+  });
 });
 
 describe("detectInstallMethod integration", () => {


### PR DESCRIPTION
## Summary

- `katulong update` now probes `/health` after the brew/git step and runs the existing `_finish-upgrade` smoke-test-and-swap when the running server's reported version differs from what's on disk. Without this, repeated runs all bailed out with "Already up to date" while the live PID kept 500-ing on a deleted Cellar.
- Decision logic is extracted into a pure `decideUpgradeAction` helper so the five branching cases (already-up-to-date, no-restart, no-running-server, binary-upgraded, running-server-stale) are unit-testable without spinning up a server.
- 7 new tests in `test/update-command.test.js` covering the matrix, including the regression case (binary == latest, running stale → finish-upgrade).

## How it manifested

A box where this happened today: `/health` reported `version: "0.60.0"`, on-disk binary was `v0.60.2`, and `~/.katulong/server.log` was full of:

```
ENOENT: no such file or directory, open
'/opt/homebrew/Cellar/katulong/0.60.0/libexec/public/index.html'
```

`katulong update` kept saying "Already up to date" because `currentVersion` and `newVersion` both came from disk and matched. The user saw `{"error":"Internal server error"}` on every static request with no obvious recovery path short of `katulong restart` or a manual `launchctl` dance.

## Test plan

- [x] `npm run test:unit` — 2591 pass, 0 fail
- [x] New `decideUpgradeAction` cases pass (7/7)
- [ ] Manual: stage a box, downgrade-then-upgrade-without-restart to reproduce the stale-Cellar state, run `katulong update`, confirm it now triggers `_finish-upgrade` instead of "Already up to date"