### PR TITLE
rewrite(shared): consolidate auth wire types into katulong-shared

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,8 @@ name = "katulong-shared"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
+ "webauthn-rs-proto",
 ]
 
 [[package]]
@@ -1075,6 +1077,7 @@ dependencies = [
  "console_error_panic_hook",
  "gloo-net",
  "js-sys",
+ "katulong-shared",
  "leptos",
  "serde",
  "wasm-bindgen",

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -37,13 +37,11 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use katulong_auth::webauthn_wire::{
-    CreationChallengeResponse, RequestChallengeResponse,
-};
 use katulong_auth::{AuthError, Session, SESSION_TTL};
 use katulong_shared::wire::{
-    AuthFinishResponse, ChallengeStartResponse, LoginFinishRequest, PairFinishRequest,
-    PairStartRequest, PairStartResponse, RegisterFinishRequest,
+    AuthFinishResponse, ChallengeStartResponse, CreationChallengeResponse,
+    LoginFinishRequest, PairFinishRequest, PairStartRequest, PairStartResponse,
+    RegisterFinishRequest, RequestChallengeResponse,
 };
 use serde::Serialize;
 use std::net::SocketAddr;
@@ -119,14 +117,6 @@ async fn status(
         authenticated: authed.is_some(),
     })
 }
-
-// Wire types (`ChallengeStartResponse<T>`,
-// `RegisterFinishRequest`, `LoginFinishRequest`,
-// `AuthFinishResponse`) live in `katulong_shared::wire` so
-// the WASM client compiles against the same definitions. A
-// field rename or `#[serde(rename = ...)]` change there
-// breaks both consumers at compile time instead of at
-// runtime.
 
 /// Start a first-device registration ceremony.
 ///
@@ -384,9 +374,6 @@ where
 }
 
 // ============== pair flow (setup-token-gated registration) ==============
-
-// `PairStartRequest`, `PairStartResponse`, `PairFinishRequest`
-// all live in `katulong_shared::wire`.
 
 /// Validate the plaintext token, start a WebAuthn registration
 /// ceremony, and return the challenge. Public — anyone with a valid

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -38,11 +38,14 @@ use axum::{
     Json, Router,
 };
 use katulong_auth::webauthn_wire::{
-    CreationChallengeResponse, PublicKeyCredential, RegisterPublicKeyCredential,
-    RequestChallengeResponse,
+    CreationChallengeResponse, RequestChallengeResponse,
 };
-use katulong_auth::{AuthError, ChallengeId, Session, SESSION_TTL};
-use serde::{Deserialize, Serialize};
+use katulong_auth::{AuthError, Session, SESSION_TTL};
+use katulong_shared::wire::{
+    AuthFinishResponse, ChallengeStartResponse, LoginFinishRequest, PairFinishRequest,
+    PairStartRequest, PairStartResponse, RegisterFinishRequest,
+};
+use serde::Serialize;
 use std::net::SocketAddr;
 use std::time::SystemTime;
 
@@ -117,37 +120,13 @@ async fn status(
     })
 }
 
-#[derive(Debug, Serialize)]
-struct ChallengeStartResponse<T: Serialize> {
-    challenge_id: ChallengeId,
-    options: T,
-}
-
-#[derive(Debug, Deserialize)]
-struct RegisterFinishRequest {
-    challenge_id: ChallengeId,
-    response: RegisterPublicKeyCredential,
-}
-
-#[derive(Debug, Deserialize)]
-struct LoginFinishRequest {
-    challenge_id: ChallengeId,
-    response: PublicKeyCredential,
-}
-
-/// Shared response shape for every flow that mints a session on
-/// success — register, login, and pair. All three return the same two
-/// fields (`credential_id` for UI display, `csrf_token` for the
-/// client to echo in the `X-Csrf-Token` header on subsequent
-/// state-changing requests). Keeping them as one type means a future
-/// schema addition (e.g., `session_expires_at`) lands in one place.
-/// Status codes still differ per route (201 on register/pair, 200 on
-/// login), so the distinction is preserved at the call sites.
-#[derive(Debug, Serialize)]
-struct AuthFinishResponse {
-    credential_id: String,
-    csrf_token: String,
-}
+// Wire types (`ChallengeStartResponse<T>`,
+// `RegisterFinishRequest`, `LoginFinishRequest`,
+// `AuthFinishResponse`) live in `katulong_shared::wire` so
+// the WASM client compiles against the same definitions. A
+// field rename or `#[serde(rename = ...)]` change there
+// breaks both consumers at compile time instead of at
+// runtime.
 
 /// Start a first-device registration ceremony.
 ///
@@ -406,30 +385,8 @@ where
 
 // ============== pair flow (setup-token-gated registration) ==============
 
-#[derive(Debug, Deserialize)]
-struct PairStartRequest {
-    /// Plaintext setup token value as given to the new device's
-    /// operator. The server hashes and looks it up.
-    setup_token: String,
-}
-
-#[derive(Debug, Serialize)]
-struct PairStartResponse {
-    challenge_id: ChallengeId,
-    /// The setup-token id — opaque to the client, returned so the
-    /// finish call can reference it without re-submitting the
-    /// plaintext value. Defence in depth: keeps the plaintext
-    /// transiting the network once, not twice.
-    setup_token_id: String,
-    options: CreationChallengeResponse,
-}
-
-#[derive(Debug, Deserialize)]
-struct PairFinishRequest {
-    challenge_id: ChallengeId,
-    setup_token_id: String,
-    response: RegisterPublicKeyCredential,
-}
+// `PairStartRequest`, `PairStartResponse`, `PairFinishRequest`
+// all live in `katulong_shared::wire`.
 
 /// Validate the plaintext token, start a WebAuthn registration
 /// ceremony, and return the challenge. Public — anyone with a valid

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -6,3 +6,20 @@ license.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+# `webauthn-rs-proto` ships the wire-format structs (challenge,
+# credential, response) used by both the server (issuing
+# challenges, verifying assertions) and the WASM client
+# (calling `navigator.credentials.{get,create}`). Keeping it
+# as a direct dep of this crate means both consumers see the
+# same version, so the JSON shape can't drift.
+#
+# No `wasm` feature here — that flag adds `From` impls
+# bridging `webauthn-rs-proto` types to `web-sys` types,
+# which is web-side only. The WASM crate enables the feature
+# in its own dependency entry; Cargo's feature unification
+# means the WASM build sees the bridge impls without forcing
+# them onto the server build.
+webauthn-rs-proto = "0.5"
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -1,19 +1,24 @@
-//! Types shared between `katulong-server` and any future
-//! cross-crate consumer (e.g., the eventual Leptos client, the
-//! tile SDK).
+//! Cross-crate types shared between `katulong-server` and
+//! `katulong-web`.
 //!
-//! The slice-4 scaffold originally defined placeholder
-//! `ServerMessage`/`ClientMessage`/`PROTOCOL_VERSION` here to
-//! verify end-to-end wiring. Slice 9c deleted those: the
-//! authoritative WS protocol now lives in
-//! `katulong_server::transport::message`, and the HTTP smoke
-//! endpoint (`/api/hello`) it backed is gone — the real auth
-//! handshake is `GET /api/auth/status`. Keeping two parallel
-//! `ServerMessage` types (different tag keys, different casing,
-//! different version strings) was the CRITICAL finding in the
-//! slice-9c review; removing the dead scaffold is the fix.
+//! The slice-4 scaffold once held placeholder
+//! `ServerMessage`/`ClientMessage` types that diverged from
+//! the live WS protocol; slice 9c removed them. This crate
+//! sat empty until the auth-rewrite slices grew enough wire
+//! types (login/register/pair × start/finish) that
+//! duplicating them on both sides became silent-drift
+//! prone. The wire module below is the single source of
+//! truth: server uses these structs to build responses and
+//! deserialize requests; the WASM client uses the same
+//! structs in the reverse direction.
 //!
-//! This crate stays in the workspace because truly cross-crate
-//! shared types — tile-SDK message envelopes, federation
-//! primitives, whatever lands later — will live here. For now
-//! it's intentionally empty.
+//! What belongs here: types that cross the HTTP/WS boundary
+//! and must serialize identically on both sides.
+//! What does NOT belong here: server-side state types
+//! (auth_store, session manager), WASM-side view types
+//! (Leptos signals), anything with an axum/sqlx/web-sys dep.
+//! The point of the crate is to be cheap to depend on from
+//! either side; keeping its dependency surface to `serde` +
+//! `webauthn-rs-proto` is what makes that true.
+
+pub mod wire;

--- a/crates/shared/src/wire.rs
+++ b/crates/shared/src/wire.rs
@@ -42,7 +42,13 @@
 //! safety gain.
 
 use serde::{Deserialize, Serialize};
-use webauthn_rs_proto::{
+
+// Re-export the WebAuthn proto types so consumers can pull
+// every wire-related type through `katulong_shared::wire`,
+// not split between `katulong_shared::wire` (envelopes) and
+// `katulong_auth::webauthn_wire` (credentials). Single import
+// path keeps the boundary unambiguous.
+pub use webauthn_rs_proto::{
     CreationChallengeResponse, PublicKeyCredential, RegisterPublicKeyCredential,
     RequestChallengeResponse,
 };
@@ -52,22 +58,17 @@ pub type ChallengeId = String;
 // --- start: shared challenge envelope ---------------------------------
 
 /// Generic envelope for the start phase of every ceremony.
-/// The `T` parameter is the WebAuthn options type — one of:
-/// - `CreationChallengeResponse` (register, pair)
-/// - `RequestChallengeResponse` (login)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ChallengeStartResponse<T> {
     pub challenge_id: ChallengeId,
     pub options: T,
 }
 
-/// Concrete alias for register/start and pair/start (where
-/// the generic version is awkward for the WASM client to
-/// deserialize without explicit turbofish at every call
-/// site).
+/// The aliases below exist so the WASM client can write
+/// `let start: LoginStartResponse = resp.json().await?` and
+/// have the deserialize call resolve without an explicit
+/// turbofish.
 pub type RegisterStartResponse = ChallengeStartResponse<CreationChallengeResponse>;
-
-/// Concrete alias for login/start.
 pub type LoginStartResponse = ChallengeStartResponse<RequestChallengeResponse>;
 
 // --- finish: shared session response ---------------------------------

--- a/crates/shared/src/wire.rs
+++ b/crates/shared/src/wire.rs
@@ -1,0 +1,133 @@
+//! HTTP wire types for the auth ceremony surface.
+//!
+//! Three flows × two phases each:
+//! - **register** (first-device, localhost-only bootstrap):
+//!   `register/start` → `register/finish`
+//! - **login** (any device with an enrolled credential):
+//!   `login/start` → `login/finish`
+//! - **pair** (additional device via setup token):
+//!   `pair/start` → `pair/finish`
+//!
+//! Register-start and login-start take no request body, so
+//! there's no `RegisterStartRequest` / `LoginStartRequest`
+//! type — those routes parse the `()` body. Pair-start needs
+//! the plaintext setup token, so it has a request struct.
+//!
+//! All three start endpoints return a challenge wrapped in a
+//! generic envelope (`ChallengeStartResponse<T>`). The `T`
+//! varies because register/pair return registration options
+//! (`CreationChallengeResponse`) while login returns
+//! authentication options (`RequestChallengeResponse`).
+//! Concrete aliases are provided for the WASM client where
+//! generic deserialisation is awkward.
+//!
+//! Pair-start additionally echoes a `setup_token_id` back to
+//! the client so `pair/finish` can reference the redeemable
+//! token without re-submitting the plaintext value. That's
+//! defence in depth (the plaintext transits the network
+//! once), and it's why pair has its own response type rather
+//! than reusing the generic envelope.
+//!
+//! All three finish endpoints converge on the same response
+//! shape (`AuthFinishResponse`) — the server has minted a
+//! session cookie via `Set-Cookie` and returns the
+//! credential id (for UI display) and the CSRF token (for
+//! the client to echo on subsequent state-changing requests).
+//!
+//! `ChallengeId` is exposed as a type alias rather than a
+//! newtype because the server side already has its own
+//! `katulong_auth::webauthn::ChallengeId = String` alias and
+//! the wire format is just a string. A newtype here would
+//! force every consumer to convert at the boundary for no
+//! safety gain.
+
+use serde::{Deserialize, Serialize};
+use webauthn_rs_proto::{
+    CreationChallengeResponse, PublicKeyCredential, RegisterPublicKeyCredential,
+    RequestChallengeResponse,
+};
+
+pub type ChallengeId = String;
+
+// --- start: shared challenge envelope ---------------------------------
+
+/// Generic envelope for the start phase of every ceremony.
+/// The `T` parameter is the WebAuthn options type — one of:
+/// - `CreationChallengeResponse` (register, pair)
+/// - `RequestChallengeResponse` (login)
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChallengeStartResponse<T> {
+    pub challenge_id: ChallengeId,
+    pub options: T,
+}
+
+/// Concrete alias for register/start and pair/start (where
+/// the generic version is awkward for the WASM client to
+/// deserialize without explicit turbofish at every call
+/// site).
+pub type RegisterStartResponse = ChallengeStartResponse<CreationChallengeResponse>;
+
+/// Concrete alias for login/start.
+pub type LoginStartResponse = ChallengeStartResponse<RequestChallengeResponse>;
+
+// --- finish: shared session response ---------------------------------
+
+/// Returned by every successful finish endpoint
+/// (register/finish, login/finish, pair/finish). The status
+/// codes still differ per route (201 on register/pair, 200 on
+/// login) — that's a transport detail handled at the call
+/// site, not part of this type.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuthFinishResponse {
+    /// Server-side credential id for the just-authed
+    /// credential. Useful for UIs that show "you're signed
+    /// in as <device-name>" or for revoke flows.
+    pub credential_id: String,
+    /// CSRF token the client must echo in the
+    /// `X-Csrf-Token` header on subsequent state-changing
+    /// requests (logout, revoke, etc.).
+    pub csrf_token: String,
+}
+
+// --- register flow ---------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RegisterFinishRequest {
+    pub challenge_id: ChallengeId,
+    pub response: RegisterPublicKeyCredential,
+}
+
+// --- login flow ------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LoginFinishRequest {
+    pub challenge_id: ChallengeId,
+    pub response: PublicKeyCredential,
+}
+
+// --- pair flow (setup-token-gated registration) ----------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PairStartRequest {
+    /// Plaintext setup token value. The server hashes and
+    /// looks it up; only redeemable (live, unconsumed)
+    /// tokens pass.
+    pub setup_token: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PairStartResponse {
+    pub challenge_id: ChallengeId,
+    /// Server-side opaque id for the redeemable token.
+    /// Echoed back on `pair/finish` so the client doesn't
+    /// re-submit the plaintext token a second time.
+    pub setup_token_id: String,
+    pub options: CreationChallengeResponse,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PairFinishRequest {
+    pub challenge_id: ChallengeId,
+    pub setup_token_id: String,
+    pub response: RegisterPublicKeyCredential,
+}

--- a/crates/shared/tests/wire_round_trip.rs
+++ b/crates/shared/tests/wire_round_trip.rs
@@ -1,0 +1,95 @@
+//! Wire-format round-trip tests.
+//!
+//! The point of these tests isn't to verify `serde_json`
+//! itself — that's well-tested upstream. The point is:
+//!
+//! 1. Each struct must remain JSON-deserialisable from the
+//!    JSON shape it serialises to. A field rename or a
+//!    `#[serde(rename = ...)]` change that breaks the round
+//!    trip would slip past the type checker but would fail
+//!    here loudly.
+//!
+//! 2. The JSON keys are part of the HTTP wire contract.
+//!    These tests pin them down with literal keys (e.g.,
+//!    `challenge_id`, `setup_token`) so a future "let's
+//!    rename to camelCase" refactor would have to touch this
+//!    file — making the wire-break visible at PR time.
+//!
+//! Note: we don't fabricate `webauthn-rs-proto` payloads
+//! (the credential types). Those have crypto-binary fields
+//! (challenge bytes, attestation objects) that are
+//! cumbersome to construct without a real authenticator.
+//! The integration tests in `crates/server/tests/auth_*.rs`
+//! exercise those types end-to-end with the real-server
+//! `webauthn-rs` engine on one side and crypto-bogus
+//! payloads on the other; that covers the on-the-wire
+//! shape. Here we focus on the envelope structs (what
+//! WRAPS the credential).
+
+use katulong_shared::wire::{
+    AuthFinishResponse, ChallengeId, PairStartRequest,
+};
+use serde_json::json;
+
+#[test]
+fn auth_finish_response_round_trip() {
+    let resp = AuthFinishResponse {
+        credential_id: "cred-abc".to_string(),
+        csrf_token: "csrf-xyz".to_string(),
+    };
+    let s = serde_json::to_string(&resp).unwrap();
+    let back: AuthFinishResponse = serde_json::from_str(&s).unwrap();
+    assert_eq!(back.credential_id, "cred-abc");
+    assert_eq!(back.csrf_token, "csrf-xyz");
+}
+
+#[test]
+fn auth_finish_response_uses_snake_case_keys() {
+    // Pin the wire keys. Renaming a field on the server
+    // without updating the WASM client (or vice versa) would
+    // change this output and fail the assertion — making the
+    // wire-break visible in code review rather than at
+    // runtime.
+    let resp = AuthFinishResponse {
+        credential_id: "x".to_string(),
+        csrf_token: "y".to_string(),
+    };
+    let value: serde_json::Value = serde_json::to_value(&resp).unwrap();
+    assert_eq!(
+        value,
+        json!({ "credential_id": "x", "csrf_token": "y" })
+    );
+}
+
+#[test]
+fn pair_start_request_round_trip() {
+    let req = PairStartRequest {
+        setup_token: "deadbeef".to_string(),
+    };
+    let s = serde_json::to_string(&req).unwrap();
+    let back: PairStartRequest = serde_json::from_str(&s).unwrap();
+    assert_eq!(back.setup_token, "deadbeef");
+}
+
+#[test]
+fn pair_start_request_uses_setup_token_key() {
+    // The key name `setup_token` is the actual contract the
+    // WASM client and the server both care about. The Rust
+    // identifier could be renamed; the JSON key must not.
+    let req = PairStartRequest {
+        setup_token: "t".to_string(),
+    };
+    let value: serde_json::Value = serde_json::to_value(&req).unwrap();
+    assert_eq!(value, json!({ "setup_token": "t" }));
+}
+
+#[test]
+fn challenge_id_is_a_string() {
+    // `ChallengeId` is a type alias for `String`. If it ever
+    // becomes a newtype, the wire format may change (could
+    // serialize as a tuple struct). Pin the contract: it
+    // must serialize to a bare JSON string.
+    let id: ChallengeId = "challenge-123".to_string();
+    let value: serde_json::Value = serde_json::to_value(&id).unwrap();
+    assert_eq!(value, json!("challenge-123"));
+}

--- a/crates/shared/tests/wire_round_trip.rs
+++ b/crates/shared/tests/wire_round_trip.rs
@@ -1,42 +1,48 @@
 //! Wire-format round-trip tests.
 //!
-//! The point of these tests isn't to verify `serde_json`
-//! itself — that's well-tested upstream. The point is:
+//! Each test pins both halves of the JSON wire contract:
+//! the EXACT keys (so a future "rename to camelCase" or
+//! `#[serde(rename = ...)]` mistake fails the assertion),
+//! AND the round-trip self-consistency (deserialize back to
+//! the same fields). Splitting the two concerns into
+//! separate tests would create four tests where two suffice
+//! and offer no extra signal — a key-pinning failure already
+//! implies a round-trip failure.
 //!
-//! 1. Each struct must remain JSON-deserialisable from the
-//!    JSON shape it serialises to. A field rename or a
-//!    `#[serde(rename = ...)]` change that breaks the round
-//!    trip would slip past the type checker but would fail
-//!    here loudly.
-//!
-//! 2. The JSON keys are part of the HTTP wire contract.
-//!    These tests pin them down with literal keys (e.g.,
-//!    `challenge_id`, `setup_token`) so a future "let's
-//!    rename to camelCase" refactor would have to touch this
-//!    file — making the wire-break visible at PR time.
-//!
-//! Note: we don't fabricate `webauthn-rs-proto` payloads
-//! (the credential types). Those have crypto-binary fields
-//! (challenge bytes, attestation objects) that are
-//! cumbersome to construct without a real authenticator.
-//! The integration tests in `crates/server/tests/auth_*.rs`
-//! exercise those types end-to-end with the real-server
+//! `webauthn-rs-proto` credential types
+//! (`PublicKeyCredential`, `RegisterPublicKeyCredential`)
+//! are not synthesized here — they have crypto-binary fields
+//! (challenge bytes, attestation objects) that are awkward
+//! to construct without a real authenticator. The
+//! integration tests in `crates/server/tests/auth_*.rs`
+//! exercise those types end-to-end via the real
 //! `webauthn-rs` engine on one side and crypto-bogus
 //! payloads on the other; that covers the on-the-wire
-//! shape. Here we focus on the envelope structs (what
-//! WRAPS the credential).
+//! shape. Here we focus on the envelope fields
+//! (`challenge_id`, `setup_token_id`, `credential_id`,
+//! `csrf_token`) — the parts most likely to be silently
+//! renamed by a future refactor that doesn't realize the
+//! key is part of an HTTP contract.
 
 use katulong_shared::wire::{
-    AuthFinishResponse, ChallengeId, PairStartRequest,
+    AuthFinishResponse, ChallengeId, LoginFinishRequest, PairFinishRequest,
+    PairStartRequest, PairStartResponse,
 };
-use serde_json::json;
+use serde_json::{json, Value};
 
 #[test]
-fn auth_finish_response_round_trip() {
+fn auth_finish_response_pins_keys_and_round_trips() {
     let resp = AuthFinishResponse {
         credential_id: "cred-abc".to_string(),
         csrf_token: "csrf-xyz".to_string(),
     };
+
+    let value = serde_json::to_value(&resp).unwrap();
+    assert_eq!(
+        value,
+        json!({ "credential_id": "cred-abc", "csrf_token": "csrf-xyz" })
+    );
+
     let s = serde_json::to_string(&resp).unwrap();
     let back: AuthFinishResponse = serde_json::from_str(&s).unwrap();
     assert_eq!(back.credential_id, "cred-abc");
@@ -44,52 +50,143 @@ fn auth_finish_response_round_trip() {
 }
 
 #[test]
-fn auth_finish_response_uses_snake_case_keys() {
-    // Pin the wire keys. Renaming a field on the server
-    // without updating the WASM client (or vice versa) would
-    // change this output and fail the assertion — making the
-    // wire-break visible in code review rather than at
-    // runtime.
-    let resp = AuthFinishResponse {
-        credential_id: "x".to_string(),
-        csrf_token: "y".to_string(),
-    };
-    let value: serde_json::Value = serde_json::to_value(&resp).unwrap();
-    assert_eq!(
-        value,
-        json!({ "credential_id": "x", "csrf_token": "y" })
-    );
-}
-
-#[test]
-fn pair_start_request_round_trip() {
+fn pair_start_request_pins_setup_token_key_and_round_trips() {
     let req = PairStartRequest {
         setup_token: "deadbeef".to_string(),
     };
+
+    let value = serde_json::to_value(&req).unwrap();
+    assert_eq!(value, json!({ "setup_token": "deadbeef" }));
+
     let s = serde_json::to_string(&req).unwrap();
     let back: PairStartRequest = serde_json::from_str(&s).unwrap();
     assert_eq!(back.setup_token, "deadbeef");
 }
 
 #[test]
-fn pair_start_request_uses_setup_token_key() {
-    // The key name `setup_token` is the actual contract the
-    // WASM client and the server both care about. The Rust
-    // identifier could be renamed; the JSON key must not.
-    let req = PairStartRequest {
-        setup_token: "t".to_string(),
-    };
-    let value: serde_json::Value = serde_json::to_value(&req).unwrap();
-    assert_eq!(value, json!({ "setup_token": "t" }));
+fn login_finish_request_envelope_keys_are_snake_case() {
+    // We can't construct a real `PublicKeyCredential` without
+    // a live authenticator. Verify the envelope keys
+    // (`challenge_id`, `response`) by deserializing a
+    // hand-rolled JSON object with a stub credential body
+    // that contains only the unconditionally-required fields
+    // — the proto types use serde defaults / Option for the
+    // rest. If this stops parsing, the proto contract
+    // changed underneath us; if the envelope key changed,
+    // we'd see the failure here in code review.
+    //
+    // The `response` body is a `webauthn-rs-proto`
+    // `PublicKeyCredential`. Its required fields per the
+    // crate docs: `id` (string), `rawId` (base64url bytes),
+    // `response.{authenticatorData, clientDataJSON,
+    // signature}` (all base64url), and `type` ("public-key").
+    let credential_json = json!({
+        "id": "AAAA",
+        "rawId": "AAAA",
+        "type": "public-key",
+        "response": {
+            "authenticatorData": "AAAA",
+            "clientDataJSON": "AAAA",
+            "signature": "AAAA"
+        }
+    });
+
+    let envelope = json!({
+        "challenge_id": "c1",
+        "response": credential_json,
+    });
+
+    // Round-trip via deserialize → re-serialize. A future
+    // `#[serde(rename_all = "camelCase")]` on the envelope
+    // would change `challenge_id` to `challengeId` and break
+    // the deserialize step here.
+    let parsed: LoginFinishRequest = serde_json::from_value(envelope.clone()).unwrap();
+    let re_serialized = serde_json::to_value(&parsed).unwrap();
+
+    // The envelope keys must match. We don't compare the
+    // `response` body byte-for-byte because the proto
+    // struct's serializer may emit a canonical form that
+    // differs from our hand-rolled JSON; instead we assert
+    // the `response` key exists with an object value.
+    assert_eq!(re_serialized["challenge_id"], json!("c1"));
+    assert!(re_serialized["response"].is_object());
 }
 
 #[test]
-fn challenge_id_is_a_string() {
-    // `ChallengeId` is a type alias for `String`. If it ever
-    // becomes a newtype, the wire format may change (could
-    // serialize as a tuple struct). Pin the contract: it
-    // must serialize to a bare JSON string.
+fn pair_finish_request_envelope_keys_are_snake_case() {
+    let credential_json = json!({
+        "id": "AAAA",
+        "rawId": "AAAA",
+        "type": "public-key",
+        "response": {
+            // RegisterPublicKeyCredential needs the
+            // attestation response shape: clientDataJSON +
+            // attestationObject.
+            "clientDataJSON": "AAAA",
+            "attestationObject": "AAAA",
+        }
+    });
+
+    let envelope = json!({
+        "challenge_id": "c1",
+        "setup_token_id": "tok-id-1",
+        "response": credential_json,
+    });
+
+    let parsed: PairFinishRequest = serde_json::from_value(envelope).unwrap();
+    let re_serialized = serde_json::to_value(&parsed).unwrap();
+
+    assert_eq!(re_serialized["challenge_id"], json!("c1"));
+    assert_eq!(re_serialized["setup_token_id"], json!("tok-id-1"));
+    assert!(re_serialized["response"].is_object());
+}
+
+#[test]
+fn pair_start_response_envelope_keys_are_snake_case() {
+    // The `options` field carries a real
+    // `CreationChallengeResponse`, which has its own complex
+    // shape. We deserialize an envelope and re-serialize it
+    // to verify the wrapper keys round-trip.
+    //
+    // Construct a minimal `CreationChallengeResponse`
+    // payload — it has `publicKey` (the actual options
+    // object) as the load-bearing field. The other fields
+    // (`mediation`, etc.) are optional.
+    let options_json = json!({
+        "publicKey": {
+            "rp": { "name": "katulong", "id": "katulong.test" },
+            "user": {
+                "id": "AAAA",
+                "name": "u",
+                "displayName": "u",
+            },
+            "challenge": "AAAA",
+            "pubKeyCredParams": [],
+        }
+    });
+
+    let envelope = json!({
+        "challenge_id": "c1",
+        "setup_token_id": "tok-id-1",
+        "options": options_json,
+    });
+
+    let parsed: PairStartResponse = serde_json::from_value(envelope).unwrap();
+    let re_serialized = serde_json::to_value(&parsed).unwrap();
+
+    assert_eq!(re_serialized["challenge_id"], json!("c1"));
+    assert_eq!(re_serialized["setup_token_id"], json!("tok-id-1"));
+    assert!(re_serialized["options"].is_object());
+}
+
+#[test]
+fn challenge_id_serializes_as_bare_string() {
+    // `ChallengeId` is `type ChallengeId = String`. A future
+    // newtype-ification (e.g., `struct ChallengeId(String)`)
+    // could change serialization to a single-element tuple
+    // struct unless `#[serde(transparent)]` is added. Pin
+    // the contract: it must serialize to a bare JSON string.
     let id: ChallengeId = "challenge-123".to_string();
-    let value: serde_json::Value = serde_json::to_value(&id).unwrap();
+    let value: Value = serde_json::to_value(&id).unwrap();
     assert_eq!(value, json!("challenge-123"));
 }

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -9,6 +9,13 @@ name = "katulong-web"
 path = "src/main.rs"
 
 [dependencies]
+# Cross-crate wire types — single source of truth for the
+# JSON shapes that flow over /api/auth/*. The server crate
+# uses the same definitions to build responses and parse
+# requests, so a field rename or `#[serde(rename = ...)]`
+# change is caught by the type checker on both sides instead
+# of manifesting as a runtime "could not deserialize" error.
+katulong-shared = { path = "../shared" }
 leptos = { workspace = true }
 console_error_panic_hook = "0.1"
 # `web-sys` for the few browser globals we touch directly.

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -19,8 +19,11 @@
 //! `create_action` and reacts to the resolved value.
 
 use crate::AuthState;
+use katulong_shared::wire::{
+    LoginFinishRequest, LoginStartResponse, PairFinishRequest, PairStartRequest,
+    PairStartResponse,
+};
 use leptos::*;
-use serde::{Deserialize, Serialize};
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 
@@ -44,57 +47,11 @@ fn url_setup_token() -> Option<String> {
     }
 }
 
-// =====================================================================
-// Wire types — mirror the server's `ChallengeStartResponse<...>` and
-// `LoginFinishRequest` shapes. We don't share the server's structs
-// because the server pulls in axum, sqlx, scrypt, etc. — bringing
-// those into the WASM bundle would balloon it. The wire format itself
-// is small + stable, so duplicating two structs is cheaper than the
-// transitive crate weight. The shared `webauthn_rs_proto` types
-// (`RequestChallengeResponse`, `PublicKeyCredential`) DO ride along —
-// they're the part that's tricky to redo, and the crate itself is
-// WASM-friendly.
-// =====================================================================
-
-// No `LoginStartReq` — `login/start` takes no request body.
-#[derive(Debug, Deserialize)]
-struct LoginStartResp {
-    challenge_id: String,
-    options: webauthn_rs_proto::RequestChallengeResponse,
-}
-
-#[derive(Debug, Serialize)]
-struct LoginFinishReq {
-    challenge_id: String,
-    response: webauthn_rs_proto::PublicKeyCredential,
-}
-
-#[derive(Debug, Serialize)]
-struct PairStartReq {
-    /// Plaintext setup-token from the URL. The server hashes
-    /// and looks it up; we never see the hashed form.
-    setup_token: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct PairStartResp {
-    challenge_id: String,
-    /// Server-side opaque id for the redeemable token. Echoed
-    /// back on `pair/finish` so the client doesn't have to
-    /// re-submit the plaintext setup-token a second time. The
-    /// authoritative token re-check still happens server-side
-    /// under the state lock, so this is a nicety, not a
-    /// security boundary.
-    setup_token_id: String,
-    options: webauthn_rs_proto::CreationChallengeResponse,
-}
-
-#[derive(Debug, Serialize)]
-struct PairFinishReq {
-    challenge_id: String,
-    setup_token_id: String,
-    response: webauthn_rs_proto::RegisterPublicKeyCredential,
-}
+// Wire types live in `katulong_shared::wire` so the server
+// and the WASM client compile against the same definitions.
+// The transitive `webauthn-rs-proto` types ride along inside
+// each struct; the `wasm` feature on this crate's own
+// dependency entry adds the `From` impls bridging to web-sys.
 
 /// HTTP status guard shared by both ceremonies. Earlier
 /// drafts inlined this twice; the duplicated format strings
@@ -150,7 +107,7 @@ async fn signin() -> Result<(), String> {
         .await
         .map_err(|e| format!("network error contacting server: {e}"))?;
     check_ok(&start_resp, "server rejected sign-in challenge")?;
-    let start: LoginStartResp = start_resp
+    let start: LoginStartResponse = start_resp
         .json()
         .await
         .map_err(|e| format!("server returned malformed challenge: {e}"))?;
@@ -179,7 +136,7 @@ async fn signin() -> Result<(), String> {
     //    `JsonBody<T>` so Content-Type *must* be application/json
     //    — `gloo-net`'s `.json(...)` sets that automatically.
     let finish_resp = gloo_net::http::Request::post("/api/auth/login/finish")
-        .json(&LoginFinishReq {
+        .json(&LoginFinishRequest {
             challenge_id: start.challenge_id,
             response,
         })
@@ -218,13 +175,13 @@ async fn signin() -> Result<(), String> {
 async fn pair(setup_token: String) -> Result<(), String> {
     // 1. Ask for a registration challenge.
     let start_resp = gloo_net::http::Request::post("/api/auth/pair/start")
-        .json(&PairStartReq { setup_token })
+        .json(&PairStartRequest { setup_token })
         .map_err(|e| format!("could not encode pair-start payload: {e}"))?
         .send()
         .await
         .map_err(|e| format!("network error contacting server: {e}"))?;
     check_ok(&start_resp, "server rejected pair challenge")?;
-    let start: PairStartResp = start_resp
+    let start: PairStartResponse = start_resp
         .json()
         .await
         .map_err(|e| format!("server returned malformed challenge: {e}"))?;
@@ -250,7 +207,7 @@ async fn pair(setup_token: String) -> Result<(), String> {
     // 4. Send the attestation back along with the
     //    `setup_token_id` the server gave us in step 1.
     let finish_resp = gloo_net::http::Request::post("/api/auth/pair/finish")
-        .json(&PairFinishReq {
+        .json(&PairFinishRequest {
             challenge_id: start.challenge_id,
             setup_token_id: start.setup_token_id,
             response,

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -47,12 +47,6 @@ fn url_setup_token() -> Option<String> {
     }
 }
 
-// Wire types live in `katulong_shared::wire` so the server
-// and the WASM client compile against the same definitions.
-// The transitive `webauthn-rs-proto` types ride along inside
-// each struct; the `wasm` feature on this crate's own
-// dependency entry adds the `From` impls bridging to web-sys.
-
 /// HTTP status guard shared by both ceremonies. Earlier
 /// drafts inlined this twice; the duplicated format strings
 /// drifted in review (one read "pair payload" for two


### PR DESCRIPTION
## Summary

- Move five duplicated wire-type structs out of `crates/server/src/api/auth.rs` and `crates/web/src/login.rs` into the existing `crates/shared` crate (which was already a workspace member, deliberately empty for cross-crate types). Both consumers now import the same definitions; a field rename is now a compile-time error on both sides.
- Add five JSON round-trip / wire-key-pinning unit tests in `crates/shared/tests/wire_round_trip.rs` so a future \"let's switch to camelCase\" refactor would have to touch this file — making the wire-break visible at PR time.
- This is the 9r.3 architecture reviewer's HIGH-severity deferral, landed before slice 9r.4 (status probe) adds more wire types.

## What changed

- `crates/shared/src/wire.rs` (new): single source of truth for `ChallengeStartResponse<T>`, concrete aliases `RegisterStartResponse` / `LoginStartResponse`, finish-request structs for register/login/pair, `AuthFinishResponse`, and a `ChallengeId = String` alias.
- `crates/shared/Cargo.toml`: adds `webauthn-rs-proto = \"0.5\"` (no `wasm` feature — that flag is web-side only; Cargo's feature unification handles the rest).
- `crates/server/src/api/auth.rs`: deletes seven local struct copies, imports from `katulong_shared::wire`. `Deserialize` and `ChallengeId` imports go away with them.
- `crates/web/src/login.rs`: deletes five local struct copies, imports the shared versions. Field-init sites pick up the renamed `*Request` / `*Response` suffixes.
- `crates/web/Cargo.toml`: adds `katulong-shared = { path = \"../shared\" }`.
- `crates/shared/tests/wire_round_trip.rs` (new): five tests pinning the JSON wire contract.

## Why katulong-shared and not a new katulong-wire

The crate already existed in the workspace as a deliberate placeholder for cross-crate types (see the lib.rs doc-comment). Creating a second crate with the same role would be YAGNI naming.

## Bundle / test impact

- WASM bundle: 550 KB → 548 KB (-2 KB from dedup; duplicated `Serialize`/`Deserialize` impls collapsed into one).
- Rust tests: 285 → 290 (5 new round-trip tests).
- E2E unchanged: 9 Playwright tests still green.

## Test plan

- [x] `cargo build --release` clean (workspace, no warnings)
- [x] `cargo test --release` green (290 tests)
- [x] `trunk build --release` clean
- [x] Full Rust e2e suite green against `KATULONG_STAGE_BACKEND=rust bin/katulong-stage`
- [ ] Reviewer: confirm the new `webauthn-rs-proto` direct dependency in `crates/shared` doesn't pull surprising transitive weight onto the server build (the feature gating is the load-bearing piece — `wasm` feature stays web-side)