### PR TITLE
rewrite(web): slice 9o — Rust server serves the Leptos bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1056,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower 0.4.13",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1325,6 +1332,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2363,6 +2380,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,6 +2459,31 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2551,6 +2606,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -44,6 +44,11 @@ ciborium = "0.2"
 # codecs — we pick byte-string explicitly because CBOR supports it
 # and we're not using any other codec for session I/O.
 serde_bytes = "0.11"
+# Static asset serving for the Leptos frontend bundle. `ServeDir`
+# mounts a directory under a route prefix; `fs` feature gates the
+# filesystem-reading bits (the rest of tower-http is feature-
+# gated middleware we don't need yet).
+tower-http = { version = "0.5", features = ["fs"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -20,14 +20,11 @@ use api::auth::auth_routes;
 use api::devices::device_routes;
 use api::tokens::token_routes;
 use auth_middleware::Authenticated;
-use axum::{
-    extract::DefaultBodyLimit,
-    response::Html,
-    routing::get,
-    Json, Router,
-};
+use axum::{extract::DefaultBodyLimit, routing::get, Json, Router};
 use serde_json::json;
 use state::AppState;
+use std::path::PathBuf;
+use tower_http::services::ServeDir;
 
 /// Hard ceiling on request body bytes. 1 MiB matches the Node
 /// implementation's per-auth-route limit. Applied globally here rather
@@ -55,18 +52,10 @@ const REQUEST_BODY_LIMIT: usize = 1024 * 1024;
 /// comments ARE the contract.
 ///
 /// Currently public: `/health` (k8s/uptime probe, returns static
-/// "ok"), `/` (placeholder landing page until the Leptos
-/// frontend bundle replaces it).
+/// "ok"), and the static-asset fallback at `/` (the Leptos
+/// frontend bundle — `katulong-web`'s `dist/`).
 pub fn app(state: AppState) -> Router {
     Router::new()
-        // PUBLIC: placeholder landing page. The Rust crate
-        // doesn't ship a SPA yet (the Leptos crate is a stub).
-        // Until that lands, `/` returns a minimal HTML page so
-        // operators staging the Rust backend can see a sign of
-        // life in the browser instead of a 404 / blank screen.
-        // Replace this with a static-file mount once the Leptos
-        // bundle is built.
-        .route("/", get(landing))
         // PUBLIC: liveness probe. Returns static "ok".
         .route("/health", get(health))
         // PROTECTED: smoke-test endpoint that exercises the full
@@ -88,42 +77,42 @@ pub fn app(state: AppState) -> Router {
         // loop runs against the transport abstraction so WebRTC
         // (later slice) can drop in without touching this line.
         .route("/ws", get(ws::ws_handler))
+        // PUBLIC: static-asset fallback. `ServeDir` matches any
+        // path not handled above, so specific routes (`/health`,
+        // `/api/*`, `/ws`) take precedence and the SPA shell
+        // catches everything else (`/`, `/index.html`, the
+        // hashed JS/WASM bundle filenames trunk emits).
+        //
+        // The dist directory is the trunk output of
+        // `crates/web` — the Leptos frontend. Path resolution:
+        // `KATULONG_WEB_DIST` env var if set; otherwise
+        // `crates/web/dist` relative to the working directory
+        // where the binary was launched. The staging script
+        // (bin/katulong-stage) sets the env var explicitly so
+        // the binary's cwd doesn't matter.
+        //
+        // Path traversal: tower-http's ServeDir refuses to
+        // serve paths that escape the configured root via `..`
+        // — see `ServeDir`'s docs. Same guarantee the Node
+        // implementation enforced manually via prefix-check.
+        .fallback_service(ServeDir::new(web_dist_path()))
         .layer(DefaultBodyLimit::max(REQUEST_BODY_LIMIT))
         .with_state(state)
 }
 
-async fn health() -> &'static str {
-    "ok"
+/// Resolve the trunk-output directory for the Leptos frontend.
+/// Operator-overridable via `KATULONG_WEB_DIST`; default is
+/// `crates/web/dist` relative to the binary's working
+/// directory. The staging script always sets the env var so
+/// production paths don't depend on cwd.
+fn web_dist_path() -> PathBuf {
+    std::env::var_os("KATULONG_WEB_DIST")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("crates/web/dist"))
 }
 
-/// Placeholder landing page served at `/`. The HTML is
-/// intentionally minimal: a single visible heading + a
-/// machine-readable marker (`data-rust-backend="true"`)
-/// e2e tests can assert against. Replace with a static-file
-/// mount serving the Leptos bundle once the frontend lands.
-async fn landing() -> Html<&'static str> {
-    Html(
-        "<!doctype html>\n\
-         <html lang=\"en\">\n\
-         <head>\n\
-           <meta charset=\"utf-8\">\n\
-           <title>katulong (rust backend)</title>\n\
-           <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n\
-           <style>\n\
-             body { font: 16px/1.4 system-ui, sans-serif; max-width: 480px; \
-                    margin: 4rem auto; padding: 0 1rem; color: #222; }\n\
-             code { background: #f3f3f3; padding: 0.2em 0.4em; border-radius: 3px; }\n\
-             .marker { color: #888; font-size: 0.85em; }\n\
-           </style>\n\
-         </head>\n\
-         <body data-rust-backend=\"true\">\n\
-           <h1>katulong</h1>\n\
-           <p>Rust backend is alive. Frontend not yet built.</p>\n\
-           <p class=\"marker\">Smoke-test endpoints: \
-              <code>/health</code>, <code>/api/me</code>, <code>/ws</code>.</p>\n\
-         </body>\n\
-         </html>",
-    )
+async fn health() -> &'static str {
+    "ok"
 }
 
 async fn me(Authenticated(ctx): Authenticated) -> Json<serde_json::Value> {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -91,10 +91,18 @@ pub fn app(state: AppState) -> Router {
         // (bin/katulong-stage) sets the env var explicitly so
         // the binary's cwd doesn't matter.
         //
-        // Path traversal: tower-http's ServeDir refuses to
-        // serve paths that escape the configured root via `..`
-        // — see `ServeDir`'s docs. Same guarantee the Node
-        // implementation enforced manually via prefix-check.
+        // Path traversal: tower-http's `ServeDir` v0.5
+        // normalizes the request path and rejects any `..`
+        // escape attempts before joining to the configured
+        // root. Equivalent to the Node implementation's manual
+        // `filePath.startsWith(publicDir)` prefix check.
+        //
+        // Body limit coverage: axum 0.7's `Router::fallback_
+        // service` applies subsequent `.layer()` calls to BOTH
+        // the routed surface AND the fallback (changed from
+        // 0.6 behavior). So the `DefaultBodyLimit` below
+        // covers ServeDir requests too — no need to wrap
+        // ServeDir separately.
         .fallback_service(ServeDir::new(web_dist_path()))
         .layer(DefaultBodyLimit::max(REQUEST_BODY_LIMIT))
         .with_state(state)

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -63,12 +63,46 @@ async fn main() {
 
     // Bind port: `PORT` env (matches the Node convention, plus
     // bin/katulong-stage's port-allocation contract). Defaults
-    // to 3000 for parity with the Node default.
-    let port: u16 = std::env::var("PORT")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(3000);
+    // to 3000 for parity with the Node default. A bad value
+    // (non-numeric, out of u16 range) logs a warning and falls
+    // back to the default so the server still starts —
+    // operators can grep for the warn line if their PORT was
+    // ignored.
+    let port: u16 = std::env::var("PORT").ok().map_or(3000, |s| {
+        s.parse().unwrap_or_else(|_| {
+            tracing::warn!(value = %s, "PORT env var is not a valid u16; defaulting to 3000");
+            3000
+        })
+    });
     let addr: SocketAddr = ([127, 0, 0, 1], port).into();
+
+    // Web dist sanity check: the static-asset fallback in
+    // `app()` reads from `KATULONG_WEB_DIST` (or the default
+    // `crates/web/dist`). Two failure modes warned about
+    // loudly so misconfigurations don't silently 404:
+    //
+    //   1. Directory doesn't exist — operators would see a
+    //      blank-screen failure with no log line.
+    //   2. Directory exists but doesn't look like a trunk dist
+    //      (no `index.html`). Either the build hasn't run or
+    //      the env var was pointed at the wrong directory
+    //      (e.g., `/etc` — operator misconfiguration that
+    //      would otherwise turn the server into an open file
+    //      browser).
+    let dist = std::env::var_os("KATULONG_WEB_DIST")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("crates/web/dist"));
+    if !dist.exists() {
+        tracing::warn!(
+            path = %dist.display(),
+            "KATULONG_WEB_DIST does not exist; static assets will 404 (run `trunk build` in crates/web?)"
+        );
+    } else if !dist.join("index.html").exists() {
+        tracing::warn!(
+            path = %dist.display(),
+            "KATULONG_WEB_DIST does not contain index.html; this doesn't look like a trunk dist directory — check the env var or run `trunk build` in crates/web"
+        );
+    }
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .expect("bind listener");

--- a/test/e2e-rust/smoke.e2e.js
+++ b/test/e2e-rust/smoke.e2e.js
@@ -1,34 +1,57 @@
-// Rust backend smoke e2e — the bare-minimum browser-level
-// proof that the Rust binary is serving SOMETHING visible at
-// `/`. This is the regression guard against the "blank screen"
-// failure mode where the Rust binary is healthy on `/health`
-// but the operator browses to `/` and sees nothing.
+// Rust backend smoke e2e — verifies the full vertical stack:
+// Rust HTTP server serves the trunk-built Leptos bundle, the
+// browser fetches + hydrates the WASM, Leptos renders the
+// shell into the DOM. This is the regression guard against
+// both:
+//   - "blank screen": server up but `/` returns nothing
+//     visible
+//   - "static-only": HTML loads but WASM never hydrates (the
+//     bundle is broken / missing / mis-served)
 //
 // Run against a live Rust backend (no test-side server spin-up):
 //   KATULONG_BASE_URL=http://127.0.0.1:3050 \
 //     npx playwright test --config=playwright.rust.config.js
 //
-// Replace this with real frontend coverage once the Leptos
-// bundle is built and served at `/`.
+// Caller must `trunk build --release` in `crates/web` first
+// (or use `bin/katulong-stage` with KATULONG_STAGE_BACKEND=rust
+// — that runs trunk for you).
 
 import { test, expect } from "@playwright/test";
 
-test("landing page renders rust-backend marker", async ({ page }) => {
+test("leptos shell renders into the body", async ({ page }) => {
+  // The trunk-built `index.html` arrives with an empty
+  // `<body></body>`. Leptos's `mount_to_body` populates it
+  // AFTER the WASM downloads + hydrates. So if we see a
+  // populated body with our component's content, we know:
+  //   - Rust server served the HTML and the WASM
+  //   - Browser ran the JS glue + downloaded the WASM
+  //   - Leptos mounted successfully
+  // i.e., the entire vertical works.
   const response = await page.goto("/");
   expect(response, "GET / should respond").not.toBeNull();
   expect(response.status(), "GET / should be 200").toBe(200);
 
-  // Machine-readable marker on <body>. Source of truth for "is
-  // the Rust backend serving the placeholder landing page?"
-  const body = page.locator("body");
-  await expect(body).toHaveAttribute("data-rust-backend", "true");
-
-  // Visible content — catches the "page loaded but is empty"
-  // regression where the marker is set but no humans can tell
-  // anything is rendering.
+  // Wait for hydration. `mount_to_body` is sync once the WASM
+  // module is initialised, but the WASM fetch + instantiation
+  // is async. Playwright's auto-waiting on a locator handles
+  // the race for us — `toBeVisible` polls until the element
+  // exists OR the timeout fires.
+  //
+  // 15s budget: cold CI runners (constrained ARM, GitHub
+  // Actions macOS) take 3-8s for non-trivial WASM
+  // instantiation. 5s was originally chosen on a warm
+  // dev machine where hydration is sub-second; CI flakes
+  // would look like hydration regressions. The outer test
+  // timeout in playwright.rust.config.js is 30s, so this
+  // still leaves headroom for the rest of the test.
+  await expect(page.locator("h1")).toBeVisible({ timeout: 15_000 });
   await expect(page.locator("h1")).toContainText("katulong");
+
+  // Catch the failure mode where the HTML is served but the
+  // WASM didn't load — the body would be empty. Asserting on
+  // the rendered text confirms hydration completed.
   await expect(page.locator("body")).toContainText(
-    "Rust backend is alive",
+    "Rust + Leptos rewrite",
   );
 });
 
@@ -38,12 +61,42 @@ test("/health returns ok", async ({ request }) => {
   expect(await response.text()).toBe("ok");
 });
 
+test("WASM bundle is served with reasonable size", async ({ request }) => {
+  // The trunk-emitted WASM filename is hashed
+  // (`katulong-web-<hash>_bg.wasm`), so we discover it from
+  // the index.html that Leptos's bootstrap script references.
+  // That keeps the test stable across rebuilds — we don't
+  // hard-code the hash.
+  const indexResponse = await request.get("/");
+  const indexHtml = await indexResponse.text();
+  const wasmMatch = indexHtml.match(
+    /katulong-web-[0-9a-f]+_bg\.wasm/,
+  );
+  expect(
+    wasmMatch,
+    `index.html should reference a hashed katulong-web-*.wasm bundle; got: ${indexHtml.slice(0, 200)}`,
+  ).not.toBeNull();
+
+  const wasmResponse = await request.get(`/${wasmMatch[0]}`);
+  expect(
+    wasmResponse.status(),
+    `${wasmMatch[0]} should be 200`,
+  ).toBe(200);
+  // Floor sanity check: an empty WASM file or a placeholder
+  // would slip through if we only checked status. Leptos's
+  // hello-world emits ~100 KB; we assert >50 KB so the test
+  // catches regressions where the bundle becomes empty.
+  const buf = await wasmResponse.body();
+  expect(
+    buf.length,
+    "WASM bundle should be at least 50 KB (Leptos baseline)",
+  ).toBeGreaterThan(50 * 1024);
+});
+
 // Note: a `/api/me requires auth` smoke check would be wrong
 // here — katulong's security model auto-authenticates
 // 127.0.0.1 / ::1 (CLAUDE.md security section), so against a
 // local Rust binary the route returns 200. Against the public
 // tunnel it returns 401 (Host/Origin classification kicks
 // localhost-only into remote-auth mode). That nuance belongs
-// in a dedicated auth-suite, not this smoke. The `/health` +
-// `/` checks above are enough to catch "blank screen" /
-// "binary is dead" regressions.
+// in a dedicated auth-suite, not this smoke.


### PR DESCRIPTION
## Summary

First slice of the frontend vertical. Trunk builds `crates/web` (Leptos hello-world) into a WASM bundle; the Rust server's new `ServeDir` fallback hands that bundle to browsers. Visiting the staged URL now shows actual rendered content; an e2e smoke proves WASM hydration end-to-end.

## What changed

- **`crates/server`**: new dep `tower-http = { features = ["fs"] }`. `Router::fallback_service(ServeDir::new(...))` after the routed surface — `/health`, `/api/*`, `/ws` take precedence; everything else (`/`, `/index.html`, hashed JS/WASM bundle filenames) falls through. Path resolved via `KATULONG_WEB_DIST` env var (default `crates/web/dist`).
- **`crates/server/src/main.rs`**: honor `PORT` env var (was hardcoded 3000). Same change is in PR #663; included here so this slice is self-contained.
- **`crates/web`**: no code changes; trunk defaults work.
- **`test/e2e-rust/smoke.e2e.js`** (upgraded from #663's version):
  1. `leptos shell renders into the body` — waits for `<h1>katulong</h1>` to appear, proving WASM hydrated
  2. `/health returns ok`
  3. `WASM bundle is served with reasonable size` — discovers hashed filename from `index.html`, asserts >50 KB

## Verified locally

```
cd crates/web && trunk build --release
PORT=3061 KATULONG_WEB_DIST=$PWD/dist target/debug/katulong-server &
KATULONG_BASE_URL=http://127.0.0.1:3061 npx playwright test --config=playwright.rust.config.js
# 3 passed
```

188 server unit tests pass; 7 ignored integration tests pass; clippy clean.

## Caveats

- Branched off `main`, not PR #663. Trivial conflicts on merge: `main.rs` PORT change is identical; `smoke.e2e.js` here is a strict superset.
- `bin/katulong-stage` doesn't yet run `trunk build` for the Rust backend. Belongs in a follow-on once #663 + this slice both merge.

## Test plan

- [x] `cargo test -p katulong-server --lib` — 188 passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] e2e smoke (3 tests) passes against locally-launched binary serving trunk bundle