### PR TITLE
test(e2e): WebAuthn happy-path harness via Chromium virtual authenticator

### DIFF
--- a/bin/katulong-stage
+++ b/bin/katulong-stage
@@ -144,6 +144,16 @@ default_name() {
 }
 
 # Ask Node for a free TCP port at or above $1.
+#
+# `process.stdout.write(String(p))` and not `console.log(p)` —
+# when FORCE_COLOR is set (Playwright sets it for colorized
+# test output, and that env propagates into our execSync
+# invocations of this script), Node's `console.log(<number>)`
+# wraps the value in ANSI yellow escape codes. Bash command
+# substitution then captures `[33m3050[39m` instead of
+# `3050`, which silently contaminates downstream KATULONG_*
+# env vars and crashes the Rust server with "invalid port
+# number". `process.stdout.write` of a string is plain.
 find_free_port() {
   local from="${1:-3050}"
   node -e "
@@ -155,7 +165,7 @@ find_free_port() {
         s.on('error', () => resolve(tryPort(p + 1)));
       });
     }
-    tryPort($from).then(p => console.log(p));
+    tryPort($from).then(p => process.stdout.write(String(p)));
   "
 }
 
@@ -560,10 +570,19 @@ cmd_start() {
       return 1
     fi
 
+    # KATULONG_ORIGIN must match the URL the browser actually
+    # uses, or webauthn-rs's clientDataJSON.origin check
+    # rejects every assertion. The default in main.rs is
+    # `http://localhost:3000`, which only happens to match
+    # when the operator hand-launches with PORT=3000. For
+    # staging on a dynamic port, the local URL is
+    # http://localhost:$port — set it here so passkey
+    # ceremonies actually verify.
     PORT="$port" \
     KATULONG_DATA_DIR="$data_dir" \
     KATULONG_TMUX_SOCKET="$tmux_socket" \
     KATULONG_WEB_DIST="$web_dist" \
+    KATULONG_ORIGIN="http://localhost:$port" \
       nohup "$rust_bin" > "$log_file" 2>&1 &
   fi
   local server_pid=$!

--- a/playwright.rust.config.js
+++ b/playwright.rust.config.js
@@ -7,18 +7,27 @@
 // mode, or the public staging URL.
 //
 // Run:
-//   KATULONG_BASE_URL=http://127.0.0.1:3050 \
-//     npx playwright test --config=playwright.rust.config.js
+//   npx playwright test --config=playwright.rust.config.js
 //
 //   KATULONG_BASE_URL=https://rewrite-rust-leptos.felixflor.es \
 //     npx playwright test --config=playwright.rust.config.js
 //
-// The default base URL points at localhost so a developer who's
-// just run `KATULONG_STAGE_BACKEND=rust bin/katulong-stage start`
-// can run the suite without thinking about flags.
+// The default base URL is `http://localhost:3050` and NOT
+// `http://127.0.0.1:3050`. The webauthn happy-path suite
+// (test/e2e-rust/webauthn.e2e.js) drives Chromium's virtual
+// authenticator, which enforces the WebAuthn spec rule that
+// the page's origin host must be a registrable suffix of the
+// configured RP ID. Katulong's default RP ID is "localhost"
+// (see crates/server/src/main.rs:126), and the browser does
+// not consider "127.0.0.1" a registrable suffix of that, so
+// passkey ceremonies on `http://127.0.0.1:3050` reject with
+// "SecurityError: This is an invalid domain." The token-rejection
+// tests in auth.e2e.js wouldn't surface this — they stub the
+// network — so the failure only appears when a real ceremony
+// runs.
 import { defineConfig, devices } from "@playwright/test";
 
-const BASE_URL = process.env.KATULONG_BASE_URL || "http://127.0.0.1:3050";
+const BASE_URL = process.env.KATULONG_BASE_URL || "http://localhost:3050";
 
 export default defineConfig({
   testDir: "test/e2e-rust",

--- a/test/e2e-rust/lib/webauthn.js
+++ b/test/e2e-rust/lib/webauthn.js
@@ -38,16 +38,13 @@ import { execSync } from "node:child_process";
 //                                          the bootstrap)
 
 /**
- * Attach a virtual CTAP2 authenticator to a page. The
- * returned `authenticatorId` is the handle used by the other
- * CDP commands; the `client` is the CDP session used to
- * issue them.
+ * Attach a virtual CTAP2 authenticator to a page.
  *
- * Defaults: USB transport, no resident keys, user
- * verification supported AND assumed to be performed (i.e.,
- * the authenticator auto-confirms — no biometric prompt to
- * dismiss). Tests get the success path without any UI
- * interaction beyond clicking the page's actual buttons.
+ * `isUserVerified: true` + `automaticPresenceSimulation:
+ * true` together make the authenticator auto-confirm
+ * ceremonies without a UV prompt to dismiss — the test
+ * exercises the success path by clicking the page's real
+ * buttons, not by simulating biometric input.
  */
 export async function setupVirtualAuthenticator(page) {
   const client = await page.context().newCDPSession(page);
@@ -118,14 +115,24 @@ export async function ensureFreshStagingDataDir(baseURL) {
       encoding: "utf8",
     });
   } catch (err) {
+    // Trim stderr to the tail to keep the test report
+    // scannable AND to avoid echoing the entire staging
+    // banner (which on the Node backend includes the
+    // plaintext setup token — see katulong-stage:723). The
+    // tail almost always contains the actual error line.
+    const tail = (s) =>
+      (s || "").toString().split("\n").slice(-10).join("\n");
     throw new Error(
-      `staging restart failed: ${err.message}\nstdout: ${err.stdout}\nstderr: ${err.stderr}`,
+      `staging restart failed: ${err.message}\n--- stderr (last 10 lines) ---\n${tail(err.stderr)}`,
     );
   }
 
-  // Wait for /health to come back. Without this poll the
-  // immediately-following bootstrap fetch would race the
-  // server's startup.
+  // Wait for /health to come back. The staging script's
+  // own `wait_for_server` already gates on this internally,
+  // so reaching this poll loop after a successful execSync
+  // means the server is at least listening — the poll is a
+  // belt-and-braces guard for the rare case where the
+  // socket is bound but the route table isn't ready yet.
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     try {
@@ -160,7 +167,7 @@ export async function ensureFreshStagingDataDir(baseURL) {
  * a fresh authenticator and inject the same credential —
  * needed because virtual authenticators are page-scoped.
  */
-export async function registerFirstDeviceViaApi(page, vauth) {
+export async function registerFirstDevice(page, vauth) {
   // The base64url ↔ ArrayBuffer dance is unavoidable: the
   // server speaks JSON-with-base64url over the wire, the
   // browser's WebAuthn API speaks ArrayBuffers. The WASM
@@ -218,7 +225,9 @@ export async function registerFirstDeviceViaApi(page, vauth) {
       }),
     });
     if (!finishResp.ok) {
-      throw new Error(`register/finish returned ${finishResp.status}`);
+      throw new Error(
+        `register/finish returned ${finishResp.status} — credential payload may be malformed or challenge expired`,
+      );
     }
     return await finishResp.json();
   });
@@ -226,12 +235,21 @@ export async function registerFirstDeviceViaApi(page, vauth) {
   // Capture the credential dump for later injection. Without
   // this, a fresh page can't sign in as this user — its
   // virtual authenticator has no credentials.
+  //
+  // Asserting `length === 1` (not just non-empty) catches
+  // the unlikely-but-real case where the CDP session
+  // already held a credential from a leaked prior context:
+  // `credentials[0]` would then be the stale one, the
+  // injection in the sign-in test would target the wrong
+  // key, and the failure mode would be a confusing
+  // "browser-credential-mismatch" message at the assertion
+  // step rather than at the boot.
   const { credentials } = await vauth.client.send("WebAuthn.getCredentials", {
     authenticatorId: vauth.authenticatorId,
   });
-  if (credentials.length === 0) {
+  if (credentials.length !== 1) {
     throw new Error(
-      "virtual authenticator reported no credentials after register/finish",
+      `virtual authenticator reported ${credentials.length} credentials after register/finish — expected exactly 1`,
     );
   }
 
@@ -277,9 +295,22 @@ export async function mintSetupToken(page, csrfToken, name) {
         body: JSON.stringify({ name: deviceName }),
       });
       if (!resp.ok) {
-        throw new Error(`setup-tokens returned ${resp.status}`);
+        throw new Error(
+          `setup-tokens returned ${resp.status} — CSRF token may be stale or session cookie missing`,
+        );
       }
       const body = await resp.json();
+      if (!body.plaintext) {
+        // An empty plaintext would silently make the pair
+        // test navigate to `/?setup_token=` (no value), which
+        // the server treats as "no token in URL" and the UI
+        // would render the sign-in mode. The test would then
+        // fail at the missing pair-CTA, with no signal that
+        // the real bug was the empty-token response.
+        throw new Error(
+          "setup-tokens response had empty `plaintext` field — server may have changed wire format",
+        );
+      }
       return body.plaintext;
     },
     { csrf: csrfToken, deviceName: name },

--- a/test/e2e-rust/lib/webauthn.js
+++ b/test/e2e-rust/lib/webauthn.js
@@ -1,0 +1,287 @@
+import { execSync } from "node:child_process";
+
+// Helpers for driving Chromium's CDP virtual WebAuthn
+// authenticator from Playwright tests.
+//
+// The story so far:
+//   - The auth.e2e.js suite verifies the UI's REJECTION
+//     paths (button wired, request shape right, error
+//     region rendered when the server returns non-2xx).
+//   - It deliberately avoids the platform credential
+//     interaction because Chromium without a virtual
+//     authenticator simply rejects every navigator.credentials
+//     call, which would mask real bugs in the success path.
+//   - This file wires the virtual authenticator so the
+//     SUCCESS paths can be exercised: a real credential is
+//     minted by the authenticator, signed by the
+//     authenticator's CTAP2 stack, verified by the real
+//     `webauthn-rs` engine on the server, and the page ends
+//     up in the post-auth view because all the wires
+//     actually connect.
+//
+// The CDP API in use:
+//   - WebAuthn.enable                    — turn on the domain
+//   - WebAuthn.addVirtualAuthenticator   — attach a software
+//                                          CTAP2 device
+//   - WebAuthn.getCredentials            — extract a minted
+//                                          credential's
+//                                          private key for
+//                                          re-injection in a
+//                                          fresh authenticator
+//   - WebAuthn.addCredential             — inject a captured
+//                                          credential into a
+//                                          fresh authenticator
+//                                          (so a "different
+//                                          page, same user"
+//                                          test can sign in
+//                                          with the cred from
+//                                          the bootstrap)
+
+/**
+ * Attach a virtual CTAP2 authenticator to a page. The
+ * returned `authenticatorId` is the handle used by the other
+ * CDP commands; the `client` is the CDP session used to
+ * issue them.
+ *
+ * Defaults: USB transport, no resident keys, user
+ * verification supported AND assumed to be performed (i.e.,
+ * the authenticator auto-confirms — no biometric prompt to
+ * dismiss). Tests get the success path without any UI
+ * interaction beyond clicking the page's actual buttons.
+ */
+export async function setupVirtualAuthenticator(page) {
+  const client = await page.context().newCDPSession(page);
+  await client.send("WebAuthn.enable");
+  const { authenticatorId } = await client.send(
+    "WebAuthn.addVirtualAuthenticator",
+    {
+      options: {
+        protocol: "ctap2",
+        transport: "internal",
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+        automaticPresenceSimulation: true,
+      },
+    },
+  );
+  return { client, authenticatorId };
+}
+
+/**
+ * Make sure the staging instance has a fresh data dir.
+ *
+ * The `register/start` endpoint succeeds only on a fresh
+ * install (no credentials registered). On a re-run of this
+ * test file, the data dir already holds the credential
+ * minted by the previous run; we need to wipe it before the
+ * bootstrap can succeed. The simplest robust path is to
+ * stop + start staging via the script — that script owns
+ * the server-process + data-dir lifecycle, and re-using its
+ * shutdown ensures we don't leak the server. After restart,
+ * the server is on a (possibly new) port; the test harness
+ * is configured against a stable `KATULONG_BASE_URL`, so
+ * the staging port allocator must hand back the same port
+ * — which it does, because the dynamic-port range starts at
+ * 3050 and the previous instance's port is freed by `stop`.
+ *
+ * Cost: ~2-5s for stop, ~3-8s for start (Rust binary is
+ * already built; trunk is no-op-fast on a hot cache). Paid
+ * once per run, not once per test.
+ */
+export async function ensureFreshStagingDataDir(baseURL) {
+  const probe = await fetch(`${baseURL}/api/auth/register/start`, {
+    method: "POST",
+  });
+  if (probe.status === 200) {
+    // Even though probe succeeded, we just consumed a
+    // challenge_id from the in-memory pending map. That's
+    // fine — challenges expire on their own and the
+    // bootstrap that follows mints its own. No need to
+    // reset.
+    return;
+  }
+  if (probe.status !== 409) {
+    throw new Error(
+      `register/start probe returned ${probe.status} — staging server may not be running or is in an unexpected state`,
+    );
+  }
+
+  // 409 means credentials already exist. Wipe staging and
+  // restart. The script's `stop` reaps the server process
+  // AND removes the data dir; subsequent `start` creates a
+  // fresh dir.
+  try {
+    execSync("bin/katulong-stage stop && bin/katulong-stage start", {
+      env: { ...process.env, KATULONG_STAGE_BACKEND: "rust" },
+      timeout: 60_000,
+      encoding: "utf8",
+    });
+  } catch (err) {
+    throw new Error(
+      `staging restart failed: ${err.message}\nstdout: ${err.stdout}\nstderr: ${err.stderr}`,
+    );
+  }
+
+  // Wait for /health to come back. Without this poll the
+  // immediately-following bootstrap fetch would race the
+  // server's startup.
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(`${baseURL}/health`);
+      if (r.ok) return;
+    } catch {
+      // server not yet listening — retry
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(
+    "staging server did not return /health=ok within 30s after restart",
+  );
+}
+
+/**
+ * Drive the first-device register ceremony entirely from
+ * inside the page so the virtual authenticator handles
+ * `navigator.credentials.create()`. We can't run the
+ * ceremony from outside the page because the virtual
+ * authenticator is bound to the page's CDP session.
+ *
+ * The server's `/register/start` route is localhost-only and
+ * requires no auth, so this only works against a local
+ * staging instance. Returns the parsed AuthFinishResponse
+ * (`credential_id`, `csrf_token`) — the caller needs the
+ * CSRF token to mint a setup token via the authed
+ * `/setup-tokens` endpoint.
+ *
+ * Also captures the credential's private key via
+ * `WebAuthn.getCredentials` so subsequent tests can spin up
+ * a fresh authenticator and inject the same credential —
+ * needed because virtual authenticators are page-scoped.
+ */
+export async function registerFirstDeviceViaApi(page, vauth) {
+  // The base64url ↔ ArrayBuffer dance is unavoidable: the
+  // server speaks JSON-with-base64url over the wire, the
+  // browser's WebAuthn API speaks ArrayBuffers. The WASM
+  // client uses webauthn-rs-proto's `From` impls; from the
+  // test we recreate the conversion in plain JS.
+  const finishResponse = await page.evaluate(async () => {
+    const b64uToBuf = (s) => {
+      const pad = (4 - (s.length % 4)) % 4;
+      const b64 = s.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat(pad);
+      return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)).buffer;
+    };
+    const bufToB64u = (buf) => {
+      const bytes = new Uint8Array(buf);
+      let s = "";
+      for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+      return btoa(s)
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+    };
+
+    const startResp = await fetch("/api/auth/register/start", {
+      method: "POST",
+    });
+    if (!startResp.ok) {
+      throw new Error(
+        `register/start returned ${startResp.status} — data dir may not be fresh`,
+      );
+    }
+    const start = await startResp.json();
+    const opts = start.options.publicKey;
+    opts.challenge = b64uToBuf(opts.challenge);
+    opts.user.id = b64uToBuf(opts.user.id);
+    if (opts.excludeCredentials) {
+      opts.excludeCredentials.forEach((c) => (c.id = b64uToBuf(c.id)));
+    }
+
+    const cred = await navigator.credentials.create({ publicKey: opts });
+
+    const credPayload = {
+      id: cred.id,
+      rawId: bufToB64u(cred.rawId),
+      type: cred.type,
+      response: {
+        clientDataJSON: bufToB64u(cred.response.clientDataJSON),
+        attestationObject: bufToB64u(cred.response.attestationObject),
+      },
+    };
+    const finishResp = await fetch("/api/auth/register/finish", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        challenge_id: start.challenge_id,
+        response: credPayload,
+      }),
+    });
+    if (!finishResp.ok) {
+      throw new Error(`register/finish returned ${finishResp.status}`);
+    }
+    return await finishResp.json();
+  });
+
+  // Capture the credential dump for later injection. Without
+  // this, a fresh page can't sign in as this user — its
+  // virtual authenticator has no credentials.
+  const { credentials } = await vauth.client.send("WebAuthn.getCredentials", {
+    authenticatorId: vauth.authenticatorId,
+  });
+  if (credentials.length === 0) {
+    throw new Error(
+      "virtual authenticator reported no credentials after register/finish",
+    );
+  }
+
+  return {
+    finishResponse,
+    credentialDump: credentials[0],
+  };
+}
+
+/**
+ * Inject a previously-captured credential into a fresh
+ * authenticator on a different page. Lets a sign-in test
+ * use a credential minted in the bootstrap test without
+ * sharing the authenticator instance.
+ */
+export async function injectCredential(vauth, credentialDump) {
+  await vauth.client.send("WebAuthn.addCredential", {
+    authenticatorId: vauth.authenticatorId,
+    credential: credentialDump,
+  });
+}
+
+/**
+ * Mint a setup token by hitting the authed
+ * `/api/auth/setup-tokens` endpoint with the session cookie
+ * + CSRF header from the bootstrap. Returns the plaintext
+ * token (caller appends to `?setup_token=` in the URL).
+ *
+ * We use page.evaluate so the request rides on the page's
+ * existing cookies. Using Playwright's `request` fixture
+ * would lose the cookie context; using `request` with
+ * explicit cookie forwarding is more code than this.
+ */
+export async function mintSetupToken(page, csrfToken, name) {
+  return await page.evaluate(
+    async ({ csrf, deviceName }) => {
+      const resp = await fetch("/api/auth/setup-tokens", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Csrf-Token": csrf,
+        },
+        body: JSON.stringify({ name: deviceName }),
+      });
+      if (!resp.ok) {
+        throw new Error(`setup-tokens returned ${resp.status}`);
+      }
+      const body = await resp.json();
+      return body.plaintext;
+    },
+    { csrf: csrfToken, deviceName: name },
+  );
+}

--- a/test/e2e-rust/webauthn.e2e.js
+++ b/test/e2e-rust/webauthn.e2e.js
@@ -1,0 +1,148 @@
+// End-to-end happy-path WebAuthn ceremonies.
+//
+// This is the suite that proves the wires actually connect:
+// a real credential is minted by Chromium's virtual
+// authenticator, the assertion is signed by the
+// authenticator's CTAP2 stack, the server's `webauthn-rs`
+// engine verifies it, and the page lands on the post-auth
+// view because every link in the chain works.
+//
+// Sibling files cover narrower contracts:
+//   - smoke.e2e.js     — shell layout + WASM bundle plumbing
+//   - auth.e2e.js      — UI rejection paths (button wired,
+//                        request shape right, error region
+//                        rendered when server says no)
+//
+// Why this file is separate: the two sibling suites run
+// without a virtual authenticator (the platform credential
+// call simply rejects, and we assert the rejection
+// rendering). Mixing happy-path tests in would require
+// per-test virtual-authenticator setup, and the file would
+// quickly drift into "is this a rejection test or a success
+// test?" confusion. The split is by what infrastructure the
+// test needs.
+//
+// Data-dir requirement: these tests bootstrap on a fresh
+// staging instance. The first test calls `register/start`,
+// which is localhost-only and only succeeds when no
+// credentials are registered. Re-running the suite against
+// the same data dir without restarting will 409 in the
+// bootstrap. CI starts a fresh data dir per run; for local
+// re-runs use:
+//   bin/katulong-stage stop <branch> &&
+//     KATULONG_STAGE_BACKEND=rust bin/katulong-stage start
+//
+// Why use `test.describe.serial` + shared bootstrap state:
+// the data dir is one-shot for register-first-device. We
+// can register exactly once per test run, so subsequent
+// tests must reuse that credential (via `injectCredential`)
+// or generate a new one through a flow that doesn't go
+// through register (the pair flow). Serial execution + a
+// captured credential dump lets each test exercise its own
+// UI flow in isolation while sharing the bootstrap cost.
+
+import { test, expect } from "@playwright/test";
+import {
+  ensureFreshStagingDataDir,
+  setupVirtualAuthenticator,
+  registerFirstDeviceViaApi,
+  injectCredential,
+  mintSetupToken,
+} from "./lib/webauthn.js";
+
+test.describe.serial("WebAuthn UI happy paths", () => {
+  // Bootstrap output captured in `beforeAll` and read by
+  // each test. The bootstrap registers a credential AND
+  // captures its private-key dump so the sign-in test on a
+  // fresh page can sign in as that user. While still
+  // authed, the bootstrap also mints a setup token so the
+  // pair test doesn't need to re-sign-in (which would use
+  // the credential a second time and trip webauthn-rs's
+  // sign-counter replay guard — counters only ever go up,
+  // and a re-injected credential dump carries the original
+  // count).
+  let bootstrap;
+  let setupToken;
+
+  test.beforeAll(async ({ browser, baseURL }) => {
+    // Self-heal the data dir if a previous run left
+    // credentials behind. Without this, every second run
+    // through the suite would 409 in the bootstrap.
+    await ensureFreshStagingDataDir(baseURL);
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto("/");
+    const vauth = await setupVirtualAuthenticator(page);
+    bootstrap = await registerFirstDeviceViaApi(page, vauth);
+    setupToken = await mintSetupToken(
+      page,
+      bootstrap.finishResponse.csrf_token,
+      "pair-test-device",
+    );
+    await context.close();
+  });
+
+  test("a registered user can sign in with their passkey", async ({
+    browser,
+  }) => {
+    // Fresh page so the bootstrap's session cookie isn't in
+    // play — we want to see the login form, click "Sign
+    // in", and end up at the post-auth view.
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto("/");
+
+    // Bootstrap minted the credential in a different
+    // browser context, whose virtual authenticator is gone.
+    // Inject the same credential into this page's
+    // authenticator so navigator.credentials.get() can find
+    // it.
+    const vauth = await setupVirtualAuthenticator(page);
+    await injectCredential(vauth, bootstrap.credentialDump);
+
+    await page
+      .getByRole("button", { name: /sign in with passkey/i })
+      .click();
+
+    // Behaviour-level assertion: after the ceremony, the
+    // post-auth view replaces the login form. We don't
+    // poke at internal data-attrs; we look for what a user
+    // would see.
+    await expect(page.getByText(/signed in/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(
+      page.getByRole("button", { name: /sign in with passkey/i }),
+    ).toHaveCount(0);
+
+    await context.close();
+  });
+
+  test("a setup-token holder can pair a new device", async ({ browser }) => {
+    // The setup token was minted in the bootstrap. From a
+    // fresh context with a fresh authenticator (no shared
+    // credentials with the first device), navigate to the
+    // pair URL and click the CTA. The virtual authenticator
+    // mints a brand-new credential; the server links it to
+    // the consumed setup token and issues a session cookie.
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const vauth = await setupVirtualAuthenticator(page);
+    // We don't need vauth's handle after setup — it's
+    // attached for the page's lifetime.
+    void vauth;
+    await page.goto(`/?setup_token=${setupToken}`);
+
+    await page.getByRole("button", { name: /pair with passkey/i }).click();
+
+    await expect(page.getByText(/signed in/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(
+      page.getByRole("button", { name: /pair with passkey/i }),
+    ).toHaveCount(0);
+
+    await context.close();
+  });
+});

--- a/test/e2e-rust/webauthn.e2e.js
+++ b/test/e2e-rust/webauthn.e2e.js
@@ -45,7 +45,7 @@ import { test, expect } from "@playwright/test";
 import {
   ensureFreshStagingDataDir,
   setupVirtualAuthenticator,
-  registerFirstDeviceViaApi,
+  registerFirstDevice,
   injectCredential,
   mintSetupToken,
 } from "./lib/webauthn.js";
@@ -74,7 +74,15 @@ test.describe.serial("WebAuthn UI happy paths", () => {
     const page = await context.newPage();
     await page.goto("/");
     const vauth = await setupVirtualAuthenticator(page);
-    bootstrap = await registerFirstDeviceViaApi(page, vauth);
+    // `bootstrap.credentialDump` carries a PKCS#8 private
+    // key for the just-minted credential. It only lives in
+    // JS memory, never in the DOM — but never log it,
+    // serialize it to disk, or pass it through
+    // `page.evaluate` (where it would land in Playwright's
+    // trace recording). The dump exists only so a fresh
+    // page in the sign-in test can inject the same
+    // credential into a new authenticator.
+    bootstrap = await registerFirstDevice(page, vauth);
     setupToken = await mintSetupToken(
       page,
       bootstrap.finishResponse.csrf_token,
@@ -128,10 +136,17 @@ test.describe.serial("WebAuthn UI happy paths", () => {
     // the consumed setup token and issues a session cookie.
     const context = await browser.newContext();
     const page = await context.newPage();
-    const vauth = await setupVirtualAuthenticator(page);
-    // We don't need vauth's handle after setup — it's
-    // attached for the page's lifetime.
-    void vauth;
+    // The authenticator is attached for the page's
+    // lifetime; we don't need its CDP handle here so we
+    // don't bind the return value.
+    await setupVirtualAuthenticator(page);
+    // The setup token rides the URL because that's the
+    // pairing flow's designed entry point — the operator
+    // gives the new device a `?setup_token=` URL. The
+    // token is a test fixture on a wiped data dir; do NOT
+    // copy this pattern with a real token, since
+    // Playwright's trace recorder captures URLs and a
+    // production token would persist in trace artifacts.
     await page.goto(`/?setup_token=${setupToken}`);
 
     await page.getByRole("button", { name: /pair with passkey/i }).click();


### PR DESCRIPTION
## Summary

The 9r.3 review consensus called the existing e2e gap "load-bearing": `auth.e2e.js` verifies the UI's REJECTION paths (button wired, request shape right, error region rendered when the server says no), but no test verified that a real WebAuthn ceremony — credential minting, CTAP2 signing, server-side `webauthn-rs` verification — actually wires together. This slice plugs that gap.

## What changed

- `test/e2e-rust/lib/webauthn.js` (new): helpers driving Chromium's CDP virtual authenticator. `setupVirtualAuthenticator`, `registerFirstDeviceViaApi`, `injectCredential`, `mintSetupToken`, `ensureFreshStagingDataDir`.
- `test/e2e-rust/webauthn.e2e.js` (new): two behaviour-level tests using role/text selectors only — no internal data-attrs, no URL sniffing.
  - "a registered user can sign in with their passkey"
  - "a setup-token holder can pair a new device"
- `bin/katulong-stage`: two infrastructure fixes the harness exposed:
  1. Sets `KATULONG_ORIGIN=http://localhost:$port` when launching the Rust backend. The server's `main.rs` default is `http://localhost:3000`, but staging dynamic-allocates a port — the URL the browser sees never matched the URL `webauthn-rs` was configured for, so `clientDataJSON.origin` verification failed. **Any real passkey enrollment via staging was silently broken**; the harness was the first thing to actually exercise the round-trip.
  2. `find_free_port` uses `process.stdout.write(String(p))` instead of `console.log(p)`. When `FORCE_COLOR` is set (Playwright sets it; it propagates into `execSync` invocations of the script), Node wraps `console.log` of NUMBERS in ANSI yellow escape codes — bash captures `[33m3050[39m` instead of `3050`, and the resulting `KATULONG_ORIGIN=http://localhost:[33m3050[39m` crashes the Rust server with "invalid port number".
- `playwright.rust.config.js`: default base URL switches from `http://127.0.0.1:3050` to `http://localhost:3050`. The browser doesn't accept `127.0.0.1` as a registrable suffix of RP ID `localhost`, so passkey ceremonies on `127.0.0.1` reject with "SecurityError: invalid domain."

## Why pre-mint the setup token in `beforeAll`

Re-using the bootstrap credential for a UI sign-in in the admin context (to mint a token in test 2) trips `webauthn-rs`'s sign-counter replay guard: the credential dump carries a frozen `signCount`, but the server's stored counter advances on each verified assertion. Pre-minting during the bootstrap (one signed assertion, never replayed) avoids the issue.

## Why `ensureFreshStagingDataDir` is in the harness, not a `globalSetup`

The webauthn tests need a fresh data dir; the smoke + auth tests don't care. A globalSetup would force the cost on every Playwright invocation. Self-healing in the harness's `beforeAll` only pays the cost when actually needed (re-runs of the suite from the same staging instance).

## Known limitation

Tunnel-side passkey access is still broken: a tunneled request hits the page at `https://<branch>.felixflor.es`, but the server is configured with `KATULONG_ORIGIN=http://localhost:$port`, so `clientDataJSON.origin` verification rejects. `webauthn-rs` supports multiple allowed origins via `append_allowed_origin` — adding the tunnel URL alongside localhost is a separate slice. The harness deliberately tests against localhost only.

## Test plan

- [x] `cargo test --release` green: 291 tests.
- [x] Full Rust e2e (11 tests) green on a **fresh** data dir.
- [x] Full Rust e2e green on a **re-run with dirty data dir** (the self-heal path triggers).
- [x] `trunk build --release` clean.
- [ ] Reviewer: confirm the `KATULONG_ORIGIN` change in `bin/katulong-stage` doesn't regress the existing manual passkey-enroll-via-tunnel flow (the known-limitation note above acknowledges that flow was already broken; this PR doesn't make it worse).