### PR TITLE
rewrite(server): stage-rust tooling — bin/katulong-stage --rust + landing page + smoke e2e

### DIFF
--- a/bin/katulong-stage
+++ b/bin/katulong-stage
@@ -218,13 +218,18 @@ resolve_host() {
 }
 
 # Wait until the staging server is responding on $1, or fail.
+# Each backend has its own canonical liveness probe:
+#   - Node: `/login` (always served, public)
+#   - Rust: `/health` (always served, public; Rust has no SPA
+#     so /login isn't a route)
 wait_for_server() {
   local port="$1"
   local pid="$2"
   local log="$3"
+  local probe="$4"
   local i
   for i in $(seq 1 20); do
-    if curl -fs -o /dev/null "http://127.0.0.1:${port}/login"; then
+    if curl -fs -o /dev/null "http://127.0.0.1:${port}${probe}"; then
       return 0
     fi
     if ! is_alive "$pid"; then
@@ -445,8 +450,29 @@ cmd_start() {
     rm -rf "$dir"
   fi
 
-  if [[ ! -f "$REPO_ROOT/server.js" ]]; then
+  # Backend selection. Default is the Node implementation
+  # (server.js); set KATULONG_STAGE_BACKEND=rust to launch the
+  # Rust crate (target/release/katulong-server) instead. The
+  # Rust path is a backend-only smoke harness — it has no SPA
+  # served yet (the Leptos crate is a stub), so "poking around"
+  # via browser shows nothing. Use it to verify the Rust binary
+  # responds on /health, accepts WebSocket upgrades, and
+  # handles auth/setup-token APIs.
+  local backend="${KATULONG_STAGE_BACKEND:-node}"
+  case "$backend" in
+    node|rust) ;;
+    *)
+      echo "ERROR: KATULONG_STAGE_BACKEND must be 'node' or 'rust' (got: $backend)" >&2
+      return 1
+      ;;
+  esac
+
+  if [[ "$backend" == "node" && ! -f "$REPO_ROOT/server.js" ]]; then
     echo "ERROR: server.js not found in $REPO_ROOT" >&2
+    return 1
+  fi
+  if [[ "$backend" == "rust" && ! -d "$REPO_ROOT/crates/server" ]]; then
+    echo "ERROR: Rust backend requested but $REPO_ROOT/crates/server not present" >&2
     return 1
   fi
 
@@ -487,15 +513,34 @@ cmd_start() {
   # test/helpers/setup-env.js for the PID-scoped test sockets.
   rm -f "${TMUX_TMPDIR:-/tmp}/tmux-$(id -u)/$tmux_socket"
 
-  if [[ ! -d "$REPO_ROOT/node_modules" ]]; then
-    echo "  installing deps..."
-    (cd "$REPO_ROOT" && npm install --silent)
+  if [[ "$backend" == "node" ]]; then
+    if [[ ! -d "$REPO_ROOT/node_modules" ]]; then
+      echo "  installing deps..."
+      (cd "$REPO_ROOT" && npm install --silent)
+    fi
+    PORT="$port" \
+    KATULONG_DATA_DIR="$data_dir" \
+    KATULONG_TMUX_SOCKET="$tmux_socket" \
+      nohup node "$REPO_ROOT/server.js" > "$log_file" 2>&1 &
+  else
+    # Rust backend. Build the release binary if missing or out
+    # of date relative to source. cargo's incremental build is
+    # cheap when nothing has changed.
+    local rust_bin="$REPO_ROOT/target/release/katulong-server"
+    echo "  building rust binary (release)..."
+    if ! (cd "$REPO_ROOT" && cargo build --release -p katulong-server 2>&1 | tail -3); then
+      echo "ERROR: cargo build failed" >&2
+      return 1
+    fi
+    if [[ ! -x "$rust_bin" ]]; then
+      echo "ERROR: $rust_bin not found after build" >&2
+      return 1
+    fi
+    PORT="$port" \
+    KATULONG_DATA_DIR="$data_dir" \
+    KATULONG_TMUX_SOCKET="$tmux_socket" \
+      nohup "$rust_bin" > "$log_file" 2>&1 &
   fi
-
-  PORT="$port" \
-  KATULONG_DATA_DIR="$data_dir" \
-  KATULONG_TMUX_SOCKET="$tmux_socket" \
-    nohup node "$REPO_ROOT/server.js" > "$log_file" 2>&1 &
   local server_pid=$!
 
   # Trap signals so an interrupted start doesn't orphan the server process.
@@ -505,19 +550,36 @@ cmd_start() {
   # shellcheck disable=SC2064
   trap "cleanup_start '$server_pid' '$dir'; exit 130" INT TERM HUP
 
-  if ! wait_for_server "$port" "$server_pid" "$log_file"; then
+  local probe_path
+  if [[ "$backend" == "rust" ]]; then
+    probe_path="/health"
+  else
+    probe_path="/login"
+  fi
+  if ! wait_for_server "$port" "$server_pid" "$log_file" "$probe_path"; then
     trap - INT TERM HUP
     cleanup_start "$server_pid" "$dir"
     return 1
   fi
 
   local token
-  token="$(mint_setup_token "$data_dir" "$name" || true)"
-  if [[ -z "$token" ]]; then
-    echo "ERROR: failed to mint setup token (server up but token CLI returned nothing)" >&2
-    trap - INT TERM HUP
-    cleanup_start "$server_pid" "$dir"
-    return 1
+  if [[ "$backend" == "rust" ]]; then
+    # The Rust server's token-mint API requires auth (CSRF +
+    # `Authenticated`), and there's no equivalent CLI yet that
+    # writes a token directly to AuthStore for bootstrap. Skip
+    # the mint and tell the caller this is a backend-only
+    # smoke instance. /health and /api/me are reachable; the
+    # full UI flow needs the Leptos frontend.
+    token=""
+    echo "  ⚠ rust backend: setup-token mint skipped (CLI not implemented)"
+  else
+    token="$(mint_setup_token "$data_dir" "$name" || true)"
+    if [[ -z "$token" ]]; then
+      echo "ERROR: failed to mint setup token (server up but token CLI returned nothing)" >&2
+      trap - INT TERM HUP
+      cleanup_start "$server_pid" "$dir"
+      return 1
+    fi
   fi
 
   # ---- Tunnel wiring ----
@@ -581,7 +643,31 @@ cmd_start() {
   # signal trap so normal script exit doesn't kill the server we just started.
   trap - INT TERM HUP
 
-  cat <<EOF
+  if [[ "$backend" == "rust" ]]; then
+    cat <<EOF
+
+Staging '$name' is live (BACKEND: rust):
+
+  URL:         $url
+  Port:        $port (pid $server_pid)
+  Tmux Socket: $tmux_socket
+  Tunnel:      $tunnel
+  Data Dir:    $data_dir
+  Log:         tail -f $log_file
+
+Verify the Rust binary is what's responding:
+  curl $url/health                    # → "ok"
+  ps -p $server_pid -o command=       # should show .../target/release/katulong-server
+
+No SPA is served (Leptos frontend is a stub). Use this to
+exercise the Rust backend's HTTP + WebSocket surface.
+
+Stop:
+  $(basename "$0") stop $name
+
+EOF
+  else
+    cat <<EOF
 
 Staging '$name' is live:
 
@@ -598,6 +684,7 @@ Stop:
   $(basename "$0") stop $name
 
 EOF
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -20,7 +20,12 @@ use api::auth::auth_routes;
 use api::devices::device_routes;
 use api::tokens::token_routes;
 use auth_middleware::Authenticated;
-use axum::{extract::DefaultBodyLimit, routing::get, Json, Router};
+use axum::{
+    extract::DefaultBodyLimit,
+    response::Html,
+    routing::get,
+    Json, Router,
+};
 use serde_json::json;
 use state::AppState;
 
@@ -49,9 +54,19 @@ const REQUEST_BODY_LIMIT: usize = 1024 * 1024;
 /// `isPublicPath()`; we enforce it socially instead, which means the
 /// comments ARE the contract.
 ///
-/// Currently public: `/health` (k8s/uptime probe, returns static "ok").
+/// Currently public: `/health` (k8s/uptime probe, returns static
+/// "ok"), `/` (placeholder landing page until the Leptos
+/// frontend bundle replaces it).
 pub fn app(state: AppState) -> Router {
     Router::new()
+        // PUBLIC: placeholder landing page. The Rust crate
+        // doesn't ship a SPA yet (the Leptos crate is a stub).
+        // Until that lands, `/` returns a minimal HTML page so
+        // operators staging the Rust backend can see a sign of
+        // life in the browser instead of a 404 / blank screen.
+        // Replace this with a static-file mount once the Leptos
+        // bundle is built.
+        .route("/", get(landing))
         // PUBLIC: liveness probe. Returns static "ok".
         .route("/health", get(health))
         // PROTECTED: smoke-test endpoint that exercises the full
@@ -79,6 +94,36 @@ pub fn app(state: AppState) -> Router {
 
 async fn health() -> &'static str {
     "ok"
+}
+
+/// Placeholder landing page served at `/`. The HTML is
+/// intentionally minimal: a single visible heading + a
+/// machine-readable marker (`data-rust-backend="true"`)
+/// e2e tests can assert against. Replace with a static-file
+/// mount serving the Leptos bundle once the frontend lands.
+async fn landing() -> Html<&'static str> {
+    Html(
+        "<!doctype html>\n\
+         <html lang=\"en\">\n\
+         <head>\n\
+           <meta charset=\"utf-8\">\n\
+           <title>katulong (rust backend)</title>\n\
+           <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n\
+           <style>\n\
+             body { font: 16px/1.4 system-ui, sans-serif; max-width: 480px; \
+                    margin: 4rem auto; padding: 0 1rem; color: #222; }\n\
+             code { background: #f3f3f3; padding: 0.2em 0.4em; border-radius: 3px; }\n\
+             .marker { color: #888; font-size: 0.85em; }\n\
+           </style>\n\
+         </head>\n\
+         <body data-rust-backend=\"true\">\n\
+           <h1>katulong</h1>\n\
+           <p>Rust backend is alive. Frontend not yet built.</p>\n\
+           <p class=\"marker\">Smoke-test endpoints: \
+              <code>/health</code>, <code>/api/me</code>, <code>/ws</code>.</p>\n\
+         </body>\n\
+         </html>",
+    )
 }
 
 async fn me(Authenticated(ctx): Authenticated) -> Json<serde_json::Value> {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -61,7 +61,14 @@ async fn main() {
         .with_sessions(sessions)
         .with_output_router(output_router);
 
-    let addr: SocketAddr = "127.0.0.1:3000".parse().expect("valid bind address");
+    // Bind port: `PORT` env (matches the Node convention, plus
+    // bin/katulong-stage's port-allocation contract). Defaults
+    // to 3000 for parity with the Node default.
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3000);
+    let addr: SocketAddr = ([127, 0, 0, 1], port).into();
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .expect("bind listener");

--- a/playwright.rust.config.js
+++ b/playwright.rust.config.js
@@ -1,0 +1,40 @@
+// Playwright config for the Rust backend e2e suite.
+//
+// Distinct from the main `playwright.config.js`: the Rust e2e
+// suite does NOT spin up its own server. Tests assume the Rust
+// backend is already reachable at `KATULONG_BASE_URL` — typically
+// the local port allocated by `bin/katulong-stage` in `--rust`
+// mode, or the public staging URL.
+//
+// Run:
+//   KATULONG_BASE_URL=http://127.0.0.1:3050 \
+//     npx playwright test --config=playwright.rust.config.js
+//
+//   KATULONG_BASE_URL=https://rewrite-rust-leptos.felixflor.es \
+//     npx playwright test --config=playwright.rust.config.js
+//
+// The default base URL points at localhost so a developer who's
+// just run `KATULONG_STAGE_BACKEND=rust bin/katulong-stage start`
+// can run the suite without thinking about flags.
+import { defineConfig, devices } from "@playwright/test";
+
+const BASE_URL = process.env.KATULONG_BASE_URL || "http://127.0.0.1:3050";
+
+export default defineConfig({
+  testDir: "test/e2e-rust",
+  testMatch: "*.e2e.js",
+  fullyParallel: true,
+  workers: 1,
+  timeout: 30_000,
+  retries: 0,
+  reporter: [["list"]],
+  use: {
+    baseURL: BASE_URL,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/test/e2e-rust/smoke.e2e.js
+++ b/test/e2e-rust/smoke.e2e.js
@@ -1,0 +1,49 @@
+// Rust backend smoke e2e — the bare-minimum browser-level
+// proof that the Rust binary is serving SOMETHING visible at
+// `/`. This is the regression guard against the "blank screen"
+// failure mode where the Rust binary is healthy on `/health`
+// but the operator browses to `/` and sees nothing.
+//
+// Run against a live Rust backend (no test-side server spin-up):
+//   KATULONG_BASE_URL=http://127.0.0.1:3050 \
+//     npx playwright test --config=playwright.rust.config.js
+//
+// Replace this with real frontend coverage once the Leptos
+// bundle is built and served at `/`.
+
+import { test, expect } from "@playwright/test";
+
+test("landing page renders rust-backend marker", async ({ page }) => {
+  const response = await page.goto("/");
+  expect(response, "GET / should respond").not.toBeNull();
+  expect(response.status(), "GET / should be 200").toBe(200);
+
+  // Machine-readable marker on <body>. Source of truth for "is
+  // the Rust backend serving the placeholder landing page?"
+  const body = page.locator("body");
+  await expect(body).toHaveAttribute("data-rust-backend", "true");
+
+  // Visible content — catches the "page loaded but is empty"
+  // regression where the marker is set but no humans can tell
+  // anything is rendering.
+  await expect(page.locator("h1")).toContainText("katulong");
+  await expect(page.locator("body")).toContainText(
+    "Rust backend is alive",
+  );
+});
+
+test("/health returns ok", async ({ request }) => {
+  const response = await request.get("/health");
+  expect(response.status(), "/health should be 200").toBe(200);
+  expect(await response.text()).toBe("ok");
+});
+
+// Note: a `/api/me requires auth` smoke check would be wrong
+// here — katulong's security model auto-authenticates
+// 127.0.0.1 / ::1 (CLAUDE.md security section), so against a
+// local Rust binary the route returns 200. Against the public
+// tunnel it returns 401 (Host/Origin classification kicks
+// localhost-only into remote-auth mode). That nuance belongs
+// in a dedicated auth-suite, not this smoke. The `/health` +
+// `/` checks above are enough to catch "blank screen" /
+// "binary is dead" regressions.


### PR DESCRIPTION
## Summary

Lets an operator stage the Rust backend on a real network without bridging it to the Node frontend (the two are incompatible — see PR description for details).

## What changed

- **`bin/katulong-stage`** — new `KATULONG_STAGE_BACKEND` env var. Default `node` (current behavior). With `rust`, builds + launches the Rust binary instead of `node server.js`, skips token-mint (no Rust CLI yet), uses `/health` as the liveness probe.
- **Rust server** — honor `PORT` env var (was hardcoded 3000); add `/` route returning a minimal HTML landing page so the staging URL shows a sign of life instead of 404. Page carries `data-rust-backend="true"` for e2e assertion.
- **`playwright.rust.config.js` + `test/e2e-rust/smoke.e2e.js`** — smoke suite that hits the live Rust backend via a real browser. No test-side server spin-up; points at `KATULONG_BASE_URL` (defaults to local staging port).

## Verified

```
KATULONG_STAGE_BACKEND=rust bin/katulong-stage start rewrite-rust-leptos
# → https://rewrite-rust-leptos.felixflor.es/ shows landing page

npx playwright test --config=playwright.rust.config.js
# → 2 passed (local)

KATULONG_BASE_URL=https://rewrite-rust-leptos.felixflor.es \
  npx playwright test --config=playwright.rust.config.js
# → 2 passed (through Cloudflare tunnel)
```

## What this is NOT

This does NOT bridge the Node frontend to the Rust backend. They're incompatible at three layers:
- Static asset serving (Rust doesn't serve `public/`)
- WebSocket wire format (Rust = CBOR per slice 9d, Node = JSON)
- API surface (Rust has only auth + WS; Node frontend calls many other routes)

Per `project_rewrite_direction` memory, bridging is rejected. The forward path is the Leptos frontend, starting in a new worktree.

## Test plan

- [x] `cargo test -p katulong-server --lib` — 188 passing
- [x] `cargo test -p katulong-server --lib -- --ignored` — 7 passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Smoke e2e passes against local Rust staging + public tunnel