### PR TITLE
feat(ollama): backend cascade — peer bridge → local 31b → local cloud

### DIFF
--- a/lib/ollama-client.js
+++ b/lib/ollama-client.js
@@ -1,25 +1,44 @@
 /**
- * Tiny Ollama HTTP client.
+ * Tiny Ollama HTTP client with backend cascade.
  *
- * Keeps the Ollama dependency isolated in one place — callers hand us
- * a user prompt and system prompt, we POST to the local Ollama
- * /api/chat endpoint and return the assistant text as a single string.
+ * Callers hand us a user prompt + system prompt; we POST to an Ollama
+ * `/api/chat` endpoint and return the assistant text as a single string.
+ * Streaming is used internally so the network doesn't sit idle waiting
+ * for slow models — callers still await one aggregated string.
  *
- * Uses Ollama's streaming mode (`stream: true`) under the hood so the
- * response headers and first chunk arrive promptly, even when the
- * model takes minutes to finish. Non-streaming mode buffers the full
- * JSON response server-side, which trips undici's 5-minute
- * `headersTimeout` on CPU-only hosts running 7B-class models — the
- * outward behaviour from callers' perspective is unchanged (they
- * still await one string), but the network path no longer sits idle
- * waiting for a completed response.
+ * ## Cascade
  *
- * Host and model both have library-level defaults, but the product
- * decision of *which* model to use belongs at the call site — not
- * here — so callers in server.js pass `model` explicitly. The
- * `OLLAMA_HOST` / `OLLAMA_MODEL` env vars are last-resort overrides
- * for ad-hoc testing, not the normal configuration path.
+ * The client supports an ordered list of `backends`, each `{ name, host,
+ * authToken, model }`. On each call:
+ *
+ *   1. If a cached "active" backend exists and its TTL hasn't expired,
+ *      try it first (fast path — no probe).
+ *   2. Otherwise, probe each backend in order via `GET /api/tags`. The
+ *      first backend that's reachable AND lists the requested model
+ *      becomes the active backend; we then issue the actual chat call.
+ *   3. If the active backend's chat call fails (network error or 4xx/5xx),
+ *      invalidate the cache and probe the rest of the list. The same
+ *      call may end up served by a different backend.
+ *
+ * Probe is cheap (`GET /api/tags`); the chat call is expensive. We trust
+ * "probe says reachable" → "chat will succeed." If a chat call fails
+ * after a successful probe (rare — load, mid-stream upstream crash),
+ * we move on. The summarizer + narrator already retry every cycle.
+ *
+ * Cached active backend has a TTL (`probeTtlMs`, default 5 minutes) so
+ * we eventually re-probe and recover when a higher-priority backend
+ * comes back online (e.g., the peer bridge restarts).
+ *
+ * ## Backward compatibility
+ *
+ * The pre-cascade API took `host`/`model`/`authToken`/`resolveEndpoint`
+ * directly. Those still work — the constructor synthesizes a single-
+ * backend list from them. New callers should pass `resolveBackends`
+ * instead, returning the ordered list fresh on each call so config
+ * changes apply without a server restart.
  */
+
+import { log } from "./log.js";
 
 const DEFAULT_HOST = process.env.OLLAMA_HOST || "http://127.0.0.1:11434";
 const DEFAULT_MODEL = process.env.OLLAMA_MODEL || "gemma3n:e2b";
@@ -28,62 +47,109 @@ const DEFAULT_MODEL = process.env.OLLAMA_MODEL || "gemma3n:e2b";
 // tolerate cold-start latency, slow networks, or a local CPU-only
 // host chewing through a multi-paragraph response.
 const DEFAULT_TIMEOUT_MS = 10 * 60_000;
+const DEFAULT_PROBE_TIMEOUT_MS = 3_000;
+const DEFAULT_PROBE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_FAIL_TTL_MS = 30 * 1000;
 
 /**
- * Create a `callOllama` function bound to a given URL/model/timeout.
- * Returns `async (userPrompt, { systemPrompt }) => string`.
- *
- * `resolveEndpoint`, when provided, is called on every request and
- * returns `{ host, authToken }`. This lets the running server pick up
- * UI-driven config changes (peer URL + token) without a restart. When
- * absent, the static `host`/`authToken` from create-time are used.
- *
- * `authToken` (when set, either statically or via resolveEndpoint) is
- * sent as `Authorization: Bearer <token>`. This is the wire shape
- * ollama-bridge expects today and the eventual katulong-app/1 runtime
- * call will keep using.
+ * Create a `callOllama` function. The returned function additionally
+ * carries `getActiveBackend()` so callers (e.g., /health) can report
+ * which backend is currently in use without forcing a probe.
  */
 export function createOllamaClient({
+  // New API
+  resolveBackends = null,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  probeTimeoutMs = DEFAULT_PROBE_TIMEOUT_MS,
+  probeTtlMs = DEFAULT_PROBE_TTL_MS,
+  failTtlMs = DEFAULT_FAIL_TTL_MS,
+  // Old API (single backend) — kept for tests + any pre-cascade callers
   host = DEFAULT_HOST,
   model = DEFAULT_MODEL,
-  timeoutMs = DEFAULT_TIMEOUT_MS,
   authToken = null,
   resolveEndpoint = null,
+  // Internal seam — tests substitute a stub fetch
+  fetchImpl = fetch,
 } = {}) {
-  return async function callOllama(userPrompt, { systemPrompt } = {}) {
+  // Synthesize a single-backend resolver if the caller used the old API.
+  const effectiveResolveBackends =
+    resolveBackends ||
+    (() => {
+      const endpoint = resolveEndpoint ? resolveEndpoint() : null;
+      return [
+        {
+          name: "single",
+          host: endpoint?.host || host,
+          authToken: endpoint?.authToken ?? authToken ?? null,
+          model,
+        },
+      ];
+    });
+
+  let activeBackend = null;
+  let activeUntil = 0;
+  let lastLoggedActiveName = null;
+
+  function noteActive(backend) {
+    if (backend.name === lastLoggedActiveName) return;
+    log.info("ollama backend selected", {
+      name: backend.name,
+      host: backend.host,
+      model: backend.model,
+      previous: lastLoggedActiveName,
+    });
+    lastLoggedActiveName = backend.name;
+  }
+
+  function noteAllUnreachable() {
+    if (lastLoggedActiveName === null) return;
+    log.warn("ollama: no backend reachable", { previous: lastLoggedActiveName });
+    lastLoggedActiveName = null;
+  }
+
+  async function probeBackend(backend) {
+    const headers = backend.authToken
+      ? { Authorization: `Bearer ${backend.authToken}` }
+      : {};
+    try {
+      const res = await fetchImpl(`${backend.host}/api/tags`, {
+        headers,
+        signal: AbortSignal.timeout(probeTimeoutMs),
+      });
+      if (!res.ok) return false;
+      const data = await res.json().catch(() => null);
+      if (!Array.isArray(data?.models)) return false;
+      return data.models.some((m) => m?.name === backend.model);
+    } catch {
+      return false;
+    }
+  }
+
+  async function callChatOnce(backend, userPrompt, systemPrompt) {
     const messages = [];
     if (systemPrompt) messages.push({ role: "system", content: systemPrompt });
     messages.push({ role: "user", content: userPrompt });
 
-    const endpoint = resolveEndpoint ? resolveEndpoint() : null;
-    const effectiveHost = endpoint?.host || host;
-    const effectiveToken = endpoint?.authToken ?? authToken;
-
     const headers = { "Content-Type": "application/json" };
-    if (effectiveToken) headers.Authorization = `Bearer ${effectiveToken}`;
+    if (backend.authToken) headers.Authorization = `Bearer ${backend.authToken}`;
 
-    const res = await fetch(`${effectiveHost}/api/chat`, {
+    const res = await fetchImpl(`${backend.host}/api/chat`, {
       method: "POST",
       headers,
-      body: JSON.stringify({ model, messages, stream: true }),
+      body: JSON.stringify({ model: backend.model, messages, stream: true }),
       signal: AbortSignal.timeout(timeoutMs),
     });
     if (!res.ok) {
-      throw new Error(`Ollama responded ${res.status}: ${await res.text().catch(() => "(no body)")}`);
+      throw new Error(
+        `Ollama responded ${res.status}: ${await res.text().catch(() => "(no body)")}`,
+      );
     }
     if (!res.body) {
       throw new Error("Ollama response missing body");
     }
 
-    // Ollama streams NDJSON: one JSON object per newline, each with an
-    // incremental `message.content` fragment, terminated by a final
-    // `{"done": true, ...}` object. Aggregate the content fragments.
-    //
-    // We always cancel the reader in a finally — on abort (timeout /
-    // caller-initiated), reader.read() rejects but the underlying
-    // ReadableStream and its fetch body are not released until someone
-    // explicitly cancels or fully drains. A cancel here detaches the
-    // stream from the connection so undici can close the socket.
+    // Ollama streams NDJSON; aggregate the message.content fragments.
+    // Always cancel the reader on abort so the underlying socket closes.
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     let buf = "";
@@ -122,5 +188,77 @@ export function createOllamaClient({
       throw new Error("Ollama response missing message.content");
     }
     return content;
+  }
+
+  function cacheActive(backend) {
+    activeBackend = backend;
+    activeUntil = Date.now() + probeTtlMs;
+  }
+
+  function invalidateActive() {
+    activeBackend = null;
+    activeUntil = Date.now() + failTtlMs;
+  }
+
+  async function callOllama(userPrompt, { systemPrompt } = {}) {
+    // Fast path: try the cached active backend without re-probing.
+    if (activeBackend && Date.now() < activeUntil) {
+      try {
+        return await callChatOnce(activeBackend, userPrompt, systemPrompt);
+      } catch (err) {
+        log.warn("ollama: active backend failed, falling back", {
+          name: activeBackend.name,
+          error: err.message,
+        });
+        invalidateActive();
+      }
+    }
+
+    // Slow path: probe each backend in order, use the first reachable
+    // one that has the right model.
+    const backends = effectiveResolveBackends();
+    if (!Array.isArray(backends) || backends.length === 0) {
+      throw new Error("ollama: no backends configured");
+    }
+
+    let lastErr = null;
+    for (const backend of backends) {
+      // Skip the cached active if we just failed it (avoids retrying
+      // the same path twice in a single call).
+      if (activeBackend === null && lastErr && backend.name === lastLoggedActiveName) {
+        continue;
+      }
+      const reachable = await probeBackend(backend);
+      if (!reachable) continue;
+      try {
+        const result = await callChatOnce(backend, userPrompt, systemPrompt);
+        cacheActive(backend);
+        noteActive(backend);
+        return result;
+      } catch (err) {
+        lastErr = err;
+        // Probe said yes but call failed — try the next backend.
+      }
+    }
+
+    noteAllUnreachable();
+    throw lastErr || new Error("ollama: no backend reachable");
+  }
+
+  callOllama.getActiveBackend = () =>
+    activeBackend
+      ? {
+          name: activeBackend.name,
+          host: activeBackend.host,
+          model: activeBackend.model,
+        }
+      : null;
+
+  /** Force the next call to re-probe (used by tests + on config change). */
+  callOllama.invalidate = () => {
+    activeBackend = null;
+    activeUntil = 0;
   };
+
+  return callOllama;
 }

--- a/lib/ollama-client.js
+++ b/lib/ollama-client.js
@@ -86,15 +86,32 @@ export function createOllamaClient({
       ];
     });
 
-  let activeBackend = null;
-  let activeUntil = 0;
+  // Three pieces of state:
+  //   cachedBackend  — the backend we trust right now (or null).
+  //   cacheUntil     — when that trust expires (TTL after a successful call).
+  //   quietUntil     — don't probe again before this (backoff after a complete
+  //                     cascade failure). Distinct from cacheUntil so the two
+  //                     post-failure states don't conflate: "we have an active
+  //                     backend, just trust it" is different from "we just tried
+  //                     everything and nothing worked, hold off."
+  let cachedBackend = null;
+  let cacheUntil = 0;
+  let quietUntil = 0;
   let lastLoggedActiveName = null;
+
+  function safeHost(host) {
+    try {
+      return new URL(host).origin;
+    } catch {
+      return "(unparseable)";
+    }
+  }
 
   function noteActive(backend) {
     if (backend.name === lastLoggedActiveName) return;
     log.info("ollama backend selected", {
       name: backend.name,
-      host: backend.host,
+      host: safeHost(backend.host),
       model: backend.model,
       previous: lastLoggedActiveName,
     });
@@ -102,7 +119,8 @@ export function createOllamaClient({
   }
 
   function noteAllUnreachable() {
-    if (lastLoggedActiveName === null) return;
+    // Always log — operator wants to see the warning even on first call,
+    // not just after a previously-active backend goes down.
     log.warn("ollama: no backend reachable", { previous: lastLoggedActiveName });
     lastLoggedActiveName = null;
   }
@@ -190,28 +208,34 @@ export function createOllamaClient({
     return content;
   }
 
-  function cacheActive(backend) {
-    activeBackend = backend;
-    activeUntil = Date.now() + probeTtlMs;
-  }
-
-  function invalidateActive() {
-    activeBackend = null;
-    activeUntil = Date.now() + failTtlMs;
-  }
-
   async function callOllama(userPrompt, { systemPrompt } = {}) {
-    // Fast path: try the cached active backend without re-probing.
-    if (activeBackend && Date.now() < activeUntil) {
+    const now = Date.now();
+
+    // Fast path: try the cached active backend without re-probing. Capture
+    // the just-failed name BEFORE entering the slow path so we can skip it
+    // there — without this, the slow path would re-probe the same backend
+    // it just failed and possibly issue a second chat call.
+    let justFailedName = null;
+    if (cachedBackend && now < cacheUntil) {
       try {
-        return await callChatOnce(activeBackend, userPrompt, systemPrompt);
+        return await callChatOnce(cachedBackend, userPrompt, systemPrompt);
       } catch (err) {
         log.warn("ollama: active backend failed, falling back", {
-          name: activeBackend.name,
+          name: cachedBackend.name,
           error: err.message,
         });
-        invalidateActive();
+        justFailedName = cachedBackend.name;
+        cachedBackend = null;
+        cacheUntil = 0;
       }
+    }
+
+    // Backoff: a complete cascade failure on the previous call set quietUntil.
+    // Don't probe-storm during an outage; the caller (summarizer / narrator)
+    // is calling on a 30-second-ish cycle and would otherwise probe every time.
+    if (Date.now() < quietUntil) {
+      throw new Error("ollama: in failure backoff, retrying after " +
+        new Date(quietUntil).toISOString());
     }
 
     // Slow path: probe each backend in order, use the first reachable
@@ -223,16 +247,16 @@ export function createOllamaClient({
 
     let lastErr = null;
     for (const backend of backends) {
-      // Skip the cached active if we just failed it (avoids retrying
-      // the same path twice in a single call).
-      if (activeBackend === null && lastErr && backend.name === lastLoggedActiveName) {
-        continue;
-      }
+      // Skip the backend that just failed the fast path (its probe may
+      // still pass — /api/tags doesn't care if /api/chat is broken — and
+      // we don't want a second chat-call attempt on the same cycle).
+      if (justFailedName && backend.name === justFailedName) continue;
       const reachable = await probeBackend(backend);
       if (!reachable) continue;
       try {
         const result = await callChatOnce(backend, userPrompt, systemPrompt);
-        cacheActive(backend);
+        cachedBackend = backend;
+        cacheUntil = Date.now() + probeTtlMs;
         noteActive(backend);
         return result;
       } catch (err) {
@@ -241,23 +265,31 @@ export function createOllamaClient({
       }
     }
 
+    // Nothing reachable. Set the backoff so the next call doesn't probe
+    // every backend again immediately.
+    quietUntil = Date.now() + failTtlMs;
     noteAllUnreachable();
     throw lastErr || new Error("ollama: no backend reachable");
   }
 
+  // host is intentionally NOT exposed here — it could contain operator-
+  // configured URLs we don't want forwarded blindly to clients. /health
+  // and other consumers only need name + model to render status.
   callOllama.getActiveBackend = () =>
-    activeBackend
-      ? {
-          name: activeBackend.name,
-          host: activeBackend.host,
-          model: activeBackend.model,
-        }
+    cachedBackend
+      ? { name: cachedBackend.name, model: cachedBackend.model }
       : null;
 
-  /** Force the next call to re-probe (used by tests + on config change). */
+  /**
+   * Force the next call to re-probe. Called on config changes (e.g.,
+   * the operator rotates the peer-bridge token via Settings) so the
+   * cached active backend doesn't keep using the stale token for up
+   * to its TTL window.
+   */
   callOllama.invalidate = () => {
-    activeBackend = null;
-    activeUntil = 0;
+    cachedBackend = null;
+    cacheUntil = 0;
+    quietUntil = 0;
   };
 
   return callOllama;

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -1022,6 +1022,12 @@ export function createAppRoutes(ctx) {
       try {
         if ("url" in body)   await configManager.setOllamaPeerUrl(body.url);
         if ("token" in body) await configManager.setOllamaPeerToken(body.token);
+        // Drop the cascade's cached active backend so the next outbound
+        // LLM call re-probes with the new url/token. Without this, a
+        // rotated token would keep getting passed through the (now-stale)
+        // cached entry for up to its 5-min TTL — including the case where
+        // the rotation was a response to compromise.
+        callOllama?.invalidate?.();
         log.info("ollamaPeer updated", {
           url: configManager.getOllamaPeerUrl(),
           hasToken: !!configManager.getOllamaPeerToken(),

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -172,7 +172,7 @@ export function createAppRoutes(ctx) {
     configManager, __dirname, DATA_DIR, APP_VERSION,
     getDraining, shortcutsPath,
     auth, csrf, topicBroker, getExternalUrl,
-    permissionStore,
+    permissionStore, callOllama,
   } = ctx;
 
   // Tracks the async pane-scan started by each PreToolUse, keyed by the
@@ -232,6 +232,13 @@ export function createAppRoutes(ctx) {
       if (isAuthenticated(req)) {
         response.pid = process.pid;
         response.uptime = process.uptime();
+        // Surface which LLM backend is currently in use (peer-bridge,
+        // local-31b, local-cloud) so an operator can see at a glance
+        // whether the cascade is hitting the bridge or has fallen back.
+        const active = callOllama?.getActiveBackend?.();
+        response.llm = active
+          ? { backend: active.name, model: active.model }
+          : { backend: null };
       }
       json(res, 200, response);
     }},

--- a/server.js
+++ b/server.js
@@ -275,25 +275,41 @@ const getDraining = () => shutdown?.isDraining() ?? false;
 const topicBroker = createTopicBroker();
 const claudeWatchlist = createWatchlist({ dataDir: DATA_DIR });
 const permissionStore = createPermissionStore();
-// Pinned to the cloud model: local backbones (gemma3n:e2b,
-// qwen2.5-coder:7b) were too resource-intensive on laptop-class hosts
-// — the model swapped out between prompts and summaries stretched to
-// minutes. The cloud offload is served through the same local Ollama
-// daemon at http://127.0.0.1:11434 after `ollama signin`, so no
-// additional config is needed beyond authenticating the daemon.
-// Single shared client is intentional: we stay Claude-specific until
-// a consumer actually needs a different model / timeout / host.
+// LLM cascade — the single shared callOllama probes a list of backends
+// in priority order on every cycle and uses the first that's reachable
+// AND has the requested model. Order:
 //
-// resolveEndpoint reads the peer Ollama config on every request, so the
-// Settings UI can swap endpoints without restarting the server. Returns
-// null when no peer is configured — the client then falls back to the
-// default localhost host.
+//   1. peer-bridge      → user-configured ollama-bridge URL (Settings →
+//                          External LLM endpoint), gemma4:31b. Lets a
+//                          GPU-poor host route inference to a GPU-rich
+//                          host running the local 31b model.
+//   2. local-31b        → this host's Ollama daemon, gemma4:31b. Used
+//                          when the local box has the model pulled.
+//   3. local-cloud      → this host's Ollama daemon, gemma4:31b-cloud
+//                          (the cloud-proxy variant). Last-resort
+//                          fallback — quota-gated, but better than
+//                          nothing if no local 31b is pulled.
+//
+// resolveBackends is called fresh on every request, so the Settings UI
+// can swap the peer URL/token at runtime. The client caches its
+// "active" pick for ~5 min then re-probes — covers the case where the
+// peer bridge restarts and we want to migrate back from the local
+// fallback.
 const callOllama = createOllamaClient({
-  model: "gemma4:31b-cloud",
-  resolveEndpoint: () => {
+  resolveBackends: () => {
+    const list = [];
     const peerUrl = configManager.getOllamaPeerUrl();
-    if (!peerUrl) return null;
-    return { host: peerUrl, authToken: configManager.getOllamaPeerToken() };
+    if (peerUrl) {
+      list.push({
+        name: "peer-bridge",
+        host: peerUrl,
+        authToken: configManager.getOllamaPeerToken(),
+        model: "gemma4:31b",
+      });
+    }
+    list.push({ name: "local-31b",    host: "http://127.0.0.1:11434", authToken: null, model: "gemma4:31b" });
+    list.push({ name: "local-cloud",  host: "http://127.0.0.1:11434", authToken: null, model: "gemma4:31b-cloud" });
+    return list;
   },
 });
 const claudeProcessor = createClaudeProcessor({
@@ -343,6 +359,7 @@ const routes = [
     auth, csrf,
     topicBroker,
     permissionStore,
+    callOllama,
     getExternalUrl: () => configManager.getPublicUrl(),
   }),
   ...createClaudeFeedRoutes({

--- a/test/ollama-client-peer.test.js
+++ b/test/ollama-client-peer.test.js
@@ -235,4 +235,94 @@ describe("createOllamaClient — cascade (resolveBackends)", () => {
     });
     await assert.rejects(() => client("hi"), /no backend reachable/);
   });
+
+  it("backs off after a complete cascade failure (no probe storm)", async () => {
+    let resolveCalls = 0;
+    const client = createOllamaClient({
+      resolveBackends: () => {
+        resolveCalls++;
+        return [{ name: "p", host: "http://127.0.0.1:1", authToken: null, model: "x" }];
+      },
+      probeTimeoutMs: 200,
+      failTtlMs: 60_000,
+    });
+    // First call exhausts the cascade and sets the backoff.
+    await assert.rejects(() => client("first"));
+    assert.equal(resolveCalls, 1);
+    // Second call hits the backoff branch — no resolveBackends, no probe.
+    await assert.rejects(() => client("second"), /failure backoff/);
+    assert.equal(resolveCalls, 1, "should not have re-resolved during backoff");
+  });
+
+  it("invalidate() clears the failure backoff too", async () => {
+    let resolveCalls = 0;
+    const client = createOllamaClient({
+      resolveBackends: () => {
+        resolveCalls++;
+        return [{ name: "p", host: "http://127.0.0.1:1", authToken: null, model: "x" }];
+      },
+      probeTimeoutMs: 200,
+      failTtlMs: 60_000,
+    });
+    await assert.rejects(() => client("first"));
+    client.invalidate();
+    // After invalidate, the backoff is gone and the next call probes again.
+    await assert.rejects(() => client("second"));
+    assert.equal(resolveCalls, 2);
+  });
+
+  it("skips the just-failed backend when fast-path falls through", async () => {
+    // A stub that answers /api/tags but 500s on /api/chat. Becomes the
+    // cached active (probe says yes), then the fast path's chat call
+    // fails. The slow path must NOT re-probe-and-call the broken
+    // backend — should jump straight to the healthy one.
+    let chatCallsToBroken = 0;
+    const brokenStub = createServer((req, res) => {
+      if (req.method === "GET" && req.url === "/api/tags") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        return res.end(JSON.stringify({ models: [{ name: "gemma4:31b" }] }));
+      }
+      chatCallsToBroken++;
+      res.writeHead(500);
+      res.end("nope");
+    });
+    await new Promise((resolve) => brokenStub.listen(0, "127.0.0.1", resolve));
+    const brokenUrl = `http://127.0.0.1:${brokenStub.address().port}`;
+
+    try {
+      const client = createOllamaClient({
+        resolveBackends: () => [
+          { name: "broken",   host: brokenUrl, authToken: null, model: "gemma4:31b" },
+          { name: "local-31b", host: localUrl, authToken: null, model: "gemma4:31b" },
+        ],
+      });
+      // First call: probe broken (ok), chat broken (fails), probe local (ok),
+      // chat local (works). One chat hit on broken, one chat hit on local.
+      await client("first");
+      assert.equal(client.getActiveBackend().name, "local-31b");
+      assert.equal(chatCallsToBroken, 1, "broken should have been tried exactly once");
+      // Second call hits the fast path on local-31b — broken not touched.
+      await client("second");
+      assert.equal(chatCallsToBroken, 1, "broken must not be retried after fast-path success");
+    } finally {
+      brokenStub.close();
+    }
+  });
+
+  it("getActiveBackend does NOT expose the host (foot-gun guard)", async () => {
+    const client = createOllamaClient({
+      resolveBackends: () => [
+        { name: "p", host: bridgeUrl, authToken: null, model: "gemma4:31b" },
+      ],
+    });
+    await client("hi");
+    const active = client.getActiveBackend();
+    assert.equal(active.name, "p");
+    assert.equal(active.model, "gemma4:31b");
+    assert.equal(
+      active.host,
+      undefined,
+      "host must not appear in getActiveBackend's return — could leak peer URL or embedded creds",
+    );
+  });
 });

--- a/test/ollama-client-peer.test.js
+++ b/test/ollama-client-peer.test.js
@@ -1,18 +1,30 @@
 /**
- * Tests the new peer-routing knobs on createOllamaClient — both the static
- * `authToken` and the dynamic `resolveEndpoint` callback. The callback is
- * what lets the running server pick up UI-driven config changes without a
- * restart, so verifying it's actually called per-request matters.
+ * Tests for createOllamaClient: backward-compat single-backend mode AND
+ * the new cascade (resolveBackends) that probes a list of backends in
+ * priority order.
  */
 
-import { describe, it, before, after } from "node:test";
+import { describe, it, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import { createOllamaClient } from "../lib/ollama-client.js";
 
-function startStubOllama() {
+/**
+ * Start a stub Ollama that answers both /api/tags (probe) and /api/chat.
+ *
+ * `availableModels` controls which models /api/tags reports — the cascade
+ * probe needs the requested model to appear in the list, otherwise it
+ * skips to the next backend.
+ */
+function startStubOllama({ availableModels = ["test-model"] } = {}) {
   const requests = [];
   const server = createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/api/tags") {
+      requests.push({ url: req.url, method: req.method, headers: req.headers });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ models: availableModels.map((name) => ({ name })) }));
+      return;
+    }
     const chunks = [];
     req.on("data", (c) => chunks.push(c));
     req.on("end", () => {
@@ -29,11 +41,13 @@ function startStubOllama() {
     });
   });
   return new Promise((resolve) => {
-    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port, requests }));
+    server.listen(0, "127.0.0.1", () =>
+      resolve({ server, port: server.address().port, requests }),
+    );
   });
 }
 
-describe("createOllamaClient — peer routing", () => {
+describe("createOllamaClient — single-backend (backward-compat)", () => {
   let stub;
   let baseUrl;
 
@@ -41,7 +55,6 @@ describe("createOllamaClient — peer routing", () => {
     stub = await startStubOllama();
     baseUrl = `http://127.0.0.1:${stub.port}`;
   });
-
   after(() => stub.server.close());
 
   it("includes Bearer header when authToken is set statically", async () => {
@@ -51,66 +64,175 @@ describe("createOllamaClient — peer routing", () => {
       authToken: "static-token-xyz",
     });
     await client("hi");
-    const last = stub.requests.at(-1);
-    assert.equal(last.headers.authorization, "Bearer static-token-xyz");
+    const lastChat = stub.requests.findLast((r) => r.url === "/api/chat");
+    assert.equal(lastChat.headers.authorization, "Bearer static-token-xyz");
   });
 
   it("omits Bearer header when authToken is null", async () => {
     const client = createOllamaClient({ host: baseUrl, model: "test-model" });
     await client("hi");
-    const last = stub.requests.at(-1);
-    assert.equal(
-      last.headers.authorization,
-      undefined,
-      "no Authorization header should be sent",
-    );
+    const lastChat = stub.requests.findLast((r) => r.url === "/api/chat");
+    assert.equal(lastChat.headers.authorization, undefined);
   });
 
-  it("calls resolveEndpoint on every request", async () => {
-    let calls = 0;
-    const client = createOllamaClient({
-      model: "test-model",
-      resolveEndpoint: () => {
-        calls++;
-        return { host: baseUrl, authToken: `token-${calls}` };
-      },
-    });
-    await client("first");
-    await client("second");
-    assert.equal(calls, 2, "resolveEndpoint should be called on each request");
-    const reqs = stub.requests.slice(-2);
-    assert.equal(reqs[0].headers.authorization, "Bearer token-1");
-    assert.equal(reqs[1].headers.authorization, "Bearer token-2");
+  it("aggregates the streamed response body", async () => {
+    const client = createOllamaClient({ host: baseUrl, model: "test-model" });
+    const result = await client("hi");
+    assert.equal(result, "hello world");
   });
 
   it("resolveEndpoint can flip between peer and local without recreating the client", async () => {
     let mode = "local";
     const client = createOllamaClient({
-      host: baseUrl, // unused while resolveEndpoint returns a host
+      host: baseUrl,
       model: "test-model",
       authToken: "fallback-static",
       resolveEndpoint: () =>
         mode === "peer"
           ? { host: baseUrl, authToken: "peer-token" }
-          : null, // null means "use static fallbacks"
+          : null,
     });
 
     await client("first");
-    assert.equal(stub.requests.at(-1).headers.authorization, "Bearer fallback-static");
+    assert.equal(
+      stub.requests.findLast((r) => r.url === "/api/chat").headers.authorization,
+      "Bearer fallback-static",
+    );
 
     mode = "peer";
+    client.invalidate(); // force re-probe so the new resolveEndpoint is sampled
     await client("second");
-    assert.equal(stub.requests.at(-1).headers.authorization, "Bearer peer-token");
+    assert.equal(
+      stub.requests.findLast((r) => r.url === "/api/chat").headers.authorization,
+      "Bearer peer-token",
+    );
+  });
+});
+
+describe("createOllamaClient — cascade (resolveBackends)", () => {
+  let bridgeStub, localStub;
+  let bridgeUrl, localUrl;
+
+  beforeEach(async () => {
+    bridgeStub = await startStubOllama({ availableModels: ["gemma4:31b"] });
+    localStub = await startStubOllama({ availableModels: ["gemma4:31b", "gemma4:31b-cloud"] });
+    bridgeUrl = `http://127.0.0.1:${bridgeStub.port}`;
+    localUrl = `http://127.0.0.1:${localStub.port}`;
+  });
+  afterEach(() => {
+    bridgeStub?.server.close();
+    localStub?.server.close();
+    bridgeStub = null;
+    localStub = null;
   });
 
-  it("is backward-compatible: no Auth, no resolver = vanilla local call", async () => {
-    const client = createOllamaClient({ host: baseUrl, model: "test-model" });
-    const result = await client("hi");
-    assert.equal(result, "hello world", "stream content should aggregate");
-    const last = stub.requests.at(-1);
-    assert.equal(last.url, "/api/chat");
-    assert.equal(last.method, "POST");
-    assert.equal(last.body.model, "test-model");
-    assert.equal(last.body.stream, true);
+  it("picks the first backend in the list when it has the requested model", async () => {
+    const client = createOllamaClient({
+      resolveBackends: () => [
+        { name: "peer-bridge", host: bridgeUrl, authToken: "tok", model: "gemma4:31b" },
+        { name: "local-31b",   host: localUrl,  authToken: null,  model: "gemma4:31b" },
+      ],
+    });
+    await client("hi");
+    const active = client.getActiveBackend();
+    assert.equal(active.name, "peer-bridge");
+    // Bridge stub got the chat call, local stub did not.
+    assert.ok(bridgeStub.requests.some((r) => r.url === "/api/chat"));
+    assert.ok(!localStub.requests.some((r) => r.url === "/api/chat"));
+  });
+
+  it("falls through to the next backend when the first lacks the model", async () => {
+    // Tier 1 is configured for gemma4:99b — the bridge stub doesn't have
+    // it, so /api/tags will not include it and the probe fails.
+    const client = createOllamaClient({
+      resolveBackends: () => [
+        { name: "peer-bridge", host: bridgeUrl, authToken: "tok", model: "nonexistent-model" },
+        { name: "local-31b",   host: localUrl,  authToken: null,  model: "gemma4:31b" },
+      ],
+    });
+    await client("hi");
+    assert.equal(client.getActiveBackend().name, "local-31b");
+    // Probe ran against bridge but no chat call was made there.
+    assert.ok(bridgeStub.requests.some((r) => r.url === "/api/tags"));
+    assert.ok(!bridgeStub.requests.some((r) => r.url === "/api/chat"));
+    assert.ok(localStub.requests.some((r) => r.url === "/api/chat"));
+  });
+
+  it("falls through to the next backend when the first is unreachable", async () => {
+    const client = createOllamaClient({
+      resolveBackends: () => [
+        { name: "peer-bridge", host: "http://127.0.0.1:1", authToken: null, model: "gemma4:31b" },
+        { name: "local-31b",   host: localUrl, authToken: null, model: "gemma4:31b" },
+      ],
+      probeTimeoutMs: 500,
+    });
+    await client("hi");
+    assert.equal(client.getActiveBackend().name, "local-31b");
+  });
+
+  it("falls through from gemma4:31b → gemma4:31b-cloud when local doesn't have :31b", async () => {
+    // Local-31b is "available" structurally but the Ollama daemon only
+    // has the cloud variant pulled. Probe filters on model name in
+    // /api/tags, so this works as expected.
+    const onlyCloudStub = await startStubOllama({ availableModels: ["gemma4:31b-cloud"] });
+    const onlyCloudUrl = `http://127.0.0.1:${onlyCloudStub.port}`;
+    try {
+      const client = createOllamaClient({
+        resolveBackends: () => [
+          { name: "local-31b",   host: onlyCloudUrl, authToken: null, model: "gemma4:31b" },
+          { name: "local-cloud", host: onlyCloudUrl, authToken: null, model: "gemma4:31b-cloud" },
+        ],
+      });
+      await client("hi");
+      assert.equal(client.getActiveBackend().name, "local-cloud");
+    } finally {
+      onlyCloudStub.server.close();
+    }
+  });
+
+  it("caches the active backend across calls (no re-probe within TTL)", async () => {
+    const client = createOllamaClient({
+      resolveBackends: () => [
+        { name: "peer-bridge", host: bridgeUrl, authToken: null, model: "gemma4:31b" },
+      ],
+    });
+    await client("first");
+    const probesAfterFirst = bridgeStub.requests.filter((r) => r.url === "/api/tags").length;
+    await client("second");
+    const probesAfterSecond = bridgeStub.requests.filter((r) => r.url === "/api/tags").length;
+    assert.equal(probesAfterFirst, 1, "first call should probe");
+    assert.equal(probesAfterSecond, 1, "second call should reuse the cached active");
+  });
+
+  it("invalidate() forces the next call to re-probe", async () => {
+    const client = createOllamaClient({
+      resolveBackends: () => [
+        { name: "peer-bridge", host: bridgeUrl, authToken: null, model: "gemma4:31b" },
+      ],
+    });
+    await client("first");
+    client.invalidate();
+    await client("second");
+    const probes = bridgeStub.requests.filter((r) => r.url === "/api/tags").length;
+    assert.equal(probes, 2, "invalidate should force a re-probe");
+  });
+
+  it("getActiveBackend returns null when nothing has been probed yet", () => {
+    const client = createOllamaClient({
+      resolveBackends: () => [
+        { name: "peer-bridge", host: bridgeUrl, authToken: null, model: "gemma4:31b" },
+      ],
+    });
+    assert.equal(client.getActiveBackend(), null);
+  });
+
+  it("throws a clear error when no backend is reachable", async () => {
+    const client = createOllamaClient({
+      resolveBackends: () => [
+        { name: "p", host: "http://127.0.0.1:1", authToken: null, model: "x" },
+      ],
+      probeTimeoutMs: 300,
+    });
+    await assert.rejects(() => client("hi"), /no backend reachable/);
   });
 });


### PR DESCRIPTION
## Summary

Replaces the single hardcoded `gemma4:31b-cloud` model with an ordered cascade. Every outbound LLM call (summarizer + narrator) probes the active backend; the client uses the first reachable backend whose Ollama daemon has the requested model pulled.

**Cascade**

1. **`peer-bridge`** — user-configured ollama-bridge URL (Settings → External LLM endpoint), `gemma4:31b`. Lets a GPU-poor host route inference to a GPU-rich host running the local 31B model.
2. **`local-31b`** — this host's Ollama daemon, `gemma4:31b`. Used when the local box has the model pulled.
3. **`local-cloud`** — this host's Ollama daemon, `gemma4:31b-cloud`. Last-resort fallback — quota-gated, but better than failing silently.

The cached active backend has a ~5 min TTL, then re-probes — recovers automatically when a higher-priority backend comes back online (e.g., the peer bridge restarts).

## Why

Pre-cascade, the model was hardcoded to `gemma4:31b-cloud` and hit Ollama's free-tier weekly quota on 2026-04-26. Every summarizer cycle silently 429'd until reset. The bridge work in v0.61.0 closed half the problem (the routing); this PR closes the rest (model selection).

## Visibility

- Authenticated `GET /health` now includes `llm: {backend, model}` so operators can see at a glance whether the cascade is on the bridge or has fallen back.
- On any backend change, logs once at `info`: `"ollama backend selected" {name, host, model, previous}`.
- On all-unreachable, logs once at `warn`.

## API

`createOllamaClient` now accepts `resolveBackends: () => Backend[]`. The single-backend API (`host`/`model`/`authToken`/`resolveEndpoint`) still works — the constructor synthesizes a one-element list.

The returned `callOllama` function exposes:
- `getActiveBackend()` — current pick (or `null` if not probed yet)
- `invalidate()` — force the next call to re-probe

## Test plan

- [x] `npm run test:unit` — 2687 pass / 0 fail / 3 skipped
- [x] 12 new test cases covering single-backend backward-compat, cascade priority, fall-through (missing model, unreachable host, cloud fallback), cache TTL, invalidate, getActiveBackend null-state, and no-backend-reachable error
- [ ] Once shipped: confirm `katulong update` on mini picks `peer-bridge` automatically (mac2024's `gemma4:31b` becomes the active backend); `/health` shows `llm.backend: "peer-bridge"`

## Operator behavior

- **With local `gemma4:31b` already pulled**: zero impact, transparent.
- **With a peer bridge configured**: inference now goes through it; on any failure falls back silently. `/health` and the backend-selected log line show what's active.
- **With NO local 31b pulled and no bridge**: still works via the cloud-proxy variant, same behavior as today's default.

Closes the missed scope from #672 (which I closed in favor of this).