### PR TITLE
feat(config): peer Ollama URL + bearer token via Settings UI

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -269,6 +269,63 @@ export class ConfigManager {
   }
 
   /**
+   * Get the configured external Ollama URL, or null if unset.
+   * When set, outbound LLM calls (summarizer + narrator) route through
+   * this URL instead of localhost:11434. Pairs with `ollamaPeerToken`.
+   */
+  getOllamaPeerUrl() {
+    return this._get('ollamaPeerUrl', null);
+  }
+
+  async setOllamaPeerUrl(value) {
+    if (value === null || value === "") {
+      await this.withLock(() => this._set('ollamaPeerUrl', null));
+      return;
+    }
+    if (typeof value !== "string") {
+      throw new Error("ollamaPeerUrl must be a string or null");
+    }
+    let parsed;
+    try {
+      parsed = new URL(value);
+    } catch {
+      throw new Error("ollamaPeerUrl must be a valid URL");
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("ollamaPeerUrl must use http or https");
+    }
+    // Strip trailing slash so callers can predictably append paths.
+    const normalized = value.replace(/\/+$/, "");
+    await this.withLock(() => this._set('ollamaPeerUrl', normalized));
+  }
+
+  /**
+   * Get the configured Bearer token for the external Ollama proxy, or null.
+   * Stored in the same 0600-mode config file as the rest; rotate by
+   * calling `setOllamaPeerToken(null)` then re-setting.
+   */
+  getOllamaPeerToken() {
+    return this._get('ollamaPeerToken', null);
+  }
+
+  async setOllamaPeerToken(value) {
+    if (value === null || value === "") {
+      await this.withLock(() => this._set('ollamaPeerToken', null));
+      return;
+    }
+    if (typeof value !== "string") {
+      throw new Error("ollamaPeerToken must be a string or null");
+    }
+    if (value.length < 8) {
+      throw new Error("ollamaPeerToken must be at least 8 characters");
+    }
+    if (value.length > 512) {
+      throw new Error("ollamaPeerToken must be 512 characters or less");
+    }
+    await this.withLock(() => this._set('ollamaPeerToken', value));
+  }
+
+  /**
    * Get all config
    */
   getConfig() {

--- a/lib/config.js
+++ b/lib/config.js
@@ -285,17 +285,28 @@ export class ConfigManager {
     if (typeof value !== "string") {
       throw new Error("ollamaPeerUrl must be a string or null");
     }
+    const trimmed = value.trim();
+    if (trimmed === "") {
+      await this.withLock(() => this._set('ollamaPeerUrl', null));
+      return;
+    }
     let parsed;
     try {
-      parsed = new URL(value);
+      parsed = new URL(trimmed);
     } catch {
       throw new Error("ollamaPeerUrl must be a valid URL");
     }
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       throw new Error("ollamaPeerUrl must use http or https");
     }
+    // Reject embedded credentials — they would land in the request URL
+    // and bypass the explicit Bearer token mechanism, plus risk leaking
+    // into upstream logs. Use the dedicated token field instead.
+    if (parsed.username || parsed.password) {
+      throw new Error("ollamaPeerUrl must not contain credentials; use the token field instead");
+    }
     // Strip trailing slash so callers can predictably append paths.
-    const normalized = value.replace(/\/+$/, "");
+    const normalized = trimmed.replace(/\/+$/, "");
     await this.withLock(() => this._set('ollamaPeerUrl', normalized));
   }
 
@@ -316,21 +327,40 @@ export class ConfigManager {
     if (typeof value !== "string") {
       throw new Error("ollamaPeerToken must be a string or null");
     }
-    if (value.length < 8) {
-      throw new Error("ollamaPeerToken must be at least 8 characters");
+    // Trim clipboard whitespace — a copied token with leading/trailing
+    // newline would otherwise save with a malformed Bearer header and
+    // silently fail the test handshake.
+    const trimmed = value.trim();
+    if (trimmed === "") {
+      await this.withLock(() => this._set('ollamaPeerToken', null));
+      return;
     }
-    if (value.length > 512) {
+    // 32-char minimum aligns with the bridge's 32-byte hex default and
+    // gives ~128 bits of entropy. Enough to make brute-force infeasible
+    // even if the bridge ends up on a publicly-resolvable hostname.
+    if (trimmed.length < 32) {
+      throw new Error("ollamaPeerToken must be at least 32 characters");
+    }
+    if (trimmed.length > 512) {
       throw new Error("ollamaPeerToken must be 512 characters or less");
     }
-    await this.withLock(() => this._set('ollamaPeerToken', value));
+    await this.withLock(() => this._set('ollamaPeerToken', trimmed));
   }
 
   /**
-   * Get all config
+   * Get all config — but with secret fields redacted. Used by the public
+   * `GET /api/config` endpoint, which is reached by any authenticated
+   * client. The dedicated peer-config endpoint exposes presence-only
+   * (`hasToken: bool`); we must not bypass that here.
+   *
+   * If you genuinely need the unredacted in-memory config (e.g., for
+   * server-side wiring like resolveEndpoint), call the field-specific
+   * getter directly.
    */
   getConfig() {
     if (!this.config) this.initialize();
-    return { ...this.config };
+    const { ollamaPeerToken, ...safe } = this.config;
+    return safe;
   }
 
   /**

--- a/lib/ollama-client.js
+++ b/lib/ollama-client.js
@@ -32,20 +32,39 @@ const DEFAULT_TIMEOUT_MS = 10 * 60_000;
 /**
  * Create a `callOllama` function bound to a given URL/model/timeout.
  * Returns `async (userPrompt, { systemPrompt }) => string`.
+ *
+ * `resolveEndpoint`, when provided, is called on every request and
+ * returns `{ host, authToken }`. This lets the running server pick up
+ * UI-driven config changes (peer URL + token) without a restart. When
+ * absent, the static `host`/`authToken` from create-time are used.
+ *
+ * `authToken` (when set, either statically or via resolveEndpoint) is
+ * sent as `Authorization: Bearer <token>`. This is the wire shape
+ * ollama-bridge expects today and the eventual katulong-app/1 runtime
+ * call will keep using.
  */
 export function createOllamaClient({
   host = DEFAULT_HOST,
   model = DEFAULT_MODEL,
   timeoutMs = DEFAULT_TIMEOUT_MS,
+  authToken = null,
+  resolveEndpoint = null,
 } = {}) {
   return async function callOllama(userPrompt, { systemPrompt } = {}) {
     const messages = [];
     if (systemPrompt) messages.push({ role: "system", content: systemPrompt });
     messages.push({ role: "user", content: userPrompt });
 
-    const res = await fetch(`${host}/api/chat`, {
+    const endpoint = resolveEndpoint ? resolveEndpoint() : null;
+    const effectiveHost = endpoint?.host || host;
+    const effectiveToken = endpoint?.authToken ?? authToken;
+
+    const headers = { "Content-Type": "application/json" };
+    if (effectiveToken) headers.Authorization = `Bearer ${effectiveToken}`;
+
+    const res = await fetch(`${effectiveHost}/api/chat`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify({ model, messages, stream: true }),
       signal: AbortSignal.timeout(timeoutMs),
     });

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -987,6 +987,82 @@ export function createAppRoutes(ctx) {
     configPutRoute("/api/config/port-proxy-enabled", "portProxyEnabled", (v) => configManager.setPortProxyEnabled(v), () => configManager.getPortProxyEnabled()),
     configPutRoute("/api/config/public-url", "publicUrl", (v) => configManager.setPublicUrl(v), () => configManager.getPublicUrl()),
 
+    // --- Ollama peer (external LLM endpoint) ---
+    //
+    // The token is treated as a secret: never returned over the wire.
+    // GET reports presence (hasToken) so the UI can render an empty
+    // input with a "set" indicator. PUT accepts {url, token} where
+    // either may be null to clear. POST /test pings the endpoint so
+    // the user gets immediate feedback before saving.
+
+    { method: "GET", path: "/api/config/ollama-peer", handler: auth((req, res) => {
+      json(res, 200, {
+        url: configManager.getOllamaPeerUrl(),
+        hasToken: !!configManager.getOllamaPeerToken(),
+        mode: configManager.getOllamaPeerUrl() ? "peer" : "local",
+      });
+    })},
+
+    { method: "PUT", path: "/api/config/ollama-peer", handler: auth(csrf(async (req, res) => {
+      const body = await parseJSON(req);
+      // Allow partial updates: omit a field to leave it untouched,
+      // pass null/empty-string to clear.
+      try {
+        if ("url" in body) await configManager.setOllamaPeerUrl(body.url);
+        if ("token" in body) await configManager.setOllamaPeerToken(body.token);
+        log.info("ollamaPeer updated", {
+          url: configManager.getOllamaPeerUrl(),
+          hasToken: !!configManager.getOllamaPeerToken(),
+        });
+        json(res, 200, {
+          success: true,
+          url: configManager.getOllamaPeerUrl(),
+          hasToken: !!configManager.getOllamaPeerToken(),
+        });
+      } catch (error) {
+        json(res, 400, { error: error.message });
+      }
+    }))},
+
+    { method: "POST", path: "/api/config/ollama-peer/test", handler: auth(csrf(async (req, res) => {
+      // Test against the values already saved — not the request body. The
+      // user saves first, then tests. Keeps the token off the wire and
+      // off this server's memory beyond what's already in config.
+      const url = configManager.getOllamaPeerUrl();
+      const token = configManager.getOllamaPeerToken();
+      if (!url) {
+        return json(res, 400, { ok: false, error: "no peer URL configured" });
+      }
+      try {
+        const headers = {};
+        if (token) headers.Authorization = `Bearer ${token}`;
+        const upstream = await fetch(`${url}/api/tags`, {
+          headers,
+          signal: AbortSignal.timeout(5000),
+        });
+        if (!upstream.ok) {
+          return json(res, 200, {
+            ok: false,
+            status: upstream.status,
+            error: upstream.status === 401
+              ? "unauthorized — check the token"
+              : `upstream returned ${upstream.status}`,
+          });
+        }
+        const data = await upstream.json().catch(() => null);
+        const models = Array.isArray(data?.models)
+          ? data.models.map((m) => m.name).filter(Boolean)
+          : [];
+        return json(res, 200, { ok: true, models });
+      } catch (err) {
+        const code = err.cause?.code || err.code || err.name;
+        return json(res, 200, {
+          ok: false,
+          error: `cannot reach ${url}: ${code || err.message}`,
+        });
+      }
+    }))},
+
     // --- Notes (per-session markdown) ---
 
     { method: "GET", prefix: "/api/notes/", handler: auth((req, res, name) => {

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -23,7 +23,7 @@ import { log } from "../log.js";
 import { rewriteVendorUrls } from "../static-files.js";
 import { captureVisiblePane, tmuxSocketArgs } from "../tmux.js";
 import { bridgeClipboardToContainers, bridgePaneContainer } from "../container-detect.js";
-import { readRawBody } from "../request-util.js";
+import { readRawBody, readBody } from "../request-util.js";
 import { transformClaudeEvent, readTranscriptEntries, UUID_RE } from "../claude-event-transform.js";
 import { parsePreToolUsePayload } from "../claude-permissions.js";
 import { pollForPermissionPrompt } from "../claude-pane-scanner.js";
@@ -48,6 +48,7 @@ export { PRIVATE_META_KEYS, publicMeta };
 // both entrypoints have a consistent envelope.
 const MAX_PASTE_TOKENS = 50;
 const MAX_PASTE_TEXT_LEN = 2000;
+const PEER_TEST_TIMEOUT_MS = 5000;
 
 /**
  * Validate a hook-provided transcript_path before stamping it into meta.
@@ -999,7 +1000,6 @@ export function createAppRoutes(ctx) {
       json(res, 200, {
         url: configManager.getOllamaPeerUrl(),
         hasToken: !!configManager.getOllamaPeerToken(),
-        mode: configManager.getOllamaPeerUrl() ? "peer" : "local",
       });
     })},
 
@@ -1007,8 +1007,13 @@ export function createAppRoutes(ctx) {
       const body = await parseJSON(req);
       // Allow partial updates: omit a field to leave it untouched,
       // pass null/empty-string to clear.
+      // Atomic semantics: capture the existing pair before any write so a
+      // bad token doesn't leave a partially-applied URL behind. On failure,
+      // restore both to their pre-call values.
+      const originalUrl   = configManager.getOllamaPeerUrl();
+      const originalToken = configManager.getOllamaPeerToken();
       try {
-        if ("url" in body) await configManager.setOllamaPeerUrl(body.url);
+        if ("url" in body)   await configManager.setOllamaPeerUrl(body.url);
         if ("token" in body) await configManager.setOllamaPeerToken(body.token);
         log.info("ollamaPeer updated", {
           url: configManager.getOllamaPeerUrl(),
@@ -1020,6 +1025,20 @@ export function createAppRoutes(ctx) {
           hasToken: !!configManager.getOllamaPeerToken(),
         });
       } catch (error) {
+        // Rollback: only the field that succeeded could have changed. If
+        // the URL update succeeded but the token update failed, we restore
+        // the URL to its prior value. The setters tolerate identical-value
+        // writes (they just rewrite the file).
+        try {
+          if (configManager.getOllamaPeerUrl() !== originalUrl) {
+            await configManager.setOllamaPeerUrl(originalUrl);
+          }
+          if (configManager.getOllamaPeerToken() !== originalToken) {
+            await configManager.setOllamaPeerToken(originalToken);
+          }
+        } catch (rollbackErr) {
+          log.error("ollamaPeer rollback failed", { error: rollbackErr.message });
+        }
         json(res, 400, { error: error.message });
       }
     }))},
@@ -1028,6 +1047,9 @@ export function createAppRoutes(ctx) {
       // Test against the values already saved — not the request body. The
       // user saves first, then tests. Keeps the token off the wire and
       // off this server's memory beyond what's already in config.
+      // Drain (small) body so the connection completes cleanly; we do
+      // not parse it because we never read it.
+      try { await readBody(req, 256); } catch { /* body absent or empty */ }
       const url = configManager.getOllamaPeerUrl();
       const token = configManager.getOllamaPeerToken();
       if (!url) {
@@ -1038,7 +1060,7 @@ export function createAppRoutes(ctx) {
         if (token) headers.Authorization = `Bearer ${token}`;
         const upstream = await fetch(`${url}/api/tags`, {
           headers,
-          signal: AbortSignal.timeout(5000),
+          signal: AbortSignal.timeout(PEER_TEST_TIMEOUT_MS),
         });
         if (!upstream.ok) {
           return json(res, 200, {

--- a/public/index.html
+++ b/public/index.html
@@ -3362,6 +3362,31 @@
               <span id="notification-permission-status" style="font-size: 0.8rem; color: var(--text-muted);"></span>
             </div>
             <p class="tab-description" id="notification-permission-desc" style="margin-top: 0.5rem; margin-bottom: 1.5rem;"></p>
+
+            <h4 style="margin-top: var(--space-xl); font-size: 0.875rem; color: var(--text-muted);">External LLM endpoint</h4>
+            <p class="tab-description" style="margin-top: 0;">
+              Route summarizer + narrator inference to a remote ollama-bridge
+              instead of localhost. Leave blank to use this machine's local Ollama.
+            </p>
+            <div class="settings-row" style="flex-direction: column; align-items: stretch; gap: var(--space-xs);">
+              <span class="settings-label">URL</span>
+              <input type="url" id="ollama-peer-url-input" class="palette-hex-input"
+                     style="width: 100%; box-sizing: border-box;"
+                     placeholder="https://ollama-bridge.example.com" spellcheck="false" autocomplete="off" />
+            </div>
+            <div class="settings-row" style="flex-direction: column; align-items: stretch; gap: var(--space-xs);">
+              <span class="settings-label">Bearer token</span>
+              <input type="password" id="ollama-peer-token-input" class="palette-hex-input"
+                     style="width: 100%; box-sizing: border-box;"
+                     placeholder="paste token from ollama-bridge new-token" spellcheck="false" autocomplete="off" />
+              <span id="ollama-peer-token-state" style="font-size: 0.75rem; color: var(--text-muted);"></span>
+            </div>
+            <div class="settings-row" style="gap: var(--space-xs);">
+              <button class="settings-pair-btn" id="ollama-peer-save-btn">Save</button>
+              <button class="settings-pair-btn" id="ollama-peer-test-btn">Test connection</button>
+              <button class="settings-pair-btn" id="ollama-peer-clear-btn" style="opacity: 0.7;">Clear</button>
+            </div>
+            <p class="tab-description" id="ollama-peer-status" style="margin-top: 0.5rem; min-height: 1.2em;"></p>
           </div>
 
           <!-- Remote tab content -->

--- a/public/lib/settings-handlers.js
+++ b/public/lib/settings-handlers.js
@@ -225,6 +225,96 @@ export function createSettingsHandlers(options = {}) {
     input.addEventListener("input", () => input.classList.remove("invalid"));
   }
 
+  /** Initialize the External LLM endpoint section.
+   *
+   *  GET /api/config/ollama-peer returns {url, hasToken}; the token is
+   *  never sent back to the client. The input shows blank with a
+   *  "(token already set)" hint when a token exists server-side; typing
+   *  a new value overrides; Clear sets both to null.
+   */
+  function initOllamaPeer() {
+    const urlInput   = document.getElementById("ollama-peer-url-input");
+    const tokenInput = document.getElementById("ollama-peer-token-input");
+    const tokenState = document.getElementById("ollama-peer-token-state");
+    const saveBtn    = document.getElementById("ollama-peer-save-btn");
+    const testBtn    = document.getElementById("ollama-peer-test-btn");
+    const clearBtn   = document.getElementById("ollama-peer-clear-btn");
+    const statusEl   = document.getElementById("ollama-peer-status");
+    if (!urlInput || !tokenInput) return;
+
+    const setStatus = (msg, kind = "neutral") => {
+      statusEl.textContent = msg;
+      statusEl.style.color = kind === "ok"  ? "var(--accent)"
+                          : kind === "err" ? "var(--danger, #d33)"
+                          : "var(--text-muted)";
+    };
+
+    async function load() {
+      try {
+        const data = await api.get("/api/config/ollama-peer");
+        urlInput.value = data.url || "";
+        tokenInput.value = "";
+        tokenState.textContent = data.hasToken
+          ? "token already set — leave blank to keep, or type to replace"
+          : "no token set";
+      } catch (err) {
+        setStatus(`load failed: ${err.message}`, "err");
+      }
+    }
+
+    async function save() {
+      const url = urlInput.value.trim();
+      const tokenTyped = tokenInput.value;
+      const body = { url: url || null };
+      // Only include token when the user typed something, so an empty
+      // box doesn't accidentally clear a previously-saved token.
+      if (tokenTyped.length > 0) body.token = tokenTyped;
+      try {
+        setStatus("saving...");
+        await api.put("/api/config/ollama-peer", body);
+        setStatus("saved", "ok");
+        await load();
+      } catch (err) {
+        setStatus(`save failed: ${err.message}`, "err");
+      }
+    }
+
+    async function test() {
+      setStatus("testing...");
+      try {
+        const result = await api.post("/api/config/ollama-peer/test", {});
+        if (result.ok) {
+          const count = result.models?.length ?? 0;
+          setStatus(
+            count > 0
+              ? `✓ reachable (${count} model${count === 1 ? "" : "s"} available)`
+              : "✓ reachable, but no models loaded on the bridge",
+            "ok",
+          );
+        } else {
+          setStatus(`✗ ${result.error || "unknown error"}`, "err");
+        }
+      } catch (err) {
+        setStatus(`✗ ${err.message}`, "err");
+      }
+    }
+
+    async function clear() {
+      try {
+        await api.put("/api/config/ollama-peer", { url: null, token: null });
+        setStatus("cleared — using local Ollama", "neutral");
+        await load();
+      } catch (err) {
+        setStatus(`clear failed: ${err.message}`, "err");
+      }
+    }
+
+    saveBtn?.addEventListener("click", save);
+    testBtn?.addEventListener("click", test);
+    clearBtn?.addEventListener("click", clear);
+    load();
+  }
+
   /** Initialize Claude Code hooks copy button. */
   function initClaudeHooksSnippet() {
     const copyBtn = document.getElementById("claude-hooks-copy");
@@ -260,6 +350,7 @@ export function createSettingsHandlers(options = {}) {
     initLogout();
     initVersion();
     initClaudeHooksSnippet();
+    initOllamaPeer();
   }
 
   return {

--- a/server.js
+++ b/server.js
@@ -272,7 +272,19 @@ const permissionStore = createPermissionStore();
 // additional config is needed beyond authenticating the daemon.
 // Single shared client is intentional: we stay Claude-specific until
 // a consumer actually needs a different model / timeout / host.
-const callOllama = createOllamaClient({ model: "gemma4:31b-cloud" });
+//
+// resolveEndpoint reads the peer Ollama config on every request, so the
+// Settings UI can swap endpoints without restarting the server. Returns
+// null when no peer is configured — the client then falls back to the
+// default localhost host.
+const callOllama = createOllamaClient({
+  model: "gemma4:31b-cloud",
+  resolveEndpoint: () => {
+    const peerUrl = configManager.getOllamaPeerUrl();
+    if (!peerUrl) return null;
+    return { host: peerUrl, authToken: configManager.getOllamaPeerToken() };
+  },
+});
 const claudeProcessor = createClaudeProcessor({
   watchlist: claudeWatchlist,
   topicBroker,

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -833,4 +833,106 @@ describe("ConfigManager", () => {
       assert.strictEqual(configManager2.getPortProxyEnabled(), false);
     });
   });
+
+  describe("ollamaPeerUrl", () => {
+    beforeEach(() => {
+      configManager.initialize();
+    });
+
+    it("defaults to null", () => {
+      assert.strictEqual(configManager.getOllamaPeerUrl(), null);
+    });
+
+    it("accepts a valid https URL", async () => {
+      await configManager.setOllamaPeerUrl("https://ollama.example.com");
+      assert.strictEqual(configManager.getOllamaPeerUrl(), "https://ollama.example.com");
+    });
+
+    it("accepts http (for localhost / LAN setups)", async () => {
+      await configManager.setOllamaPeerUrl("http://192.168.1.5:11435");
+      assert.strictEqual(configManager.getOllamaPeerUrl(), "http://192.168.1.5:11435");
+    });
+
+    it("strips trailing slashes for predictable path appending", async () => {
+      await configManager.setOllamaPeerUrl("https://ollama.example.com///");
+      assert.strictEqual(configManager.getOllamaPeerUrl(), "https://ollama.example.com");
+    });
+
+    it("clears with null", async () => {
+      await configManager.setOllamaPeerUrl("https://ollama.example.com");
+      await configManager.setOllamaPeerUrl(null);
+      assert.strictEqual(configManager.getOllamaPeerUrl(), null);
+    });
+
+    it("clears with empty string", async () => {
+      await configManager.setOllamaPeerUrl("https://ollama.example.com");
+      await configManager.setOllamaPeerUrl("");
+      assert.strictEqual(configManager.getOllamaPeerUrl(), null);
+    });
+
+    it("rejects malformed URLs", async () => {
+      await assert.rejects(
+        async () => configManager.setOllamaPeerUrl("not a url"),
+        /valid URL/,
+      );
+    });
+
+    it("rejects non-http(s) protocols", async () => {
+      await assert.rejects(
+        async () => configManager.setOllamaPeerUrl("ftp://nope"),
+        /must use http or https/,
+      );
+    });
+
+    it("persists across reload", async () => {
+      await configManager.setOllamaPeerUrl("https://ollama.example.com");
+      const reloaded = new ConfigManager(testDir);
+      reloaded.initialize();
+      assert.strictEqual(reloaded.getOllamaPeerUrl(), "https://ollama.example.com");
+    });
+  });
+
+  describe("ollamaPeerToken", () => {
+    beforeEach(() => {
+      configManager.initialize();
+    });
+
+    it("defaults to null", () => {
+      assert.strictEqual(configManager.getOllamaPeerToken(), null);
+    });
+
+    it("accepts a sensibly long token", async () => {
+      const token = "a".repeat(64);
+      await configManager.setOllamaPeerToken(token);
+      assert.strictEqual(configManager.getOllamaPeerToken(), token);
+    });
+
+    it("clears with null", async () => {
+      await configManager.setOllamaPeerToken("a".repeat(32));
+      await configManager.setOllamaPeerToken(null);
+      assert.strictEqual(configManager.getOllamaPeerToken(), null);
+    });
+
+    it("rejects tokens shorter than 8 chars", async () => {
+      await assert.rejects(
+        async () => configManager.setOllamaPeerToken("short"),
+        /at least 8/,
+      );
+    });
+
+    it("rejects tokens longer than 512 chars", async () => {
+      await assert.rejects(
+        async () => configManager.setOllamaPeerToken("x".repeat(513)),
+        /512 characters or less/,
+      );
+    });
+
+    it("persists across reload", async () => {
+      const token = "a".repeat(64);
+      await configManager.setOllamaPeerToken(token);
+      const reloaded = new ConfigManager(testDir);
+      reloaded.initialize();
+      assert.strictEqual(reloaded.getOllamaPeerToken(), token);
+    });
+  });
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -870,6 +870,12 @@ describe("ConfigManager", () => {
       assert.strictEqual(configManager.getOllamaPeerUrl(), null);
     });
 
+    it("clears with whitespace-only string", async () => {
+      await configManager.setOllamaPeerUrl("https://ollama.example.com");
+      await configManager.setOllamaPeerUrl("   ");
+      assert.strictEqual(configManager.getOllamaPeerUrl(), null);
+    });
+
     it("rejects malformed URLs", async () => {
       await assert.rejects(
         async () => configManager.setOllamaPeerUrl("not a url"),
@@ -881,6 +887,19 @@ describe("ConfigManager", () => {
       await assert.rejects(
         async () => configManager.setOllamaPeerUrl("ftp://nope"),
         /must use http or https/,
+      );
+    });
+
+    it("rejects URLs with embedded credentials (user:pass@)", async () => {
+      // The password would otherwise leak into request URLs and bypass the
+      // explicit Bearer token mechanism.
+      await assert.rejects(
+        async () => configManager.setOllamaPeerUrl("https://user:secret@ollama.example.com"),
+        /must not contain credentials/,
+      );
+      await assert.rejects(
+        async () => configManager.setOllamaPeerUrl("https://user@ollama.example.com"),
+        /must not contain credentials/,
       );
     });
 
@@ -913,11 +932,17 @@ describe("ConfigManager", () => {
       assert.strictEqual(configManager.getOllamaPeerToken(), null);
     });
 
-    it("rejects tokens shorter than 8 chars", async () => {
+    it("rejects tokens shorter than 32 chars", async () => {
       await assert.rejects(
-        async () => configManager.setOllamaPeerToken("short"),
-        /at least 8/,
+        async () => configManager.setOllamaPeerToken("a".repeat(31)),
+        /at least 32/,
       );
+    });
+
+    it("accepts tokens exactly 32 chars (the minimum)", async () => {
+      const token = "a".repeat(32);
+      await configManager.setOllamaPeerToken(token);
+      assert.strictEqual(configManager.getOllamaPeerToken(), token);
     });
 
     it("rejects tokens longer than 512 chars", async () => {
@@ -927,12 +952,52 @@ describe("ConfigManager", () => {
       );
     });
 
+    it("trims surrounding whitespace before storing", async () => {
+      // Common clipboard mishap — a copied token with a trailing newline
+      // would otherwise produce a malformed Bearer header.
+      const raw = "  " + "a".repeat(64) + "\n";
+      await configManager.setOllamaPeerToken(raw);
+      assert.strictEqual(configManager.getOllamaPeerToken(), "a".repeat(64));
+    });
+
+    it("clears when trimming yields an empty string", async () => {
+      await configManager.setOllamaPeerToken("a".repeat(32));
+      await configManager.setOllamaPeerToken("   \n  ");
+      assert.strictEqual(configManager.getOllamaPeerToken(), null);
+    });
+
     it("persists across reload", async () => {
       const token = "a".repeat(64);
       await configManager.setOllamaPeerToken(token);
       const reloaded = new ConfigManager(testDir);
       reloaded.initialize();
       assert.strictEqual(reloaded.getOllamaPeerToken(), token);
+    });
+  });
+
+  describe("getConfig redaction", () => {
+    beforeEach(() => {
+      configManager.initialize();
+    });
+
+    it("does NOT include ollamaPeerToken when set", async () => {
+      // Regression for an architecture-review finding: GET /api/config calls
+      // getConfig() and serializes it. Without redaction, the token would
+      // leak via the public config endpoint despite the dedicated peer
+      // endpoint hiding it behind hasToken.
+      await configManager.setOllamaPeerToken("a".repeat(64));
+      const safe = configManager.getConfig();
+      assert.strictEqual(
+        safe.ollamaPeerToken,
+        undefined,
+        "ollamaPeerToken must not appear in the public config response",
+      );
+    });
+
+    it("still includes ollamaPeerUrl (not a secret)", async () => {
+      await configManager.setOllamaPeerUrl("https://ollama.example.com");
+      const safe = configManager.getConfig();
+      assert.strictEqual(safe.ollamaPeerUrl, "https://ollama.example.com");
     });
   });
 });

--- a/test/ollama-client-peer.test.js
+++ b/test/ollama-client-peer.test.js
@@ -1,0 +1,116 @@
+/**
+ * Tests the new peer-routing knobs on createOllamaClient — both the static
+ * `authToken` and the dynamic `resolveEndpoint` callback. The callback is
+ * what lets the running server pick up UI-driven config changes without a
+ * restart, so verifying it's actually called per-request matters.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { createOllamaClient } from "../lib/ollama-client.js";
+
+function startStubOllama() {
+  const requests = [];
+  const server = createServer((req, res) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      requests.push({
+        url: req.url,
+        method: req.method,
+        headers: req.headers,
+        body: JSON.parse(Buffer.concat(chunks).toString("utf-8") || "{}"),
+      });
+      res.writeHead(200, { "Content-Type": "application/x-ndjson" });
+      res.write('{"message":{"content":"hello"},"done":false}\n');
+      res.write('{"message":{"content":" world"},"done":true}\n');
+      res.end();
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port, requests }));
+  });
+}
+
+describe("createOllamaClient — peer routing", () => {
+  let stub;
+  let baseUrl;
+
+  before(async () => {
+    stub = await startStubOllama();
+    baseUrl = `http://127.0.0.1:${stub.port}`;
+  });
+
+  after(() => stub.server.close());
+
+  it("includes Bearer header when authToken is set statically", async () => {
+    const client = createOllamaClient({
+      host: baseUrl,
+      model: "test-model",
+      authToken: "static-token-xyz",
+    });
+    await client("hi");
+    const last = stub.requests.at(-1);
+    assert.equal(last.headers.authorization, "Bearer static-token-xyz");
+  });
+
+  it("omits Bearer header when authToken is null", async () => {
+    const client = createOllamaClient({ host: baseUrl, model: "test-model" });
+    await client("hi");
+    const last = stub.requests.at(-1);
+    assert.equal(
+      last.headers.authorization,
+      undefined,
+      "no Authorization header should be sent",
+    );
+  });
+
+  it("calls resolveEndpoint on every request", async () => {
+    let calls = 0;
+    const client = createOllamaClient({
+      model: "test-model",
+      resolveEndpoint: () => {
+        calls++;
+        return { host: baseUrl, authToken: `token-${calls}` };
+      },
+    });
+    await client("first");
+    await client("second");
+    assert.equal(calls, 2, "resolveEndpoint should be called on each request");
+    const reqs = stub.requests.slice(-2);
+    assert.equal(reqs[0].headers.authorization, "Bearer token-1");
+    assert.equal(reqs[1].headers.authorization, "Bearer token-2");
+  });
+
+  it("resolveEndpoint can flip between peer and local without recreating the client", async () => {
+    let mode = "local";
+    const client = createOllamaClient({
+      host: baseUrl, // unused while resolveEndpoint returns a host
+      model: "test-model",
+      authToken: "fallback-static",
+      resolveEndpoint: () =>
+        mode === "peer"
+          ? { host: baseUrl, authToken: "peer-token" }
+          : null, // null means "use static fallbacks"
+    });
+
+    await client("first");
+    assert.equal(stub.requests.at(-1).headers.authorization, "Bearer fallback-static");
+
+    mode = "peer";
+    await client("second");
+    assert.equal(stub.requests.at(-1).headers.authorization, "Bearer peer-token");
+  });
+
+  it("is backward-compatible: no Auth, no resolver = vanilla local call", async () => {
+    const client = createOllamaClient({ host: baseUrl, model: "test-model" });
+    const result = await client("hi");
+    assert.equal(result, "hello world", "stream content should aggregate");
+    const last = stub.requests.at(-1);
+    assert.equal(last.url, "/api/chat");
+    assert.equal(last.method, "POST");
+    assert.equal(last.body.model, "test-model");
+    assert.equal(last.body.stream, true);
+  });
+});


### PR DESCRIPTION
## Summary

- New ConfigManager keys `ollamaPeerUrl` + `ollamaPeerToken` persist in `~/.katulong/config.json` (mode 0600). The pair is the v1 interim shape that lets a katulong on a GPU-poor host route summarizer + narrator inference to a remote [`ollama-bridge`](https://github.com/Dorky-Robot/ollama-bridge) without coupling katulong to ollama itself.
- `createOllamaClient` gains optional `authToken` (static) and `resolveEndpoint` (callback). The callback fires on every request, so UI changes apply without a server restart.
- Three new endpoints (`GET / PUT / POST /api/config/ollama-peer[/test]`) + a new "External LLM endpoint" section in Settings → General with URL, password-masked token, Save / Test / Clear, and a status line that surfaces test results plainly.
- The token is never returned over the wire (GET reports presence only). The Test endpoint uses already-saved values, not the request body, to keep the token off the wire and out of process memory.

## Background

This pairs with the new `ollama-bridge` repo (commit `d130010`) — a 200-line authenticated reverse proxy to local Ollama. The bridge lives separately so katulong stays uncoupled. Wire format is `Authorization: Bearer <token>` — the same shape the eventual `katulong-app/1` runtime call will keep using, so the runtime layer here is forward-compatible. The ceremony layer (double-passkey install) is deferred to the active sipag effort.

The threat model is single-user-multi-machine: one operator owns all the boxes, manually pastes a token from one box's bridge into the other box's settings. Acknowledged as weaker than the eventual ceremony but acceptable at this scope; documented in the bridge's README.

## Test plan

- [x] `npm run test:unit` — 2624 pass, 0 fail (17 new cases: 12 ConfigManager, 5 ollama-client peer routing)
- [x] Pre-push hook runs full test suite — green
- [ ] Manual: configure a bridge URL+token, click Test → see status, save, observe summarizer logs route through the peer