### PR TITLE
rewrite(web): slice 9q — Leptos shell layout (header + main + connection status)

### DIFF
--- a/crates/web/index.html
+++ b/crates/web/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>katulong</title>
+    <link data-trunk rel="css" href="style.css">
   </head>
   <body></body>
 </html>

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -1,3 +1,21 @@
+// Leptos shell — slice 9q.
+//
+// Layout primitives (header + main) replace the slice-9o
+// hello-world `<main>`. The shell is intentionally a frame
+// with NO real content yet: subsequent slices fill `<Main/>`
+// with login → terminal → tile-grid as those land. The
+// Header carries a connection-status signal that future
+// slices will wire to the WS attach state; today it's
+// hardcoded to `false` so the visible truth ("disconnected")
+// matches the actual state.
+//
+// FP-leaning per memory `feedback_rewrite_fp_direction`: the
+// shell is built from small pure components composed into a
+// tree. Connection state lives in a single signal provided
+// at the App root and consumed via context — no global
+// mutable state, no scattered RwSignal allocations across
+// components.
+
 use leptos::*;
 
 fn main() {
@@ -5,12 +23,76 @@ fn main() {
     mount_to_body(|| view! { <App/> });
 }
 
+/// Reactive connection-state signal exposed to descendants
+/// via context. `false` until a future slice wires the WS
+/// attach handshake to flip it.
+#[derive(Copy, Clone)]
+struct ConnectionStatus(ReadSignal<bool>);
+
 #[component]
 fn App() -> impl IntoView {
+    // Connection signal lives at the root so any descendant
+    // can read it without prop-drilling. The setter half is
+    // discarded for now — only future slices that own the WS
+    // lifecycle will need it, and they'll re-create the
+    // signal at a more appropriate scope (e.g., inside the
+    // WS-driving component) rather than mutating shared state
+    // from anywhere.
+    let (connected, _set_connected) = create_signal(false);
+    provide_context(ConnectionStatus(connected));
+
     view! {
-        <main>
-            <h1>"katulong"</h1>
-            <p>"Rust + Leptos rewrite — hello world"</p>
+        <div id="kat-shell">
+            <Header/>
+            <Main/>
+        </div>
+    }
+}
+
+#[component]
+fn Header() -> impl IntoView {
+    let ConnectionStatus(connected) = expect_context();
+    // The status attribute is what the CSS dot color binds
+    // to. Computing it as a derived signal means the DOM
+    // attribute mutates only when the underlying boolean
+    // flips — no manual class-toggle dance.
+    let status_attr = move || {
+        if connected.get() {
+            "connected"
+        } else {
+            "disconnected"
+        }
+    };
+    let status_label = move || {
+        if connected.get() {
+            "connected"
+        } else {
+            "disconnected"
+        }
+    };
+
+    view! {
+        <header id="kat-header">
+            <span class="brand">
+                "kat" <span class="accent">"•"</span> "ulong"
+            </span>
+            <span class="status" data-status=status_attr>
+                <span class="dot" aria-hidden="true"></span>
+                <span class="label">{status_label}</span>
+            </span>
+        </header>
+    }
+}
+
+#[component]
+fn Main() -> impl IntoView {
+    // Placeholder content. Replaced by:
+    //   - slice 9r: <Login/> when no session cookie
+    //   - slice 9s: <Terminal/> when authenticated
+    //   - slice 9t+: tile grid
+    view! {
+        <main id="kat-main">
+            <p>"Rust + Leptos rewrite — shell ready, content pending."</p>
         </main>
     }
 }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -1,0 +1,95 @@
+/* Slice 9q layout primitives.
+ *
+ * Zero design system here yet — just the bones a future
+ * frontend slice can extend. Goals:
+ *   - body fills the viewport, no margins
+ *   - header is sticky, full-width, fixed-height
+ *   - main fills the remaining vertical space, scrolls on
+ *     overflow (so the future tile grid can scroll
+ *     independently of the chrome)
+ *   - status dot in the header tints itself based on a
+ *     `data-status` attribute the WASM toggles
+ *
+ * The next slice swaps these vanilla rules for whatever
+ * design system we land on (Tailwind, design tokens, etc).
+ * Keep it dependency-free and overridable until that decision.
+ */
+
+:root {
+  --kat-bg: #0e0e10;
+  --kat-fg: #e6e6e6;
+  --kat-fg-dim: #8a8a90;
+  --kat-accent: #4dd0e1;
+  --kat-status-disconnected: #d04d4d;
+  --kat-status-connected: #4dd07a;
+  --kat-header-h: 44px;
+  --kat-pad: 12px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: var(--kat-bg);
+  color: var(--kat-fg);
+  font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI",
+    system-ui, sans-serif;
+}
+
+#kat-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+#kat-header {
+  flex: 0 0 var(--kat-header-h);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--kat-pad);
+  background: rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+#kat-header .brand {
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: var(--kat-fg);
+}
+
+#kat-header .brand .accent {
+  color: var(--kat-accent);
+}
+
+#kat-header .status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--kat-fg-dim);
+}
+
+#kat-header .status .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--kat-status-disconnected);
+  transition: background 120ms ease;
+}
+
+#kat-header .status[data-status="connected"] .dot {
+  background: var(--kat-status-connected);
+}
+
+#kat-main {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: var(--kat-pad);
+  color: var(--kat-fg-dim);
+}

--- a/test/e2e-rust/smoke.e2e.js
+++ b/test/e2e-rust/smoke.e2e.js
@@ -18,7 +18,7 @@
 
 import { test, expect } from "@playwright/test";
 
-test("leptos shell renders into the body", async ({ page }) => {
+test("leptos shell renders header + main + status", async ({ page }) => {
   // The trunk-built `index.html` arrives with an empty
   // `<body></body>`. Leptos's `mount_to_body` populates it
   // AFTER the WASM downloads + hydrates. So if we see a
@@ -33,26 +33,41 @@ test("leptos shell renders into the body", async ({ page }) => {
 
   // Wait for hydration. `mount_to_body` is sync once the WASM
   // module is initialised, but the WASM fetch + instantiation
-  // is async. Playwright's auto-waiting on a locator handles
-  // the race for us — `toBeVisible` polls until the element
-  // exists OR the timeout fires.
+  // is async. Playwright's auto-waiting on the shell root
+  // handles the race for us — `toBeVisible` polls until the
+  // element exists OR the timeout fires.
   //
   // 15s budget: cold CI runners (constrained ARM, GitHub
   // Actions macOS) take 3-8s for non-trivial WASM
-  // instantiation. 5s was originally chosen on a warm
-  // dev machine where hydration is sub-second; CI flakes
-  // would look like hydration regressions. The outer test
-  // timeout in playwright.rust.config.js is 30s, so this
-  // still leaves headroom for the rest of the test.
-  await expect(page.locator("h1")).toBeVisible({ timeout: 15_000 });
-  await expect(page.locator("h1")).toContainText("katulong");
+  // instantiation. The outer test timeout in
+  // playwright.rust.config.js is 30s, so this still leaves
+  // headroom for the rest of the test.
+  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
 
-  // Catch the failure mode where the HTML is served but the
-  // WASM didn't load — the body would be empty. Asserting on
-  // the rendered text confirms hydration completed.
-  await expect(page.locator("body")).toContainText(
-    "Rust + Leptos rewrite",
+  // Header presence — slice 9q layout primitive. The brand
+  // text uses a `kat•ulong` glyph split, so we match
+  // case-insensitively on the substring.
+  const header = page.locator("#kat-header");
+  await expect(header).toBeVisible();
+  await expect(header.locator(".brand")).toContainText("kat");
+  await expect(header.locator(".brand")).toContainText("ulong");
+
+  // Connection status indicator: starts disconnected (no WS
+  // yet). The `data-status` attribute drives the dot color
+  // via CSS; future slices flip it to "connected" when WS
+  // attach succeeds.
+  await expect(header.locator(".status")).toHaveAttribute(
+    "data-status",
+    "disconnected",
   );
+  await expect(header.locator(".status .label")).toHaveText("disconnected");
+
+  // Main content area exists with the placeholder copy. Will
+  // be replaced by Login / Terminal / TileGrid in subsequent
+  // slices.
+  const main = page.locator("#kat-main");
+  await expect(main).toBeVisible();
+  await expect(main).toContainText("shell ready, content pending");
 });
 
 test("/health returns ok", async ({ request }) => {


### PR DESCRIPTION
## Summary

Replaces the hello-world Leptos page with a real shell: header (with brand + connection-status indicator), main content area (placeholder), minimal CSS. Sets the structural foundation for the auth/terminal/tile-grid components that follow.

## What changed

- **`src/main.rs`**: `App` provides a `ConnectionStatus(ReadSignal<bool>)` via Leptos context. `Header` reads it and exposes a `data-status` CSS hook that flips between "disconnected" / "connected". `Main` is a placeholder.
- **`style.css`** (new): vanilla CSS layout — body fills viewport, sticky header, scrollable main, status dot tinted via `data-status`. Trunk auto-hashes via `<link data-trunk>`.
- **`index.html`**: adds the trunk CSS link.
- **`smoke.e2e.js`**: assertions updated for the new structure (header brand, status attribute, main placeholder).

## FP-leaning shape

- Connection state is ONE root signal; read-half shared via context, set-half deferred to the future WS-owning component (avoids "set state from anywhere" antipattern).
- Status attribute + label are derived signals — reactive, not imperative. CSS owns the visual state via `data-status`.

## Verified

```
cd crates/web && trunk build --release
KATULONG_BASE_URL=http://127.0.0.1:3063 npx playwright test --config=playwright.rust.config.js
# 3 passed
```

## Test plan

- [x] Trunk build succeeds, emits hashed JS/WASM/CSS
- [x] e2e smoke (3 tests) passes against locally-launched binary