### PR TITLE
rewrite(web): slice 9r.2 — sign-in WebAuthn ceremony wired to the API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,6 @@ dependencies = [
  "js-sys",
  "leptos",
  "serde",
- "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,8 +1073,15 @@ name = "katulong-web"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
+ "gloo-net",
+ "js-sys",
  "leptos",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
+ "webauthn-rs-proto",
 ]
 
 [[package]]
@@ -2736,6 +2743,8 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -2902,9 +2911,13 @@ checksum = "16a1fb2580ce73baa42d3011a24de2ceab0d428de1879ece06e02e8c416e497c"
 dependencies = [
  "base64 0.21.7",
  "base64urlsafedata",
+ "js-sys",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "url",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -46,5 +46,7 @@ wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 # JSON in/out at the HTTP boundary. The server speaks plain
 # JSON for auth (CBOR is session-layer only per slice 9d).
+# `gloo-net`'s `.json(...)` pulls in `serde_json` transitively;
+# we don't list it here because no code in this crate calls
+# `serde_json::` directly. If a future slice does, add it back.
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -11,9 +11,40 @@ path = "src/main.rs"
 [dependencies]
 leptos = { workspace = true }
 console_error_panic_hook = "0.1"
-# `web-sys` for the few browser globals we touch directly
-# (URL query parsing today; future slices will add WebAuthn,
-# fetch, WebSocket, navigation). Feature-gated narrowly to
-# keep the WASM bundle lean — only enable each interface when
-# a slice actually uses it.
-web-sys = { version = "0.3", features = ["Window", "Location", "UrlSearchParams"] }
+# `web-sys` for the few browser globals we touch directly.
+# Slice 9r.2 adds the WebAuthn surface (Navigator,
+# CredentialsContainer, CredentialRequestOptions,
+# PublicKeyCredential). Earlier slices added URL parsing.
+# Feature-gated narrowly to keep the WASM bundle lean.
+web-sys = { version = "0.3", features = [
+    "Window",
+    "Location",
+    "UrlSearchParams",
+    "Navigator",
+    "CredentialsContainer",
+    "CredentialRequestOptions",
+    "PublicKeyCredential",
+] }
+# WebAuthn wire types — the same types the Rust server
+# `webauthn_wire` re-exports. The `wasm` feature provides
+# `From<RequestChallengeResponse> for
+# web_sys::CredentialRequestOptions` and the reverse for
+# the assertion, so we don't hand-roll the binary
+# (challenge / rawId / signature) base64url ↔ Uint8Array
+# conversion.
+webauthn-rs-proto = { version = "0.5", features = ["wasm"] }
+# WASM-friendly fetch wrapper. `gloo-net` is the de-facto
+# choice for Leptos apps that need plain JSON HTTP — small,
+# well-tested, builds on web-sys's Fetch API. The `http`
+# feature is the only one we need; `websocket` lands later
+# alongside the terminal slice.
+gloo-net = { version = "0.6", default-features = false, features = ["http"] }
+# Async glue: `JsFuture::from(promise).await` for
+# `navigator.credentials.get(...)`.
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
+# JSON in/out at the HTTP boundary. The server speaks plain
+# JSON for auth (CBOR is session-layer only per slice 9d).
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -1,0 +1,345 @@
+//! Login component + sign-in WebAuthn ceremony.
+//!
+//! Slice 9r.1 landed the form shell + URL-based pair vs.
+//! sign-in mode swap. Slice 9r.2 wired the sign-in ceremony.
+//! Slice 9r.3 (planned) lands the pair ceremony, which will
+//! reuse the `LoginPhase` machine and the HTTP glue here.
+//!
+//! FP-leaning per memory `feedback_rewrite_fp_direction`:
+//! `signin()` is a pure async pipeline (no shared state, no
+//! callbacks); the component dispatches it via
+//! `create_action` and reacts to the resolved value.
+
+use crate::AuthState;
+use leptos::*;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+
+/// Setup-token from the URL's `?setup_token=...` query, or
+/// `None` if not present. Read once at component construction
+/// — Leptos signals will track changes if a future slice
+/// needs that, but the initial-load read is enough for slice
+/// 9r.1's mode toggle.
+fn url_setup_token() -> Option<String> {
+    let location = web_sys::window()?.location();
+    let search = location.search().ok()?;
+    if search.is_empty() {
+        return None;
+    }
+    let params = web_sys::UrlSearchParams::new_with_str(&search).ok()?;
+    let token = params.get("setup_token")?;
+    if token.is_empty() {
+        None
+    } else {
+        Some(token)
+    }
+}
+
+// =====================================================================
+// Wire types — mirror the server's `ChallengeStartResponse<...>` and
+// `LoginFinishRequest` shapes. We don't share the server's structs
+// because the server pulls in axum, sqlx, scrypt, etc. — bringing
+// those into the WASM bundle would balloon it. The wire format itself
+// is small + stable, so duplicating two structs is cheaper than the
+// transitive crate weight. The shared `webauthn_rs_proto` types
+// (`RequestChallengeResponse`, `PublicKeyCredential`) DO ride along —
+// they're the part that's tricky to redo, and the crate itself is
+// WASM-friendly.
+// =====================================================================
+
+#[derive(Debug, Deserialize)]
+struct LoginStartResp {
+    challenge_id: String,
+    options: webauthn_rs_proto::RequestChallengeResponse,
+}
+
+#[derive(Debug, Serialize)]
+struct LoginFinishReq {
+    challenge_id: String,
+    response: webauthn_rs_proto::PublicKeyCredential,
+}
+
+/// Run the full sign-in WebAuthn ceremony.
+///
+/// Pure-by-shape: takes nothing, returns `Result<(), String>`.
+/// Side effects (network, browser API calls) are linear from
+/// top to bottom; nothing leaks back into shared state. The
+/// caller (a Leptos action) owns the resulting state machine.
+///
+/// Errors come back as `String` because the failure modes are
+/// heterogeneous (network vs. browser-API vs. server-side
+/// rejection) and the UI just shows the message; a typed
+/// error enum would be premature until a future slice needs
+/// to branch on the variant (e.g., "session expired" vs.
+/// "credential revoked" surfacing different recovery UIs).
+async fn signin() -> Result<(), String> {
+    // 1. Ask the server for a challenge. `login_start` takes
+    //    no body, so a bare POST with no Content-Type works —
+    //    the route doesn't use `JsonBody<T>`.
+    let start_resp = gloo_net::http::Request::post("/api/auth/login/start")
+        .send()
+        .await
+        .map_err(|e| format!("network error contacting server: {e}"))?;
+
+    if !start_resp.ok() {
+        return Err(format!(
+            "server rejected sign-in challenge ({})",
+            start_resp.status()
+        ));
+    }
+
+    let start: LoginStartResp = start_resp
+        .json()
+        .await
+        .map_err(|e| format!("server returned malformed challenge: {e}"))?;
+
+    // 2. Convert the wire challenge to the JS shape that
+    //    `navigator.credentials.get()` expects. `webauthn-rs-proto`
+    //    with the `wasm` feature does the binary base64url ↔
+    //    Uint8Array dance inside the From impl, so we don't
+    //    hand-roll it.
+    let options: web_sys::CredentialRequestOptions = start.options.into();
+
+    // 3. Run the platform ceremony. `credentials.get()` either
+    //    resolves with a `PublicKeyCredential` (user confirmed
+    //    with biometric/PIN) or rejects (cancel, no credential,
+    //    timeout, virtual-authenticator absent in test env).
+    let window = web_sys::window().ok_or("browser window unavailable")?;
+    let credentials = window.navigator().credentials();
+    let promise = credentials
+        .get_with_options(&options)
+        .map_err(|e| format!("browser refused credential request: {}", js_err(&e)))?;
+    let credential_js = JsFuture::from(promise)
+        .await
+        .map_err(|e| format!("passkey ceremony failed: {}", js_err(&e)))?;
+
+    let credential: web_sys::PublicKeyCredential = credential_js
+        .dyn_into()
+        .map_err(|v| format!("browser returned an unexpected credential type: {}", js_err(&v)))?;
+    let response: webauthn_rs_proto::PublicKeyCredential = credential.into();
+
+    // 4. Send the assertion back. `login_finish` uses
+    //    `JsonBody<T>` so Content-Type *must* be application/json
+    //    — `gloo-net`'s `.json(...)` sets that automatically.
+    let finish_resp = gloo_net::http::Request::post("/api/auth/login/finish")
+        .json(&LoginFinishReq {
+            challenge_id: start.challenge_id,
+            response,
+        })
+        .map_err(|e| format!("could not encode sign-in payload: {e}"))?
+        .send()
+        .await
+        .map_err(|e| format!("network error completing sign-in: {e}"))?;
+
+    if !finish_resp.ok() {
+        return Err(format!(
+            "server rejected sign-in ({})",
+            finish_resp.status()
+        ));
+    }
+
+    // We don't need to parse the body — the server set the
+    // session cookie via Set-Cookie, which the browser
+    // automatically applies. The caller flips the auth-state
+    // signal so the UI swaps to the post-auth view; future
+    // slices that need the credential id or csrf token will
+    // parse the response then.
+    Ok(())
+}
+
+/// Render a `JsValue` error into a human-readable string.
+///
+/// Two layers, both bounded:
+/// 1. If the value is a JS string, return it.
+/// 2. If it has a non-empty `.message` property (the conventional
+///    field on `Error` / `DOMException`), return that.
+///
+/// We deliberately do NOT fall back to `format!("{v:?}")`. Debug
+/// formatting of a `JsValue` in some browsers/extensions can
+/// surface internal state into the user-visible error string, and
+/// since we render that string into the DOM via Leptos's text
+/// nodes, we'd be giving the user (or an over-the-shoulder
+/// observer) detail they don't need. The console gets the
+/// debug form for operator triage; the UI gets a generic message.
+fn js_err(v: &JsValue) -> String {
+    if let Some(s) = v.as_string() {
+        return s;
+    }
+    // Most browser-thrown exceptions are `Error` instances
+    // with a `.message` property. Reflecting it out is the
+    // closest equivalent to JS's `e.message`.
+    if let Ok(msg) = js_sys::Reflect::get(v, &JsValue::from_str("message")) {
+        if let Some(s) = msg.as_string() {
+            if !s.is_empty() {
+                return s;
+            }
+        }
+    }
+    // Operator-side detail goes to the console; the user-side
+    // string stays generic. Useful when triaging weird browser
+    // / extension errors that don't follow the `Error` shape.
+    web_sys::console::warn_2(&JsValue::from_str("katulong: unstructured signin error"), v);
+    "unexpected browser error".to_string()
+}
+
+/// Login phase — local to `<Login/>`. The three states form a
+/// minimal state machine: idle → in-flight → (idle | error).
+/// Encoded as an enum (rather than a pair of bool signals) so
+/// "in-flight" and "error" can never co-exist; `pending` would
+/// be ambiguous if both were independent.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum LoginPhase {
+    Idle,
+    InFlight,
+    Error(String),
+}
+
+/// Visual shell of the auth ceremony. Two modes, switched by
+/// the presence of `?setup_token=` in the URL:
+///
+/// - **Pair mode** (token present): "Pair this device — name
+///   it and confirm with your passkey." This is the
+///   add-additional-device flow that the Node implementation
+///   exposes via the staging script's printed pair URL.
+///
+/// - **Sign-in mode** (no token): "Sign in with your
+///   passkey." Pure WebAuthn login, no setup token needed.
+///   On a fresh data dir with no enrolled passkeys this will
+///   be a dead-end — the bootstrap path (first device, no
+///   token) is a separate question that 9r.4 will resolve.
+///
+/// Slice 9r.2 wires the sign-in ceremony only. The pair
+/// ceremony stays inert until 9r.3 — the `<button>` is
+/// disabled in pair mode so a user can't click it and get
+/// nothing.
+#[component]
+pub fn Login() -> impl IntoView {
+    let setup_token = url_setup_token();
+    let is_pair_mode = setup_token.is_some();
+    // 9r.3 will read `setup_token` to forward into the pair
+    // ceremony. Holding it in a binding (not just discarding)
+    // documents that intent.
+    let _setup_token_for_9r3 = setup_token;
+
+    // The form has a separate identity for tests / future
+    // styling: `data-mode` swaps copy + behavior between the
+    // two ceremonies.
+    let mode_attr = if is_pair_mode { "pair" } else { "signin" };
+    let title = if is_pair_mode {
+        "Pair this device"
+    } else {
+        "Sign in"
+    };
+    let cta_idle = if is_pair_mode {
+        "Pair with passkey"
+    } else {
+        "Sign in with passkey"
+    };
+    let blurb = if is_pair_mode {
+        "Name this device and confirm with your passkey to add it to your account."
+    } else {
+        "Use your passkey to sign in."
+    };
+
+    let auth = expect_context::<AuthState>();
+
+    // Local state machine. `phase` drives the CTA copy +
+    // disabled state and renders the error region.
+    let (phase, set_phase) = create_signal(LoginPhase::Idle);
+
+    // The ceremony itself is dispatched via `create_action`.
+    // That gives us:
+    //   - automatic pending tracking (we don't fire twice on
+    //     a fast double-click — the action is gated by the
+    //     button's `disabled` attribute, which we wire to
+    //     `phase == InFlight`)
+    //   - automatic cleanup if the component unmounts mid-
+    //     flight (Leptos cancels the future)
+    //   - composability: the action handler reads/writes the
+    //     same `set_phase` signal, keeping all state
+    //     transitions in one place.
+    let signin_action = create_action(move |_: &()| async move {
+        match signin().await {
+            Ok(()) => {
+                // Flip global auth state — `<Main/>` swaps to
+                // the post-auth view, unmounting this
+                // component in the process. We don't reset
+                // `phase` here because the unmount discards
+                // the signal anyway; resetting would just be
+                // a write into a dropped scope.
+                auth.set_signed_in.set(true);
+            }
+            Err(message) => {
+                set_phase.set(LoginPhase::Error(message));
+            }
+        }
+    });
+
+    let cta_label = move || match phase.get() {
+        LoginPhase::InFlight => "Signing in…".to_string(),
+        _ => cta_idle.to_string(),
+    };
+    let cta_disabled = move || {
+        // Sign-in: disable while a ceremony is mid-flight.
+        // Pair mode: disabled outright in 9r.2 — clicking it
+        // would do nothing because we haven't wired the pair
+        // ceremony yet. Greying the button out is a clearer
+        // signal than letting the user click into the void.
+        is_pair_mode || matches!(phase.get(), LoginPhase::InFlight)
+    };
+    // Signal: are we in the error state? Drives a conditional
+    // <p class="error">. Reading the message directly out of
+    // the signal would clone an empty string in the non-error
+    // case, hence the `Show` + accessor split.
+    let error_message = move || match phase.get() {
+        LoginPhase::Error(msg) => Some(msg),
+        _ => None,
+    };
+
+    view! {
+        <section id="kat-login" data-mode=mode_attr>
+            <h1 class="title">{title}</h1>
+            <p class="blurb">{blurb}</p>
+            // Pair mode collects a device name (e.g.,
+            // "felix-iphone"). Sign-in mode skips it — the
+            // passkey itself identifies the credential.
+            {is_pair_mode.then(|| view! {
+                <label class="field">
+                    <span class="label">"Device name"</span>
+                    <input
+                        type="text"
+                        name="device-name"
+                        autocomplete="off"
+                        placeholder="e.g. felix-iphone"
+                    />
+                </label>
+            })}
+            <button
+                type="button"
+                class="cta"
+                prop:disabled=cta_disabled
+                on:click=move |_| {
+                    // Set InFlight directly here, not inside
+                    // the action future. The action's first
+                    // poll runs on a microtask, so an Idle →
+                    // InFlight transition done inside the
+                    // future would leave a tick where the
+                    // button is briefly enabled — long enough
+                    // for a synthetic double-click to fire a
+                    // second concurrent ceremony. Setting
+                    // InFlight synchronously here closes that
+                    // window: the disabled re-render happens
+                    // before the second click can be queued.
+                    set_phase.set(LoginPhase::InFlight);
+                    signin_action.dispatch(());
+                }
+            >
+                {cta_label}
+            </button>
+            {move || error_message().map(|msg| view! {
+                <p class="error" role="alert">{msg}</p>
+            })}
+        </section>
+    }
+}

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -3,20 +3,23 @@
 // Slice 9q: layout primitives (header + main).
 // Slice 9r.1: <Login/> form shell with URL-based mode switch.
 // Slice 9r.2: sign-in WebAuthn ceremony wired to the API.
+//   Login + ceremony moved to `login.rs` — this file owns
+//   only the shell layout, the App-root signal contexts, and
+//   the auth-state-driven swap in <Main/>.
 //
 // FP-leaning per memory `feedback_rewrite_fp_direction`: the
 // shell is built from small pure components composed into a
 // tree. Auth + connection state live in signals provided at
 // the App root; the ceremony itself is a pure async function
-// (`signin()`) that returns a `Result` — the component just
-// dispatches it via `create_action` and reacts to the
+// (`login::signin`) that returns a `Result` — the component
+// just dispatches it via `create_action` and reacts to the
 // resolved value. No scattered globals, no callbacks-on-
 // callbacks.
 
 use leptos::*;
-use serde::{Deserialize, Serialize};
-use wasm_bindgen::{JsCast, JsValue};
-use wasm_bindgen_futures::JsFuture;
+
+mod login;
+use login::Login;
 
 fn main() {
     console_error_panic_hook::set_once();
@@ -39,9 +42,9 @@ struct ConnectionStatus(ReadSignal<bool>);
 /// parent. Logout (a future slice) will use the same setter
 /// in reverse.
 #[derive(Copy, Clone)]
-struct AuthState {
-    signed_in: ReadSignal<bool>,
-    set_signed_in: WriteSignal<bool>,
+pub struct AuthState {
+    pub signed_in: ReadSignal<bool>,
+    pub set_signed_in: WriteSignal<bool>,
 }
 
 #[component]
@@ -80,18 +83,13 @@ fn App() -> impl IntoView {
 #[component]
 fn Header() -> impl IntoView {
     let ConnectionStatus(connected) = expect_context();
-    // The status attribute is what the CSS dot color binds
-    // to. Computing it as a derived signal means the DOM
-    // attribute mutates only when the underlying boolean
-    // flips — no manual class-toggle dance.
-    let status_attr = move || {
-        if connected.get() {
-            "connected"
-        } else {
-            "disconnected"
-        }
-    };
-    let status_label = move || {
+    // Single derived view of the connection bool — used both
+    // for the `data-status` attribute (CSS dot color hook)
+    // and the visible label. Two separate closures would
+    // create two reactive subscriptions and risk silent
+    // divergence if one ever changed; this folds them into
+    // one read per render.
+    let status = move || {
         if connected.get() {
             "connected"
         } else {
@@ -104,9 +102,9 @@ fn Header() -> impl IntoView {
             <span class="brand">
                 "kat" <span class="accent">"•"</span> "ulong"
             </span>
-            <span class="status" data-status=status_attr>
+            <span class="status" data-status=status>
                 <span class="dot" aria-hidden="true"></span>
-                <span class="label">{status_label}</span>
+                <span class="label">{status}</span>
             </span>
         </header>
     }
@@ -145,310 +143,6 @@ fn TerminalStub() -> impl IntoView {
         <section id="kat-terminal-stub">
             <h1 class="title">"Signed in"</h1>
             <p class="blurb">"Terminal view lands in a future slice."</p>
-        </section>
-    }
-}
-
-/// Setup-token from the URL's `?setup_token=...` query, or
-/// `None` if not present. Read once at component construction
-/// — Leptos signals will track changes if a future slice
-/// needs that, but the initial-load read is enough for slice
-/// 9r.1's mode toggle.
-fn url_setup_token() -> Option<String> {
-    let location = web_sys::window()?.location();
-    let search = location.search().ok()?;
-    if search.is_empty() {
-        return None;
-    }
-    let params = web_sys::UrlSearchParams::new_with_str(&search).ok()?;
-    let token = params.get("setup_token")?;
-    if token.is_empty() {
-        None
-    } else {
-        Some(token)
-    }
-}
-
-// =====================================================================
-// Wire types — mirror the server's `ChallengeStartResponse<...>` and
-// `LoginFinishRequest` shapes. We don't share the server's structs
-// because the server pulls in axum, sqlx, scrypt, etc. — bringing
-// those into the WASM bundle would balloon it. The wire format itself
-// is small + stable, so duplicating two structs is cheaper than the
-// transitive crate weight. The shared `webauthn_rs_proto` types
-// (`RequestChallengeResponse`, `PublicKeyCredential`) DO ride along —
-// they're the part that's tricky to redo, and the crate itself is
-// WASM-friendly.
-// =====================================================================
-
-#[derive(Debug, Deserialize)]
-struct LoginStartResp {
-    challenge_id: String,
-    options: webauthn_rs_proto::RequestChallengeResponse,
-}
-
-#[derive(Debug, Serialize)]
-struct LoginFinishReq {
-    challenge_id: String,
-    response: webauthn_rs_proto::PublicKeyCredential,
-}
-
-/// Run the full sign-in WebAuthn ceremony.
-///
-/// Pure-by-shape: takes nothing, returns `Result<(), String>`.
-/// Side effects (network, browser API calls) are linear from
-/// top to bottom; nothing leaks back into shared state. The
-/// caller (a Leptos action) owns the resulting state machine.
-///
-/// Errors come back as `String` because the failure modes are
-/// heterogeneous (network vs. browser-API vs. server-side
-/// rejection) and the UI just shows the message; a typed
-/// error enum would be premature until a future slice needs
-/// to branch on the variant (e.g., "session expired" vs.
-/// "credential revoked" surfacing different recovery UIs).
-async fn signin() -> Result<(), String> {
-    // 1. Ask the server for a challenge. `login_start` takes
-    //    no body, so a bare POST with no Content-Type works —
-    //    the route doesn't use `JsonBody<T>`.
-    let start_resp = gloo_net::http::Request::post("/api/auth/login/start")
-        .send()
-        .await
-        .map_err(|e| format!("network error contacting server: {e}"))?;
-
-    if !start_resp.ok() {
-        return Err(format!(
-            "server rejected sign-in challenge ({})",
-            start_resp.status()
-        ));
-    }
-
-    let start: LoginStartResp = start_resp
-        .json()
-        .await
-        .map_err(|e| format!("server returned malformed challenge: {e}"))?;
-
-    // 2. Convert the wire challenge to the JS shape that
-    //    `navigator.credentials.get()` expects. `webauthn-rs-proto`
-    //    with the `wasm` feature does the binary base64url ↔
-    //    Uint8Array dance inside the From impl, so we don't
-    //    hand-roll it.
-    let options: web_sys::CredentialRequestOptions = start.options.into();
-
-    // 3. Run the platform ceremony. `credentials.get()` either
-    //    resolves with a `PublicKeyCredential` (user confirmed
-    //    with biometric/PIN) or rejects (cancel, no credential,
-    //    timeout, virtual-authenticator absent in test env).
-    let window = web_sys::window().ok_or("browser window unavailable")?;
-    let credentials = window.navigator().credentials();
-    let promise = credentials
-        .get_with_options(&options)
-        .map_err(|e| format!("browser refused credential request: {}", js_err(&e)))?;
-    let credential_js = JsFuture::from(promise)
-        .await
-        .map_err(|e| format!("passkey ceremony failed: {}", js_err(&e)))?;
-
-    let credential: web_sys::PublicKeyCredential = credential_js
-        .dyn_into()
-        .map_err(|_| "browser returned an unexpected credential type".to_string())?;
-    let response: webauthn_rs_proto::PublicKeyCredential = credential.into();
-
-    // 4. Send the assertion back. `login_finish` uses
-    //    `JsonBody<T>` so Content-Type *must* be application/json
-    //    — `gloo-net`'s `.json(...)` sets that automatically.
-    let finish_resp = gloo_net::http::Request::post("/api/auth/login/finish")
-        .json(&LoginFinishReq {
-            challenge_id: start.challenge_id,
-            response,
-        })
-        .map_err(|e| format!("could not encode sign-in payload: {e}"))?
-        .send()
-        .await
-        .map_err(|e| format!("network error completing sign-in: {e}"))?;
-
-    if !finish_resp.ok() {
-        return Err(format!(
-            "server rejected sign-in ({})",
-            finish_resp.status()
-        ));
-    }
-
-    // We don't need to parse the body — the server set the
-    // session cookie via Set-Cookie, which the browser
-    // automatically applies. The caller flips the auth-state
-    // signal so the UI swaps to the post-auth view; future
-    // slices that need the credential id or csrf token will
-    // parse the response then.
-    Ok(())
-}
-
-/// Render a `JsValue` error into a human-readable string.
-/// `JsValue::as_string()` is the cheap path for proper `Error`
-/// objects; for opaque exceptions (e.g., DOMException without
-/// a message) we fall back to debug formatting so the user
-/// sees *something* rather than an empty box.
-fn js_err(v: &JsValue) -> String {
-    if let Some(s) = v.as_string() {
-        return s;
-    }
-    // Most browser-thrown exceptions are `Error` instances
-    // with a `.message` property. Reflecting it out is the
-    // closest equivalent to JS's `e.message`.
-    if let Ok(msg) = js_sys::Reflect::get(v, &JsValue::from_str("message")) {
-        if let Some(s) = msg.as_string() {
-            if !s.is_empty() {
-                return s;
-            }
-        }
-    }
-    format!("{v:?}")
-}
-
-/// Login phase — local to `<Login/>`. The four states form a
-/// minimal state machine: idle → in-flight → (idle | error).
-/// Encoded as an enum (rather than a pair of bool signals) so
-/// "in-flight" and "error" can never co-exist; `pending` would
-/// be ambiguous if both were independent.
-#[derive(Clone, Debug, PartialEq, Eq)]
-enum LoginPhase {
-    Idle,
-    InFlight,
-    Error(String),
-}
-
-/// Visual shell of the auth ceremony. Two modes, switched by
-/// the presence of `?setup_token=` in the URL:
-///
-/// - **Pair mode** (token present): "Pair this device — name
-///   it and confirm with your passkey." This is the
-///   add-additional-device flow that the Node implementation
-///   exposes via the staging script's printed pair URL.
-///
-/// - **Sign-in mode** (no token): "Sign in with your
-///   passkey." Pure WebAuthn login, no setup token needed.
-///   On a fresh data dir with no enrolled passkeys this will
-///   be a dead-end — the bootstrap path (first device, no
-///   token) is a separate question that 9r.4 will resolve.
-///
-/// Slice 9r.2 wires the sign-in ceremony only. The pair
-/// ceremony stays inert until 9r.3 — the `<button>` is
-/// disabled in pair mode so a user can't click it and get
-/// nothing.
-#[component]
-fn Login() -> impl IntoView {
-    let setup_token = url_setup_token();
-    let is_pair_mode = setup_token.is_some();
-
-    // The form has a separate identity for tests / future
-    // styling: `data-mode` swaps copy + behavior between the
-    // two ceremonies.
-    let mode_attr = if is_pair_mode { "pair" } else { "signin" };
-    let title = if is_pair_mode {
-        "Pair this device"
-    } else {
-        "Sign in"
-    };
-    let cta_idle = if is_pair_mode {
-        "Pair with passkey"
-    } else {
-        "Sign in with passkey"
-    };
-    let blurb = if is_pair_mode {
-        "Name this device and confirm with your passkey to add it to your account."
-    } else {
-        "Use your passkey to sign in."
-    };
-
-    let auth = expect_context::<AuthState>();
-
-    // Local state machine. `phase` drives the CTA copy +
-    // disabled state and renders the error region.
-    let (phase, set_phase) = create_signal(LoginPhase::Idle);
-
-    // The ceremony itself is dispatched via `create_action`.
-    // That gives us:
-    //   - automatic pending tracking (we don't fire twice on
-    //     a fast double-click — the action is gated by the
-    //     button's `disabled` attribute, which we wire to
-    //     `phase == InFlight`)
-    //   - automatic cleanup if the component unmounts mid-
-    //     flight (Leptos cancels the future)
-    //   - composability: the action handler reads/writes the
-    //     same `set_phase` signal, keeping all state
-    //     transitions in one place.
-    let signin_action = create_action(move |_: &()| async move {
-        set_phase.set(LoginPhase::InFlight);
-        match signin().await {
-            Ok(()) => {
-                // Flip global auth state — `<Main/>` swaps to
-                // the post-auth view. We deliberately leave
-                // `phase` at InFlight here; the component is
-                // about to unmount as a result of the swap, so
-                // there's no Idle state to return to.
-                auth.set_signed_in.set(true);
-            }
-            Err(message) => {
-                set_phase.set(LoginPhase::Error(message));
-            }
-        }
-    });
-
-    let cta_label = move || match phase.get() {
-        LoginPhase::InFlight => "Signing in…".to_string(),
-        _ => cta_idle.to_string(),
-    };
-    let cta_disabled = move || {
-        // Sign-in: disable while a ceremony is mid-flight.
-        // Pair mode: disabled outright in 9r.2 — clicking it
-        // would do nothing because we haven't wired the pair
-        // ceremony yet. Greying the button out is a clearer
-        // signal than letting the user click into the void.
-        is_pair_mode || matches!(phase.get(), LoginPhase::InFlight)
-    };
-    // Signal: are we in the error state? Drives a conditional
-    // <p class="error">. Reading the message directly out of
-    // the signal would clone an empty string in the non-error
-    // case, hence the `Show` + accessor split.
-    let error_message = move || match phase.get() {
-        LoginPhase::Error(msg) => Some(msg),
-        _ => None,
-    };
-
-    view! {
-        <section id="kat-login" data-mode=mode_attr>
-            <h1 class="title">{title}</h1>
-            <p class="blurb">{blurb}</p>
-            // Pair mode collects a device name (e.g.,
-            // "felix-iphone"). Sign-in mode skips it — the
-            // passkey itself identifies the credential.
-            {is_pair_mode.then(|| view! {
-                <label class="field">
-                    <span class="label">"Device name"</span>
-                    <input
-                        type="text"
-                        name="device-name"
-                        autocomplete="off"
-                        placeholder="e.g. felix-iphone"
-                    />
-                </label>
-            })}
-            <button
-                type="button"
-                class="cta"
-                prop:disabled=cta_disabled
-                on:click=move |_| {
-                    // Clear any prior error so a retry
-                    // doesn't render stale text under the
-                    // button while the new ceremony is
-                    // pending.
-                    set_phase.set(LoginPhase::Idle);
-                    signin_action.dispatch(());
-                }
-            >
-                {cta_label}
-            </button>
-            {move || error_message().map(|msg| view! {
-                <p class="error" role="alert">{msg}</p>
-            })}
         </section>
     }
 }

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -1,22 +1,22 @@
-// Leptos shell — slice 9q.
+// Leptos shell.
 //
-// Layout primitives (header + main) replace the slice-9o
-// hello-world `<main>`. The shell is intentionally a frame
-// with NO real content yet: subsequent slices fill `<Main/>`
-// with login → terminal → tile-grid as those land. The
-// Header carries a connection-status signal that future
-// slices will wire to the WS attach state; today it's
-// hardcoded to `false` so the visible truth ("disconnected")
-// matches the actual state.
+// Slice 9q: layout primitives (header + main).
+// Slice 9r.1: <Login/> form shell with URL-based mode switch.
+// Slice 9r.2: sign-in WebAuthn ceremony wired to the API.
 //
 // FP-leaning per memory `feedback_rewrite_fp_direction`: the
 // shell is built from small pure components composed into a
-// tree. Connection state lives in a single signal provided
-// at the App root and consumed via context — no global
-// mutable state, no scattered RwSignal allocations across
-// components.
+// tree. Auth + connection state live in signals provided at
+// the App root; the ceremony itself is a pure async function
+// (`signin()`) that returns a `Result` — the component just
+// dispatches it via `create_action` and reacts to the
+// resolved value. No scattered globals, no callbacks-on-
+// callbacks.
 
 use leptos::*;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
 
 fn main() {
     console_error_panic_hook::set_once();
@@ -29,6 +29,21 @@ fn main() {
 #[derive(Copy, Clone)]
 struct ConnectionStatus(ReadSignal<bool>);
 
+/// Reactive auth-state signal exposed to descendants via
+/// context. Slice 9r.2 flips it on successful sign-in so
+/// `<Main/>` can swap from `<Login/>` to a stub. Future
+/// slices read the same signal to gate WS attach + tile
+/// rendering. The setter half travels alongside the reader
+/// because the sign-in ceremony — owned by `<Login/>` —
+/// needs to publish success up to its sibling-switching
+/// parent. Logout (a future slice) will use the same setter
+/// in reverse.
+#[derive(Copy, Clone)]
+struct AuthState {
+    signed_in: ReadSignal<bool>,
+    set_signed_in: WriteSignal<bool>,
+}
+
 #[component]
 fn App() -> impl IntoView {
     // Connection signal lives at the root so any descendant
@@ -40,6 +55,19 @@ fn App() -> impl IntoView {
     // from anywhere.
     let (connected, _set_connected) = create_signal(false);
     provide_context(ConnectionStatus(connected));
+
+    // Auth signal also lives at the root because two siblings
+    // need it: `<Login/>` writes (on ceremony success) and
+    // `<Main/>` reads (to swap children). A future
+    // `<Header/>` logout button will also write through this
+    // setter. Initial value `false` because we haven't yet
+    // checked `/api/auth/status`; slice 9r.3 lands the
+    // session-restore-on-load probe.
+    let (signed_in, set_signed_in) = create_signal(false);
+    provide_context(AuthState {
+        signed_in,
+        set_signed_in,
+    });
 
     view! {
         <div id="kat-shell">
@@ -86,21 +114,38 @@ fn Header() -> impl IntoView {
 
 #[component]
 fn Main() -> impl IntoView {
-    // Slice 9r.1 lands the visual + URL-mode-switching part
-    // of the login flow. The actual WebAuthn ceremony (calls
-    // to `/api/auth/registration/begin` /
-    // `navigator.credentials.create()` / etc.) lands in 9r.2.
-    //
-    // Today we always render `<Login/>` here — there's no
-    // notion of "authenticated session" yet because no slice
-    // has read the session cookie or the WS attach state.
-    // Once 9r.2 lands, the post-success path will set a
-    // signal that switches `<Main/>` to the (still-stub)
-    // terminal view.
+    let auth = expect_context::<AuthState>();
+    // Switch on auth state. While unauthenticated → `<Login/>`.
+    // Once the sign-in ceremony flips `signed_in`, render the
+    // (still-stub) terminal placeholder. This is the FP-leaning
+    // shape: parent consumes a signal, returns the right child
+    // — no imperative DOM swap, no shared mutable view-state.
     view! {
         <main id="kat-main">
-            <Login/>
+            <Show
+                when=move || auth.signed_in.get()
+                fallback=|| view! { <Login/> }
+            >
+                <TerminalStub/>
+            </Show>
         </main>
+    }
+}
+
+/// Placeholder for the post-auth terminal UI. Slice 9r.2
+/// only needs *something* to render after sign-in so the e2e
+/// can assert the auth-state-driven swap; the real terminal
+/// view is a separate slice that lands the WS attach + xterm
+/// hookup. Keeping it as a literal stub here means we don't
+/// preemptively design the terminal module before its
+/// dependencies (WS protocol, tile spec) are settled.
+#[component]
+fn TerminalStub() -> impl IntoView {
+    view! {
+        <section id="kat-terminal-stub">
+            <h1 class="title">"Signed in"</h1>
+            <p class="blurb">"Terminal view lands in a future slice."</p>
+        </section>
     }
 }
 
@@ -124,6 +169,152 @@ fn url_setup_token() -> Option<String> {
     }
 }
 
+// =====================================================================
+// Wire types — mirror the server's `ChallengeStartResponse<...>` and
+// `LoginFinishRequest` shapes. We don't share the server's structs
+// because the server pulls in axum, sqlx, scrypt, etc. — bringing
+// those into the WASM bundle would balloon it. The wire format itself
+// is small + stable, so duplicating two structs is cheaper than the
+// transitive crate weight. The shared `webauthn_rs_proto` types
+// (`RequestChallengeResponse`, `PublicKeyCredential`) DO ride along —
+// they're the part that's tricky to redo, and the crate itself is
+// WASM-friendly.
+// =====================================================================
+
+#[derive(Debug, Deserialize)]
+struct LoginStartResp {
+    challenge_id: String,
+    options: webauthn_rs_proto::RequestChallengeResponse,
+}
+
+#[derive(Debug, Serialize)]
+struct LoginFinishReq {
+    challenge_id: String,
+    response: webauthn_rs_proto::PublicKeyCredential,
+}
+
+/// Run the full sign-in WebAuthn ceremony.
+///
+/// Pure-by-shape: takes nothing, returns `Result<(), String>`.
+/// Side effects (network, browser API calls) are linear from
+/// top to bottom; nothing leaks back into shared state. The
+/// caller (a Leptos action) owns the resulting state machine.
+///
+/// Errors come back as `String` because the failure modes are
+/// heterogeneous (network vs. browser-API vs. server-side
+/// rejection) and the UI just shows the message; a typed
+/// error enum would be premature until a future slice needs
+/// to branch on the variant (e.g., "session expired" vs.
+/// "credential revoked" surfacing different recovery UIs).
+async fn signin() -> Result<(), String> {
+    // 1. Ask the server for a challenge. `login_start` takes
+    //    no body, so a bare POST with no Content-Type works —
+    //    the route doesn't use `JsonBody<T>`.
+    let start_resp = gloo_net::http::Request::post("/api/auth/login/start")
+        .send()
+        .await
+        .map_err(|e| format!("network error contacting server: {e}"))?;
+
+    if !start_resp.ok() {
+        return Err(format!(
+            "server rejected sign-in challenge ({})",
+            start_resp.status()
+        ));
+    }
+
+    let start: LoginStartResp = start_resp
+        .json()
+        .await
+        .map_err(|e| format!("server returned malformed challenge: {e}"))?;
+
+    // 2. Convert the wire challenge to the JS shape that
+    //    `navigator.credentials.get()` expects. `webauthn-rs-proto`
+    //    with the `wasm` feature does the binary base64url ↔
+    //    Uint8Array dance inside the From impl, so we don't
+    //    hand-roll it.
+    let options: web_sys::CredentialRequestOptions = start.options.into();
+
+    // 3. Run the platform ceremony. `credentials.get()` either
+    //    resolves with a `PublicKeyCredential` (user confirmed
+    //    with biometric/PIN) or rejects (cancel, no credential,
+    //    timeout, virtual-authenticator absent in test env).
+    let window = web_sys::window().ok_or("browser window unavailable")?;
+    let credentials = window.navigator().credentials();
+    let promise = credentials
+        .get_with_options(&options)
+        .map_err(|e| format!("browser refused credential request: {}", js_err(&e)))?;
+    let credential_js = JsFuture::from(promise)
+        .await
+        .map_err(|e| format!("passkey ceremony failed: {}", js_err(&e)))?;
+
+    let credential: web_sys::PublicKeyCredential = credential_js
+        .dyn_into()
+        .map_err(|_| "browser returned an unexpected credential type".to_string())?;
+    let response: webauthn_rs_proto::PublicKeyCredential = credential.into();
+
+    // 4. Send the assertion back. `login_finish` uses
+    //    `JsonBody<T>` so Content-Type *must* be application/json
+    //    — `gloo-net`'s `.json(...)` sets that automatically.
+    let finish_resp = gloo_net::http::Request::post("/api/auth/login/finish")
+        .json(&LoginFinishReq {
+            challenge_id: start.challenge_id,
+            response,
+        })
+        .map_err(|e| format!("could not encode sign-in payload: {e}"))?
+        .send()
+        .await
+        .map_err(|e| format!("network error completing sign-in: {e}"))?;
+
+    if !finish_resp.ok() {
+        return Err(format!(
+            "server rejected sign-in ({})",
+            finish_resp.status()
+        ));
+    }
+
+    // We don't need to parse the body — the server set the
+    // session cookie via Set-Cookie, which the browser
+    // automatically applies. The caller flips the auth-state
+    // signal so the UI swaps to the post-auth view; future
+    // slices that need the credential id or csrf token will
+    // parse the response then.
+    Ok(())
+}
+
+/// Render a `JsValue` error into a human-readable string.
+/// `JsValue::as_string()` is the cheap path for proper `Error`
+/// objects; for opaque exceptions (e.g., DOMException without
+/// a message) we fall back to debug formatting so the user
+/// sees *something* rather than an empty box.
+fn js_err(v: &JsValue) -> String {
+    if let Some(s) = v.as_string() {
+        return s;
+    }
+    // Most browser-thrown exceptions are `Error` instances
+    // with a `.message` property. Reflecting it out is the
+    // closest equivalent to JS's `e.message`.
+    if let Ok(msg) = js_sys::Reflect::get(v, &JsValue::from_str("message")) {
+        if let Some(s) = msg.as_string() {
+            if !s.is_empty() {
+                return s;
+            }
+        }
+    }
+    format!("{v:?}")
+}
+
+/// Login phase — local to `<Login/>`. The four states form a
+/// minimal state machine: idle → in-flight → (idle | error).
+/// Encoded as an enum (rather than a pair of bool signals) so
+/// "in-flight" and "error" can never co-exist; `pending` would
+/// be ambiguous if both were independent.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum LoginPhase {
+    Idle,
+    InFlight,
+    Error(String),
+}
+
 /// Visual shell of the auth ceremony. Two modes, switched by
 /// the presence of `?setup_token=` in the URL:
 ///
@@ -138,9 +329,10 @@ fn url_setup_token() -> Option<String> {
 ///   be a dead-end — the bootstrap path (first device, no
 ///   token) is a separate question that 9r.4 will resolve.
 ///
-/// Slice 9r.1 only renders the form. The buttons currently
-/// have no `on:click` handlers; 9r.2 wires the WebAuthn
-/// ceremony.
+/// Slice 9r.2 wires the sign-in ceremony only. The pair
+/// ceremony stays inert until 9r.3 — the `<button>` is
+/// disabled in pair mode so a user can't click it and get
+/// nothing.
 #[component]
 fn Login() -> impl IntoView {
     let setup_token = url_setup_token();
@@ -155,7 +347,7 @@ fn Login() -> impl IntoView {
     } else {
         "Sign in"
     };
-    let cta = if is_pair_mode {
+    let cta_idle = if is_pair_mode {
         "Pair with passkey"
     } else {
         "Sign in with passkey"
@@ -164,6 +356,61 @@ fn Login() -> impl IntoView {
         "Name this device and confirm with your passkey to add it to your account."
     } else {
         "Use your passkey to sign in."
+    };
+
+    let auth = expect_context::<AuthState>();
+
+    // Local state machine. `phase` drives the CTA copy +
+    // disabled state and renders the error region.
+    let (phase, set_phase) = create_signal(LoginPhase::Idle);
+
+    // The ceremony itself is dispatched via `create_action`.
+    // That gives us:
+    //   - automatic pending tracking (we don't fire twice on
+    //     a fast double-click — the action is gated by the
+    //     button's `disabled` attribute, which we wire to
+    //     `phase == InFlight`)
+    //   - automatic cleanup if the component unmounts mid-
+    //     flight (Leptos cancels the future)
+    //   - composability: the action handler reads/writes the
+    //     same `set_phase` signal, keeping all state
+    //     transitions in one place.
+    let signin_action = create_action(move |_: &()| async move {
+        set_phase.set(LoginPhase::InFlight);
+        match signin().await {
+            Ok(()) => {
+                // Flip global auth state — `<Main/>` swaps to
+                // the post-auth view. We deliberately leave
+                // `phase` at InFlight here; the component is
+                // about to unmount as a result of the swap, so
+                // there's no Idle state to return to.
+                auth.set_signed_in.set(true);
+            }
+            Err(message) => {
+                set_phase.set(LoginPhase::Error(message));
+            }
+        }
+    });
+
+    let cta_label = move || match phase.get() {
+        LoginPhase::InFlight => "Signing in…".to_string(),
+        _ => cta_idle.to_string(),
+    };
+    let cta_disabled = move || {
+        // Sign-in: disable while a ceremony is mid-flight.
+        // Pair mode: disabled outright in 9r.2 — clicking it
+        // would do nothing because we haven't wired the pair
+        // ceremony yet. Greying the button out is a clearer
+        // signal than letting the user click into the void.
+        is_pair_mode || matches!(phase.get(), LoginPhase::InFlight)
+    };
+    // Signal: are we in the error state? Drives a conditional
+    // <p class="error">. Reading the message directly out of
+    // the signal would clone an empty string in the non-error
+    // case, hence the `Show` + accessor split.
+    let error_message = move || match phase.get() {
+        LoginPhase::Error(msg) => Some(msg),
+        _ => None,
     };
 
     view! {
@@ -184,7 +431,24 @@ fn Login() -> impl IntoView {
                     />
                 </label>
             })}
-            <button type="button" class="cta">{cta}</button>
+            <button
+                type="button"
+                class="cta"
+                prop:disabled=cta_disabled
+                on:click=move |_| {
+                    // Clear any prior error so a retry
+                    // doesn't render stale text under the
+                    // button while the new ceremony is
+                    // pending.
+                    set_phase.set(LoginPhase::Idle);
+                    signin_action.dispatch(());
+                }
+            >
+                {cta_label}
+            </button>
+            {move || error_message().map(|msg| view! {
+                <p class="error" role="alert">{msg}</p>
+            })}
         </section>
     }
 }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -155,6 +155,51 @@ body {
   cursor: pointer;
 }
 
-#kat-login .cta:hover {
+#kat-login .cta:hover:not(:disabled) {
   filter: brightness(1.05);
+}
+
+#kat-login .cta:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* Error region rendered below the CTA when the ceremony
+ * fails (network, browser-API rejection, server reject).
+ * Conservative red on dark; the role="alert" surface is what
+ * matters semantically — color is reinforcement. */
+#kat-login .error {
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(208, 77, 77, 0.12);
+  border: 1px solid rgba(208, 77, 77, 0.4);
+  color: #f5b8b8;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+/* Terminal stub (slice 9r.2). The real terminal view lands
+ * in a future slice; this is what `<Main/>` shows after the
+ * sign-in ceremony succeeds, so the auth-state-driven swap
+ * has something to render. */
+#kat-terminal-stub {
+  max-width: 360px;
+  margin: 64px auto 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: var(--kat-fg);
+}
+
+#kat-terminal-stub .title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+#kat-terminal-stub .blurb {
+  margin: 0;
+  color: var(--kat-fg-dim);
+  font-size: 13px;
 }

--- a/test/e2e-rust/auth.e2e.js
+++ b/test/e2e-rust/auth.e2e.js
@@ -1,0 +1,134 @@
+// Auth ceremony e2e — verifies the Login component's
+// URL-driven mode switch and the sign-in WebAuthn ceremony
+// wiring. Sibling to `smoke.e2e.js`, which only covers the
+// shell layout + WASM bundle.
+//
+// Slice 9r.1 introduced the form shell + pair/sign-in mode
+// swap. Slice 9r.2 wired the actual sign-in ceremony.
+// Slice 9r.3 (planned) will wire the pair ceremony.
+//
+// We deliberately don't run the full happy-path WebAuthn
+// ceremony here — that needs Chromium's CDP virtual
+// authenticator (`WebAuthn.addVirtualAuthenticator`), which
+// is a separate setup. The tests below cover everything
+// EXCEPT the platform credential interaction:
+//   - mode swap based on `?setup_token=`
+//   - CTA enabled/disabled state per mode
+//   - the start-call fires when the user clicks (button is
+//     wired, URL is right, method is POST)
+//   - server rejection renders a visible error region
+// The "did the passkey actually verify" assertion belongs in
+// a dedicated suite once the virtual authenticator is wired.
+//
+// Run against a live Rust backend (no test-side server spin-up):
+//   KATULONG_BASE_URL=http://127.0.0.1:3050 \
+//     npx playwright test --config=playwright.rust.config.js
+
+import { test, expect } from "@playwright/test";
+
+test("login defaults to sign-in mode without setup_token", async ({ page }) => {
+  // No `?setup_token=...` query: Login should render its
+  // sign-in mode — no device-name field, "Sign in with
+  // passkey" CTA, `data-mode="signin"` for future styling +
+  // selector hooks.
+  await page.goto("/");
+  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
+
+  const login = page.locator("#kat-login");
+  await expect(login).toHaveAttribute("data-mode", "signin");
+  await expect(login.locator(".title")).toHaveText("Sign in");
+  await expect(login.locator(".cta")).toHaveText("Sign in with passkey");
+  // Sign-in mode CTA must be enabled in the idle state — the
+  // ceremony is wired (slice 9r.2). Disabled-by-default would
+  // be a regression that strands users on a dead button.
+  await expect(login.locator(".cta")).toBeEnabled();
+  // No device-name field in sign-in mode.
+  await expect(login.locator('input[name="device-name"]')).toHaveCount(0);
+});
+
+test("login switches to pair mode with setup_token", async ({ page }) => {
+  // Presence of `?setup_token=` flips the form to pair mode
+  // — adds the device-name field, swaps title + CTA copy,
+  // sets `data-mode="pair"`. Slice 9r.2 wires the sign-in
+  // ceremony only; the pair ceremony is still inert, so the
+  // CTA is disabled to avoid a button that does nothing.
+  // 9r.3 will land the pair ceremony and remove the disabled
+  // bit.
+  await page.goto("/?setup_token=abcdef0123456789");
+  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
+
+  const login = page.locator("#kat-login");
+  await expect(login).toHaveAttribute("data-mode", "pair");
+  await expect(login.locator(".title")).toHaveText("Pair this device");
+  await expect(login.locator(".cta")).toHaveText("Pair with passkey");
+  await expect(login.locator(".cta")).toBeDisabled();
+  // Pair mode shows the device-name input.
+  await expect(login.locator('input[name="device-name"]')).toBeVisible();
+});
+
+test("sign-in click hits /api/auth/login/start", async ({ page }) => {
+  // The CTA in sign-in mode is wired to dispatch the WebAuthn
+  // ceremony (slice 9r.2). We can't run the full ceremony in
+  // headless Chromium without a virtual authenticator, but we
+  // CAN verify the first hop — the POST to
+  // `/api/auth/login/start`. That alone catches the
+  // "button does nothing" regression that the slice 9r.1 stub
+  // had: the click handler is real, the URL is right, the
+  // method is POST.
+  //
+  // Note: the start-call is fired through Leptos's
+  // `create_action` queue, which means a microtask separates
+  // the `click()` and the actual fetch. Setting up
+  // `waitForRequest` BEFORE `click()` is the only race-free
+  // ordering — the timeout is the safety net, not the primary
+  // mechanism.
+  await page.goto("/");
+  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
+
+  const requestPromise = page.waitForRequest(
+    (req) =>
+      req.url().endsWith("/api/auth/login/start") && req.method() === "POST",
+    { timeout: 5_000 },
+  );
+  await page.locator("#kat-login .cta").click();
+  await requestPromise;
+});
+
+test("sign-in renders error region on server rejection", async ({ page }) => {
+  // When the start endpoint returns a non-2xx (the typical
+  // case being 409 on a fresh data dir with no credentials),
+  // the UI must render that as a visible error instead of
+  // silently swallowing it — otherwise the user has no idea
+  // why the button "stopped working." We don't assert the
+  // exact message text (the server controls that wording);
+  // we just assert that an error region appears with the
+  // status code embedded so the failure mode is observable.
+  //
+  // We use `page.route` to stub the response rather than
+  // depending on the live server's auth state. That keeps
+  // the test deterministic across staging-script runs (which
+  // may or may not have credentials enrolled in the data
+  // dir) without changing what the WASM client does on a
+  // real 409 — the rendering code path is identical.
+  await page.route("**/api/auth/login/start", (route) =>
+    route.fulfill({
+      status: 409,
+      contentType: "application/json",
+      body: JSON.stringify({
+        error: { code: "conflict", message: "no credentials registered" },
+      }),
+    }),
+  );
+
+  await page.goto("/");
+  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
+
+  await page.locator("#kat-login .cta").click();
+
+  // The error <p role="alert"> is the user-visible result.
+  // role=alert is what assistive tech reads; we double-check
+  // class for the styling hook.
+  const error = page.locator('#kat-login .error[role="alert"]');
+  await expect(error).toBeVisible({ timeout: 5_000 });
+  await expect(error).toContainText("409");
+});

--- a/test/e2e-rust/smoke.e2e.js
+++ b/test/e2e-rust/smoke.e2e.js
@@ -8,6 +8,10 @@
 //   - "static-only": HTML loads but WASM never hydrates (the
 //     bundle is broken / missing / mis-served)
 //
+// Auth-ceremony tests (login mode swap, sign-in click wiring,
+// error rendering) live in `auth.e2e.js` — this file stays
+// focused on the layout + bundle plumbing.
+//
 // Run against a live Rust backend (no test-side server spin-up):
 //   KATULONG_BASE_URL=http://127.0.0.1:3050 \
 //     npx playwright test --config=playwright.rust.config.js
@@ -68,112 +72,6 @@ test("leptos shell renders header + main + status", async ({ page }) => {
   const main = page.locator("#kat-main");
   await expect(main).toBeVisible();
   await expect(main.locator("#kat-login")).toBeVisible();
-});
-
-test("login defaults to sign-in mode without setup_token", async ({ page }) => {
-  // No `?setup_token=...` query: Login should render its
-  // sign-in mode — no device-name field, "Sign in with
-  // passkey" CTA, `data-mode="signin"` for future styling +
-  // selector hooks.
-  await page.goto("/");
-  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
-
-  const login = page.locator("#kat-login");
-  await expect(login).toHaveAttribute("data-mode", "signin");
-  await expect(login.locator(".title")).toHaveText("Sign in");
-  await expect(login.locator(".cta")).toHaveText("Sign in with passkey");
-  // Sign-in mode CTA must be enabled in the idle state — the
-  // ceremony is wired (slice 9r.2). Disabled-by-default would
-  // be a regression that strands users on a dead button.
-  await expect(login.locator(".cta")).toBeEnabled();
-  // No device-name field in sign-in mode.
-  await expect(login.locator('input[name="device-name"]')).toHaveCount(0);
-});
-
-test("login switches to pair mode with setup_token", async ({ page }) => {
-  // Presence of `?setup_token=` flips the form to pair mode
-  // — adds the device-name field, swaps title + CTA copy,
-  // sets `data-mode="pair"`. Slice 9r.2 wires the sign-in
-  // ceremony only; the pair ceremony is still inert, so the
-  // CTA is disabled to avoid a button that does nothing.
-  // 9r.3 will land the pair ceremony and remove the disabled
-  // bit.
-  await page.goto("/?setup_token=abcdef0123456789");
-  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
-
-  const login = page.locator("#kat-login");
-  await expect(login).toHaveAttribute("data-mode", "pair");
-  await expect(login.locator(".title")).toHaveText("Pair this device");
-  await expect(login.locator(".cta")).toHaveText("Pair with passkey");
-  await expect(login.locator(".cta")).toBeDisabled();
-  // Pair mode shows the device-name input.
-  await expect(login.locator('input[name="device-name"]')).toBeVisible();
-});
-
-test("sign-in click hits /api/auth/login/start", async ({ page }) => {
-  // The CTA in sign-in mode is wired to dispatch the WebAuthn
-  // ceremony (slice 9r.2). We can't run the full ceremony in
-  // headless Chromium without a virtual authenticator, but we
-  // CAN verify the first hop — the POST to
-  // `/api/auth/login/start`. That alone catches the
-  // "button does nothing" regression that the slice 9r.1 stub
-  // had: the click handler is real, the URL is right, the
-  // method is POST.
-  await page.goto("/");
-  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
-
-  // Listen for the request before clicking — the start-call
-  // is fired synchronously from the click handler so a race
-  // here would show up as a flaky test, not a missed call.
-  const requestPromise = page.waitForRequest(
-    (req) =>
-      req.url().endsWith("/api/auth/login/start") && req.method() === "POST",
-    { timeout: 5_000 },
-  );
-  await page.locator("#kat-login .cta").click();
-  await requestPromise;
-});
-
-test("sign-in surfaces server error on fresh install", async ({ page }) => {
-  // On a fresh data dir with no credentials, the server's
-  // `/api/auth/login/start` returns 409 ("no credentials
-  // registered; first device must register…"). The UI must
-  // render that as a visible error instead of silently
-  // swallowing it — otherwise the user has no idea why the
-  // button "stopped working." We don't assert the exact
-  // message text (the server controls that wording); we just
-  // assert that an error region appears.
-  //
-  // This test is conditional on a fresh data dir. The Rust
-  // staging script (`bin/katulong-stage` in --rust mode)
-  // creates a fresh data dir per run, so this holds in the
-  // default e2e setup. If a future slice changes that, the
-  // test will need a route-mock fallback.
-  //
-  // Route-stubbing the start endpoint to 409 is the
-  // belt-and-suspenders alternative; we use it here so the
-  // assertion holds regardless of the server's auth state.
-  await page.route("**/api/auth/login/start", (route) =>
-    route.fulfill({
-      status: 409,
-      contentType: "application/json",
-      body: JSON.stringify({
-        error: { code: "conflict", message: "no credentials registered" },
-      }),
-    }),
-  );
-
-  await page.goto("/");
-  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
-
-  await page.locator("#kat-login .cta").click();
-
-  // The error <p role="alert"> is the user-visible result.
-  // role=alert is what assistive tech reads; we double-check
-  // class for the styling hook.
-  const error = page.locator('#kat-login .error[role="alert"]');
-  await expect(error).toBeVisible({ timeout: 5_000 });
-  await expect(error).toContainText("409");
 });
 
 test("/health returns ok", async ({ request }) => {

--- a/test/e2e-rust/smoke.e2e.js
+++ b/test/e2e-rust/smoke.e2e.js
@@ -82,6 +82,10 @@ test("login defaults to sign-in mode without setup_token", async ({ page }) => {
   await expect(login).toHaveAttribute("data-mode", "signin");
   await expect(login.locator(".title")).toHaveText("Sign in");
   await expect(login.locator(".cta")).toHaveText("Sign in with passkey");
+  // Sign-in mode CTA must be enabled in the idle state — the
+  // ceremony is wired (slice 9r.2). Disabled-by-default would
+  // be a regression that strands users on a dead button.
+  await expect(login.locator(".cta")).toBeEnabled();
   // No device-name field in sign-in mode.
   await expect(login.locator('input[name="device-name"]')).toHaveCount(0);
 });
@@ -89,9 +93,11 @@ test("login defaults to sign-in mode without setup_token", async ({ page }) => {
 test("login switches to pair mode with setup_token", async ({ page }) => {
   // Presence of `?setup_token=` flips the form to pair mode
   // — adds the device-name field, swaps title + CTA copy,
-  // sets `data-mode="pair"`. The token value isn't read by
-  // 9r.1 (the WebAuthn ceremony in 9r.2 will consume it);
-  // this test only asserts the visible mode swap.
+  // sets `data-mode="pair"`. Slice 9r.2 wires the sign-in
+  // ceremony only; the pair ceremony is still inert, so the
+  // CTA is disabled to avoid a button that does nothing.
+  // 9r.3 will land the pair ceremony and remove the disabled
+  // bit.
   await page.goto("/?setup_token=abcdef0123456789");
   await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
 
@@ -99,8 +105,75 @@ test("login switches to pair mode with setup_token", async ({ page }) => {
   await expect(login).toHaveAttribute("data-mode", "pair");
   await expect(login.locator(".title")).toHaveText("Pair this device");
   await expect(login.locator(".cta")).toHaveText("Pair with passkey");
+  await expect(login.locator(".cta")).toBeDisabled();
   // Pair mode shows the device-name input.
   await expect(login.locator('input[name="device-name"]')).toBeVisible();
+});
+
+test("sign-in click hits /api/auth/login/start", async ({ page }) => {
+  // The CTA in sign-in mode is wired to dispatch the WebAuthn
+  // ceremony (slice 9r.2). We can't run the full ceremony in
+  // headless Chromium without a virtual authenticator, but we
+  // CAN verify the first hop — the POST to
+  // `/api/auth/login/start`. That alone catches the
+  // "button does nothing" regression that the slice 9r.1 stub
+  // had: the click handler is real, the URL is right, the
+  // method is POST.
+  await page.goto("/");
+  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
+
+  // Listen for the request before clicking — the start-call
+  // is fired synchronously from the click handler so a race
+  // here would show up as a flaky test, not a missed call.
+  const requestPromise = page.waitForRequest(
+    (req) =>
+      req.url().endsWith("/api/auth/login/start") && req.method() === "POST",
+    { timeout: 5_000 },
+  );
+  await page.locator("#kat-login .cta").click();
+  await requestPromise;
+});
+
+test("sign-in surfaces server error on fresh install", async ({ page }) => {
+  // On a fresh data dir with no credentials, the server's
+  // `/api/auth/login/start` returns 409 ("no credentials
+  // registered; first device must register…"). The UI must
+  // render that as a visible error instead of silently
+  // swallowing it — otherwise the user has no idea why the
+  // button "stopped working." We don't assert the exact
+  // message text (the server controls that wording); we just
+  // assert that an error region appears.
+  //
+  // This test is conditional on a fresh data dir. The Rust
+  // staging script (`bin/katulong-stage` in --rust mode)
+  // creates a fresh data dir per run, so this holds in the
+  // default e2e setup. If a future slice changes that, the
+  // test will need a route-mock fallback.
+  //
+  // Route-stubbing the start endpoint to 409 is the
+  // belt-and-suspenders alternative; we use it here so the
+  // assertion holds regardless of the server's auth state.
+  await page.route("**/api/auth/login/start", (route) =>
+    route.fulfill({
+      status: 409,
+      contentType: "application/json",
+      body: JSON.stringify({
+        error: { code: "conflict", message: "no credentials registered" },
+      }),
+    }),
+  );
+
+  await page.goto("/");
+  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
+
+  await page.locator("#kat-login .cta").click();
+
+  // The error <p role="alert"> is the user-visible result.
+  // role=alert is what assistive tech reads; we double-check
+  // class for the styling hook.
+  const error = page.locator('#kat-login .error[role="alert"]');
+  await expect(error).toBeVisible({ timeout: 5_000 });
+  await expect(error).toContainText("409");
 });
 
 test("/health returns ok", async ({ request }) => {


### PR DESCRIPTION
## Summary

Slice 9r.2 of the Rust+Leptos rewrite: the sign-in CTA is no longer
inert — clicking it runs the full passkey ceremony against the
Rust backend's `/api/auth/login/start` + `/api/auth/login/finish`
endpoints. On success the server sets the session cookie and the UI
swaps `<Main/>` from `<Login/>` to a `<TerminalStub/>` placeholder.
On failure (network, browser-API rejection, server reject) an error
region renders below the CTA.

- New `signin()` async function: a pure, top-to-bottom pipeline
  through start → `navigator.credentials.get()` → finish. Dispatched
  via `create_action` so we get pending tracking and
  cancellation-on-unmount for free.
- New `LoginPhase` enum (Idle | InFlight | Error) — single signal
  that drives CTA copy, `prop:disabled`, and the conditional
  `<p class="error">` region.
- New `AuthState` context-provided signal at the App root; `<Main/>`
  reads via `<Show/>` to switch children, `<Login/>` writes through
  the setter on success.
- Pair mode CTA is greyed out (`prop:disabled`) — 9r.3 wires the
  pair ceremony.

## Why this shape

- **Pure ceremony, imperative shell.** `signin()` takes nothing,
  returns `Result<(), String>`, has no shared state. Per memory
  `feedback_rewrite_fp_direction` — pure core, imperative shell.
- **Wire types duplicated, not shared with server.** Six lines of
  duplication beats pulling axum/sqlx/scrypt into the WASM bundle.
  `webauthn-rs-proto` itself rides along (with the `wasm` feature)
  for the `web_sys` ↔ wire-type conversions — that's the part that's
  tricky to redo.
- **Errors as `String`.** Heterogeneous failure modes; the UI just
  shows the message. Typed error variants are premature until a
  future slice needs to branch on them.

## Bundle size

215 KB → 459 KB (well under the 1 MB sanity floor in the smoke
test). Bulk: `webauthn-rs-proto` + `gloo-net` + `serde-wasm-bindgen`.

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown` — clean
- [x] `trunk build --release` — 459 KB WASM, no warnings
- [x] `cargo build --release -p katulong-server` — clean
- [x] All 7 Rust e2e tests pass against live backend on 127.0.0.1:3050:
  - existing 5 still pass (shell render, signin/pair mode, /health, WASM size)
  - new: `sign-in click hits /api/auth/login/start` (verifies the
    click handler is wired and the URL/method are right)
  - new: `sign-in surfaces server error on fresh install`
    (route-stubs start to 409, asserts the error region appears with
    the status in the text)

## What's next

- 9r.3: wire the pair ceremony (`/api/auth/pair/*`) using the same
  pattern — likely a small refactor to factor out the shared HTTP
  glue and re-use the `LoginPhase` machine.
- 9r.4: `/api/auth/status` probe on load → if `authenticated`, skip
  Login entirely and go straight to the (still-stub) terminal view.
- A full happy-path e2e using Chromium's CDP virtual authenticator
  (`WebAuthn.addVirtualAuthenticator`) once we have register +
  signin both wired.