### PR TITLE
rewrite(web): slice 9r.1 — Login component shell + URL-based mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,6 +1074,7 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
  "leptos",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -11,3 +11,9 @@ path = "src/main.rs"
 [dependencies]
 leptos = { workspace = true }
 console_error_panic_hook = "0.1"
+# `web-sys` for the few browser globals we touch directly
+# (URL query parsing today; future slices will add WebAuthn,
+# fetch, WebSocket, navigation). Feature-gated narrowly to
+# keep the WASM bundle lean — only enable each interface when
+# a slice actually uses it.
+web-sys = { version = "0.3", features = ["Window", "Location", "UrlSearchParams"] }

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -86,13 +86,105 @@ fn Header() -> impl IntoView {
 
 #[component]
 fn Main() -> impl IntoView {
-    // Placeholder content. Replaced by:
-    //   - slice 9r: <Login/> when no session cookie
-    //   - slice 9s: <Terminal/> when authenticated
-    //   - slice 9t+: tile grid
+    // Slice 9r.1 lands the visual + URL-mode-switching part
+    // of the login flow. The actual WebAuthn ceremony (calls
+    // to `/api/auth/registration/begin` /
+    // `navigator.credentials.create()` / etc.) lands in 9r.2.
+    //
+    // Today we always render `<Login/>` here — there's no
+    // notion of "authenticated session" yet because no slice
+    // has read the session cookie or the WS attach state.
+    // Once 9r.2 lands, the post-success path will set a
+    // signal that switches `<Main/>` to the (still-stub)
+    // terminal view.
     view! {
         <main id="kat-main">
-            <p>"Rust + Leptos rewrite — shell ready, content pending."</p>
+            <Login/>
         </main>
+    }
+}
+
+/// Setup-token from the URL's `?setup_token=...` query, or
+/// `None` if not present. Read once at component construction
+/// — Leptos signals will track changes if a future slice
+/// needs that, but the initial-load read is enough for slice
+/// 9r.1's mode toggle.
+fn url_setup_token() -> Option<String> {
+    let location = web_sys::window()?.location();
+    let search = location.search().ok()?;
+    if search.is_empty() {
+        return None;
+    }
+    let params = web_sys::UrlSearchParams::new_with_str(&search).ok()?;
+    let token = params.get("setup_token")?;
+    if token.is_empty() {
+        None
+    } else {
+        Some(token)
+    }
+}
+
+/// Visual shell of the auth ceremony. Two modes, switched by
+/// the presence of `?setup_token=` in the URL:
+///
+/// - **Pair mode** (token present): "Pair this device — name
+///   it and confirm with your passkey." This is the
+///   add-additional-device flow that the Node implementation
+///   exposes via the staging script's printed pair URL.
+///
+/// - **Sign-in mode** (no token): "Sign in with your
+///   passkey." Pure WebAuthn login, no setup token needed.
+///   On a fresh data dir with no enrolled passkeys this will
+///   be a dead-end — the bootstrap path (first device, no
+///   token) is a separate question that 9r.4 will resolve.
+///
+/// Slice 9r.1 only renders the form. The buttons currently
+/// have no `on:click` handlers; 9r.2 wires the WebAuthn
+/// ceremony.
+#[component]
+fn Login() -> impl IntoView {
+    let setup_token = url_setup_token();
+    let is_pair_mode = setup_token.is_some();
+
+    // The form has a separate identity for tests / future
+    // styling: `data-mode` swaps copy + behavior between the
+    // two ceremonies.
+    let mode_attr = if is_pair_mode { "pair" } else { "signin" };
+    let title = if is_pair_mode {
+        "Pair this device"
+    } else {
+        "Sign in"
+    };
+    let cta = if is_pair_mode {
+        "Pair with passkey"
+    } else {
+        "Sign in with passkey"
+    };
+    let blurb = if is_pair_mode {
+        "Name this device and confirm with your passkey to add it to your account."
+    } else {
+        "Use your passkey to sign in."
+    };
+
+    view! {
+        <section id="kat-login" data-mode=mode_attr>
+            <h1 class="title">{title}</h1>
+            <p class="blurb">{blurb}</p>
+            // Pair mode collects a device name (e.g.,
+            // "felix-iphone"). Sign-in mode skips it — the
+            // passkey itself identifies the credential.
+            {is_pair_mode.then(|| view! {
+                <label class="field">
+                    <span class="label">"Device name"</span>
+                    <input
+                        type="text"
+                        name="device-name"
+                        autocomplete="off"
+                        placeholder="e.g. felix-iphone"
+                    />
+                </label>
+            })}
+            <button type="button" class="cta">{cta}</button>
+        </section>
     }
 }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -93,3 +93,68 @@ body {
   padding: var(--kat-pad);
   color: var(--kat-fg-dim);
 }
+
+/* Login (slice 9r.1) — shell only, no ceremony wiring yet.
+ * Centered form, dim background, accent CTA. The form's
+ * `data-mode` attribute distinguishes pair vs. signin for
+ * future-styling hooks but currently doesn't change visuals. */
+#kat-login {
+  max-width: 360px;
+  margin: 64px auto 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  color: var(--kat-fg);
+}
+
+#kat-login .title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+#kat-login .blurb {
+  margin: 0;
+  color: var(--kat-fg-dim);
+  font-size: 13px;
+}
+
+#kat-login .field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#kat-login .field .label {
+  font-size: 12px;
+  color: var(--kat-fg-dim);
+}
+
+#kat-login .field input {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--kat-fg);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font: inherit;
+  outline: none;
+}
+
+#kat-login .field input:focus {
+  border-color: var(--kat-accent);
+}
+
+#kat-login .cta {
+  background: var(--kat-accent);
+  color: var(--kat-bg);
+  border: 0;
+  border-radius: 6px;
+  padding: 10px 14px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+#kat-login .cta:hover {
+  filter: brightness(1.05);
+}

--- a/test/e2e-rust/smoke.e2e.js
+++ b/test/e2e-rust/smoke.e2e.js
@@ -62,12 +62,45 @@ test("leptos shell renders header + main + status", async ({ page }) => {
   );
   await expect(header.locator(".status .label")).toHaveText("disconnected");
 
-  // Main content area exists with the placeholder copy. Will
-  // be replaced by Login / Terminal / TileGrid in subsequent
-  // slices.
+  // Main content area renders the Login form (slice 9r.1).
+  // Visible at every page load until a future slice gates
+  // it on the authenticated-session signal.
   const main = page.locator("#kat-main");
   await expect(main).toBeVisible();
-  await expect(main).toContainText("shell ready, content pending");
+  await expect(main.locator("#kat-login")).toBeVisible();
+});
+
+test("login defaults to sign-in mode without setup_token", async ({ page }) => {
+  // No `?setup_token=...` query: Login should render its
+  // sign-in mode — no device-name field, "Sign in with
+  // passkey" CTA, `data-mode="signin"` for future styling +
+  // selector hooks.
+  await page.goto("/");
+  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
+
+  const login = page.locator("#kat-login");
+  await expect(login).toHaveAttribute("data-mode", "signin");
+  await expect(login.locator(".title")).toHaveText("Sign in");
+  await expect(login.locator(".cta")).toHaveText("Sign in with passkey");
+  // No device-name field in sign-in mode.
+  await expect(login.locator('input[name="device-name"]')).toHaveCount(0);
+});
+
+test("login switches to pair mode with setup_token", async ({ page }) => {
+  // Presence of `?setup_token=` flips the form to pair mode
+  // — adds the device-name field, swaps title + CTA copy,
+  // sets `data-mode="pair"`. The token value isn't read by
+  // 9r.1 (the WebAuthn ceremony in 9r.2 will consume it);
+  // this test only asserts the visible mode swap.
+  await page.goto("/?setup_token=abcdef0123456789");
+  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
+
+  const login = page.locator("#kat-login");
+  await expect(login).toHaveAttribute("data-mode", "pair");
+  await expect(login.locator(".title")).toHaveText("Pair this device");
+  await expect(login.locator(".cta")).toHaveText("Pair with passkey");
+  // Pair mode shows the device-name input.
+  await expect(login.locator('input[name="device-name"]')).toBeVisible();
 });
 
 test("/health returns ok", async ({ request }) => {


### PR DESCRIPTION
## Summary

Lays in the visual half of the auth flow. The Login form switches between **sign-in** and **pair** modes based on the URL's `?setup_token=...` query param. No WebAuthn ceremony wiring yet — that's slice 9r.2.

## What changed

- **`crates/web/Cargo.toml`**: `web-sys` with `Window` + `Location` + `UrlSearchParams` features (narrow-gated to keep WASM lean).
- **`<Login/>` component** (replaces slice-9q placeholder in `<Main/>`):
  - sign-in mode (no token): passkey-only sign-in, no fields
  - pair mode (`?setup_token=...`): device-name field + "Pair with passkey" CTA
  - `data-mode` attribute on `<section id="kat-login">` for selector + future-styling hooks
- **CSS**: centered form layout, accent CTA. Vanilla, no new tokens.
- **e2e**: 2 new tests covering both modes; existing shell test updated.

## Why no `leptos_router`

One query-param read doesn't justify a router crate. `web_sys::UrlSearchParams` is ~10 lines and zero router state.

## Verified

```
cd crates/web && trunk build --release
KATULONG_BASE_URL=http://127.0.0.1:3064 npx playwright test --config=playwright.rust.config.js
# 5 passed (3 inherited + 2 new login-mode tests)
```

## Test plan

- [x] Trunk build clean
- [x] 5 e2e tests pass against locally-launched binary
- [x] No backend changes