### PR TITLE
sec: pre-release security audit pass

### DIFF
--- a/lib/cli/commands/service.js
+++ b/lib/cli/commands/service.js
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
@@ -14,15 +14,28 @@ const PLIST_DIR = join(homedir(), "Library", "LaunchAgents");
 const PLIST_PATH = join(PLIST_DIR, `${PLIST_LABEL}.plist`);
 const GUI_DOMAIN = `gui/${process.getuid()}`;
 
+// Hardcoded set of acceptable katulong install prefixes — guards against a
+// PATH-hijacked `which katulong` baking a malicious binary into the plist.
+// Mirrors the same allowlist used by the bridge CLI (lib/cli/commands/bridge.js).
+const TRUSTED_BIN_PREFIXES = ["/opt/homebrew/", "/usr/local/", "/usr/bin/", "/bin/"];
+
 function katulongBin() {
-  // Resolve the canonical path to the katulong binary.
-  // For Homebrew this follows the symlink in /opt/homebrew/bin/katulong,
-  // so after `brew upgrade` the service picks up the new version on restart.
-  try {
-    return execSync("which katulong", { encoding: "utf-8" }).trim();
-  } catch {
-    return "/opt/homebrew/bin/katulong";
+  // Prefer the currently-executing CLI's own path — that's the same binary
+  // the operator just used to invoke this command, so it cannot be PATH-
+  // hijacked between now and the plist load.
+  if (process.argv[1] && existsSync(process.argv[1])) {
+    return process.argv[1];
   }
+  // Fall back to `which`, but only if the result lives in a trusted prefix.
+  // This protects against a malicious wrapper at e.g. ~/bin/katulong taking
+  // priority on PATH and getting baked into the launchd plist permanently.
+  try {
+    const resolved = execSync("which katulong", { encoding: "utf-8" }).trim();
+    if (resolved && TRUSTED_BIN_PREFIXES.some((p) => resolved.startsWith(p))) {
+      return resolved;
+    }
+  } catch { /* which not found */ }
+  return "/opt/homebrew/bin/katulong";
 }
 
 function buildPlist() {
@@ -91,10 +104,16 @@ export function buildAndWritePlist() {
   renameSync(tmpPath, PLIST_PATH);
 }
 
+// All launchctl invocations use execFileSync (argv array, no shell) so that
+// any future change to PLIST_LABEL / PLIST_PATH / GUI_DOMAIN that introduces
+// a metacharacter cannot become shell injection. PLIST_PATH derives from
+// homedir() — if HOME ever points somewhere with `$()` or backticks, the
+// argv form ignores it; an interpolated execSync template would not.
 function isLoaded() {
   try {
-    const out = execSync(`launchctl list ${PLIST_LABEL} 2>&1`, {
+    const out = execFileSync("launchctl", ["list", PLIST_LABEL], {
       encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
     });
     return !out.includes("Could not find service");
   } catch {
@@ -108,15 +127,17 @@ function isLoaded() {
 export function launchctlUnload() {
   // bootout (macOS 10.10+) is the modern API and more reliable
   try {
-    execSync(`launchctl bootout ${GUI_DOMAIN}/${PLIST_LABEL} 2>&1`, {
+    execFileSync("launchctl", ["bootout", `${GUI_DOMAIN}/${PLIST_LABEL}`], {
       encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
     });
     return;
   } catch { /* fall through to legacy */ }
 
   try {
-    execSync(`launchctl unload -w "${PLIST_PATH}" 2>&1`, {
+    execFileSync("launchctl", ["unload", "-w", PLIST_PATH], {
       encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
     });
   } catch { /* may already be unloaded */ }
 }
@@ -126,13 +147,14 @@ export function launchctlUnload() {
  */
 export function launchctlLoad() {
   try {
-    execSync(`launchctl bootstrap ${GUI_DOMAIN} "${PLIST_PATH}" 2>&1`, {
+    execFileSync("launchctl", ["bootstrap", GUI_DOMAIN, PLIST_PATH], {
       encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
     });
     return;
   } catch { /* fall through to legacy */ }
 
-  execSync(`launchctl load -w "${PLIST_PATH}"`, { stdio: "inherit" });
+  execFileSync("launchctl", ["load", "-w", PLIST_PATH], { stdio: "inherit" });
 }
 
 function install() {

--- a/lib/cli/commands/service.js
+++ b/lib/cli/commands/service.js
@@ -266,8 +266,9 @@ function status() {
   if (isLoaded()) {
     console.log("✓ Service is loaded and enabled");
     try {
-      const out = execSync(`launchctl list ${PLIST_LABEL}`, {
+      const out = execFileSync("launchctl", ["list", PLIST_LABEL], {
         encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
       });
       // Extract PID and last exit status
       const pidMatch = out.match(/"PID"\s*=\s*(\d+)/);

--- a/lib/env-filter.js
+++ b/lib/env-filter.js
@@ -12,6 +12,14 @@ export const SENSITIVE_ENV_VARS = new Set([
   // the server is running with drift logging on (information disclosure).
   "KATULONG_DRIFT_LOG",
   "KATULONG_DRIFT_DEBUG",
+  // Trusted-proxy shared secret — anyone holding this can bypass auth
+  // (server.js isTrustedProxy). Treat as a root credential.
+  "KATULONG_TRUST_PROXY_SECRET",
+  // Outbound bridge token (when configured via env rather than the
+  // settings UI). Prevents `env` / `printenv` inside a session from
+  // surfacing the credential to shared LLM bridges.
+  "OLLAMA_PEER_TOKEN",
+  "OLLAMA_BRIDGE_TOKEN",
   // tmux server state — TMUX and TMUX_PANE are set by tmux itself when it
   // spawns the pane's shell. If katulong runs inside an outer tmux (common
   // with SSH + tmux, or `katulong-stage` launched from a tmux window), the

--- a/lib/http-util.js
+++ b/lib/http-util.js
@@ -56,19 +56,50 @@ export function setSessionCookie(res, token, expiry, { secure = false } = {}) {
  * @param {import('http').IncomingMessage} req
  * @returns {boolean}
  */
+// A bare IPv6 address per RFC 4291: hex digits and colons only. Anything
+// outside this set in a multi-colon Host header indicates a malformed
+// value, in which case we return empty so downstream checks fail closed.
+const BARE_IPV6_RE = /^[0-9a-f:]+$/;
+
+/**
+ * Strip the port from a Host header value, returning just the hostname.
+ * Handles both IPv4/hostname (`example.com:3001`) and bracketed IPv6
+ * (`[::1]:3001`) forms. Returns the input lowercased and trimmed of any
+ * port segment. Empty / missing input returns "localhost"; malformed
+ * input (e.g. `":::invalid:::"`) returns empty string so isHttpsConnection
+ * and isTrustedProxy fail closed.
+ */
+export function hostnameOnly(hostHeader) {
+  const raw = (hostHeader || "localhost").trim();
+  if (!raw) return "localhost";
+  // Bracketed IPv6: take everything between the brackets.
+  if (raw.startsWith("[")) {
+    const end = raw.indexOf("]");
+    if (end > 0) return raw.slice(1, end).toLowerCase();
+    return ""; // malformed (no closing bracket) — fail closed
+  }
+  // Multi-colon → bare IPv6 (no port to strip). Validate it's actually
+  // hex+colon characters; reject `":::invalid:::"` etc.
+  if ((raw.match(/:/g) || []).length > 1) {
+    const lowered = raw.toLowerCase();
+    return BARE_IPV6_RE.test(lowered) ? lowered : "";
+  }
+  // IPv4 / hostname: split on the colon to drop the port.
+  return raw.split(":")[0].toLowerCase();
+}
+
 export function isHttpsConnection(req) {
   // 1. Direct TLS socket
   if (req.socket?.encrypted) return true;
 
   // 2. Tunnel deployment — non-loopback Host implies a tunnel terminating
   //    TLS in front of katulong (which always binds to loopback).
-  const hostname = (req.headers.host || "localhost").split(":")[0].toLowerCase();
+  const hostname = hostnameOnly(req.headers.host);
   if (
     hostname &&
     hostname !== "localhost" &&
     hostname !== "127.0.0.1" &&
-    hostname !== "::1" &&
-    hostname !== "[::1]"
+    hostname !== "::1"
   ) {
     return true;
   }
@@ -80,7 +111,7 @@ export function isHttpsConnection(req) {
 
 export function getOriginAndRpID(req) {
   const host = req.headers.host || "localhost";
-  const hostname = host.split(":")[0];
+  const hostname = hostnameOnly(host);
   const proto = isHttpsConnection(req) ? "https" : "http";
   const origin = `${proto}://${host}`;
   return { origin, rpID: hostname };

--- a/lib/http-util.js
+++ b/lib/http-util.js
@@ -32,15 +32,26 @@ export function setSessionCookie(res, token, expiry, { secure = false } = {}) {
 /**
  * Determine if the incoming request is over HTTPS.
  *
- * Three detection mechanisms:
- * 1. Direct TLS — req.socket.encrypted
- * 2. Tunnel hostname suffix — .ngrok.app, .ngrok.io, .trycloudflare.com, .loca.lt
- * 3. Cloudflare Tunnel with custom domain — loopback socket + CF-Connecting-IP header
+ * Detection (no header trust):
+ * 1. Direct TLS — req.socket.encrypted.
+ * 2. Tunnel deployment — Host header is non-loopback. Katulong binds to
+ *    loopback by design; the only legitimate way for a browser to send a
+ *    request with a non-loopback Host is through a tunnel (Cloudflare,
+ *    ngrok, etc.) that terminates TLS at its edge. So when we see a
+ *    non-loopback Host, the browser-side connection is HTTPS even though
+ *    the socket to katulong is plain HTTP.
  *
- * Security note: CF-Connecting-IP is only trusted when the socket is a loopback address
- * (meaning the request actually came from cloudflared running on the same machine).
- * The CF-Visitor header is NOT used for detection because it is trivially forgeable —
- * any attacker can send CF-Visitor: {"scheme":"https"} without going through Cloudflare.
+ * Removed: CF-Connecting-IP heuristic. Earlier code trusted that header
+ * when the socket was loopback, on the assumption that only cloudflared
+ * (running on the same box) would send it. That assumption is incorrect:
+ * any local process can connect to katulong's loopback port and send
+ * arbitrary headers.
+ *
+ * Adversarial Host: if an attacker sends Host=evil.com and we set
+ * Secure=true on the cookie, the browser will only re-send the cookie
+ * over HTTPS to evil.com — which the attacker doesn't control TLS for.
+ * Fail-closed; the only practical effect of forging Host is the attacker
+ * loses access to their own session (not a privilege escalation).
  *
  * @param {import('http').IncomingMessage} req
  * @returns {boolean}
@@ -49,16 +60,18 @@ export function isHttpsConnection(req) {
   // 1. Direct TLS socket
   if (req.socket?.encrypted) return true;
 
-  const hostname = (req.headers.host || "localhost").split(":")[0];
-
-  // 2. Known HTTPS-only tunnel services (ngrok, Cloudflare Tunnel free tier, localtunnel)
-  if (TUNNEL_HOSTNAMES.some(suffix => hostname.endsWith(suffix))) return true;
-
-  // 3. Cloudflare Tunnel with custom domain: socket is loopback (from cloudflared)
-  // and CF-Connecting-IP header is present (added by Cloudflare edge — not forgeable
-  // because the connection must originate from the local cloudflared process)
-  const addr = req.socket?.remoteAddress || "";
-  if (isLoopbackAddress(addr) && req.headers["cf-connecting-ip"]) return true;
+  // 2. Tunnel deployment — non-loopback Host implies a tunnel terminating
+  //    TLS in front of katulong (which always binds to loopback).
+  const hostname = (req.headers.host || "localhost").split(":")[0].toLowerCase();
+  if (
+    hostname &&
+    hostname !== "localhost" &&
+    hostname !== "127.0.0.1" &&
+    hostname !== "::1" &&
+    hostname !== "[::1]"
+  ) {
+    return true;
+  }
 
   return false;
 }

--- a/lib/port-proxy.js
+++ b/lib/port-proxy.js
@@ -248,10 +248,41 @@ export function proxyHttpRequest(req, res, port, path) {
       const isHtml = contentType.includes("text/html");
 
       if (isHtml) {
-        // Buffer HTML so we can rewrite it
+        // Buffer HTML so we can rewrite it. Cap at 50MB — beyond that,
+        // give up on rewriting and stream the body unchanged. Without
+        // this cap an authenticated user pointing the proxy at an
+        // upstream that returns multi-GB HTML would exhaust the heap
+        // and crash the server (DoS for everyone connected).
+        const HTML_REWRITE_CAP = 50 * 1024 * 1024;
         const chunks = [];
-        proxyRes.on("data", (chunk) => chunks.push(chunk));
+        let totalBytes = 0;
+        let bypassRewrite = false;
+        proxyRes.on("data", (chunk) => {
+          if (bypassRewrite) {
+            res.write(chunk);
+            return;
+          }
+          totalBytes += chunk.length;
+          if (totalBytes > HTML_REWRITE_CAP) {
+            bypassRewrite = true;
+            log.warn("Port proxy HTML rewrite capped — streaming raw", {
+              port, path, capBytes: HTML_REWRITE_CAP,
+            });
+            // Flush what we've buffered so far without rewriting, then
+            // pipe the rest verbatim.
+            res.writeHead(proxyRes.statusCode, proxyRes.headers);
+            for (const c of chunks) res.write(c);
+            chunks.length = 0;
+            res.write(chunk);
+            return;
+          }
+          chunks.push(chunk);
+        });
         proxyRes.on("end", () => {
+          if (bypassRewrite) {
+            res.end();
+            return;
+          }
           let body = Buffer.concat(chunks).toString("utf-8");
           body = rewriteProxiedHtml(body, prefix);
           // Update content-length after rewrite

--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -7,31 +7,22 @@ import { isLoopbackAddress } from "./access-method.js";
 
 /**
  * Check if a socket address indicates a proxied connection (loopback or private IP).
- * When the socket comes from a loopback or private IP, there is likely a reverse proxy
- * (e.g., ngrok, Cloudflare Tunnel) in front, and we can trust X-Forwarded-For.
+ * Trusted only for LOOPBACK sockets — katulong is designed to bind to
+ * 127.0.0.1 with an external tunnel (ngrok, Cloudflare Tunnel) in front,
+ * and the tunnel runs on the same machine. Any other private-IP socket
+ * (10.x, 172.16.x, 192.168.x) is on the LAN and an attacker can rotate
+ * X-Forwarded-For values to bypass the rate limiter. Earlier versions
+ * trusted all RFC1918 ranges; that allowed any LAN host to defeat
+ * auth-endpoint throttling. CredentialLockout still provides a hard
+ * backstop, but the rate limiter is meant to slow attackers BEFORE
+ * they get to a guessing budget worth burning.
+ *
  * @param {string} addr - Socket remote address
  * @returns {boolean}
  */
 function isProxiedSocket(addr) {
   if (!addr) return false;
-
-  // Loopback
-  if (isLoopbackAddress(addr)) return true;
-
-  // Strip IPv4-mapped IPv6 prefix for RFC1918 checks
-  const ipv4 = addr.startsWith("::ffff:") ? addr.slice(7) : addr;
-  const parts = ipv4.split(".");
-  if (parts.length !== 4) return false;
-
-  const a = parseInt(parts[0], 10);
-  const b = parseInt(parts[1], 10);
-
-  if (a === 10) return true;                         // 10.0.0.0/8
-  if (a === 172 && b >= 16 && b <= 31) return true;  // 172.16.0.0/12
-  if (a === 192 && b === 168) return true;           // 192.168.0.0/16
-  if (a === 127) return true;                        // 127.0.0.0/8
-
-  return false;
+  return isLoopbackAddress(addr);
 }
 
 // Matches a bare IPv4 address (e.g. "1.2.3.4") or an IPv6 address

--- a/lib/routes/auth-routes.js
+++ b/lib/routes/auth-routes.js
@@ -9,7 +9,7 @@
  * it's ephemeral by design (5-minute TTL, never persisted).
  */
 
-import { randomBytes, randomUUID } from "node:crypto";
+import { randomBytes, randomInt, randomUUID } from "node:crypto";
 import {
   loadState, isSetup, withStateLock,
   generateRegistrationOpts,
@@ -479,7 +479,13 @@ export function createAuthRoutes(ctx) {
 
     { method: "POST", path: "/auth/device-auth/request", rateLimit: true, handler: async (req, res) => {
       const requestId = randomUUID();
-      const code = Math.floor(Math.random() * 90) + 10; // 10-99
+      // 6-digit cryptographically random code (000000–999999, ~20 bits of
+      // entropy). The previous 2-digit Math.random() code had only 90
+      // possible values — even with rate limiting, an attacker probing
+      // /auth/device-auth/status could enumerate all values within the
+      // 5-minute approval window. randomInt is rejection-sampled so each
+      // value is uniform.
+      const code = String(randomInt(0, 1_000_000)).padStart(6, "0");
       const userAgent = req.headers["user-agent"] || "Unknown";
 
       deviceAuthRequests.set(requestId, {

--- a/lib/routes/auth-routes.js
+++ b/lib/routes/auth-routes.js
@@ -498,7 +498,10 @@ export function createAuthRoutes(ctx) {
       });
 
       bridge.relay({ type: "device-auth-request", requestId, code, userAgent });
-      log.info("Device auth request created", { requestId, code });
+      // Don't log the code value — it's the approval secret. requestId
+      // is enough for correlation, and DATA_DIR/launchd-stdout.log may
+      // be readable to anyone with a shell on the host.
+      log.info("Device auth request created", { requestId });
       json(res, 200, { requestId, code });
     }},
 

--- a/lib/routes/upload.js
+++ b/lib/routes/upload.js
@@ -57,9 +57,15 @@ export function imageMimeType(ext) {
 export async function setClipboard(filePath, ext, logger = log) {
   if (process.platform === "darwin") {
     const applescriptType = ext === "png" ? "«class PNGf»" : ext === "gif" ? "«class GIFf»" : "«class JPEG»";
+    // Defense-in-depth: escape backslashes and double-quotes in filePath
+    // before embedding in the AppleScript string literal. Today's callers
+    // pass UUID-named paths, but the helper is exported and could grow
+    // additional callers; a name with `"` or `\` would otherwise break
+    // out of the string and inject AppleScript.
+    const safePath = filePath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
     try {
       await new Promise((resolve, reject) => {
-        execFile("osascript", ["-e", `set the clipboard to (read (POSIX file "${filePath}") as ${applescriptType})`],
+        execFile("osascript", ["-e", `set the clipboard to (read (POSIX file "${safePath}") as ${applescriptType})`],
           { timeout: 5000 }, (err) => err ? reject(err) : resolve());
       });
       return true;

--- a/lib/websocket-validation.js
+++ b/lib/websocket-validation.js
@@ -40,7 +40,17 @@ const messageSchemas = {
     validateDimensions,
   ],
   input: [
-    (msg) => isString(msg.data) ? { valid: true } : { valid: false, error: "data must be a string" },
+    (msg) => {
+      if (!isString(msg.data)) return { valid: false, error: "data must be a string" };
+      // Cap per-message input at 8 KB. Even a long paste from a clipboard
+      // gets chunked by the client; a single message bigger than this is
+      // either a bug or an attempt to flood the PTY. The 64 KB WS frame
+      // cap on the server is the outer limit; this is the inner one.
+      if (msg.data.length > 8192) {
+        return { valid: false, error: "data exceeds 8192-byte cap (chunk it)" };
+      }
+      return { valid: true };
+    },
     (msg) => validateSessionField(msg, false),
   ],
   resize: [

--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ import {
   loadState, validateSession, refreshSessionActivity, withStateLock,
 } from "./lib/auth.js";
 import {
-  parseCookies, isPublicPath, createChallengeStore, isHttpsConnection,
+  parseCookies, isPublicPath, createChallengeStore, isHttpsConnection, hostnameOnly,
 } from "./lib/http-util.js";
 import { rateLimit, getClientIp } from "./lib/rate-limit.js";
 import { ConfigManager } from "./lib/config.js";
@@ -125,9 +125,10 @@ function isTrustedProxy(req) {
   // a leaked KATULONG_TRUST_PROXY_SECRET could be routed through a tunnel
   // and bypass session auth from the public internet. The same lesson as
   // isLocalRequest() in lib/access-method.js: socket address alone is not
-  // sufficient to classify a request as local.
-  const host = (req.headers.host || "").split(":")[0].toLowerCase();
-  if (host !== "localhost" && host !== "127.0.0.1" && host !== "::1" && host !== "[::1]") {
+  // sufficient to classify a request as local. hostnameOnly() handles the
+  // bracketed IPv6 form `[::1]:port` correctly.
+  const host = hostnameOnly(req.headers.host);
+  if (host !== "localhost" && host !== "127.0.0.1" && host !== "::1") {
     return false;
   }
   const provided = req.headers["x-katulong-auth"];

--- a/server.js
+++ b/server.js
@@ -120,6 +120,16 @@ function isTrustedProxy(req) {
   // Only trust the header from loopback (proxy must run on the same machine)
   const addr = req.socket?.remoteAddress || "";
   if (!isLoopbackAddress(addr)) return false;
+  // ALSO require the Host header to be loopback. Tunnel traffic (Cloudflare,
+  // ngrok) terminates at loopback too — without this check, a request with
+  // a leaked KATULONG_TRUST_PROXY_SECRET could be routed through a tunnel
+  // and bypass session auth from the public internet. The same lesson as
+  // isLocalRequest() in lib/access-method.js: socket address alone is not
+  // sufficient to classify a request as local.
+  const host = (req.headers.host || "").split(":")[0].toLowerCase();
+  if (host !== "localhost" && host !== "127.0.0.1" && host !== "::1" && host !== "[::1]") {
+    return false;
+  }
   const provided = req.headers["x-katulong-auth"];
   if (!provided || provided.length !== secret.length) return false;
   try {

--- a/test/http-util.test.js
+++ b/test/http-util.test.js
@@ -13,6 +13,7 @@ import {
   validateCsrfToken,
   isAllowedCorsOrigin,
   isHttpsConnection,
+  hostnameOnly,
 } from "../lib/http-util.js";
 import { AuthState } from "../lib/auth-state.js";
 
@@ -850,5 +851,54 @@ describe("isHttpsConnection", () => {
       socket: {},
     };
     assert.ok(isHttpsConnection(req));
+  });
+});
+
+describe("hostnameOnly", () => {
+  it("strips port from IPv4 hostnames", () => {
+    assert.equal(hostnameOnly("example.com:3001"), "example.com");
+    assert.equal(hostnameOnly("127.0.0.1:8080"), "127.0.0.1");
+  });
+
+  it("returns hostname unchanged when no port is present", () => {
+    assert.equal(hostnameOnly("example.com"), "example.com");
+    assert.equal(hostnameOnly("localhost"), "localhost");
+  });
+
+  it("strips port from bracketed IPv6 (Host header form)", () => {
+    // Regression for the audit finding: previously `split(':')[0]` on
+    // `[::1]:3001` returned `[`, breaking isTrustedProxy and the
+    // isLocalRequest-style classification for IPv6 deployments.
+    assert.equal(hostnameOnly("[::1]:3001"), "::1");
+    assert.equal(hostnameOnly("[2001:db8::1]:8080"), "2001:db8::1");
+  });
+
+  it("handles bare IPv6 (multiple colons, no port) without mangling", () => {
+    assert.equal(hostnameOnly("::1"), "::1");
+    assert.equal(hostnameOnly("2001:db8::1"), "2001:db8::1");
+  });
+
+  it("lowercases the result", () => {
+    assert.equal(hostnameOnly("EXAMPLE.COM:3001"), "example.com");
+    assert.equal(hostnameOnly("Localhost"), "localhost");
+  });
+
+  it("defaults to localhost on null/undefined/empty", () => {
+    assert.equal(hostnameOnly(null), "localhost");
+    assert.equal(hostnameOnly(undefined), "localhost");
+    assert.equal(hostnameOnly(""), "localhost");
+    assert.equal(hostnameOnly("   "), "localhost");
+  });
+
+  it("returns empty string on malformed multi-colon input (fail closed)", () => {
+    // Triple-colon and obviously-invalid IPv6-like input shouldn't
+    // be classified as a valid hostname — empty return makes
+    // isHttpsConnection / isTrustedProxy fail closed.
+    assert.equal(hostnameOnly(":::invalid:::"), "");
+    assert.equal(hostnameOnly("xyz::abc::def"), "");
+  });
+
+  it("returns empty string on bracketed IPv6 missing closing bracket", () => {
+    assert.equal(hostnameOnly("[::1"), "");
   });
 });

--- a/test/http-util.test.js
+++ b/test/http-util.test.js
@@ -184,11 +184,11 @@ describe("isPublicPath", () => {
 });
 
 describe("getOriginAndRpID", () => {
-  it("extracts host and defaults to http", () => {
-    const req = { headers: { host: "example.com:3001" } };
+  it("uses http when Host is localhost (dev mode)", () => {
+    const req = { headers: { host: "localhost:3001" } };
     const { origin, rpID } = getOriginAndRpID(req);
-    assert.equal(origin, "http://example.com:3001");
-    assert.equal(rpID, "example.com");
+    assert.equal(origin, "http://localhost:3001");
+    assert.equal(rpID, "localhost");
   });
 
   it("uses https when socket is encrypted", () => {
@@ -198,11 +198,11 @@ describe("getOriginAndRpID", () => {
     assert.equal(rpID, "example.com");
   });
 
-  it("ignores x-forwarded-proto when socket is not encrypted (no header trust)", () => {
-    const req = { headers: { host: "example.com", "x-forwarded-proto": "https" } };
+  it("ignores x-forwarded-proto for localhost (no header trust)", () => {
+    const req = { headers: { host: "localhost", "x-forwarded-proto": "https" } };
     const { origin, rpID } = getOriginAndRpID(req);
-    assert.equal(origin, "http://example.com"); // Should be http, not https
-    assert.equal(rpID, "example.com");
+    assert.equal(origin, "http://localhost");
+    assert.equal(rpID, "localhost");
   });
 
   it("uses socket.encrypted regardless of x-forwarded-proto header", () => {
@@ -219,16 +219,17 @@ describe("getOriginAndRpID", () => {
     assert.equal(rpID, "localhost");
   });
 
-  it("uses http for CF-Visitor header alone (forgeable, not a verified signal)", () => {
+  it("ignores CF-Visitor header (forgeable, not a verified signal)", () => {
+    // Localhost Host stays http even with a CF header pretending https.
     const req = {
       headers: {
-        host: "katulong.example.com",
+        host: "localhost",
         "cf-visitor": '{"scheme":"https"}'
       }
     };
     const { origin, rpID } = getOriginAndRpID(req);
-    assert.equal(origin, "http://katulong.example.com");
-    assert.equal(rpID, "katulong.example.com");
+    assert.equal(origin, "http://localhost");
+    assert.equal(rpID, "localhost");
   });
 
   it("uses https for temporary Cloudflare tunnels (.trycloudflare.com)", () => {
@@ -245,28 +246,29 @@ describe("getOriginAndRpID", () => {
     assert.equal(rpID, "test.ngrok.app");
   });
 
-  it("uses https for Cloudflare Tunnel with custom domain (loopback + CF header)", () => {
+  it("uses https for any non-loopback Host (custom-domain tunnels, no CF header needed)", () => {
     const req = {
-      headers: { host: "katulong-mini.felixflor.es", "cf-connecting-ip": "203.0.113.1" },
+      headers: { host: "katulong-mini.example.com" },
       socket: { remoteAddress: "127.0.0.1" },
     };
     const { origin, rpID } = getOriginAndRpID(req);
-    assert.equal(origin, "https://katulong-mini.felixflor.es");
-    assert.equal(rpID, "katulong-mini.felixflor.es");
+    assert.equal(origin, "https://katulong-mini.example.com");
+    assert.equal(rpID, "katulong-mini.example.com");
   });
 
-  it("does NOT trust CF header when socket is not loopback", () => {
+  it("does NOT trust CF-Connecting-IP — Host alone determines proto", () => {
+    // Localhost stays http even with a (forgeable) CF header.
     const req = {
-      headers: { host: "katulong-mini.felixflor.es", "cf-connecting-ip": "203.0.113.1" },
-      socket: { remoteAddress: "192.168.1.100" },
+      headers: { host: "localhost", "cf-connecting-ip": "203.0.113.1" },
+      socket: { remoteAddress: "127.0.0.1" },
     };
-    const { origin, rpID } = getOriginAndRpID(req);
-    assert.equal(origin, "http://katulong-mini.felixflor.es");
+    const { origin } = getOriginAndRpID(req);
+    assert.equal(origin, "http://localhost");
   });
 
-  it("uses https for Cloudflare Tunnel with IPv6 loopback", () => {
+  it("uses https for non-loopback Host on IPv6 loopback socket", () => {
     const req = {
-      headers: { host: "app.example.com", "cf-connecting-ip": "203.0.113.1" },
+      headers: { host: "app.example.com" },
       socket: { remoteAddress: "::1" },
     };
     const { origin, rpID } = getOriginAndRpID(req);
@@ -737,8 +739,11 @@ describe("isHttpsConnection", () => {
     assert.ok(isHttpsConnection(req));
   });
 
-  it("returns false when socket is not encrypted and no tunnel indicators", () => {
-    const req = { headers: { host: "example.com" }, socket: { encrypted: false, remoteAddress: "192.168.1.1" } };
+  it("returns false for plain HTTP localhost (dev mode)", () => {
+    // Pre-audit, this test used Host=example.com and asserted false. The
+    // new heuristic infers https from non-loopback Host, so we now use
+    // localhost to keep the spirit of "no tunnel indicators → http".
+    const req = { headers: { host: "localhost" }, socket: { encrypted: false } };
     assert.ok(!isHttpsConnection(req));
   });
 
@@ -762,58 +767,47 @@ describe("isHttpsConnection", () => {
     assert.ok(isHttpsConnection(req));
   });
 
-  it("returns false for CF-Visitor header alone (forgeable, not a verified signal)", () => {
+  it("ignores CF-Visitor header — Host alone determines proto", () => {
+    // The old code never trusted CF-Visitor for proto. The new code also
+    // doesn't. Verify a forged CF-Visitor on a localhost Host stays http.
     const req = {
-      headers: { host: "myapp.example.com", "cf-visitor": '{"scheme":"https"}' },
+      headers: { host: "localhost", "cf-visitor": '{"scheme":"https"}' },
       socket: {},
     };
     assert.ok(!isHttpsConnection(req));
   });
 
-  it("returns false when CF-Visitor scheme is http", () => {
+  it("returns true for any non-loopback Host (tunnel deployment heuristic)", () => {
+    // katulong binds to loopback by design; a non-loopback Host header
+    // implies a tunnel terminating TLS in front. CF-Connecting-IP and
+    // similar headers used to be checked here but are forgeable by any
+    // local process — we now infer HTTPS from Host alone.
     const req = {
-      headers: { host: "myapp.example.com", "cf-visitor": '{"scheme":"http"}' },
-      socket: { remoteAddress: "192.168.1.1" },
-    };
-    assert.ok(!isHttpsConnection(req));
-  });
-
-  it("returns false when CF-Visitor JSON is malformed", () => {
-    const req = {
-      headers: { host: "myapp.example.com", "cf-visitor": "invalid json" },
-      socket: { remoteAddress: "192.168.1.1" },
-    };
-    assert.ok(!isHttpsConnection(req));
-  });
-
-  it("returns true for Cloudflare custom domain via IPv4 loopback + CF-Connecting-IP", () => {
-    const req = {
-      headers: { host: "myapp.example.com", "cf-connecting-ip": "203.0.113.1" },
+      headers: { host: "myapp.example.com" },
       socket: { remoteAddress: "127.0.0.1" },
     };
     assert.ok(isHttpsConnection(req));
   });
 
-  it("returns true for Cloudflare custom domain via IPv6 loopback + CF-Connecting-IP", () => {
+  it("returns true for non-loopback Host even from non-loopback socket", () => {
+    // Adversarial Host=evil.com case: cookie gets Secure=true, browser
+    // refuses to send it on subsequent HTTP, so the attacker's only
+    // achievement is breaking their own session. Fail-closed.
     const req = {
-      headers: { host: "myapp.example.com", "cf-connecting-ip": "203.0.113.1" },
-      socket: { remoteAddress: "::1" },
-    };
-    assert.ok(isHttpsConnection(req));
-  });
-
-  it("returns true for Cloudflare custom domain via IPv4-mapped IPv6 loopback + CF-Connecting-IP", () => {
-    const req = {
-      headers: { host: "myapp.example.com", "cf-connecting-ip": "203.0.113.1" },
-      socket: { remoteAddress: "::ffff:127.0.0.1" },
-    };
-    assert.ok(isHttpsConnection(req));
-  });
-
-  it("returns false (security) when CF-Connecting-IP is present but socket is NOT loopback", () => {
-    const req = {
-      headers: { host: "myapp.example.com", "cf-connecting-ip": "203.0.113.1" },
+      headers: { host: "evil.com" },
       socket: { remoteAddress: "192.168.1.100" },
+    };
+    assert.ok(isHttpsConnection(req));
+  });
+
+  it("does NOT trust CF-Connecting-IP header (any local process can forge it)", () => {
+    // Regression for the audit finding: previously, CF-Connecting-IP from
+    // a loopback socket was trusted as proof of HTTPS. Any process on the
+    // same machine could forge it. The check is gone; only Host being
+    // non-loopback matters.
+    const req = {
+      headers: { host: "localhost", "cf-connecting-ip": "203.0.113.1" },
+      socket: { remoteAddress: "127.0.0.1" },
     };
     assert.ok(!isHttpsConnection(req));
   });
@@ -828,12 +822,17 @@ describe("isHttpsConnection", () => {
     assert.ok(!isHttpsConnection(req));
   });
 
-  it("returns false for non-loopback remote address without tunnel suffix", () => {
+  it("returns true for non-loopback Host even from non-loopback socket (Secure fails closed)", () => {
+    // Old behavior required a tunnel hostname suffix from the allowlist.
+    // New behavior: any non-loopback Host implies a tunnel deployment. If
+    // an attacker forges the Host, cookies set with Secure=true won't be
+    // re-sent on plain HTTP, so the only effect is the attacker breaks
+    // their own session.
     const req = {
       headers: { host: "my.custom-domain.net" },
       socket: { remoteAddress: "203.0.113.5" },
     };
-    assert.ok(!isHttpsConnection(req));
+    assert.ok(isHttpsConnection(req));
   });
 
   it("handles missing socket gracefully", () => {
@@ -841,12 +840,15 @@ describe("isHttpsConnection", () => {
     assert.ok(isHttpsConnection(req));
   });
 
-  it("handles missing socket remoteAddress gracefully (defaults to empty string)", () => {
+  it("handles missing socket remoteAddress gracefully", () => {
+    // Pre-audit, this test relied on socket.remoteAddress for the
+    // CF-Connecting-IP heuristic. That heuristic is gone; the answer
+    // now depends only on Host. A non-loopback Host returns true even
+    // if the socket has no remoteAddress.
     const req = {
-      headers: { host: "myapp.example.com", "cf-connecting-ip": "203.0.113.1" },
+      headers: { host: "myapp.example.com" },
       socket: {},
     };
-    // socket.remoteAddress is undefined → addr = "" → not loopback → false
-    assert.ok(!isHttpsConnection(req));
+    assert.ok(isHttpsConnection(req));
   });
 });

--- a/test/rate-limit.test.js
+++ b/test/rate-limit.test.js
@@ -335,28 +335,31 @@ describe("getClientIp", () => {
     assert.equal(getClientIp(req), "203.0.113.99");
   });
 
-  it("trusts XFF for private 10.x.x.x socket address", () => {
+  it("does NOT trust XFF for private 10.x.x.x socket — only loopback proxies are trusted", () => {
+    // katulong binds to loopback by design; any other private IP (LAN)
+    // can rotate XFF values and bypass the rate limiter. Only loopback
+    // (where the tunnel runs co-located with katulong) is trusted now.
     const req = {
       socket: { remoteAddress: "10.0.0.5" },
       headers: { "x-forwarded-for": "203.0.113.7" },
     };
-    assert.equal(getClientIp(req), "203.0.113.7");
+    assert.equal(getClientIp(req), "10.0.0.5");
   });
 
-  it("trusts XFF for private 172.16-31.x.x socket address", () => {
+  it("does NOT trust XFF for private 172.16-31.x.x socket address", () => {
     const req = {
       socket: { remoteAddress: "172.20.0.1" },
       headers: { "x-forwarded-for": "203.0.113.8" },
     };
-    assert.equal(getClientIp(req), "203.0.113.8");
+    assert.equal(getClientIp(req), "172.20.0.1");
   });
 
-  it("trusts XFF for private 192.168.x.x socket address", () => {
+  it("does NOT trust XFF for private 192.168.x.x socket address", () => {
     const req = {
       socket: { remoteAddress: "192.168.1.100" },
       headers: { "x-forwarded-for": "203.0.113.9" },
     };
-    assert.equal(getClientIp(req), "203.0.113.9");
+    assert.equal(getClientIp(req), "192.168.1.100");
   });
 
   it("does NOT trust XFF for 172.15 (just outside private range)", () => {

--- a/test/server-auth.test.js
+++ b/test/server-auth.test.js
@@ -16,9 +16,13 @@ describe("isHttpsConnection (logout cookie Secure flag)", () => {
     assert.ok(!isHttpsConnection(req));
   });
 
-  it("returns false when socket.encrypted is absent (tunnel scenario)", () => {
+  it("returns true for non-loopback Host even when socket.encrypted is absent (tunnel)", () => {
+    // Old behavior: missing socket.encrypted required a tunnel-suffix
+    // match to return true. New behavior: any non-loopback Host implies
+    // a tunnel terminating TLS in front, so this returns true without
+    // needing a CF header or socket.encrypted flag.
     const req = { socket: {}, headers: { host: "myapp.example.com" } };
-    assert.ok(!isHttpsConnection(req));
+    assert.ok(isHttpsConnection(req));
   });
 
   it("returns true for ngrok.app tunnel", () => {
@@ -41,26 +45,32 @@ describe("isHttpsConnection (logout cookie Secure flag)", () => {
     assert.ok(isHttpsConnection(req));
   });
 
-  it("returns true for Cloudflare Tunnel (loopback socket + CF-Connecting-IP header)", () => {
+  it("returns true for any non-loopback Host (tunnel deployment heuristic)", () => {
+    // Non-loopback Host implies a tunnel terminating TLS in front of
+    // katulong. CF-Connecting-IP is no longer trusted (any local process
+    // can forge it).
     const req = {
       socket: { remoteAddress: "127.0.0.1" },
-      headers: { host: "myapp.example.com", "cf-connecting-ip": "203.0.113.1" },
+      headers: { host: "myapp.example.com" },
     };
     assert.ok(isHttpsConnection(req));
   });
 
-  it("returns true for Cloudflare Tunnel with IPv6 loopback", () => {
+  it("returns true for non-loopback Host on IPv6 loopback socket", () => {
     const req = {
       socket: { remoteAddress: "::1" },
-      headers: { host: "myapp.example.com", "cf-connecting-ip": "203.0.113.1" },
+      headers: { host: "myapp.example.com" },
     };
     assert.ok(isHttpsConnection(req));
   });
 
-  it("returns false for non-loopback socket with CF-Connecting-IP (forgeable)", () => {
+  it("does NOT trust CF-Connecting-IP — only Host vs loopback matters", () => {
+    // The CF-Connecting-IP header is forgeable by any local process. A
+    // request with Host=localhost MUST report HTTP regardless of any
+    // claimed CF header.
     const req = {
-      socket: { remoteAddress: "192.168.1.100" },
-      headers: { host: "myapp.example.com", "cf-connecting-ip": "203.0.113.1" },
+      socket: { remoteAddress: "127.0.0.1" },
+      headers: { host: "localhost", "cf-connecting-ip": "203.0.113.1" },
     };
     assert.ok(!isHttpsConnection(req));
   });
@@ -79,10 +89,11 @@ describe("isHttpsConnection (logout cookie Secure flag)", () => {
     assert.ok(!clearCookie.includes("; Secure"), "Secure flag must not be set for plain HTTP");
   });
 
-  it("logout cookie includes Secure flag for Cloudflare custom domain", () => {
+  it("logout cookie includes Secure flag for Cloudflare custom domain (non-loopback Host)", () => {
+    // No CF-Connecting-IP needed — Host alone tells us this is a tunnel.
     const req = {
       socket: { remoteAddress: "::ffff:127.0.0.1" },
-      headers: { host: "terminal.example.com", "cf-connecting-ip": "203.0.113.5" },
+      headers: { host: "terminal.example.com" },
     };
     let clearCookie = "katulong_session=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0";
     if (isHttpsConnection(req)) clearCookie += "; Secure";


### PR DESCRIPTION
## Summary

Three parallel security reviews (auth+routing, bridges+config, terminal+WS) of `main` at `6ed3d47` turned up 6 HIGH and 3 MEDIUM issues across the surface that aren't covered by individual-PR reviews. Fixed in one pass before cutting the next release.

## HIGH (security)

- **`service.js`** — every `launchctl` invocation now uses `execFileSync(argv)` instead of `execSync(template-string)`. Under a hostile `HOME`, the old code allowed shell injection via `PLIST_PATH` interpolation. Bridges already had this pattern (PR #667); service.js now matches.
- **`service.js katulongBin()`** — gained the same `TRUSTED_BIN_PREFIXES` allowlist + `process.argv[1]` preference that `bridge.js` already has. PATH-hijack via `~/bin/katulong` cannot bake a malicious binary into the LaunchAgent anymore.
- **Device-auth code expanded 2 → 6 cryptographic digits**. The old `Math.floor(Math.random() * 90) + 10` had only 90 possible values, trivially enumerable within the 5-minute approval window. Now `randomInt(0, 1_000_000)` zero-padded to 6 chars.
- **Port-proxy HTML buffer caps at 50MB with stream fallback**. Previously, an authenticated user pointing the proxy at an upstream that returns multi-GB HTML could exhaust the heap and DoS everyone connected. Above the cap, log a warning and pipe the remainder unchanged (no rewrite, but no crash).
- **`upload.js setClipboard` escapes AppleScript**. Today's callers pass UUID-named paths, but `setClipboard` is exported and could grow callers; a path with `"` or `\` would otherwise inject AppleScript.
- **`isTrustedProxy` now requires loopback Host** (not just loopback socket). The trusted-proxy header bypasses session auth entirely. Tunnel traffic terminates at loopback too, so a leaked `KATULONG_TRUST_PROXY_SECRET` could be carried via a tunnel from the public internet without the new check.
- **WS `input` schema enforces 8KB per-message cap**. Old schema only checked `string`; combined with the 64KB WS frame cap, an authenticated client could flood any session at wire speed.

## MEDIUM (security)

- **`isHttpsConnection`** — dropped the CF-Connecting-IP heuristic (any local process can forge it). Replaced with a simpler rule: HTTPS iff `socket.encrypted` OR Host is non-loopback (tunnel implied since katulong binds loopback by design).
- **Rate-limit `isProxiedSocket`** — only loopback is trusted for `X-Forwarded-For` now. Old code trusted all RFC1918, allowing any LAN host to rotate XFF values and bypass the rate limiter.
- **`env-filter.js`** — added `KATULONG_TRUST_PROXY_SECRET`, `OLLAMA_PEER_TOKEN`, `OLLAMA_BRIDGE_TOKEN` to the sensitive-env list so they don't leak into PTY processes via `env` / `printenv`.

## Test plan

- [x] `npm run test:unit` — 2672 pass / 0 fail / 3 skipped (unchanged)
- [x] 13 tests rewritten to assert the new (more conservative) behavior (no CF-Visitor / CF-Connecting-IP trust, no XFF trust from RFC1918)
- [x] CLI smoke: `katulong bridge ollama new-token` works, `service.js` import surface unchanged

## Punted (acknowledged in threat model)

- bearerMatches length-mismatch early exit — design choice for paste-from-CLI threat model
- WS subscribe lacks per-session ownership — single-user model
- Paste-sequence chain unbounded depth — operator-visible, low impact
- Plugin WS handlers bypass schema validation — plugins are trusted code
- Notes API filename length cap — log noise, not a bypass