### PR TITLE
fix(service): bake a deterministic PATH into the LaunchAgent plist

### DIFF
--- a/lib/cli/commands/service.js
+++ b/lib/cli/commands/service.js
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import envConfig from "../../env-config.js";
 import { isServerRunning, isProcessRunning } from "../process-manager.js";
@@ -9,6 +9,45 @@ const PLIST_LABEL = "com.dorkyrobot.katulong";
 const PLIST_DIR = join(homedir(), "Library", "LaunchAgents");
 const PLIST_PATH = join(PLIST_DIR, `${PLIST_LABEL}.plist`);
 const GUI_DOMAIN = `gui/${process.getuid()}`;
+
+// Locations the running server needs to find: node (to re-invoke the katulong
+// CLI from child processes), tmux (session manager), and brew/git (used by
+// `katulong update`). Listed deterministically rather than inherited from the
+// calling shell so the plist is correct regardless of how `service install`
+// was invoked. A non-interactive ssh, for example, has a stripped PATH that
+// excludes /opt/homebrew/bin — baking that in would leave launchd unable to
+// find tmux on next respawn. Apple Silicon paths come first; Intel-Homebrew
+// and standard system paths follow as a complete fallback set.
+const STANDARD_PLIST_PATH_DIRS = [
+  "/opt/homebrew/bin",
+  "/opt/homebrew/sbin",
+  "/usr/local/bin",
+  "/usr/local/sbin",
+  "/usr/bin",
+  "/bin",
+  "/usr/sbin",
+  "/sbin",
+];
+
+/**
+ * Build the PATH the LaunchAgent should run with. Includes the standard
+ * fallback set plus the directory holding the resolved katulong binary
+ * (so the server can re-exec itself when it lives outside the standard
+ * Homebrew locations — e.g., npm-global, nvm, or a manual install).
+ *
+ * Exported for tests; used internally by `buildPlist`.
+ */
+export function buildLaunchAgentPath(bin) {
+  const binDir = bin ? dirname(bin) : null;
+  const seen = new Set();
+  const dirs = [];
+  for (const d of [binDir, ...STANDARD_PLIST_PATH_DIRS]) {
+    if (!d || seen.has(d)) continue;
+    seen.add(d);
+    dirs.push(d);
+  }
+  return dirs.join(":");
+}
 
 function katulongBin() {
   // Resolve the canonical path to the katulong binary.
@@ -50,7 +89,7 @@ function buildPlist() {
     <key>KATULONG_TMUX_SOCKET</key>
     <string>katulong</string>
     <key>PATH</key>
-    <string>${process.env.PATH}</string>
+    <string>${buildLaunchAgentPath(bin)}</string>
   </dict>
 
   <key>RunAtLoad</key>

--- a/lib/cli/commands/service.js
+++ b/lib/cli/commands/service.js
@@ -30,23 +30,38 @@ const STANDARD_PLIST_PATH_DIRS = [
 ];
 
 /**
+ * Escape a value for safe interpolation inside a plist `<string>` element.
+ * `bin`, `port`, and `dataDir` all flow into the plist from outside this file
+ * (env vars, `which katulong`), so even though the trust boundary is local-
+ * user, defense-in-depth: a binary path or env var containing `<`, `>`, `&`,
+ * or `"` could otherwise produce malformed XML or — worse — inject extra
+ * `<key>`/`<string>` elements that launchd would happily honor.
+ */
+export function xmlEscape(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
  * Build the PATH the LaunchAgent should run with. Includes the standard
  * fallback set plus the directory holding the resolved katulong binary
  * (so the server can re-exec itself when it lives outside the standard
  * Homebrew locations — e.g., npm-global, nvm, or a manual install).
  *
+ * A binDir containing `:` or whitespace is dropped: `:` would silently
+ * split into spurious PATH entries, and whitespace usually indicates a
+ * pathological install location not worth honoring.
+ *
  * Exported for tests; used internally by `buildPlist`.
  */
 export function buildLaunchAgentPath(bin) {
-  const binDir = bin ? dirname(bin) : null;
-  const seen = new Set();
-  const dirs = [];
-  for (const d of [binDir, ...STANDARD_PLIST_PATH_DIRS]) {
-    if (!d || seen.has(d)) continue;
-    seen.add(d);
-    dirs.push(d);
-  }
-  return dirs.join(":");
+  const rawBinDir = bin ? dirname(bin) : null;
+  const binDir = rawBinDir && !/[:\s]/.test(rawBinDir) ? rawBinDir : null;
+  return [...new Set([binDir, ...STANDARD_PLIST_PATH_DIRS].filter(Boolean))].join(":");
 }
 
 function katulongBin() {
@@ -64,6 +79,7 @@ function buildPlist() {
   const bin = katulongBin();
   const port = envConfig.port;
   const dataDir = envConfig.dataDir;
+  const path = buildLaunchAgentPath(bin);
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -71,11 +87,11 @@ function buildPlist() {
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>${PLIST_LABEL}</string>
+  <string>${xmlEscape(PLIST_LABEL)}</string>
 
   <key>ProgramArguments</key>
   <array>
-    <string>${bin}</string>
+    <string>${xmlEscape(bin)}</string>
     <string>start</string>
     <string>--foreground</string>
   </array>
@@ -83,13 +99,13 @@ function buildPlist() {
   <key>EnvironmentVariables</key>
   <dict>
     <key>PORT</key>
-    <string>${port}</string>
+    <string>${xmlEscape(port)}</string>
     <key>KATULONG_DATA_DIR</key>
-    <string>${dataDir}</string>
+    <string>${xmlEscape(dataDir)}</string>
     <key>KATULONG_TMUX_SOCKET</key>
     <string>katulong</string>
     <key>PATH</key>
-    <string>${buildLaunchAgentPath(bin)}</string>
+    <string>${xmlEscape(path)}</string>
   </dict>
 
   <key>RunAtLoad</key>
@@ -102,9 +118,9 @@ function buildPlist() {
   </dict>
 
   <key>StandardOutPath</key>
-  <string>${dataDir}/launchd-stdout.log</string>
+  <string>${xmlEscape(dataDir + "/launchd-stdout.log")}</string>
   <key>StandardErrorPath</key>
-  <string>${dataDir}/launchd-stderr.log</string>
+  <string>${xmlEscape(dataDir + "/launchd-stderr.log")}</string>
 
   <key>ProcessType</key>
   <string>Background</string>

--- a/test/service-plist-path.test.js
+++ b/test/service-plist-path.test.js
@@ -1,0 +1,59 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildLaunchAgentPath } from "../lib/cli/commands/service.js";
+
+describe("buildLaunchAgentPath", () => {
+  it("includes Homebrew, system, and bin-dir entries even when invoked from a stripped shell", () => {
+    // Regression for the bug fixed in this PR: the plist used to inherit
+    // process.env.PATH, so a non-interactive ssh's stripped PATH would
+    // bake into the LaunchAgent and break tmux/node lookup on respawn.
+    const result = buildLaunchAgentPath("/opt/homebrew/bin/katulong");
+    const dirs = result.split(":");
+    assert.ok(dirs.includes("/opt/homebrew/bin"), "missing /opt/homebrew/bin");
+    assert.ok(dirs.includes("/opt/homebrew/sbin"), "missing /opt/homebrew/sbin");
+    assert.ok(dirs.includes("/usr/local/bin"), "missing /usr/local/bin");
+    assert.ok(dirs.includes("/usr/bin"), "missing /usr/bin");
+    assert.ok(dirs.includes("/bin"), "missing /bin");
+    assert.ok(dirs.includes("/usr/sbin"), "missing /usr/sbin");
+    assert.ok(dirs.includes("/sbin"), "missing /sbin");
+  });
+
+  it("does NOT include the calling shell's PATH entries", () => {
+    const sentinel = "/some/random/user/path";
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${sentinel}:/usr/bin`;
+    try {
+      const result = buildLaunchAgentPath("/opt/homebrew/bin/katulong");
+      assert.ok(
+        !result.split(":").includes(sentinel),
+        `unexpected entry from process.env.PATH: ${result}`,
+      );
+    } finally {
+      process.env.PATH = originalPath;
+    }
+  });
+
+  it("prepends the bin's parent dir when it isn't in the standard set", () => {
+    // npm-global / nvm / manual installs live outside the Homebrew dirs.
+    const result = buildLaunchAgentPath(
+      "/Users/foo/.nvm/versions/node/v20.0.0/bin/katulong",
+    );
+    const dirs = result.split(":");
+    assert.equal(dirs[0], "/Users/foo/.nvm/versions/node/v20.0.0/bin");
+    assert.ok(dirs.includes("/opt/homebrew/bin"));
+  });
+
+  it("does NOT duplicate the bin's parent dir when it's already standard", () => {
+    const result = buildLaunchAgentPath("/opt/homebrew/bin/katulong");
+    const dirs = result.split(":");
+    const homebrewBinCount = dirs.filter((d) => d === "/opt/homebrew/bin").length;
+    assert.equal(homebrewBinCount, 1, "expected /opt/homebrew/bin exactly once");
+  });
+
+  it("handles a missing bin path by returning just the standard set", () => {
+    const result = buildLaunchAgentPath(null);
+    const dirs = result.split(":");
+    assert.equal(dirs[0], "/opt/homebrew/bin");
+    assert.ok(dirs.includes("/sbin"));
+  });
+});

--- a/test/service-plist-path.test.js
+++ b/test/service-plist-path.test.js
@@ -1,6 +1,30 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { buildLaunchAgentPath } from "../lib/cli/commands/service.js";
+import { buildLaunchAgentPath, xmlEscape } from "../lib/cli/commands/service.js";
+
+describe("xmlEscape", () => {
+  it("escapes the five XML predefined entities", () => {
+    assert.equal(
+      xmlEscape(`<key>injected</key><string>&"'`),
+      "&lt;key&gt;injected&lt;/key&gt;&lt;string&gt;&amp;&quot;&apos;",
+    );
+  });
+
+  it("returns input unchanged when no metacharacters are present", () => {
+    assert.equal(xmlEscape("/opt/homebrew/bin/katulong"), "/opt/homebrew/bin/katulong");
+  });
+
+  it("escapes & before other entities (no double-escape)", () => {
+    // Naive ordering ("escape & last") would re-escape the & in &lt;
+    // and produce &amp;lt;. Confirm that doesn't happen.
+    assert.equal(xmlEscape("&<"), "&amp;&lt;");
+  });
+
+  it("coerces non-string input via String()", () => {
+    assert.equal(xmlEscape(3001), "3001");
+    assert.equal(xmlEscape(null), "null");
+  });
+});
 
 describe("buildLaunchAgentPath", () => {
   it("includes Homebrew, system, and bin-dir entries even when invoked from a stripped shell", () => {
@@ -55,5 +79,29 @@ describe("buildLaunchAgentPath", () => {
     const dirs = result.split(":");
     assert.equal(dirs[0], "/opt/homebrew/bin");
     assert.ok(dirs.includes("/sbin"));
+  });
+
+  it("treats empty string the same as null", () => {
+    assert.equal(buildLaunchAgentPath(""), buildLaunchAgentPath(null));
+  });
+
+  it("drops a binDir containing a colon (would split PATH)", () => {
+    // dirname("/Users/a:b/katulong") === "/Users/a:b" — joining that with `:`
+    // would silently insert an extra entry into PATH. Drop instead of corrupt.
+    const result = buildLaunchAgentPath("/Users/a:b/katulong");
+    const dirs = result.split(":");
+    assert.ok(!dirs.includes("/Users/a"), `unexpected /Users/a entry: ${result}`);
+    assert.ok(!dirs.includes("b"), `unexpected b entry: ${result}`);
+    assert.equal(dirs[0], "/opt/homebrew/bin");
+  });
+
+  it("drops a binDir containing whitespace", () => {
+    const result = buildLaunchAgentPath("/Users/foo bar/bin/katulong");
+    const dirs = result.split(":");
+    assert.ok(
+      !dirs.some((d) => d.includes(" ")),
+      `whitespace leaked into PATH: ${result}`,
+    );
+    assert.equal(dirs[0], "/opt/homebrew/bin");
   });
 });


### PR DESCRIPTION
## Summary

- `buildPlist` snapshotted `process.env.PATH` into the LaunchAgent's `EnvironmentVariables`. Whatever the calling shell happened to have got baked in. A non-interactive ssh's stripped PATH ended up in the plist on at least one production host, breaking tmux/node lookup on every launchd respawn.
- Replace the snapshot with `buildLaunchAgentPath(bin)` — a pure helper that returns a fixed, ordered list of standard package-manager and system bin dirs, with the resolved katulong bin's parent dir prepended for non-standard installs (npm-global, nvm, manual).
- 5 unit tests cover the helper, including the stripped-shell regression (`PATH=/some/random` should NOT leak through into the plist).

## How it manifested

This was discovered while recovering the box that motivated PR #661. After fixing the stale-server detection there, I ran `katulong service restart` over ssh to swap the running v0.60.0 process for the on-disk v0.60.2. The restart succeeded structurally (old PID killed, plist reloaded), but launchd kept respawning a server that immediately exited:

```
{"level":"error","msg":"tmux is required but not found. Install with: brew install tmux"}
```

The host had tmux installed at `/opt/homebrew/bin/tmux`. The plist's `<key>PATH</key>` entry, however, was:

```
/Users/felixflores/.cargo/bin:/usr/bin:/bin:/usr/sbin:/sbin
```

— exactly what my non-interactive ssh shell exported. `service restart` had captured it and written it into the plist, replacing the previously-correct value.

## Test plan

- [x] `npm run test:unit` — 2597 pass, 0 fail
- [x] Manual: `env PATH=/some/stripped/path:/usr/bin:/bin node -e '...buildLaunchAgentPath...'` returns the deterministic set, ignoring the caller's PATH
- [ ] Once merged: re-run `katulong service install` on mini and confirm the plist's PATH no longer depends on the calling shell