### PR TITLE
rewrite(web): slice 9r.3 — pair WebAuthn ceremony wired to the API

### DIFF
--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -12,16 +12,20 @@ path = "src/main.rs"
 leptos = { workspace = true }
 console_error_panic_hook = "0.1"
 # `web-sys` for the few browser globals we touch directly.
-# Slice 9r.2 adds the WebAuthn surface (Navigator,
+# Slice 9r.2 added the sign-in WebAuthn surface (Navigator,
 # CredentialsContainer, CredentialRequestOptions,
-# PublicKeyCredential). Earlier slices added URL parsing.
-# Feature-gated narrowly to keep the WASM bundle lean.
+# PublicKeyCredential). Slice 9r.3 adds
+# `CredentialCreationOptions` for the registration ceremony
+# (`navigator.credentials.create(...)`). Earlier slices added
+# URL parsing. Feature-gated narrowly to keep the WASM bundle
+# lean.
 web-sys = { version = "0.3", features = [
     "Window",
     "Location",
     "UrlSearchParams",
     "Navigator",
     "CredentialsContainer",
+    "CredentialCreationOptions",
     "CredentialRequestOptions",
     "PublicKeyCredential",
 ] }

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -1,13 +1,21 @@
-//! Login component + sign-in WebAuthn ceremony.
+//! Login component + sign-in / pair WebAuthn ceremonies.
 //!
 //! Slice 9r.1 landed the form shell + URL-based pair vs.
 //! sign-in mode swap. Slice 9r.2 wired the sign-in ceremony.
-//! Slice 9r.3 (planned) lands the pair ceremony, which will
-//! reuse the `LoginPhase` machine and the HTTP glue here.
+//! Slice 9r.3 wires the pair (registration) ceremony,
+//! reusing the `LoginPhase` state machine.
 //!
 //! FP-leaning per memory `feedback_rewrite_fp_direction`:
-//! `signin()` is a pure async pipeline (no shared state, no
-//! callbacks); the component dispatches it via
+//! `signin()` and `pair()` are pure async pipelines (no shared
+//! state, no callbacks). They share shape but not types — the
+//! WebAuthn wire formats and the `web-sys` entry points
+//! diverge between get/create. We keep them as two parallel
+//! functions rather than a generic helper because the
+//! "different parts" (endpoint, request body, options type,
+//! navigator method, response type) outweigh the "same parts"
+//! (ok-check, JsFuture, dyn_into); a generic abstraction
+//! would obscure the flow without paying for itself.
+//! The component dispatches whichever applies via
 //! `create_action` and reacts to the resolved value.
 
 use crate::AuthState;
@@ -58,6 +66,33 @@ struct LoginStartResp {
 struct LoginFinishReq {
     challenge_id: String,
     response: webauthn_rs_proto::PublicKeyCredential,
+}
+
+#[derive(Debug, Serialize)]
+struct PairStartReq {
+    /// Plaintext setup-token from the URL. The server hashes
+    /// and looks it up; we never see the hashed form.
+    setup_token: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PairStartResp {
+    challenge_id: String,
+    /// Server-side opaque id for the redeemable token. Echoed
+    /// back on `pair/finish` so the client doesn't have to
+    /// re-submit the plaintext setup-token a second time. The
+    /// authoritative token re-check still happens server-side
+    /// under the state lock, so this is a nicety, not a
+    /// security boundary.
+    setup_token_id: String,
+    options: webauthn_rs_proto::CreationChallengeResponse,
+}
+
+#[derive(Debug, Serialize)]
+struct PairFinishReq {
+    challenge_id: String,
+    setup_token_id: String,
+    response: webauthn_rs_proto::RegisterPublicKeyCredential,
 }
 
 /// Run the full sign-in WebAuthn ceremony.
@@ -148,6 +183,101 @@ async fn signin() -> Result<(), String> {
     Ok(())
 }
 
+/// Run the full pair (WebAuthn registration) ceremony.
+///
+/// Symmetric to `signin()` but uses the registration variant
+/// of every step:
+///   - POST `/api/auth/pair/start` with the plaintext
+///     setup-token in the body (vs. no body for sign-in)
+///   - convert `CreationChallengeResponse` →
+///     `web_sys::CredentialCreationOptions` (vs. request
+///     options for sign-in)
+///   - call `navigator.credentials.create(...)` (vs.
+///     `.get(...)`)
+///   - convert returned credential →
+///     `RegisterPublicKeyCredential` (vs. assertion type)
+///   - POST `/api/auth/pair/finish` with the
+///     `setup_token_id` echoed alongside the assertion
+///
+/// The setup-token is moved in (not borrowed) because the
+/// dispatched action future has no upper-bounded lifetime —
+/// once the click fires, the future may outlive any borrow we
+/// could have given it.
+async fn pair(setup_token: String) -> Result<(), String> {
+    // 1. Ask for a registration challenge. This route uses
+    //    `JsonBody<T>`, so we must send a body with
+    //    Content-Type: application/json — `gloo-net`'s
+    //    `.json(...)` handles the header automatically.
+    let start_resp = gloo_net::http::Request::post("/api/auth/pair/start")
+        .json(&PairStartReq { setup_token })
+        .map_err(|e| format!("could not encode pair payload: {e}"))?
+        .send()
+        .await
+        .map_err(|e| format!("network error contacting server: {e}"))?;
+
+    if !start_resp.ok() {
+        return Err(format!(
+            "server rejected pair challenge ({})",
+            start_resp.status()
+        ));
+    }
+
+    let start: PairStartResp = start_resp
+        .json()
+        .await
+        .map_err(|e| format!("server returned malformed challenge: {e}"))?;
+
+    // 2. Convert the wire challenge to the JS shape that
+    //    `navigator.credentials.create()` expects. Same
+    //    `webauthn-rs-proto` `wasm` feature handles the
+    //    base64url ↔ Uint8Array dance.
+    let options: web_sys::CredentialCreationOptions = start.options.into();
+
+    // 3. Run the platform registration ceremony. `.create()`
+    //    either resolves with a `PublicKeyCredential` (user
+    //    confirmed with biometric/PIN, authenticator minted a
+    //    new keypair) or rejects (cancel, "already
+    //    registered", timeout, no authenticator available).
+    let window = web_sys::window().ok_or("browser window unavailable")?;
+    let credentials = window.navigator().credentials();
+    let promise = credentials
+        .create_with_options(&options)
+        .map_err(|e| format!("browser refused credential creation: {}", js_err(&e)))?;
+    let credential_js = JsFuture::from(promise)
+        .await
+        .map_err(|e| format!("passkey ceremony failed: {}", js_err(&e)))?;
+
+    let credential: web_sys::PublicKeyCredential = credential_js
+        .dyn_into()
+        .map_err(|v| format!("browser returned an unexpected credential type: {}", js_err(&v)))?;
+    let response: webauthn_rs_proto::RegisterPublicKeyCredential = credential.into();
+
+    // 4. Send the attestation back along with the
+    //    `setup_token_id` the server gave us in step 1.
+    let finish_resp = gloo_net::http::Request::post("/api/auth/pair/finish")
+        .json(&PairFinishReq {
+            challenge_id: start.challenge_id,
+            setup_token_id: start.setup_token_id,
+            response,
+        })
+        .map_err(|e| format!("could not encode pair payload: {e}"))?
+        .send()
+        .await
+        .map_err(|e| format!("network error completing pair: {e}"))?;
+
+    if !finish_resp.ok() {
+        return Err(format!(
+            "server rejected pair ({})",
+            finish_resp.status()
+        ));
+    }
+
+    // Same as sign-in: the server set the session cookie via
+    // Set-Cookie. We let the caller flip the auth-state
+    // signal so the post-auth view replaces this component.
+    Ok(())
+}
+
 /// Render a `JsValue` error into a human-readable string.
 ///
 /// Two layers, both bounded:
@@ -209,18 +339,14 @@ enum LoginPhase {
 ///   be a dead-end — the bootstrap path (first device, no
 ///   token) is a separate question that 9r.4 will resolve.
 ///
-/// Slice 9r.2 wires the sign-in ceremony only. The pair
-/// ceremony stays inert until 9r.3 — the `<button>` is
-/// disabled in pair mode so a user can't click it and get
-/// nothing.
+/// Both ceremonies are wired as of slice 9r.3. The component
+/// constructs one `create_action` per mode so the active
+/// dispatch path is statically determined at component
+/// construction; the click handler picks which to fire.
 #[component]
 pub fn Login() -> impl IntoView {
     let setup_token = url_setup_token();
     let is_pair_mode = setup_token.is_some();
-    // 9r.3 will read `setup_token` to forward into the pair
-    // ceremony. Holding it in a binding (not just discarding)
-    // documents that intent.
-    let _setup_token_for_9r3 = setup_token;
 
     // The form has a separate identity for tests / future
     // styling: `data-mode` swaps copy + behavior between the
@@ -248,46 +374,58 @@ pub fn Login() -> impl IntoView {
     // disabled state and renders the error region.
     let (phase, set_phase) = create_signal(LoginPhase::Idle);
 
-    // The ceremony itself is dispatched via `create_action`.
-    // That gives us:
+    // Both ceremonies share the same post-resolve handler:
+    // success flips global auth state (which unmounts this
+    // component, so we don't bother resetting `phase`); error
+    // moves the local state machine into Error so the alert
+    // renders. Defining the handler once keeps the two
+    // actions in lockstep — adding a new "logging" hook later
+    // means changing one place, not two.
+    let resolve = move |result: Result<(), String>| match result {
+        Ok(()) => auth.set_signed_in.set(true),
+        Err(message) => set_phase.set(LoginPhase::Error(message)),
+    };
+
+    // The ceremonies themselves are dispatched via
+    // `create_action`. That gives us:
     //   - automatic pending tracking (we don't fire twice on
     //     a fast double-click — the action is gated by the
     //     button's `disabled` attribute, which we wire to
     //     `phase == InFlight`)
     //   - automatic cleanup if the component unmounts mid-
     //     flight (Leptos cancels the future)
-    //   - composability: the action handler reads/writes the
-    //     same `set_phase` signal, keeping all state
-    //     transitions in one place.
+    //   - composability: each handler funnels its result
+    //     through `resolve`, keeping all state transitions in
+    //     one place.
+    //
+    // We construct both actions unconditionally even though
+    // only one will be dispatched per component instance. The
+    // unused action is a small allocation; branching on
+    // `is_pair_mode` here would force the click handler to
+    // hold either an `Action<(), ()>` or an `Action<String,
+    // ()>` (different input types), which doesn't compose
+    // without erasure. Keeping both visible is also useful
+    // for future slices that may want a "switch mode" toggle.
     let signin_action = create_action(move |_: &()| async move {
-        match signin().await {
-            Ok(()) => {
-                // Flip global auth state — `<Main/>` swaps to
-                // the post-auth view, unmounting this
-                // component in the process. We don't reset
-                // `phase` here because the unmount discards
-                // the signal anyway; resetting would just be
-                // a write into a dropped scope.
-                auth.set_signed_in.set(true);
-            }
-            Err(message) => {
-                set_phase.set(LoginPhase::Error(message));
-            }
+        resolve(signin().await);
+    });
+    let pair_action = create_action(move |token: &String| {
+        let token = token.clone();
+        async move {
+            resolve(pair(token).await);
         }
     });
 
     let cta_label = move || match phase.get() {
-        LoginPhase::InFlight => "Signing in…".to_string(),
+        LoginPhase::InFlight => if is_pair_mode {
+            "Pairing…"
+        } else {
+            "Signing in…"
+        }
+        .to_string(),
         _ => cta_idle.to_string(),
     };
-    let cta_disabled = move || {
-        // Sign-in: disable while a ceremony is mid-flight.
-        // Pair mode: disabled outright in 9r.2 — clicking it
-        // would do nothing because we haven't wired the pair
-        // ceremony yet. Greying the button out is a clearer
-        // signal than letting the user click into the void.
-        is_pair_mode || matches!(phase.get(), LoginPhase::InFlight)
-    };
+    let cta_disabled = move || matches!(phase.get(), LoginPhase::InFlight);
     // Signal: are we in the error state? Drives a conditional
     // <p class="error">. Reading the message directly out of
     // the signal would clone an empty string in the non-error
@@ -297,6 +435,33 @@ pub fn Login() -> impl IntoView {
         _ => None,
     };
 
+    // Click handler picks the ceremony based on mode and
+    // dispatches with the appropriate input. The `setup_token`
+    // is captured by clone into the closure so each click can
+    // hand a fresh `String` to `pair_action.dispatch`. Cloning
+    // a hex string is trivial; `Rc<String>` would buy nothing.
+    let setup_token_for_click = setup_token;
+    let on_click = move |_| {
+        // Set InFlight directly here, not inside the action
+        // future. The action's first poll runs on a microtask,
+        // so an Idle → InFlight transition done inside the
+        // future would leave a tick where the button is
+        // briefly enabled — long enough for a synthetic
+        // double-click to fire a second concurrent ceremony.
+        // Setting InFlight synchronously here closes that
+        // window: the disabled re-render happens before the
+        // second click can be queued.
+        set_phase.set(LoginPhase::InFlight);
+        match &setup_token_for_click {
+            Some(token) => {
+                pair_action.dispatch(token.clone());
+            }
+            None => {
+                signin_action.dispatch(());
+            }
+        }
+    };
+
     view! {
         <section id="kat-login" data-mode=mode_attr>
             <h1 class="title">{title}</h1>
@@ -304,6 +469,12 @@ pub fn Login() -> impl IntoView {
             // Pair mode collects a device name (e.g.,
             // "felix-iphone"). Sign-in mode skips it — the
             // passkey itself identifies the credential.
+            // Slice 9r.3 wires the ceremony but does NOT yet
+            // forward the device name to the server (the
+            // pair_finish endpoint takes only the credential
+            // assertion). A future slice will plumb it
+            // through once a credential-name field exists in
+            // the auth schema.
             {is_pair_mode.then(|| view! {
                 <label class="field">
                     <span class="label">"Device name"</span>
@@ -319,21 +490,7 @@ pub fn Login() -> impl IntoView {
                 type="button"
                 class="cta"
                 prop:disabled=cta_disabled
-                on:click=move |_| {
-                    // Set InFlight directly here, not inside
-                    // the action future. The action's first
-                    // poll runs on a microtask, so an Idle →
-                    // InFlight transition done inside the
-                    // future would leave a tick where the
-                    // button is briefly enabled — long enough
-                    // for a synthetic double-click to fire a
-                    // second concurrent ceremony. Setting
-                    // InFlight synchronously here closes that
-                    // window: the disabled re-render happens
-                    // before the second click can be queued.
-                    set_phase.set(LoginPhase::InFlight);
-                    signin_action.dispatch(());
-                }
+                on:click=on_click
             >
                 {cta_label}
             </button>

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -56,6 +56,7 @@ fn url_setup_token() -> Option<String> {
 // WASM-friendly.
 // =====================================================================
 
+// No `LoginStartReq` — `login/start` takes no request body.
 #[derive(Debug, Deserialize)]
 struct LoginStartResp {
     challenge_id: String,
@@ -95,6 +96,40 @@ struct PairFinishReq {
     response: webauthn_rs_proto::RegisterPublicKeyCredential,
 }
 
+/// HTTP status guard shared by both ceremonies. Earlier
+/// drafts inlined this twice; the duplicated format strings
+/// drifted in review (one read "pair payload" for two
+/// different payloads), which is exactly the failure mode a
+/// helper prevents. Returns the status code embedded in the
+/// message because the e2e suite asserts on it
+/// (`toContainText("401")`).
+fn check_ok(resp: &gloo_net::http::Response, label: &str) -> Result<(), String> {
+    if resp.ok() {
+        Ok(())
+    } else {
+        Err(format!("{label} ({})", resp.status()))
+    }
+}
+
+/// Resolve a `navigator.credentials.{get,create}` promise into
+/// the `web_sys::PublicKeyCredential` both ceremonies consume.
+/// The promise is owned (not borrowed) because `JsFuture::from`
+/// takes ownership; once we hand it over, the caller has no
+/// remaining handle anyway.
+async fn credential_from_promise(
+    promise: js_sys::Promise,
+) -> Result<web_sys::PublicKeyCredential, String> {
+    let credential_js = JsFuture::from(promise)
+        .await
+        .map_err(|e| format!("passkey ceremony failed: {}", js_err(&e)))?;
+    credential_js.dyn_into().map_err(|v| {
+        format!(
+            "browser returned an unexpected credential type: {}",
+            js_err(&v)
+        )
+    })
+}
+
 /// Run the full sign-in WebAuthn ceremony.
 ///
 /// Pure-by-shape: takes nothing, returns `Result<(), String>`.
@@ -109,21 +144,12 @@ struct PairFinishReq {
 /// to branch on the variant (e.g., "session expired" vs.
 /// "credential revoked" surfacing different recovery UIs).
 async fn signin() -> Result<(), String> {
-    // 1. Ask the server for a challenge. `login_start` takes
-    //    no body, so a bare POST with no Content-Type works —
-    //    the route doesn't use `JsonBody<T>`.
+    // 1. Ask the server for a challenge.
     let start_resp = gloo_net::http::Request::post("/api/auth/login/start")
         .send()
         .await
         .map_err(|e| format!("network error contacting server: {e}"))?;
-
-    if !start_resp.ok() {
-        return Err(format!(
-            "server rejected sign-in challenge ({})",
-            start_resp.status()
-        ));
-    }
-
+    check_ok(&start_resp, "server rejected sign-in challenge")?;
     let start: LoginStartResp = start_resp
         .json()
         .await
@@ -141,17 +167,12 @@ async fn signin() -> Result<(), String> {
     //    with biometric/PIN) or rejects (cancel, no credential,
     //    timeout, virtual-authenticator absent in test env).
     let window = web_sys::window().ok_or("browser window unavailable")?;
-    let credentials = window.navigator().credentials();
-    let promise = credentials
+    let promise = window
+        .navigator()
+        .credentials()
         .get_with_options(&options)
         .map_err(|e| format!("browser refused credential request: {}", js_err(&e)))?;
-    let credential_js = JsFuture::from(promise)
-        .await
-        .map_err(|e| format!("passkey ceremony failed: {}", js_err(&e)))?;
-
-    let credential: web_sys::PublicKeyCredential = credential_js
-        .dyn_into()
-        .map_err(|v| format!("browser returned an unexpected credential type: {}", js_err(&v)))?;
+    let credential = credential_from_promise(promise).await?;
     let response: webauthn_rs_proto::PublicKeyCredential = credential.into();
 
     // 4. Send the assertion back. `login_finish` uses
@@ -166,20 +187,11 @@ async fn signin() -> Result<(), String> {
         .send()
         .await
         .map_err(|e| format!("network error completing sign-in: {e}"))?;
+    check_ok(&finish_resp, "server rejected sign-in")?;
 
-    if !finish_resp.ok() {
-        return Err(format!(
-            "server rejected sign-in ({})",
-            finish_resp.status()
-        ));
-    }
-
-    // We don't need to parse the body — the server set the
-    // session cookie via Set-Cookie, which the browser
-    // automatically applies. The caller flips the auth-state
-    // signal so the UI swaps to the post-auth view; future
-    // slices that need the credential id or csrf token will
-    // parse the response then.
+    // The server set the session cookie via Set-Cookie. The
+    // caller flips the auth-state signal so the UI swaps to
+    // the post-auth view.
     Ok(())
 }
 
@@ -204,33 +216,21 @@ async fn signin() -> Result<(), String> {
 /// once the click fires, the future may outlive any borrow we
 /// could have given it.
 async fn pair(setup_token: String) -> Result<(), String> {
-    // 1. Ask for a registration challenge. This route uses
-    //    `JsonBody<T>`, so we must send a body with
-    //    Content-Type: application/json — `gloo-net`'s
-    //    `.json(...)` handles the header automatically.
+    // 1. Ask for a registration challenge.
     let start_resp = gloo_net::http::Request::post("/api/auth/pair/start")
         .json(&PairStartReq { setup_token })
-        .map_err(|e| format!("could not encode pair payload: {e}"))?
+        .map_err(|e| format!("could not encode pair-start payload: {e}"))?
         .send()
         .await
         .map_err(|e| format!("network error contacting server: {e}"))?;
-
-    if !start_resp.ok() {
-        return Err(format!(
-            "server rejected pair challenge ({})",
-            start_resp.status()
-        ));
-    }
-
+    check_ok(&start_resp, "server rejected pair challenge")?;
     let start: PairStartResp = start_resp
         .json()
         .await
         .map_err(|e| format!("server returned malformed challenge: {e}"))?;
 
     // 2. Convert the wire challenge to the JS shape that
-    //    `navigator.credentials.create()` expects. Same
-    //    `webauthn-rs-proto` `wasm` feature handles the
-    //    base64url ↔ Uint8Array dance.
+    //    `navigator.credentials.create()` expects.
     let options: web_sys::CredentialCreationOptions = start.options.into();
 
     // 3. Run the platform registration ceremony. `.create()`
@@ -239,17 +239,12 @@ async fn pair(setup_token: String) -> Result<(), String> {
     //    new keypair) or rejects (cancel, "already
     //    registered", timeout, no authenticator available).
     let window = web_sys::window().ok_or("browser window unavailable")?;
-    let credentials = window.navigator().credentials();
-    let promise = credentials
+    let promise = window
+        .navigator()
+        .credentials()
         .create_with_options(&options)
         .map_err(|e| format!("browser refused credential creation: {}", js_err(&e)))?;
-    let credential_js = JsFuture::from(promise)
-        .await
-        .map_err(|e| format!("passkey ceremony failed: {}", js_err(&e)))?;
-
-    let credential: web_sys::PublicKeyCredential = credential_js
-        .dyn_into()
-        .map_err(|v| format!("browser returned an unexpected credential type: {}", js_err(&v)))?;
+    let credential = credential_from_promise(promise).await?;
     let response: webauthn_rs_proto::RegisterPublicKeyCredential = credential.into();
 
     // 4. Send the attestation back along with the
@@ -260,21 +255,12 @@ async fn pair(setup_token: String) -> Result<(), String> {
             setup_token_id: start.setup_token_id,
             response,
         })
-        .map_err(|e| format!("could not encode pair payload: {e}"))?
+        .map_err(|e| format!("could not encode pair-finish payload: {e}"))?
         .send()
         .await
         .map_err(|e| format!("network error completing pair: {e}"))?;
+    check_ok(&finish_resp, "server rejected pair")?;
 
-    if !finish_resp.ok() {
-        return Err(format!(
-            "server rejected pair ({})",
-            finish_resp.status()
-        ));
-    }
-
-    // Same as sign-in: the server set the session cookie via
-    // Set-Cookie. We let the caller flip the auth-state
-    // signal so the post-auth view replaces this component.
     Ok(())
 }
 
@@ -436,23 +422,20 @@ pub fn Login() -> impl IntoView {
     };
 
     // Click handler picks the ceremony based on mode and
-    // dispatches with the appropriate input. The `setup_token`
-    // is captured by clone into the closure so each click can
-    // hand a fresh `String` to `pair_action.dispatch`. Cloning
-    // a hex string is trivial; `Rc<String>` would buy nothing.
-    let setup_token_for_click = setup_token;
+    // dispatches with the appropriate input. `setup_token` is
+    // moved into the closure; each click clones the inner
+    // `String` into the dispatch.
     let on_click = move |_| {
-        // Set InFlight directly here, not inside the action
-        // future. The action's first poll runs on a microtask,
-        // so an Idle → InFlight transition done inside the
-        // future would leave a tick where the button is
-        // briefly enabled — long enough for a synthetic
-        // double-click to fire a second concurrent ceremony.
-        // Setting InFlight synchronously here closes that
-        // window: the disabled re-render happens before the
-        // second click can be queued.
+        // Set InFlight synchronously, not inside the action
+        // future. `create_action`'s first poll runs on a
+        // microtask, so an Idle → InFlight transition done
+        // inside the future would leave a tick where the
+        // button is briefly enabled — long enough for a
+        // synthetic double-click to fire a second concurrent
+        // ceremony. The disabled re-render must happen before
+        // the second click can be queued.
         set_phase.set(LoginPhase::InFlight);
-        match &setup_token_for_click {
+        match &setup_token {
             Some(token) => {
                 pair_action.dispatch(token.clone());
             }
@@ -466,26 +449,12 @@ pub fn Login() -> impl IntoView {
         <section id="kat-login" data-mode=mode_attr>
             <h1 class="title">{title}</h1>
             <p class="blurb">{blurb}</p>
-            // Pair mode collects a device name (e.g.,
-            // "felix-iphone"). Sign-in mode skips it — the
-            // passkey itself identifies the credential.
-            // Slice 9r.3 wires the ceremony but does NOT yet
-            // forward the device name to the server (the
-            // pair_finish endpoint takes only the credential
-            // assertion). A future slice will plumb it
-            // through once a credential-name field exists in
-            // the auth schema.
-            {is_pair_mode.then(|| view! {
-                <label class="field">
-                    <span class="label">"Device name"</span>
-                    <input
-                        type="text"
-                        name="device-name"
-                        autocomplete="off"
-                        placeholder="e.g. felix-iphone"
-                    />
-                </label>
-            })}
+            // Device-name input deliberately absent. A future
+            // slice that adds a `credential_name` field to the
+            // auth schema will reintroduce it; rendering the
+            // affordance before the wire type carries the
+            // value would silently discard whatever the user
+            // typed.
             <button
                 type="button"
                 class="cta"

--- a/test/e2e-rust/auth.e2e.js
+++ b/test/e2e-rust/auth.e2e.js
@@ -4,8 +4,8 @@
 // shell layout + WASM bundle.
 //
 // Slice 9r.1 introduced the form shell + pair/sign-in mode
-// swap. Slice 9r.2 wired the actual sign-in ceremony.
-// Slice 9r.3 (planned) will wire the pair ceremony.
+// swap. Slice 9r.2 wired the sign-in ceremony. Slice 9r.3
+// wires the pair ceremony.
 //
 // We deliberately don't run the full happy-path WebAuthn
 // ceremony here — that needs Chromium's CDP virtual
@@ -13,9 +13,10 @@
 // is a separate setup. The tests below cover everything
 // EXCEPT the platform credential interaction:
 //   - mode swap based on `?setup_token=`
-//   - CTA enabled/disabled state per mode
-//   - the start-call fires when the user clicks (button is
-//     wired, URL is right, method is POST)
+//   - CTA enabled state in idle, both modes
+//   - the start-call fires when the user clicks, with the
+//     right URL + method per mode (and the right body for
+//     pair, since pair/start needs the setup_token)
 //   - server rejection renders a visible error region
 // The "did the passkey actually verify" assertion belongs in
 // a dedicated suite once the virtual authenticator is wired.
@@ -49,11 +50,9 @@ test("login defaults to sign-in mode without setup_token", async ({ page }) => {
 test("login switches to pair mode with setup_token", async ({ page }) => {
   // Presence of `?setup_token=` flips the form to pair mode
   // — adds the device-name field, swaps title + CTA copy,
-  // sets `data-mode="pair"`. Slice 9r.2 wires the sign-in
-  // ceremony only; the pair ceremony is still inert, so the
-  // CTA is disabled to avoid a button that does nothing.
-  // 9r.3 will land the pair ceremony and remove the disabled
-  // bit.
+  // sets `data-mode="pair"`. Slice 9r.3 wires the ceremony,
+  // so the CTA must be enabled in idle (the 9r.2 disabled
+  // bit was a placeholder that this slice removes).
   await page.goto("/?setup_token=abcdef0123456789");
   await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
 
@@ -61,7 +60,10 @@ test("login switches to pair mode with setup_token", async ({ page }) => {
   await expect(login).toHaveAttribute("data-mode", "pair");
   await expect(login.locator(".title")).toHaveText("Pair this device");
   await expect(login.locator(".cta")).toHaveText("Pair with passkey");
-  await expect(login.locator(".cta")).toBeDisabled();
+  // Pair mode CTA must be enabled now that the ceremony is
+  // wired (slice 9r.3). A disabled CTA here would be a
+  // regression back to the inert 9r.2 stub.
+  await expect(login.locator(".cta")).toBeEnabled();
   // Pair mode shows the device-name input.
   await expect(login.locator('input[name="device-name"]')).toBeVisible();
 });
@@ -131,4 +133,62 @@ test("sign-in renders error region on server rejection", async ({ page }) => {
   const error = page.locator('#kat-login .error[role="alert"]');
   await expect(error).toBeVisible({ timeout: 5_000 });
   await expect(error).toContainText("409");
+});
+
+test("pair click hits /api/auth/pair/start with setup_token", async ({
+  page,
+}) => {
+  // Slice 9r.3 wires the pair ceremony parallel to sign-in.
+  // The first hop is POST /api/auth/pair/start with the
+  // plaintext setup_token in the JSON body — the server
+  // hashes + looks it up. We assert URL, method, and body
+  // because the body is the load-bearing part: a wired
+  // button that posts to the right URL but forgets the
+  // setup_token would 401 in production and look like
+  // "the button does nothing" without diagnostics.
+  const SETUP_TOKEN = "abcdef0123456789".repeat(4); // 64 hex chars, real-token shape
+  await page.goto(`/?setup_token=${SETUP_TOKEN}`);
+  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
+
+  const requestPromise = page.waitForRequest(
+    (req) =>
+      req.url().endsWith("/api/auth/pair/start") && req.method() === "POST",
+    { timeout: 5_000 },
+  );
+  await page.locator("#kat-login .cta").click();
+  const request = await requestPromise;
+
+  // Body shape: `{ setup_token: "<plaintext>" }`. The server
+  // accepts only this exact field name; a typo here would
+  // make the start call 400 with `JsonBody` deserialization
+  // failure, looking like "the button is broken."
+  const body = request.postDataJSON();
+  expect(body).toEqual({ setup_token: SETUP_TOKEN });
+});
+
+test("pair renders error region on server rejection", async ({ page }) => {
+  // Symmetric to the sign-in error test. A 401 here is the
+  // typical "setup token expired / already redeemed / never
+  // issued" case — the user has no other channel to learn
+  // why the ceremony failed, so silent failure is a UX trap.
+  // Stubbing the response keeps the test deterministic
+  // regardless of staging-data state.
+  await page.route("**/api/auth/pair/start", (route) =>
+    route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({
+        error: { code: "unauthorized", message: "setup token not redeemable" },
+      }),
+    }),
+  );
+
+  await page.goto("/?setup_token=abcdef0123456789");
+  await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
+
+  await page.locator("#kat-login .cta").click();
+
+  const error = page.locator('#kat-login .error[role="alert"]');
+  await expect(error).toBeVisible({ timeout: 5_000 });
+  await expect(error).toContainText("401");
 });

--- a/test/e2e-rust/auth.e2e.js
+++ b/test/e2e-rust/auth.e2e.js
@@ -64,8 +64,12 @@ test("login switches to pair mode with setup_token", async ({ page }) => {
   // wired (slice 9r.3). A disabled CTA here would be a
   // regression back to the inert 9r.2 stub.
   await expect(login.locator(".cta")).toBeEnabled();
-  // Pair mode shows the device-name input.
-  await expect(login.locator('input[name="device-name"]')).toBeVisible();
+  // Device-name input is intentionally absent: `pair_finish`
+  // doesn't carry a name field yet, so rendering an input
+  // would silently discard whatever the user typed. Future
+  // slice that lands a credential-name schema field will
+  // reintroduce it.
+  await expect(login.locator('input[name="device-name"]')).toHaveCount(0);
 });
 
 test("sign-in click hits /api/auth/login/start", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Adds the symmetric pair (registration) ceremony in `crates/web/src/login.rs` parallel to the sign-in path landed in 9r.2; URL with `?setup_token=…` now drives a real WebAuthn registration through `navigator.credentials.create()` and lands on the post-auth view.
- Refactors `<Login/>` to construct both `signin_action` and `pair_action`, branching on `is_pair_mode` only at click time. A single `resolve(Result<(), String>)` closure funnels both ceremonies' results through the same state-machine transitions.
- E2E: pair-mode CTA flipped from `toBeDisabled` to `toBeEnabled`, plus new outbound-request assertion (`{ setup_token }` body shape) and pair-side error rendering test.

## What changed

- `crates/web/src/login.rs`: add `pair()` async fn, `PairStartReq`/`PairStartResp`/`PairFinishReq` wire types, `pair_action` create-action, `resolve` shared post-resolve handler. Remove `is_pair_mode` from CTA-disabled gate. CTA copy now varies between "Pairing…" and "Signing in…" while in flight.
- `crates/web/Cargo.toml`: add `CredentialCreationOptions` feature to `web-sys`.
- `test/e2e-rust/auth.e2e.js`: pair-mode CTA expects enabled; new pair start-call test (URL + method + body); new pair error-rendering test (stubbed 401).

## Why two parallel functions

The two ceremonies share roughly a third of their bytes (ok-check, JsFuture wrap, dyn_into) but diverge in the other two thirds (endpoint, request body type, options conversion, navigator method, response type, finish body). Generic abstraction over four diverging types would obscure the flow more than the duplication does. The shared post-resolve handler IS factored out (`resolve`) because that part is genuinely identical.

## Why the InFlight transition is synchronous

Same reasoning as 9r.2 — `create_action`'s first poll runs on a microtask, so an Idle → InFlight transition done inside the future would leave a tick where the button is enabled. A synthetic double-click could fire a second concurrent ceremony. Setting InFlight synchronously before `dispatch()` closes the window.

## Why we don't forward the device-name input yet

The `<input name="device-name">` field has been there since 9r.1, but `pair_finish` takes only the credential assertion — there's no schema slot for a name. A future slice will plumb it through once the auth schema gains a credential-name field. Wiring the field to nowhere now would create a dead binding.

## Bundle size

WASM grows from ~459 KB to ~550 KB (+91 KB). The registration types pull in `webauthn-rs-proto`'s attestation parsing surface. Still well under the 1 MB sanity floor in the smoke test.

## Test plan

- [x] `trunk build --release` clean
- [x] Full Rust e2e suite green (9 tests across smoke + auth) against `KATULONG_STAGE_BACKEND=rust bin/katulong-stage`
- [x] Existing sign-in tests still pass — click-handler refactor doesn't change the no-token dispatch semantics
- [ ] Reviewer: confirm the pair-mode error path (network/server failure → visible alert) is covered by the new stubbed-401 test