### PR TITLE
fix: collapse iPad scroll duplication by going all-JS, no native scroll

### DIFF
--- a/public/early-scroll-lock.js
+++ b/public/early-scroll-lock.js
@@ -3,8 +3,10 @@
 //
 // Extracted from inline <script> in index.html so the Content-Security-Policy
 // can use strict script-src 'self' without needing 'unsafe-inline' or a nonce.
+// Terminal panes use touch-action:none + initTouchScroll's pointer bridge,
+// so they don't need (and shouldn't have) a native-scroll allowance here.
 document.addEventListener('touchmove', function(e) {
-  if (e.target.closest('.xterm-viewport, .tab-scroll-area, .modal-panel, #sidebar-content')) return;
+  if (e.target.closest('.tab-scroll-area, .modal-panel, #sidebar-content')) return;
   e.preventDefault();
 }, { passive: false });
 document.addEventListener('scroll', function() { window.scrollTo(0, 0); });

--- a/public/index.html
+++ b/public/index.html
@@ -730,12 +730,15 @@
     /* Scroll is JS-driven (xterm's wheel handler + initTouchScroll's pointer
        bridge → term.scrollLines). Override xterm.css's overflow-y:scroll so
        no native scroll container exists on iOS — native momentum scrolling
-       on this layer fights the WebGL canvas redraw and ghosts rows on iPad.
-       Background override is !important because xterm.css hardcodes #000. */
+       on this layer fights the WebGL canvas redraw and ghosts rows on iPad. */
     #terminal-container .xterm-viewport,
     #terminal-container .xterm-scrollable-element {
       overflow: hidden;
     }
+    /* Transparent (not a fixed color) so whatever paints behind the viewport
+       — card-face surface in carousel mode, --bg in non-carousel — shows
+       through the gap below the last row. !important because xterm.css
+       hardcodes background:#000 on .xterm-viewport. */
     #terminal-container .xterm-viewport {
       background-color: transparent !important;
     }

--- a/public/index.html
+++ b/public/index.html
@@ -727,21 +727,18 @@
        between left and right instead of accumulating on the right only.
        .xterm-screen has a definite width (set by xterm to cols*cellWidth). */
     .terminal-pane .xterm-screen { margin-left: auto; margin-right: auto; }
+    /* Scroll is JS-driven (xterm's wheel handler + initTouchScroll's pointer
+       bridge → term.scrollLines). Override xterm.css's overflow-y:scroll so
+       no native scroll container exists on iOS — native momentum scrolling
+       on this layer fights the WebGL canvas redraw and ghosts rows on iPad.
+       Background override is !important because xterm.css hardcodes #000. */
     #terminal-container .xterm-viewport,
     #terminal-container .xterm-scrollable-element {
-      -webkit-overflow-scrolling: touch;
-      overscroll-behavior: contain;
+      overflow: hidden;
     }
-    /* Override xterm.css default #000 background with transparent so whatever
-       paints behind the viewport (card-face surface in carousel mode,
-       #terminal-container var(--bg) in non-carousel mode) shows through the
-       gap below the last terminal row instead of a mismatched strip. Must be
-       !important because xterm.css hardcodes background:#000 on .xterm-viewport. */
     #terminal-container .xterm-viewport {
       background-color: transparent !important;
-      scrollbar-width: none; /* Firefox */
     }
-    #terminal-container .xterm-viewport::-webkit-scrollbar { display: none; } /* Chrome/Safari */
     /* xterm's input textarea is moved into this off-screen wrapper at the DOM
        level (see terminal-pool.js) so the system caret can never appear in the
        visible terminal area.  No opacity/clip-path hacks needed. */

--- a/public/lib/scroll-utils.js
+++ b/public/lib/scroll-utils.js
@@ -28,14 +28,6 @@
 // --- Per-terminal scroll-lock state (WeakMap so GC-friendly) ---
 const _scrollLocked = new WeakMap();
 
-/** Derive the scrollable viewport element from a terminal instance's own DOM */
-export function viewportOf(term) {
-  const pane = term?.element?.closest(".terminal-pane");
-  if (!pane) return null;
-  // xterm 6 uses .xterm-scrollable-element; fall back to .xterm-viewport for older versions
-  return pane.querySelector(".xterm-scrollable-element") || pane.querySelector(".xterm-viewport") || null;
-}
-
 /**
  * Check if terminal is scrolled to the bottom.
  * Uses xterm.js buffer API, not DOM scroll properties.

--- a/public/lib/scroll-utils.js
+++ b/public/lib/scroll-utils.js
@@ -3,12 +3,19 @@
  *
  * Composable scroll management helpers for terminal.
  *
- * Tracks user-initiated scrolling so that rapid terminal output (e.g.
- * Claude Code working) doesn't yank the viewport back to the bottom
- * every frame.  The lock is set on wheel / touchmove events when the
- * viewport is away from the bottom, and cleared when the viewport
- * reaches the bottom again (via any means — manual scroll, button
- * click, or programmatic scrollToBottom).
+ * Tracks scroll state so rapid terminal output (e.g. Claude Code typing)
+ * doesn't yank the viewport back to the bottom while the user is reading
+ * scrollback.  The lock follows the buffer's viewport position: set when
+ * away from bottom, cleared on arrival.
+ *
+ * Scroll architecture: native browser scroll is disabled on the terminal
+ * pane (#terminal-container .xterm-viewport { overflow: hidden }) so all
+ * viewport movement flows through `term.scrollLines()`:
+ *   - wheel/trackpad → xterm's built-in wheel handler
+ *   - touch drag    → initTouchScroll's pointer bridge
+ *   - programmatic  → scrollToBottom, etc.
+ * Every path triggers `term.onScroll`, which is the single source of
+ * truth for tracking scroll-lock state.
  *
  * IMPORTANT: xterm.js 6 uses a custom scrollable element — native DOM
  * scroll properties (scrollTop, scrollHeight) are NOT meaningful. All
@@ -43,29 +50,15 @@ export function isAtBottom(term) {
  * Attach scroll-lock tracking to a terminal.
  * Call once per terminal (idempotent — skips if already attached).
  *
- * Wheel / touchmove away from bottom → lock (suppress auto-scroll).
- * Scroll back to bottom (via term.onScroll) → unlock.
+ * Lock follows the buffer position via term.onScroll, which fires for
+ * every viewport movement (wheel, touch, scrollbar, programmatic).
  */
 export function initScrollTracking(term) {
   if (_scrollLocked.has(term)) return;
   _scrollLocked.set(term, false);
 
-  const viewport = viewportOf(term);
-
-  const markUserScroll = () => {
-    if (!isAtBottom(term)) _scrollLocked.set(term, true);
-  };
-
-  // Wheel and touchmove fire on the custom scrollable even in xterm.js 6
-  if (viewport) {
-    viewport.addEventListener("wheel", markUserScroll, { passive: true });
-    viewport.addEventListener("touchmove", markUserScroll, { passive: true });
-  }
-
-  // Clear lock when terminal reaches bottom — use term.onScroll which
-  // fires reliably (unlike native DOM scroll events on xterm 6).
   term.onScroll(() => {
-    if (isAtBottom(term)) _scrollLocked.set(term, false);
+    _scrollLocked.set(term, !isAtBottom(term));
   });
 }
 

--- a/public/lib/viewport-manager.js
+++ b/public/lib/viewport-manager.js
@@ -4,7 +4,7 @@
  * Handles viewport resizing, scroll button UI, and terminal gesture handlers.
  */
 
-import { viewportOf, isAtBottom, scrollToBottom } from "/lib/scroll-utils.js";
+import { isAtBottom, scrollToBottom } from "/lib/scroll-utils.js";
 
 /**
  * Viewport Manager


### PR DESCRIPTION
## Summary

iPad reproducibly showed duplicated terminal lines during touch-drag scroll on a katulong tile — the same row appeared in two places instead of the upper one scrolling out of view. Root cause was four overlapping scroll mechanisms accumulated over time, two of which directly contradicted each other:

- `-webkit-overflow-scrolling: touch` + `overscroll-behavior: contain` on `.xterm-viewport` / `.xterm-scrollable-element` (added in `372b08e`, extended in `c1a651b`) — opted iOS into native momentum scrolling.
- `touch-action: none` on `.xterm` — tried to disable native gestures.
- xterm v6's built-in wheel handler — drives scroll via `term.scrollLines()` with no native-scroll dependency.
- `initTouchScroll` (`scroll-utils.js`) — pointer-event bridge that converts touch drag into `term.scrollLines()` calls; xterm v6 explicitly does not handle touch.

The first two were leftovers from a half-removed native-scroll model that the latter two made unnecessary. On iPad, native momentum scroll on the viewport layer was still translating the WebGL-rendered canvas's compositor layer while `term.scrollLines()` simultaneously advanced `buffer.viewportY`, producing ghost rows during the gesture.

This PR commits fully to JS-driven scroll with `term.onScroll` as the single source of truth — one mechanism, one buffer state, no compositor wars.

- `public/index.html` — viewport elements get `overflow: hidden`; drop `-webkit-overflow-scrolling: touch` and `overscroll-behavior: contain`.
- `public/early-scroll-lock.js` — drop `.xterm-viewport` from the touchmove allowlist (terminal panes don't need a native-scroll exception anymore).
- `public/lib/scroll-utils.js` — collapse `initScrollTracking` to a single `term.onScroll` listener; the wheel/touchmove DOM listeners on the viewport were tracking native-scroll events that no longer occur. Lock now follows buffer position (set when away from bottom, cleared on arrival).
- `public/lib/viewport-manager.js` — drop now-unused `viewportOf` import.

## Test plan

- [x] `npm test` passes (2691/2691)
- [x] Smoke E2E + unit/integration tests pass via pre-push hook
- [x] Manually verified on iPad via `/stage` — touch-drag scroll no longer duplicates lines
- [ ] Mouse wheel + trackpad still scroll the terminal on desktop
- [ ] Two-finger trackpad scroll on iPad still works (regression check for `eb7fd4b`)
- [ ] Pinch-zoom still works (untouched, but shares the wheel path)