### PR TITLE
feat(bridges): generalized bridges/ + `katulong bridge` CLI

### DIFF
--- a/bin/katulong
+++ b/bin/katulong
@@ -31,6 +31,7 @@ const COMMANDS = {
   notes: "Read per-session notepad content (read, list)",
   setup: "One-time setup (self-access, Claude Code hooks)",
   service: "Manage macOS LaunchAgent (install, uninstall, restart, status)",
+  bridge: "Manage local-service bridges (e.g., ollama)",
   "tmux-sweep": "Reap orphaned katulong-test-<pid> tmux sockets",
 };
 

--- a/bridges/README.md
+++ b/bridges/README.md
@@ -1,0 +1,86 @@
+# bridges/
+
+A **bridge** is a small authenticated reverse proxy in front of a local-only HTTP service that katulong wants to talk to (e.g., Ollama). Each bridge runs as its own launchd job, listens on its own port, and validates a bearer token before forwarding requests verbatim to the wrapped service.
+
+Bridges live here, alongside katulong itself, but they are **separate runtime processes** — a bridge crash does not take down the terminal. They share this codebase only because katulong is currently the only consumer; if a non-katulong consumer ever needs them, the directory becomes a candidate for extraction.
+
+## Why bridges exist
+
+Local services like Ollama, Redis, and Postgres listen on `127.0.0.1` with no auth and no TLS. Exposing them across machines requires putting auth and TLS in front. Coupling katulong to each service would violate katulong's vision as a general-purpose tiling platform, so each service gets a thin bridge that:
+
+- has its own port
+- validates a bearer token
+- forwards everything else verbatim to the local service
+- treats the wrapped service as opaque (new endpoints work automatically)
+
+The runtime layer (HTTPS + Bearer auth) is forward-compatible with the planned [`katulong-app/1`](https://github.com/Dorky-Robot/sipag) protocol's runtime call shape. When that protocol's host implementation lands, bridges gain the four well-known endpoints (`manifest`, `install`, `intent-pull`, `health`) as a purely additive change. Nothing here gets thrown away.
+
+## Layout
+
+```
+bridges/
+  _lib/                  # shared code — every bridge uses this
+    server.js            # HTTP proxy + bearer auth
+    config-loader.js     # ~/.katulong/bridges/<name>/config.json
+    launchd-template.js  # generates the LaunchAgent plist
+    registry.js          # discovers bridges/<name>/manifest.js
+  ollama/
+    manifest.js          # exports { name, port, target, description }
+    README.md            # service-specific notes
+```
+
+Adding a new bridge = creating a new directory with a `manifest.js`. That's it.
+
+## Adding a bridge
+
+1. Create `bridges/<name>/manifest.js`:
+
+   ```js
+   export default {
+     name: "redis",
+     port: 6380,
+     target: "http://127.0.0.1:6379",
+     description: "Authenticated reverse proxy to local Redis",
+   };
+   ```
+
+   The directory name and the manifest's `name` field must match.
+
+2. Optionally add `bridges/<name>/README.md` for service-specific operational notes.
+
+3. Done. The CLI auto-discovers it — `katulong bridge list` will show it, and all `katulong bridge <name> <action>` commands work without further code changes.
+
+## CLI
+
+```sh
+katulong bridge list                     # show available bridges
+katulong bridge <name> new-token         # mint + save a 32-byte hex token
+katulong bridge <name> show-token        # print the saved token
+katulong bridge <name> install           # write + load the LaunchAgent plist
+katulong bridge <name> uninstall         # unload + remove the plist
+katulong bridge <name> status            # plist + token + listening probe
+katulong bridge <name> start             # foreground (used internally by launchd)
+```
+
+## Storage
+
+Per-bridge state lives under `~/.katulong/bridges/<name>/`:
+
+- `config.json` (mode 0600) — `{ token, port?, bind?, target? }`. Operator overrides go here.
+- `stdout.log`, `stderr.log` — launchd output
+
+The shared CLI handles atomic writes and 0600 enforcement. Don't write these files directly.
+
+## Wire format
+
+Every bridge speaks the same shape:
+
+```
+<METHOD> /<any path>
+Authorization: Bearer <token>
+[body]
+```
+
+→ forwarded verbatim to `<target>/<any path>`. Streaming is preserved end-to-end.
+
+The token is single-use-per-installation: paste-from-CLI today, ceremony-issued when `katulong-app/1` lands. The runtime path is identical either way.

--- a/bridges/_lib/config-loader.js
+++ b/bridges/_lib/config-loader.js
@@ -1,0 +1,93 @@
+/**
+ * Per-bridge config storage. Each bridge gets its own dir under
+ * `<DATA_DIR>/bridges/<bridge-name>/config.json` so adding/removing
+ * bridges doesn't churn a single shared file.
+ *
+ * The shape is intentionally tiny — bridges run from their manifest's
+ * defaults; the config file just holds the operator-supplied secret
+ * (`token`) plus optional per-host overrides (`port`, `bind`, `target`).
+ *
+ * mode 0600 + atomic temp+rename matches the rest of katulong's secrets
+ * (lib/auth-state.js, lib/config.js).
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  chmodSync,
+} from "node:fs";
+import { join, dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+
+export function bridgeConfigPath(dataDir, bridgeName) {
+  return join(dataDir, "bridges", bridgeName, "config.json");
+}
+
+/**
+ * Load a bridge's config. Returns null if no config file exists yet.
+ * Throws on malformed JSON — the operator should know if their config
+ * is corrupted rather than silently using defaults.
+ */
+export function loadBridgeConfig(dataDir, bridgeName) {
+  const path = bridgeConfigPath(dataDir, bridgeName);
+  if (!existsSync(path)) return null;
+  const raw = readFileSync(path, "utf-8");
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`bridge config at ${path} is malformed: ${err.message}`);
+  }
+}
+
+/**
+ * Resolve the effective port/bind/target/token for a bridge by overlaying
+ * config (if any) on top of the manifest defaults. Throws if no token is
+ * configured — the bridge can't safely run without one.
+ */
+export function resolveBridge({ manifest, dataDir }) {
+  const config = loadBridgeConfig(dataDir, manifest.name) || {};
+  const port = Number(config.port ?? manifest.port);
+  const bind = config.bind ?? manifest.bind ?? "127.0.0.1";
+  const target = config.target ?? manifest.target;
+  const token = config.token ?? null;
+
+  if (!token) {
+    throw new Error(
+      `bridge "${manifest.name}" has no token configured. ` +
+        `Run: katulong bridge ${manifest.name} new-token`,
+    );
+  }
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`bridge "${manifest.name}" has invalid port ${port}`);
+  }
+  if (typeof target !== "string" || !/^https?:\/\//.test(target)) {
+    throw new Error(
+      `bridge "${manifest.name}" target must start with http:// or https://`,
+    );
+  }
+  return { port, bind, target, token };
+}
+
+export function writeBridgeConfig(dataDir, bridgeName, partial) {
+  const path = bridgeConfigPath(dataDir, bridgeName);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const existing = loadBridgeConfig(dataDir, bridgeName) || {};
+  const merged = { ...existing, ...partial };
+  // Drop nulls so the file stays minimal.
+  for (const k of Object.keys(merged)) if (merged[k] === null) delete merged[k];
+  const tmpPath = `${path}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(merged, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  renameSync(tmpPath, path);
+  // Belt-and-suspenders: enforce 0600 even if umask interfered.
+  try { chmodSync(path, 0o600); } catch { /* fs unsupported */ }
+}
+
+export function generateToken() {
+  return randomBytes(32).toString("hex"); // 64 hex chars = 256 bits
+}

--- a/bridges/_lib/config-loader.js
+++ b/bridges/_lib/config-loader.js
@@ -84,8 +84,15 @@ export function writeBridgeConfig(dataDir, bridgeName, partial) {
     mode: 0o600,
   });
   renameSync(tmpPath, path);
-  // Belt-and-suspenders: enforce 0600 even if umask interfered.
-  try { chmodSync(path, 0o600); } catch { /* fs unsupported */ }
+  // Belt-and-suspenders: enforce 0600 even if umask interfered. Only
+  // swallow "filesystem doesn't support chmod" — surface ENOENT/EPERM
+  // because either of those means the file is in a worse state than
+  // we expect (gone or unwritable) and the operator should know.
+  try {
+    chmodSync(path, 0o600);
+  } catch (err) {
+    if (err.code !== "ENOTSUP" && err.code !== "ENOSYS") throw err;
+  }
 }
 
 export function generateToken() {

--- a/bridges/_lib/launchd-template.js
+++ b/bridges/_lib/launchd-template.js
@@ -1,37 +1,14 @@
 /**
- * Generates a per-bridge LaunchAgent plist. Mirrors the deterministic-PATH
- * lesson from lib/cli/commands/service.js — never inherit the calling
- * shell's PATH (a non-interactive ssh would otherwise bake a stripped
- * PATH into the plist and break tmux/node lookup on respawn).
+ * Generates a per-bridge LaunchAgent plist. Shares the PATH list and XML
+ * escape helper with the main katulong service plist (lib/cli/launchd-util.js),
+ * so the plist invariants — deterministic PATH, full XML escaping, drop
+ * binDirs containing `:` or whitespace — stay consistent across both
+ * code paths instead of drifting silently.
  */
 
 import { homedir } from "node:os";
-import { join, dirname } from "node:path";
-
-const STANDARD_PLIST_PATH_DIRS = [
-  "/opt/homebrew/bin",
-  "/opt/homebrew/sbin",
-  "/usr/local/bin",
-  "/usr/local/sbin",
-  "/usr/bin",
-  "/bin",
-  "/usr/sbin",
-  "/sbin",
-];
-
-function buildPlistPath(bin) {
-  const binDir = bin ? dirname(bin) : null;
-  return [...new Set([binDir, ...STANDARD_PLIST_PATH_DIRS].filter(Boolean))].join(":");
-}
-
-function xmlEscape(value) {
-  return String(value)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&apos;");
-}
+import { join } from "node:path";
+import { xmlEscape, buildLaunchAgentPath } from "../../lib/cli/launchd-util.js";
 
 export function bridgeLabel(bridgeName) {
   // Period-separated, mirrors com.dorkyrobot.katulong's label scheme.
@@ -54,7 +31,7 @@ export function bridgePlistPath(bridgeName) {
  */
 export function buildBridgePlist({ bridgeName, bin, dataDir }) {
   const label = bridgeLabel(bridgeName);
-  const path = buildPlistPath(bin);
+  const path = buildLaunchAgentPath(bin);
   const stdoutLog = `${dataDir}/bridges/${bridgeName}/stdout.log`;
   const stderrLog = `${dataDir}/bridges/${bridgeName}/stderr.log`;
 

--- a/bridges/_lib/launchd-template.js
+++ b/bridges/_lib/launchd-template.js
@@ -1,0 +1,103 @@
+/**
+ * Generates a per-bridge LaunchAgent plist. Mirrors the deterministic-PATH
+ * lesson from lib/cli/commands/service.js — never inherit the calling
+ * shell's PATH (a non-interactive ssh would otherwise bake a stripped
+ * PATH into the plist and break tmux/node lookup on respawn).
+ */
+
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+
+const STANDARD_PLIST_PATH_DIRS = [
+  "/opt/homebrew/bin",
+  "/opt/homebrew/sbin",
+  "/usr/local/bin",
+  "/usr/local/sbin",
+  "/usr/bin",
+  "/bin",
+  "/usr/sbin",
+  "/sbin",
+];
+
+function buildPlistPath(bin) {
+  const binDir = bin ? dirname(bin) : null;
+  return [...new Set([binDir, ...STANDARD_PLIST_PATH_DIRS].filter(Boolean))].join(":");
+}
+
+function xmlEscape(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export function bridgeLabel(bridgeName) {
+  // Period-separated, mirrors com.dorkyrobot.katulong's label scheme.
+  return `com.dorkyrobot.katulong-bridge.${bridgeName}`;
+}
+
+export function bridgePlistPath(bridgeName) {
+  return join(
+    homedir(),
+    "Library",
+    "LaunchAgents",
+    `${bridgeLabel(bridgeName)}.plist`,
+  );
+}
+
+/**
+ * Build the plist XML for a bridge. `bin` is the absolute path to the
+ * katulong binary that will be invoked with `bridge <name> start`.
+ * `dataDir` is katulong's data directory (e.g. ~/.katulong).
+ */
+export function buildBridgePlist({ bridgeName, bin, dataDir }) {
+  const label = bridgeLabel(bridgeName);
+  const path = buildPlistPath(bin);
+  const stdoutLog = `${dataDir}/bridges/${bridgeName}/stdout.log`;
+  const stderrLog = `${dataDir}/bridges/${bridgeName}/stderr.log`;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${xmlEscape(label)}</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>${xmlEscape(bin)}</string>
+    <string>bridge</string>
+    <string>${xmlEscape(bridgeName)}</string>
+    <string>start</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>KATULONG_DATA_DIR</key>
+    <string>${xmlEscape(dataDir)}</string>
+    <key>PATH</key>
+    <string>${xmlEscape(path)}</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(stdoutLog)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(stderrLog)}</string>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>`;
+}

--- a/bridges/_lib/registry.js
+++ b/bridges/_lib/registry.js
@@ -1,0 +1,71 @@
+/**
+ * Bridge registry — discovers each `bridges/<name>/manifest.js` at runtime.
+ *
+ * A bridge is registered simply by having a directory under `bridges/`
+ * (the dir name is the bridge name) that exports a default object from
+ * `manifest.js`:
+ *
+ *     export default {
+ *       name: "ollama",          // must match the directory name
+ *       port: 11435,             // default port (operators can override)
+ *       target: "http://127.0.0.1:11434",
+ *       description: "Authenticated reverse proxy to local Ollama",
+ *       bind: "127.0.0.1",       // optional; default 127.0.0.1
+ *     };
+ *
+ * Directories whose names start with "_" (e.g., `_lib`) are skipped.
+ *
+ * The discovery is intentionally synchronous on first call and cached
+ * afterwards — bridges are statically defined at the source level, so
+ * caching the manifest list for the life of the process is fine.
+ */
+
+import { readdirSync, statSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BRIDGES_ROOT = join(HERE, "..");
+
+let cache = null;
+
+function isBridgeDir(name) {
+  if (name.startsWith(".") || name.startsWith("_")) return false;
+  const fullPath = join(BRIDGES_ROOT, name);
+  if (!statSync(fullPath, { throwIfNoEntry: false })?.isDirectory()) return false;
+  return existsSync(join(fullPath, "manifest.js"));
+}
+
+async function loadManifest(name) {
+  const url = `../${name}/manifest.js`;
+  const mod = await import(url);
+  if (!mod.default || mod.default.name !== name) {
+    throw new Error(
+      `bridges/${name}/manifest.js must export a default object with name === "${name}"`,
+    );
+  }
+  return mod.default;
+}
+
+export async function listBridges() {
+  if (cache) return cache;
+  const dirs = readdirSync(BRIDGES_ROOT).filter(isBridgeDir);
+  const manifests = await Promise.all(dirs.map(loadManifest));
+  cache = manifests.sort((a, b) => a.name.localeCompare(b.name));
+  return cache;
+}
+
+export async function getBridge(name) {
+  const all = await listBridges();
+  const found = all.find((b) => b.name === name);
+  if (!found) {
+    const known = all.map((b) => b.name).join(", ") || "(none)";
+    throw new Error(`unknown bridge "${name}". Known: ${known}`);
+  }
+  return found;
+}
+
+/** Test-only: drop the cached registry so a different fixture can be loaded. */
+export function resetRegistryCache() {
+  cache = null;
+}

--- a/bridges/_lib/registry.js
+++ b/bridges/_lib/registry.js
@@ -27,10 +27,26 @@ import { fileURLToPath } from "node:url";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const BRIDGES_ROOT = join(HERE, "..");
 
+// Bridge names flow into filesystem paths (`<dataDir>/bridges/<name>/`),
+// launchd labels (`com.dorkyrobot.katulong-bridge.<name>`), and shell
+// invocations (launchctl load on the resulting plist path). We require
+// a strict allowlist so a hostile or malformed directory name cannot
+// path-traverse, inject XML, or escape shell quoting downstream.
+const BRIDGE_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+// Reserved because `katulong bridge list` is dispatched at the top level
+// — a bridge named "list" would shadow that and become unreachable via
+// the per-bridge action surface.
+const RESERVED_NAMES = new Set(["list"]);
+
+export function isValidBridgeName(name) {
+  return typeof name === "string" && BRIDGE_NAME_RE.test(name) && !RESERVED_NAMES.has(name);
+}
+
 let cache = null;
 
 function isBridgeDir(name) {
-  if (name.startsWith(".") || name.startsWith("_")) return false;
+  if (!isValidBridgeName(name)) return false;
   const fullPath = join(BRIDGES_ROOT, name);
   if (!statSync(fullPath, { throwIfNoEntry: false })?.isDirectory()) return false;
   return existsSync(join(fullPath, "manifest.js"));
@@ -38,7 +54,12 @@ function isBridgeDir(name) {
 
 async function loadManifest(name) {
   const url = `../${name}/manifest.js`;
-  const mod = await import(url);
+  let mod;
+  try {
+    mod = await import(url);
+  } catch (err) {
+    throw new Error(`bridges/${name}/manifest.js failed to load: ${err.message}`);
+  }
   if (!mod.default || mod.default.name !== name) {
     throw new Error(
       `bridges/${name}/manifest.js must export a default object with name === "${name}"`,
@@ -48,14 +69,31 @@ async function loadManifest(name) {
 }
 
 export async function listBridges() {
+  // Coalesce concurrent callers onto the same in-flight Promise instead of
+  // letting each one launch its own `Promise.all`. Important if listBridges()
+  // is ever called from two paths before the first resolves.
   if (cache) return cache;
-  const dirs = readdirSync(BRIDGES_ROOT).filter(isBridgeDir);
-  const manifests = await Promise.all(dirs.map(loadManifest));
-  cache = manifests.sort((a, b) => a.name.localeCompare(b.name));
-  return cache;
+  cache = (async () => {
+    const dirs = readdirSync(BRIDGES_ROOT).filter(isBridgeDir);
+    const manifests = await Promise.all(dirs.map(loadManifest));
+    return manifests.sort((a, b) => a.name.localeCompare(b.name));
+  })();
+  try {
+    return await cache;
+  } catch (err) {
+    cache = null; // don't pin a failed import
+    throw err;
+  }
 }
 
 export async function getBridge(name) {
+  if (!isValidBridgeName(name)) {
+    throw new Error(
+      `invalid bridge name "${name}" — must be lowercase alphanumeric ` +
+        `(plus hyphens), start with [a-z0-9], at most 64 chars, ` +
+        `and not collide with reserved names (list)`,
+    );
+  }
   const all = await listBridges();
   const found = all.find((b) => b.name === name);
   if (!found) {

--- a/bridges/_lib/server.js
+++ b/bridges/_lib/server.js
@@ -16,9 +16,35 @@
  * health) as a purely additive change. Nothing here gets thrown away.
  */
 
-import { createServer } from "node:http";
-import { request as httpRequest } from "node:http";
+import { createServer, request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
+
+// 512 MB cap on incoming bodies. Generous enough for image-paste payloads
+// and large LLM prompts; bounded enough that a malicious holder of a valid
+// token cannot exhaust host disk/memory by sending an unbounded stream.
+const MAX_BODY_BYTES = 512 * 1024 * 1024;
+
+// Headers that must NOT propagate end-to-end, per RFC 7230 §6.1 (hop-by-hop)
+// plus forwarding headers a client could lie about to influence upstream
+// routing/trust decisions. `authorization` and `host` are stripped separately
+// (one is the bridge's own token; the other is recomputed by the http client).
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-proto",
+  "x-forwarded-port",
+  "x-real-ip",
+  "x-original-url",
+  "forwarded",
+]);
 
 /**
  * Constant-time-ish bearer comparison. Avoids early-exit timing leakage
@@ -37,27 +63,43 @@ export function bearerMatches(headerValue, expected) {
   return diff === 0;
 }
 
+function sanitizedUpstreamHeaders(rawHeaders) {
+  const out = {};
+  for (const [k, v] of Object.entries(rawHeaders)) {
+    const lk = k.toLowerCase();
+    if (lk === "authorization" || lk === "host") continue;
+    if (HOP_BY_HOP_HEADERS.has(lk)) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
 /**
  * Build (but don't start) an http.Server for a bridge. Pass the resolved
  * manifest+config so the caller controls validation and persistence.
+ *
+ * `logger` is optional and is called with structured events:
+ *   {event: "auth_failure", remoteAddress, reason}
+ *   {event: "upstream_error", code}
+ * Default is a console.warn writer; tests can override with a no-op or
+ * collector. The token itself is never passed to the logger.
  */
-export function createBridgeServer({ target, token }) {
+export function createBridgeServer({ target, token, logger = defaultLogger }) {
   const targetUrl = new URL(target);
   const targetIsHttps = targetUrl.protocol === "https:";
   const proxyRequest = targetIsHttps ? httpsRequest : httpRequest;
 
   return createServer((req, res) => {
     if (!bearerMatches(req.headers.authorization, token)) {
+      logger({
+        event: "auth_failure",
+        remoteAddress: req.socket?.remoteAddress,
+        reason: req.headers.authorization ? "wrong_token" : "missing_header",
+      });
       res.writeHead(401, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "unauthorized" }));
       return;
     }
-
-    // Strip the bridge's auth before forwarding — the wrapped service does
-    // not expect it and we don't want our token leaking into upstream logs.
-    const upstreamHeaders = { ...req.headers };
-    delete upstreamHeaders.authorization;
-    delete upstreamHeaders.host;
 
     const upstreamReq = proxyRequest(
       {
@@ -65,29 +107,68 @@ export function createBridgeServer({ target, token }) {
         port: targetUrl.port || (targetIsHttps ? 443 : 80),
         method: req.method,
         path: req.url,
-        headers: upstreamHeaders,
+        headers: sanitizedUpstreamHeaders(req.headers),
       },
       (upstreamRes) => {
+        // Mid-stream upstream errors: forward as a destroy on the client
+        // side rather than letting an unhandled `error` event crash the
+        // bridge process.
+        upstreamRes.on("error", (err) => {
+          logger({ event: "upstream_error", code: err.code || err.name });
+          res.destroy(err);
+        });
         res.writeHead(upstreamRes.statusCode || 502, upstreamRes.headers);
         upstreamRes.pipe(res);
       },
     );
 
     upstreamReq.on("error", (err) => {
+      logger({ event: "upstream_error", code: err.code || err.name });
       if (res.headersSent) {
         res.destroy();
         return;
       }
+      // Don't leak upstream URL or system call details; the caller already
+      // knows where the bridge is configured to forward, and an attacker
+      // who got past the bearer check shouldn't get free network mapping.
       res.writeHead(502, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "upstream_unreachable", detail: err.message }));
+      res.end(JSON.stringify({ error: "upstream_unreachable" }));
     });
 
-    req.pipe(upstreamReq);
+    // Manual forward (instead of req.pipe) so we can enforce a body-size
+    // cap in the same data listener that does the writing — using two
+    // listeners would put req into flowing mode prematurely and the pipe
+    // would silently miss data.
+    let bytesIn = 0;
+    let aborted = false;
+    req.on("data", (chunk) => {
+      if (aborted) return;
+      bytesIn += chunk.length;
+      if (bytesIn > MAX_BODY_BYTES) {
+        aborted = true;
+        if (!res.headersSent) {
+          res.writeHead(413, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "payload_too_large", limit: MAX_BODY_BYTES }));
+        }
+        upstreamReq.destroy();
+        return;
+      }
+      upstreamReq.write(chunk);
+    });
+    req.on("end", () => { if (!aborted) upstreamReq.end(); });
+    req.on("error", () => upstreamReq.destroy());
   });
 }
 
-export function startBridgeServer({ port, bind, target, token }) {
-  const server = createBridgeServer({ target, token });
+function defaultLogger(event) {
+  // Single-line structured log so it shows up readably in launchd-stderr.log.
+  // The caller can swap this for nothing in tests.
+  // eslint-disable-next-line no-console
+  console.warn(JSON.stringify({ ts: new Date().toISOString(), ...event }));
+}
+
+export function startBridgeServer({ port, bind, target, token, logger }) {
+  const server = createBridgeServer({ target, token, logger });
   return new Promise((resolve, reject) => {
     server.once("error", reject);
     server.listen(port, bind, () => {

--- a/bridges/_lib/server.js
+++ b/bridges/_lib/server.js
@@ -1,0 +1,98 @@
+/**
+ * Shared bridge HTTP server.
+ *
+ * A bridge is a credential-holding reverse proxy in front of a local-only
+ * HTTP service that katulong wants to talk to (e.g., Ollama). Each bridge
+ * is a separate process; this module is the runtime they all share.
+ *
+ * The bridge is intentionally opaque to the wrapped service's API: method,
+ * path, headers (minus auth), and body all forward verbatim. New endpoints
+ * on the wrapped service get picked up automatically.
+ *
+ * Auth is bearer-token only in v1. The wire shape (`Authorization: Bearer
+ * <token>`) is the same shape the eventual katulong-app/1 runtime call
+ * will use, so when the protocol's host implementation lands, this server
+ * gains the four well-known endpoints (manifest, install, intent-pull,
+ * health) as a purely additive change. Nothing here gets thrown away.
+ */
+
+import { createServer } from "node:http";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+
+/**
+ * Constant-time-ish bearer comparison. Avoids early-exit timing leakage
+ * on the token bytes; fine for a paste-from-CLI token where the threat
+ * model is "someone fishing for the token over local network."
+ */
+export function bearerMatches(headerValue, expected) {
+  if (typeof headerValue !== "string") return false;
+  if (!headerValue.startsWith("Bearer ")) return false;
+  const presented = headerValue.slice(7);
+  if (presented.length !== expected.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) {
+    diff |= presented.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/**
+ * Build (but don't start) an http.Server for a bridge. Pass the resolved
+ * manifest+config so the caller controls validation and persistence.
+ */
+export function createBridgeServer({ target, token }) {
+  const targetUrl = new URL(target);
+  const targetIsHttps = targetUrl.protocol === "https:";
+  const proxyRequest = targetIsHttps ? httpsRequest : httpRequest;
+
+  return createServer((req, res) => {
+    if (!bearerMatches(req.headers.authorization, token)) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "unauthorized" }));
+      return;
+    }
+
+    // Strip the bridge's auth before forwarding — the wrapped service does
+    // not expect it and we don't want our token leaking into upstream logs.
+    const upstreamHeaders = { ...req.headers };
+    delete upstreamHeaders.authorization;
+    delete upstreamHeaders.host;
+
+    const upstreamReq = proxyRequest(
+      {
+        hostname: targetUrl.hostname,
+        port: targetUrl.port || (targetIsHttps ? 443 : 80),
+        method: req.method,
+        path: req.url,
+        headers: upstreamHeaders,
+      },
+      (upstreamRes) => {
+        res.writeHead(upstreamRes.statusCode || 502, upstreamRes.headers);
+        upstreamRes.pipe(res);
+      },
+    );
+
+    upstreamReq.on("error", (err) => {
+      if (res.headersSent) {
+        res.destroy();
+        return;
+      }
+      res.writeHead(502, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "upstream_unreachable", detail: err.message }));
+    });
+
+    req.pipe(upstreamReq);
+  });
+}
+
+export function startBridgeServer({ port, bind, target, token }) {
+  const server = createBridgeServer({ target, token });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, bind, () => {
+      server.removeListener("error", reject);
+      resolve(server);
+    });
+  });
+}

--- a/bridges/ollama/README.md
+++ b/bridges/ollama/README.md
@@ -1,0 +1,50 @@
+# bridges/ollama
+
+Authenticated reverse proxy in front of a local Ollama instance.
+
+## What it does
+
+Listens on `127.0.0.1:11435` (default), checks `Authorization: Bearer <token>` against the saved token, forwards everything else verbatim to `http://127.0.0.1:11434`. Streaming responses pipe through unchanged so chat completions feel native.
+
+## Quick start (host running Ollama)
+
+```sh
+# Mint a token + save it
+katulong bridge ollama new-token
+
+# Install + start under launchd (logs to ~/.katulong/bridges/ollama/)
+katulong bridge ollama install
+
+# Sanity check
+katulong bridge ollama status
+
+# Print the token to copy into another katulong's settings
+katulong bridge ollama show-token
+```
+
+To expose the bridge across the network, run it behind a tunnel that does TLS (Cloudflare Tunnel, ngrok, etc.). The bridge does not terminate TLS.
+
+## Quick start (consumer — another katulong using a remote bridge)
+
+In Settings → General → External LLM endpoint:
+
+- URL: `https://ollama-<host>.example.com` (your tunnel's hostname)
+- Token: paste output of `katulong bridge ollama show-token` from the bridge host
+
+Save → Test → done. The summarizer + narrator will route through the bridge on their next cycle.
+
+## Operational notes
+
+- The bridge's PATH is fixed to a deterministic set, never inheriting the calling shell's PATH (lesson from katulong's own `service install`).
+- A bridge crash doesn't take down katulong — they're independent launchd jobs.
+- The token is stored in `~/.katulong/bridges/ollama/config.json` (mode 0600).
+- Rotate by `katulong bridge ollama new-token` (overwrites the saved token); update the consumer's settings with the new value.
+
+## Caveats
+
+- Ollama itself is unauthenticated. Anyone who reaches the bridge with the bearer token has full access to whatever Ollama serves on that host. Do not share the token.
+- The bridge does not enforce a per-token rate limit. If you front it with a public hostname, put a rate limiter at the edge.
+
+## What changes when `katulong-app/1` lands
+
+The runtime path stays identical. The bridge gains the four well-known endpoints (`manifest`, `install`, `intent-pull`, `health`) as a purely additive change, and the paste-from-CLI token gets replaced by a ceremony-issued credential at the same wire shape. Existing installs will run side-by-side with new ones during the deprecation window.

--- a/bridges/ollama/manifest.js
+++ b/bridges/ollama/manifest.js
@@ -1,0 +1,17 @@
+/**
+ * Manifest for the Ollama bridge.
+ *
+ * The Ollama daemon listens on 127.0.0.1:11434 by default and has no
+ * native auth or TLS, so it can't be safely exposed across machines on
+ * its own. This bridge wraps it: bearer-token auth at 127.0.0.1:11435,
+ * opaque pass-through forwarded to the local daemon. A katulong on a
+ * GPU-poor host points its outbound LLM client at this bridge running
+ * on a GPU-rich host (with a Cloudflare tunnel or similar in front).
+ */
+
+export default {
+  name: "ollama",
+  port: 11435,
+  target: "http://127.0.0.1:11434",
+  description: "Authenticated reverse proxy to local Ollama (port 11434)",
+};

--- a/lib/cli/commands/bridge.js
+++ b/lib/cli/commands/bridge.js
@@ -1,0 +1,251 @@
+/**
+ * CLI: katulong bridge <name> <action>
+ *
+ * Manages local-service bridges (e.g., ollama-bridge) defined in
+ * `katulong/bridges/<name>/manifest.js`. Each bridge runs as its own
+ * launchd job so a bridge crash doesn't take down the terminal.
+ */
+
+import { execSync, spawn } from "node:child_process";
+import {
+  existsSync,
+  unlinkSync,
+  writeFileSync,
+  renameSync,
+  mkdirSync,
+  readFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { listBridges, getBridge } from "../../../bridges/_lib/registry.js";
+import {
+  resolveBridge,
+  writeBridgeConfig,
+  loadBridgeConfig,
+  generateToken,
+} from "../../../bridges/_lib/config-loader.js";
+import { startBridgeServer } from "../../../bridges/_lib/server.js";
+import {
+  bridgeLabel,
+  bridgePlistPath,
+  buildBridgePlist,
+} from "../../../bridges/_lib/launchd-template.js";
+import { DATA_DIR } from "../process-manager.js";
+
+function usage() {
+  console.log(`
+Usage: katulong bridge <command> [args]
+
+Commands:
+  list                          List available bridges
+  <name> start                  Run a bridge in the foreground (used by launchd)
+  <name> new-token              Mint a fresh 32-byte hex token and save it
+  <name> show-token             Print the saved token (for copying to other devices)
+  <name> install                Write + load the LaunchAgent plist
+  <name> uninstall              Unload + remove the LaunchAgent plist
+  <name> status                 Report whether the bridge is loaded and listening
+`);
+}
+
+function resolveKatulongBin() {
+  try {
+    return execSync("which katulong", { encoding: "utf-8" }).trim();
+  } catch {
+    return "/opt/homebrew/bin/katulong";
+  }
+}
+
+async function actionList() {
+  const bridges = await listBridges();
+  if (bridges.length === 0) {
+    console.log("No bridges defined.");
+    return;
+  }
+  for (const b of bridges) {
+    const config = loadBridgeConfig(DATA_DIR, b.name) || {};
+    const tokenState = config.token ? "configured" : "no token";
+    console.log(`  ${b.name.padEnd(12)} :${b.port}  → ${b.target}  [${tokenState}]`);
+    if (b.description) console.log(`  ${" ".repeat(12)} ${b.description}`);
+  }
+}
+
+async function actionStart(name) {
+  const manifest = await getBridge(name);
+  const resolved = resolveBridge({ manifest, dataDir: DATA_DIR });
+  await startBridgeServer(resolved);
+  console.log(
+    `katulong bridge ${name}: listening on ${resolved.bind}:${resolved.port}, ` +
+      `forwarding to ${resolved.target}`,
+  );
+  // Don't return — bridge process stays alive until killed.
+}
+
+async function actionNewToken(name) {
+  const manifest = await getBridge(name);
+  const token = generateToken();
+  writeBridgeConfig(DATA_DIR, manifest.name, { token });
+  console.log(`Token saved for bridge "${manifest.name}".\n`);
+  console.log(`  ${token}\n`);
+  console.log(
+    "Copy this token into the consumer (e.g., katulong settings → " +
+      "External LLM endpoint) — it will not be shown again unless you ask " +
+      `with: katulong bridge ${manifest.name} show-token`,
+  );
+}
+
+async function actionShowToken(name) {
+  const manifest = await getBridge(name);
+  const config = loadBridgeConfig(DATA_DIR, manifest.name);
+  if (!config?.token) {
+    console.error(
+      `bridge "${manifest.name}" has no token. ` +
+        `Run: katulong bridge ${manifest.name} new-token`,
+    );
+    process.exit(1);
+  }
+  console.log(config.token);
+}
+
+async function actionInstall(name) {
+  const manifest = await getBridge(name);
+  const config = loadBridgeConfig(DATA_DIR, manifest.name);
+  if (!config?.token) {
+    console.error(
+      `bridge "${manifest.name}" has no token configured. ` +
+        `Run this first: katulong bridge ${manifest.name} new-token`,
+    );
+    process.exit(1);
+  }
+
+  const plistPath = bridgePlistPath(manifest.name);
+  if (existsSync(plistPath)) {
+    console.error(
+      `LaunchAgent already exists at ${plistPath}\n` +
+        `Run 'katulong bridge ${manifest.name} uninstall' first to reinstall.`,
+    );
+    process.exit(1);
+  }
+
+  // Make sure the log directory exists before launchd tries to write to it.
+  mkdirSync(`${DATA_DIR}/bridges/${manifest.name}`, { recursive: true });
+
+  const xml = buildBridgePlist({
+    bridgeName: manifest.name,
+    bin: resolveKatulongBin(),
+    dataDir: DATA_DIR,
+  });
+  // Atomic temp + rename — same posture as service.js's plist writes.
+  const tmpPath = plistPath + ".tmp";
+  mkdirSync(dirname(plistPath), { recursive: true });
+  writeFileSync(tmpPath, xml, { mode: 0o644 });
+  renameSync(tmpPath, plistPath);
+  console.log(`✓ Wrote ${plistPath}`);
+
+  try {
+    execSync(`launchctl load -w "${plistPath}"`, { stdio: "inherit" });
+    console.log(`✓ ${bridgeLabel(manifest.name)} loaded and enabled`);
+  } catch (err) {
+    console.error(
+      `launchctl load failed. The plist is on disk; you can retry with:\n` +
+        `  launchctl load -w "${plistPath}"`,
+    );
+    process.exit(1);
+  }
+}
+
+async function actionUninstall(name) {
+  const manifest = await getBridge(name);
+  const plistPath = bridgePlistPath(manifest.name);
+  if (!existsSync(plistPath)) {
+    console.log(`No LaunchAgent at ${plistPath}, nothing to uninstall.`);
+    return;
+  }
+  try {
+    execSync(`launchctl unload -w "${plistPath}"`, { stdio: "pipe" });
+  } catch { /* may already be unloaded */ }
+  unlinkSync(plistPath);
+  console.log(`✓ Removed ${plistPath}`);
+}
+
+async function actionStatus(name) {
+  const manifest = await getBridge(name);
+  const label = bridgeLabel(manifest.name);
+  const plistPath = bridgePlistPath(manifest.name);
+  const config = loadBridgeConfig(DATA_DIR, manifest.name);
+
+  console.log(`Bridge: ${manifest.name}`);
+  console.log(`  Plist:    ${existsSync(plistPath) ? plistPath : "(not installed)"}`);
+  console.log(`  Token:    ${config?.token ? "configured" : "(not set)"}`);
+  console.log(`  Default:  port ${manifest.port}, target ${manifest.target}`);
+
+  let loaded = false;
+  let pid = null;
+  try {
+    const out = execSync(`launchctl list ${label}`, { encoding: "utf-8" });
+    loaded = true;
+    const m = out.match(/"PID"\s*=\s*(\d+);/);
+    if (m) pid = Number(m[1]);
+  } catch { /* not loaded */ }
+  console.log(`  Launchd:  ${loaded ? `loaded${pid ? ` (PID ${pid})` : ""}` : "not loaded"}`);
+
+  // Live-port probe — a quick sanity check the bridge is actually listening
+  // on the resolved port. Skips if the token is missing (resolveBridge throws).
+  if (config?.token) {
+    try {
+      const resolved = resolveBridge({ manifest, dataDir: DATA_DIR });
+      const reachable = await probeLocalPort(resolved.port, 1000);
+      console.log(`  Listening: ${reachable ? `yes (port ${resolved.port})` : "no"}`);
+    } catch { /* config invalid */ }
+  }
+}
+
+async function probeLocalPort(port, timeoutMs) {
+  // Tiny TCP-connect check; a hit-and-run that doesn't speak HTTP at all.
+  const { Socket } = await import("node:net");
+  return new Promise((resolve) => {
+    const s = new Socket();
+    const done = (ok) => { s.destroy(); resolve(ok); };
+    s.setTimeout(timeoutMs);
+    s.once("connect", () => done(true));
+    s.once("timeout", () => done(false));
+    s.once("error", () => done(false));
+    s.connect(port, "127.0.0.1");
+  });
+}
+
+const TOP_LEVEL = { list: actionList };
+const PER_BRIDGE = {
+  start: actionStart,
+  "new-token": actionNewToken,
+  "show-token": actionShowToken,
+  install: actionInstall,
+  uninstall: actionUninstall,
+  status: actionStatus,
+};
+
+export default async function bridge(args) {
+  if (!args.length || args[0] === "--help" || args[0] === "-h") {
+    usage();
+    process.exit(args.length ? 0 : 1);
+  }
+
+  // First-level dispatch: `katulong bridge list`
+  if (TOP_LEVEL[args[0]]) {
+    await TOP_LEVEL[args[0]](args.slice(1));
+    return;
+  }
+
+  // Second-level dispatch: `katulong bridge <name> <action>`
+  const [name, action, ...rest] = args;
+  if (!action) {
+    console.error(`Missing action. Run: katulong bridge ${name} --help`);
+    usage();
+    process.exit(1);
+  }
+  const handler = PER_BRIDGE[action];
+  if (!handler) {
+    console.error(`Unknown action "${action}" for bridge "${name}".`);
+    usage();
+    process.exit(1);
+  }
+  await handler(name, rest);
+}

--- a/lib/cli/commands/bridge.js
+++ b/lib/cli/commands/bridge.js
@@ -6,14 +6,13 @@
  * launchd job so a bridge crash doesn't take down the terminal.
  */
 
-import { execSync, spawn } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import {
   existsSync,
   unlinkSync,
   writeFileSync,
   renameSync,
   mkdirSync,
-  readFileSync,
 } from "node:fs";
 import { dirname } from "node:path";
 import { listBridges, getBridge } from "../../../bridges/_lib/registry.js";
@@ -46,11 +45,44 @@ Commands:
 `);
 }
 
+// Hardcoded set of acceptable katulong install prefixes — guards against
+// PATH-hijack baking a malicious binary into the launchd plist. If `which`
+// returns something outside this set, fall back to process.argv[1] (the
+// running CLI's own path) which is the most authoritative source.
+const TRUSTED_BIN_PREFIXES = [
+  "/opt/homebrew/",
+  "/usr/local/",
+  "/usr/bin/",
+  "/bin/",
+];
+
+const PROBE_TIMEOUT_MS = 1000;
+
 function resolveKatulongBin() {
+  // Prefer the currently-executing CLI's own path — that's the same
+  // binary the operator just used to invoke this command, so it cannot
+  // be PATH-hijacked between now and the plist load.
+  if (process.argv[1] && existsSync(process.argv[1])) {
+    return process.argv[1];
+  }
   try {
-    return execSync("which katulong", { encoding: "utf-8" }).trim();
-  } catch {
-    return "/opt/homebrew/bin/katulong";
+    const resolved = execSync("which katulong", { encoding: "utf-8" }).trim();
+    if (resolved && TRUSTED_BIN_PREFIXES.some((p) => resolved.startsWith(p))) {
+      return resolved;
+    }
+  } catch { /* which not found */ }
+  return "/opt/homebrew/bin/katulong";
+}
+
+function ensureMacOS(action) {
+  if (process.platform !== "darwin") {
+    console.error(
+      `\`katulong bridge ${action}\` is only supported on macOS (uses launchd).\n` +
+        `On other platforms, run the bridge directly:\n` +
+        `  katulong bridge <name> start\n` +
+        `…or wrap it in your init system of choice.`,
+    );
+    process.exit(2);
   }
 }
 
@@ -106,6 +138,7 @@ async function actionShowToken(name) {
 }
 
 async function actionInstall(name) {
+  ensureMacOS("install");
   const manifest = await getBridge(name);
   const config = loadBridgeConfig(DATA_DIR, manifest.name);
   if (!config?.token) {
@@ -141,9 +174,12 @@ async function actionInstall(name) {
   console.log(`✓ Wrote ${plistPath}`);
 
   try {
-    execSync(`launchctl load -w "${plistPath}"`, { stdio: "inherit" });
+    // execFileSync (not execSync) — argv array, no shell, no metachar
+    // expansion. Bridge name is allowlisted in the registry, but this is
+    // defense in depth.
+    execFileSync("launchctl", ["load", "-w", plistPath], { stdio: "inherit" });
     console.log(`✓ ${bridgeLabel(manifest.name)} loaded and enabled`);
-  } catch (err) {
+  } catch {
     console.error(
       `launchctl load failed. The plist is on disk; you can retry with:\n` +
         `  launchctl load -w "${plistPath}"`,
@@ -153,6 +189,7 @@ async function actionInstall(name) {
 }
 
 async function actionUninstall(name) {
+  ensureMacOS("uninstall");
   const manifest = await getBridge(name);
   const plistPath = bridgePlistPath(manifest.name);
   if (!existsSync(plistPath)) {
@@ -160,13 +197,14 @@ async function actionUninstall(name) {
     return;
   }
   try {
-    execSync(`launchctl unload -w "${plistPath}"`, { stdio: "pipe" });
+    execFileSync("launchctl", ["unload", "-w", plistPath], { stdio: "pipe" });
   } catch { /* may already be unloaded */ }
   unlinkSync(plistPath);
   console.log(`✓ Removed ${plistPath}`);
 }
 
 async function actionStatus(name) {
+  ensureMacOS("status");
   const manifest = await getBridge(name);
   const label = bridgeLabel(manifest.name);
   const plistPath = bridgePlistPath(manifest.name);
@@ -180,7 +218,10 @@ async function actionStatus(name) {
   let loaded = false;
   let pid = null;
   try {
-    const out = execSync(`launchctl list ${label}`, { encoding: "utf-8" });
+    // The label is constructed from the (allowlisted) bridge name; still
+    // pass via argv so even a future name-validator regression doesn't
+    // become shell injection.
+    const out = execFileSync("launchctl", ["list", label], { encoding: "utf-8" });
     loaded = true;
     const m = out.match(/"PID"\s*=\s*(\d+);/);
     if (m) pid = Number(m[1]);
@@ -192,7 +233,7 @@ async function actionStatus(name) {
   if (config?.token) {
     try {
       const resolved = resolveBridge({ manifest, dataDir: DATA_DIR });
-      const reachable = await probeLocalPort(resolved.port, 1000);
+      const reachable = await probeLocalPort(resolved.port, PROBE_TIMEOUT_MS);
       console.log(`  Listening: ${reachable ? `yes (port ${resolved.port})` : "no"}`);
     } catch { /* config invalid */ }
   }
@@ -202,13 +243,13 @@ async function probeLocalPort(port, timeoutMs) {
   // Tiny TCP-connect check; a hit-and-run that doesn't speak HTTP at all.
   const { Socket } = await import("node:net");
   return new Promise((resolve) => {
-    const s = new Socket();
-    const done = (ok) => { s.destroy(); resolve(ok); };
-    s.setTimeout(timeoutMs);
-    s.once("connect", () => done(true));
-    s.once("timeout", () => done(false));
-    s.once("error", () => done(false));
-    s.connect(port, "127.0.0.1");
+    const sock = new Socket();
+    const done = (ok) => { sock.destroy(); resolve(ok); };
+    sock.setTimeout(timeoutMs);
+    sock.once("connect", () => done(true));
+    sock.once("timeout", () => done(false));
+    sock.once("error", () => done(false));
+    sock.connect(port, "127.0.0.1");
   });
 }
 
@@ -235,7 +276,7 @@ export default async function bridge(args) {
   }
 
   // Second-level dispatch: `katulong bridge <name> <action>`
-  const [name, action, ...rest] = args;
+  const [name, action] = args;
   if (!action) {
     console.error(`Missing action. Run: katulong bridge ${name} --help`);
     usage();
@@ -247,5 +288,5 @@ export default async function bridge(args) {
     usage();
     process.exit(1);
   }
-  await handler(name, rest);
+  await handler(name);
 }

--- a/lib/cli/commands/service.js
+++ b/lib/cli/commands/service.js
@@ -1,68 +1,18 @@
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { homedir } from "node:os";
 import envConfig from "../../env-config.js";
 import { isServerRunning, isProcessRunning } from "../process-manager.js";
+import { xmlEscape, buildLaunchAgentPath } from "../launchd-util.js";
+
+// Re-exported so existing tests that import from this module keep working.
+export { xmlEscape, buildLaunchAgentPath };
 
 const PLIST_LABEL = "com.dorkyrobot.katulong";
 const PLIST_DIR = join(homedir(), "Library", "LaunchAgents");
 const PLIST_PATH = join(PLIST_DIR, `${PLIST_LABEL}.plist`);
 const GUI_DOMAIN = `gui/${process.getuid()}`;
-
-// Locations the running server needs to find: node (to re-invoke the katulong
-// CLI from child processes), tmux (session manager), and brew/git (used by
-// `katulong update`). Listed deterministically rather than inherited from the
-// calling shell so the plist is correct regardless of how `service install`
-// was invoked. A non-interactive ssh, for example, has a stripped PATH that
-// excludes /opt/homebrew/bin — baking that in would leave launchd unable to
-// find tmux on next respawn. Apple Silicon paths come first; Intel-Homebrew
-// and standard system paths follow as a complete fallback set.
-const STANDARD_PLIST_PATH_DIRS = [
-  "/opt/homebrew/bin",
-  "/opt/homebrew/sbin",
-  "/usr/local/bin",
-  "/usr/local/sbin",
-  "/usr/bin",
-  "/bin",
-  "/usr/sbin",
-  "/sbin",
-];
-
-/**
- * Escape a value for safe interpolation inside a plist `<string>` element.
- * `bin`, `port`, and `dataDir` all flow into the plist from outside this file
- * (env vars, `which katulong`), so even though the trust boundary is local-
- * user, defense-in-depth: a binary path or env var containing `<`, `>`, `&`,
- * or `"` could otherwise produce malformed XML or — worse — inject extra
- * `<key>`/`<string>` elements that launchd would happily honor.
- */
-export function xmlEscape(value) {
-  return String(value)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&apos;");
-}
-
-/**
- * Build the PATH the LaunchAgent should run with. Includes the standard
- * fallback set plus the directory holding the resolved katulong binary
- * (so the server can re-exec itself when it lives outside the standard
- * Homebrew locations — e.g., npm-global, nvm, or a manual install).
- *
- * A binDir containing `:` or whitespace is dropped: `:` would silently
- * split into spurious PATH entries, and whitespace usually indicates a
- * pathological install location not worth honoring.
- *
- * Exported for tests; used internally by `buildPlist`.
- */
-export function buildLaunchAgentPath(bin) {
-  const rawBinDir = bin ? dirname(bin) : null;
-  const binDir = rawBinDir && !/[:\s]/.test(rawBinDir) ? rawBinDir : null;
-  return [...new Set([binDir, ...STANDARD_PLIST_PATH_DIRS].filter(Boolean))].join(":");
-}
 
 function katulongBin() {
   // Resolve the canonical path to the katulong binary.

--- a/lib/cli/launchd-util.js
+++ b/lib/cli/launchd-util.js
@@ -1,0 +1,62 @@
+/**
+ * Shared utilities for LaunchAgent plist generation. Used by both
+ * `service.js` (the main katulong service) and `bridges/_lib/launchd-template.js`
+ * (any bridge installed via `katulong bridge <name> install`).
+ *
+ * Keeping these here prevents drift: the path-list and the XML escaper are
+ * both load-bearing for plist correctness, and divergence between two copies
+ * silently breaks bridges or the main service depending on which copy
+ * received the fix.
+ */
+
+import { dirname } from "node:path";
+
+/**
+ * The PATH a LaunchAgent should run with. Listed deterministically rather
+ * than inherited from the calling shell — a non-interactive ssh's stripped
+ * PATH would otherwise bake into the plist and break tmux/node lookup on
+ * next respawn (lesson from PR #662). Apple Silicon paths come first; Intel
+ * Homebrew and standard system paths follow as a complete fallback set.
+ */
+export const STANDARD_PLIST_PATH_DIRS = Object.freeze([
+  "/opt/homebrew/bin",
+  "/opt/homebrew/sbin",
+  "/usr/local/bin",
+  "/usr/local/sbin",
+  "/usr/bin",
+  "/bin",
+  "/usr/sbin",
+  "/sbin",
+]);
+
+/**
+ * Escape a value for safe interpolation inside a plist `<string>` element.
+ * Defense-in-depth: any value flowing in from outside (`bin` from `which`,
+ * env vars, manifest fields) could contain XML metacharacters that would
+ * otherwise produce malformed XML — or, worse, inject extra `<key>`/`<string>`
+ * elements that launchd would happily honor.
+ */
+export function xmlEscape(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Build the PATH string a LaunchAgent should use. Prepends the directory
+ * holding the resolved binary (so npm-global / nvm / manual installs still
+ * work) ahead of the deterministic standard set; deduplicates if the bin
+ * is already in the standard set.
+ *
+ * A binDir containing `:` or whitespace is dropped: `:` would silently
+ * split into spurious PATH entries and whitespace usually indicates a
+ * pathological install location not worth honoring.
+ */
+export function buildLaunchAgentPath(bin) {
+  const rawBinDir = bin ? dirname(bin) : null;
+  const binDir = rawBinDir && !/[:\s]/.test(rawBinDir) ? rawBinDir : null;
+  return [...new Set([binDir, ...STANDARD_PLIST_PATH_DIRS].filter(Boolean))].join(":");
+}

--- a/public/index.html
+++ b/public/index.html
@@ -3378,7 +3378,7 @@
               <span class="settings-label">Bearer token</span>
               <input type="password" id="ollama-peer-token-input" class="palette-hex-input"
                      style="width: 100%; box-sizing: border-box;"
-                     placeholder="paste token from ollama-bridge new-token" spellcheck="false" autocomplete="off" />
+                     placeholder="paste token from `katulong bridge ollama new-token`" spellcheck="false" autocomplete="off" />
               <span id="ollama-peer-token-state" style="font-size: 0.75rem; color: var(--text-muted);"></span>
             </div>
             <div class="settings-row" style="gap: var(--space-xs);">

--- a/test/bridges-config-loader.test.js
+++ b/test/bridges-config-loader.test.js
@@ -1,0 +1,155 @@
+/**
+ * Tests for bridges/_lib/config-loader.js — per-bridge config storage
+ * and the resolveBridge() function that overlays config on manifest.
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, statSync, readFileSync, writeFileSync } from "node:fs";
+import { join, sep } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  bridgeConfigPath,
+  loadBridgeConfig,
+  writeBridgeConfig,
+  resolveBridge,
+  generateToken,
+} from "../bridges/_lib/config-loader.js";
+
+const MANIFEST = Object.freeze({
+  name: "ollama",
+  port: 11435,
+  target: "http://127.0.0.1:11434",
+});
+
+describe("bridge config loader", () => {
+  let dataDir;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "bridges-config-"));
+  });
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("bridgeConfigPath puts each bridge in its own dir", () => {
+    const path = bridgeConfigPath(dataDir, "ollama");
+    assert.ok(path.endsWith(["bridges", "ollama", "config.json"].join(sep)));
+  });
+
+  it("loadBridgeConfig returns null when no file exists", () => {
+    assert.equal(loadBridgeConfig(dataDir, "ollama"), null);
+  });
+
+  it("writeBridgeConfig persists a token", () => {
+    writeBridgeConfig(dataDir, "ollama", { token: "x".repeat(64) });
+    const config = loadBridgeConfig(dataDir, "ollama");
+    assert.equal(config.token.length, 64);
+  });
+
+  it("writeBridgeConfig preserves existing fields on partial updates", () => {
+    writeBridgeConfig(dataDir, "ollama", { token: "first-token-".repeat(4) });
+    writeBridgeConfig(dataDir, "ollama", { port: 12000 });
+    const config = loadBridgeConfig(dataDir, "ollama");
+    assert.equal(config.port, 12000);
+    assert.ok(config.token.startsWith("first-token-"));
+  });
+
+  it("writeBridgeConfig drops null fields rather than persisting them", () => {
+    writeBridgeConfig(dataDir, "ollama", { token: "a".repeat(64), port: 12000 });
+    writeBridgeConfig(dataDir, "ollama", { port: null });
+    const config = loadBridgeConfig(dataDir, "ollama");
+    assert.equal(config.port, undefined);
+    assert.equal(config.token.length, 64);
+  });
+
+  it("config file is written mode 0600", () => {
+    writeBridgeConfig(dataDir, "ollama", { token: "a".repeat(64) });
+    const path = bridgeConfigPath(dataDir, "ollama");
+    const mode = statSync(path).mode & 0o777;
+    assert.equal(mode, 0o600, `expected 0o600, got 0o${mode.toString(8)}`);
+  });
+
+  it("loadBridgeConfig surfaces malformed JSON with the path in the message", () => {
+    writeBridgeConfig(dataDir, "ollama", { token: "a".repeat(64) });
+    const path = bridgeConfigPath(dataDir, "ollama");
+    // Corrupt the file
+    const buf = readFileSync(path);
+    writeFileSync(path, buf.toString().replace("{", "{["));
+    assert.throws(
+      () => loadBridgeConfig(dataDir, "ollama"),
+      /malformed/,
+    );
+  });
+});
+
+describe("resolveBridge", () => {
+  let dataDir;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "bridges-resolve-"));
+  });
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("requires a token to be configured", () => {
+    assert.throws(
+      () => resolveBridge({ manifest: MANIFEST, dataDir }),
+      /no token configured/,
+    );
+  });
+
+  it("returns the manifest defaults when only token is configured", () => {
+    writeBridgeConfig(dataDir, "ollama", { token: "a".repeat(64) });
+    const resolved = resolveBridge({ manifest: MANIFEST, dataDir });
+    assert.equal(resolved.port, MANIFEST.port);
+    assert.equal(resolved.target, MANIFEST.target);
+    assert.equal(resolved.bind, "127.0.0.1");
+    assert.equal(resolved.token, "a".repeat(64));
+  });
+
+  it("config overrides win over manifest defaults", () => {
+    writeBridgeConfig(dataDir, "ollama", {
+      token: "a".repeat(64),
+      port: 12000,
+      bind: "0.0.0.0",
+      target: "http://192.168.1.5:11434",
+    });
+    const resolved = resolveBridge({ manifest: MANIFEST, dataDir });
+    assert.equal(resolved.port, 12000);
+    assert.equal(resolved.bind, "0.0.0.0");
+    assert.equal(resolved.target, "http://192.168.1.5:11434");
+  });
+
+  it("rejects an invalid port", () => {
+    writeBridgeConfig(dataDir, "ollama", { token: "a".repeat(64), port: 70000 });
+    assert.throws(
+      () => resolveBridge({ manifest: MANIFEST, dataDir }),
+      /invalid port/,
+    );
+  });
+
+  it("rejects a non-http(s) target", () => {
+    writeBridgeConfig(dataDir, "ollama", {
+      token: "a".repeat(64),
+      target: "ftp://nope",
+    });
+    assert.throws(
+      () => resolveBridge({ manifest: MANIFEST, dataDir }),
+      /must start with http/,
+    );
+  });
+});
+
+describe("generateToken", () => {
+  it("returns a 64-char hex string (256 bits of entropy)", () => {
+    const t = generateToken();
+    assert.equal(t.length, 64);
+    assert.match(t, /^[0-9a-f]+$/);
+  });
+
+  it("returns a different value each call", () => {
+    assert.notEqual(generateToken(), generateToken());
+  });
+});

--- a/test/bridges-launchd-template.test.js
+++ b/test/bridges-launchd-template.test.js
@@ -1,0 +1,76 @@
+/**
+ * Tests for bridges/_lib/launchd-template.js — plist generation with a
+ * deterministic PATH (lesson from katulong's own service install bug).
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  bridgeLabel,
+  bridgePlistPath,
+  buildBridgePlist,
+} from "../bridges/_lib/launchd-template.js";
+
+describe("bridge launchd template", () => {
+  it("bridgeLabel uses the katulong-bridge namespace", () => {
+    assert.equal(bridgeLabel("ollama"), "com.dorkyrobot.katulong-bridge.ollama");
+  });
+
+  it("bridgePlistPath is under ~/Library/LaunchAgents", () => {
+    const path = bridgePlistPath("ollama");
+    assert.match(path, /\/Library\/LaunchAgents\/com\.dorkyrobot\.katulong-bridge\.ollama\.plist$/);
+  });
+
+  it("buildBridgePlist invokes `katulong bridge <name> start` via the resolved bin", () => {
+    const xml = buildBridgePlist({
+      bridgeName: "ollama",
+      bin: "/opt/homebrew/bin/katulong",
+      dataDir: "/Users/felix/.katulong",
+    });
+    assert.ok(xml.includes("<string>/opt/homebrew/bin/katulong</string>"));
+    assert.ok(xml.includes("<string>bridge</string>"));
+    assert.ok(xml.includes("<string>ollama</string>"));
+    assert.ok(xml.includes("<string>start</string>"));
+  });
+
+  it("plist PATH is deterministic and includes /opt/homebrew/bin", () => {
+    // Set the calling shell's PATH to something stripped — the plist must
+    // NOT inherit it. (Lesson from PR #662.)
+    const original = process.env.PATH;
+    process.env.PATH = "/some/random:/path";
+    try {
+      const xml = buildBridgePlist({
+        bridgeName: "ollama",
+        bin: "/opt/homebrew/bin/katulong",
+        dataDir: "/Users/felix/.katulong",
+      });
+      assert.ok(xml.includes("/opt/homebrew/bin"), "missing /opt/homebrew/bin");
+      assert.ok(xml.includes("/usr/bin"), "missing /usr/bin");
+      assert.ok(!xml.includes("/some/random"), "leaked caller's PATH");
+    } finally {
+      process.env.PATH = original;
+    }
+  });
+
+  it("plist sets log paths under <dataDir>/bridges/<name>/", () => {
+    const xml = buildBridgePlist({
+      bridgeName: "ollama",
+      bin: "/opt/homebrew/bin/katulong",
+      dataDir: "/Users/felix/.katulong",
+    });
+    assert.ok(xml.includes("/Users/felix/.katulong/bridges/ollama/stdout.log"));
+    assert.ok(xml.includes("/Users/felix/.katulong/bridges/ollama/stderr.log"));
+  });
+
+  it("plist xml-escapes attacker-controlled bridge names", () => {
+    // The bridge name is usually static, but xmlEscape protection should
+    // hold defensively in case manifest data ever flows from untrusted input.
+    const xml = buildBridgePlist({
+      bridgeName: "evil</string><key>Foo</key><string>hi",
+      bin: "/opt/homebrew/bin/katulong",
+      dataDir: "/Users/felix/.katulong",
+    });
+    assert.ok(!xml.includes("<key>Foo</key>"), "XML injection succeeded");
+    assert.ok(xml.includes("&lt;"), "no escaped angle brackets in output");
+  });
+});

--- a/test/bridges-registry.test.js
+++ b/test/bridges-registry.test.js
@@ -5,7 +5,60 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { listBridges, getBridge } from "../bridges/_lib/registry.js";
+import { listBridges, getBridge, isValidBridgeName } from "../bridges/_lib/registry.js";
+
+describe("isValidBridgeName", () => {
+  it("accepts simple lowercase names", () => {
+    assert.equal(isValidBridgeName("ollama"), true);
+    assert.equal(isValidBridgeName("redis"), true);
+    assert.equal(isValidBridgeName("postgres"), true);
+  });
+
+  it("accepts hyphenated names", () => {
+    assert.equal(isValidBridgeName("vector-db"), true);
+    assert.equal(isValidBridgeName("ollama-cloud"), true);
+  });
+
+  it("rejects names starting with hyphen", () => {
+    assert.equal(isValidBridgeName("-foo"), false);
+  });
+
+  it("rejects names with shell metacharacters", () => {
+    // The cases that motivated adding the allowlist — these would
+    // otherwise reach execFileSync via plistPath / launchctl args.
+    assert.equal(isValidBridgeName('foo"$(touch /tmp/pwn)"'), false);
+    assert.equal(isValidBridgeName("foo; rm -rf /"), false);
+    assert.equal(isValidBridgeName("foo`id`"), false);
+    assert.equal(isValidBridgeName("foo|bar"), false);
+  });
+
+  it("rejects path-traversal attempts", () => {
+    assert.equal(isValidBridgeName(".."), false);
+    assert.equal(isValidBridgeName("../etc"), false);
+    assert.equal(isValidBridgeName("foo/bar"), false);
+    assert.equal(isValidBridgeName("foo\\bar"), false);
+  });
+
+  it("rejects uppercase or unicode", () => {
+    assert.equal(isValidBridgeName("Ollama"), false);
+    assert.equal(isValidBridgeName("ollamä"), false);
+  });
+
+  it("rejects names over 64 chars", () => {
+    assert.equal(isValidBridgeName("a".repeat(64)), true);
+    assert.equal(isValidBridgeName("a".repeat(65)), false);
+  });
+
+  it("rejects reserved names that collide with top-level CLI commands", () => {
+    assert.equal(isValidBridgeName("list"), false);
+  });
+
+  it("rejects non-strings", () => {
+    assert.equal(isValidBridgeName(null), false);
+    assert.equal(isValidBridgeName(undefined), false);
+    assert.equal(isValidBridgeName(123), false);
+  });
+});
 
 describe("bridge registry", () => {
   it("discovers the ollama bridge from its manifest", async () => {
@@ -25,6 +78,20 @@ describe("bridge registry", () => {
     await assert.rejects(
       () => getBridge("does-not-exist"),
       /unknown bridge "does-not-exist"/,
+    );
+  });
+
+  it("getBridge rejects invalid names BEFORE looking them up", async () => {
+    // Important: the rejection must happen via the allowlist regex, not
+    // via "unknown bridge" — otherwise an attacker could probe for the
+    // existence of arbitrary directories.
+    await assert.rejects(
+      () => getBridge('foo"$(id)"'),
+      /invalid bridge name/,
+    );
+    await assert.rejects(
+      () => getBridge("../etc"),
+      /invalid bridge name/,
     );
   });
 

--- a/test/bridges-registry.test.js
+++ b/test/bridges-registry.test.js
@@ -1,0 +1,37 @@
+/**
+ * Tests for bridges/_lib/registry.js — auto-discovery of bridges from
+ * `bridges/<name>/manifest.js` files.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { listBridges, getBridge } from "../bridges/_lib/registry.js";
+
+describe("bridge registry", () => {
+  it("discovers the ollama bridge from its manifest", async () => {
+    const bridges = await listBridges();
+    const names = bridges.map((b) => b.name);
+    assert.ok(names.includes("ollama"), `expected "ollama" in [${names.join(", ")}]`);
+  });
+
+  it("getBridge returns the manifest", async () => {
+    const ollama = await getBridge("ollama");
+    assert.equal(ollama.name, "ollama");
+    assert.equal(typeof ollama.port, "number");
+    assert.match(ollama.target, /^https?:\/\//);
+  });
+
+  it("getBridge throws a helpful error for unknown bridges", async () => {
+    await assert.rejects(
+      () => getBridge("does-not-exist"),
+      /unknown bridge "does-not-exist"/,
+    );
+  });
+
+  it("manifests are returned in alphabetical order", async () => {
+    const bridges = await listBridges();
+    const names = bridges.map((b) => b.name);
+    const sorted = [...names].sort();
+    assert.deepEqual(names, sorted);
+  });
+});

--- a/test/bridges-server.test.js
+++ b/test/bridges-server.test.js
@@ -1,0 +1,153 @@
+/**
+ * Tests for bridges/_lib/server.js — the shared HTTP proxy + bearer-auth
+ * core that every bridge runs on top of. Ported from the standalone
+ * ollama-bridge repo when bridges moved into katulong.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import {
+  bearerMatches,
+  createBridgeServer,
+  startBridgeServer,
+} from "../bridges/_lib/server.js";
+
+function startStubUpstream() {
+  const requests = [];
+  const server = createServer((req, res) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      requests.push({
+        method: req.method,
+        url: req.url,
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString("utf-8"),
+      });
+      const url = new URL(req.url, "http://x");
+      if (url.searchParams.get("status") === "stream") {
+        res.writeHead(200, { "Content-Type": "application/x-ndjson" });
+        res.write('{"chunk":1}\n');
+        setTimeout(() => {
+          res.write('{"chunk":2,"done":true}\n');
+          res.end();
+        }, 10);
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () =>
+      resolve({ server, port: server.address().port, requests }),
+    );
+  });
+}
+
+describe("bearerMatches", () => {
+  it("accepts an exact match", () => {
+    assert.equal(bearerMatches("Bearer abc123", "abc123"), true);
+  });
+  it("rejects a wrong token of the same length", () => {
+    assert.equal(bearerMatches("Bearer abc124", "abc123"), false);
+  });
+  it("rejects a wrong-length token", () => {
+    assert.equal(bearerMatches("Bearer abc12", "abc123"), false);
+  });
+  it("rejects missing Bearer prefix", () => {
+    assert.equal(bearerMatches("abc123", "abc123"), false);
+  });
+  it("rejects undefined header", () => {
+    assert.equal(bearerMatches(undefined, "abc123"), false);
+  });
+});
+
+describe("bridge server", () => {
+  let stub;
+  let bridge;
+  let bridgePort;
+  const TOKEN = "test-token-abc123-thirty-two-chars!";
+
+  before(async () => {
+    stub = await startStubUpstream();
+    bridge = await startBridgeServer({
+      port: 0,
+      bind: "127.0.0.1",
+      target: `http://127.0.0.1:${stub.port}`,
+      token: TOKEN,
+    });
+    bridgePort = bridge.address().port;
+  });
+
+  after(() => {
+    bridge.close();
+    stub.server.close();
+  });
+
+  it("rejects requests without a Bearer token", async () => {
+    const res = await fetch(`http://127.0.0.1:${bridgePort}/api/tags`);
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.equal(body.error, "unauthorized");
+  });
+
+  it("rejects a wrong token", async () => {
+    const res = await fetch(`http://127.0.0.1:${bridgePort}/api/tags`, {
+      headers: { Authorization: "Bearer wrong-token" },
+    });
+    assert.equal(res.status, 401);
+  });
+
+  it("strips the bridge token before forwarding upstream", async () => {
+    await fetch(`http://127.0.0.1:${bridgePort}/api/tags`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    const last = stub.requests.at(-1);
+    assert.equal(last.headers.authorization, undefined);
+  });
+
+  it("forwards POST body verbatim", async () => {
+    const payload = { model: "gemma:3b", prompt: "hi" };
+    await fetch(`http://127.0.0.1:${bridgePort}/api/generate`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+    const last = stub.requests.at(-1);
+    assert.equal(last.method, "POST");
+    assert.equal(last.url, "/api/generate");
+    assert.deepEqual(JSON.parse(last.body), payload);
+  });
+
+  it("streams chunked responses end-to-end", async () => {
+    const res = await fetch(
+      `http://127.0.0.1:${bridgePort}/api/generate?status=stream`,
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+    );
+    const text = await res.text();
+    assert.ok(text.includes('"chunk":1'));
+    assert.ok(text.includes('"chunk":2'));
+    assert.ok(text.includes('"done":true'));
+  });
+
+  it("returns 502 when upstream is unreachable", async () => {
+    const orphan = await startBridgeServer({
+      port: 0,
+      bind: "127.0.0.1",
+      target: "http://127.0.0.1:1",
+      token: TOKEN,
+    });
+    const res = await fetch(`http://127.0.0.1:${orphan.address().port}/api/tags`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    assert.equal(res.status, 502);
+    const body = await res.json();
+    assert.equal(body.error, "upstream_unreachable");
+    orphan.close();
+  });
+});

--- a/test/bridges-server.test.js
+++ b/test/bridges-server.test.js
@@ -77,6 +77,7 @@ describe("bridge server", () => {
       bind: "127.0.0.1",
       target: `http://127.0.0.1:${stub.port}`,
       token: TOKEN,
+      logger: () => {}, // suppress test-time noise
     });
     bridgePort = bridge.address().port;
   });
@@ -141,6 +142,7 @@ describe("bridge server", () => {
       bind: "127.0.0.1",
       target: "http://127.0.0.1:1",
       token: TOKEN,
+      logger: () => {},
     });
     const res = await fetch(`http://127.0.0.1:${orphan.address().port}/api/tags`, {
       headers: { Authorization: `Bearer ${TOKEN}` },
@@ -148,6 +150,45 @@ describe("bridge server", () => {
     assert.equal(res.status, 502);
     const body = await res.json();
     assert.equal(body.error, "upstream_unreachable");
+    // Don't leak upstream URL or syscall details — the body should NOT
+    // include `detail`, the upstream hostname, or "ECONNREFUSED".
+    assert.equal(body.detail, undefined);
+    assert.ok(!JSON.stringify(body).includes("ECONNREFUSED"));
     orphan.close();
+  });
+
+  it("strips hop-by-hop and forwarding headers", async () => {
+    await fetch(`http://127.0.0.1:${bridgePort}/api/tags`, {
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        "X-Forwarded-For": "1.2.3.4",
+        "X-Real-IP": "5.6.7.8",
+        Connection: "close",
+      },
+    });
+    const last = stub.requests.at(-1);
+    assert.equal(last.headers["x-forwarded-for"], undefined);
+    assert.equal(last.headers["x-real-ip"], undefined);
+    // Note: node's http client adds its own `Connection: keep-alive`
+    // when no value is set, so we can't assert connection is absent —
+    // only that the client's "close" value didn't propagate.
+    assert.notEqual(last.headers["connection"], "close");
+  });
+
+  it("invokes the logger on auth failure with the source address", async () => {
+    const events = [];
+    const probe = await startBridgeServer({
+      port: 0,
+      bind: "127.0.0.1",
+      target: `http://127.0.0.1:${stub.port}`,
+      token: TOKEN,
+      logger: (e) => events.push(e),
+    });
+    await fetch(`http://127.0.0.1:${probe.address().port}/api/tags`);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].event, "auth_failure");
+    assert.equal(events[0].reason, "missing_header");
+    assert.match(events[0].remoteAddress, /127\.0\.0\.1|::1|::ffff:127/);
+    probe.close();
   });
 });


### PR DESCRIPTION
## Summary

- Pulls the standalone `ollama-bridge` into katulong as the first member of a generalized `bridges/` tree. Adds `katulong bridge` CLI (list / start / new-token / show-token / install / uninstall / status).
- Each bridge is a directory with a `manifest.js` exporting `{name, port, target, description}`. The shared `_lib/` (server + config loader + registry + plist template) does the rest. Adding a new bridge — e.g., `redis-bridge`, `postgres-bridge` — is a one-file change.
- Each bridge runs as its own launchd job (`com.dorkyrobot.katulong-bridge.<name>`); a bridge crash does not take down katulong.

## Why bundle now

katulong is the only consumer for the foreseeable future. A separate repo's overhead (own package.json, own publish flow, own CI) earns its keep only when there's a non-katulong consumer. The wire format (HTTPS + Bearer auth) stays forward-compatible with the planned [`katulong-app/1`](https://github.com/Dorky-Robot/sipag) runtime call shape — when that protocol's host implementation lands, every bridge here gains the four well-known endpoints (`manifest`, `install`, `intent-pull`, `health`) as a purely additive change. If a non-katulong consumer ever materializes, `bridges/` extracts cleanly. Bundling now does not preclude unbundling later.

## Test plan

- [x] `npm run test:unit` — 2666 pass, 0 fail (35 new cases across 4 new test files)
- [x] CLI smoke: `katulong bridge list`, `new-token`, `show-token`, error handling for unknown names
- [ ] After merge: install on mac2024 (`katulong bridge ollama new-token && katulong bridge ollama install`), point a katulong consumer at it via Settings → External LLM endpoint