### PR TITLE
bridge: inject SSE keepalive on silent text/event-stream responses

### DIFF
--- a/bridges/_lib/server.js
+++ b/bridges/_lib/server.js
@@ -9,6 +9,13 @@
  * path, headers (minus auth), and body all forward verbatim. New endpoints
  * on the wrapped service get picked up automatically.
  *
+ * One transport-level carve-out: when the upstream returns
+ * `Content-Type: text/event-stream`, the bridge injects keepalive SSE
+ * comments during upstream silence and forces no-cache headers, so long
+ * generations survive intermediate-proxy idle timeouts. The keepalive
+ * frame (`: keepalive\n\n`) is spec-defined as ignored by SSE clients,
+ * so the wrapped service's wire contract is preserved.
+ *
  * Auth is bearer-token only in v1. The wire shape (`Authorization: Bearer
  * <token>`) is the same shape the eventual katulong-app/1 runtime call
  * will use, so when the protocol's host implementation lands, this server
@@ -95,6 +102,13 @@ function sanitizedUpstreamHeaders(rawHeaders) {
  * collector. The token itself is never passed to the logger.
  */
 export function createBridgeServer({ target, token, logger = defaultLogger, keepaliveMs = SSE_KEEPALIVE_MS }) {
+  // Defensive clamp: any non-finite or sub-50ms value would either crash
+  // setInterval (NaN → 1ms CPU burn) or pin the loop with sub-millisecond
+  // ticks. The lower floor matches `Math.max(50, …)` below so callers can
+  // still tune low for tests without falling off the cliff.
+  if (!Number.isFinite(keepaliveMs) || keepaliveMs < 50) {
+    keepaliveMs = SSE_KEEPALIVE_MS;
+  }
   const targetUrl = new URL(target);
   const targetIsHttps = targetUrl.protocol === "https:";
   const proxyRequest = targetIsHttps ? httpsRequest : httpRequest;
@@ -120,15 +134,8 @@ export function createBridgeServer({ target, token, logger = defaultLogger, keep
         headers: sanitizedUpstreamHeaders(req.headers),
       },
       (upstreamRes) => {
-        // Mid-stream upstream errors: forward as a destroy on the client
-        // side rather than letting an unhandled `error` event crash the
-        // bridge process.
-        upstreamRes.on("error", (err) => {
-          logger({ event: "upstream_error", code: err.code || err.name });
-          res.destroy(err);
-        });
         const isSse = (upstreamRes.headers["content-type"] || "").startsWith(SSE_CT_PREFIX);
-        forwardResponse({ upstreamRes, res, isSse, keepaliveMs });
+        forwardResponse({ upstreamRes, upstreamReq, res, isSse, keepaliveMs, logger });
       },
     );
 
@@ -175,8 +182,24 @@ export function createBridgeServer({ target, token, logger = defaultLogger, keep
  * Forward an upstream response to the client. For SSE responses, inject
  * keepalive comments during upstream silence so intermediate proxies
  * don't time out. For everything else, this is a verbatim pipe.
+ *
+ * On client disconnect (the very scenario keepalive enables — long-lived
+ * SSE responses), we explicitly destroy `upstreamReq` so the upstream
+ * stops generating bytes for a connection that has nowhere to go. We
+ * also gate every `res.write` on `res.destroyed || res.writableEnded`
+ * so a stale data event between client-close and upstream-teardown
+ * cannot trigger an unhandled `ERR_STREAM_DESTROYED`. (The non-SSE
+ * `pipe(res)` path gets these properties from Node's stream plumbing
+ * for free; the manual forward here has to declare them.)
  */
-function forwardResponse({ upstreamRes, res, isSse, keepaliveMs }) {
+function forwardResponse({ upstreamRes, upstreamReq, res, isSse, keepaliveMs, logger }) {
+  // Single source of truth for upstream errors on either branch. Logging
+  // and tearing down `res` is consistent across SSE/non-SSE.
+  upstreamRes.on("error", (err) => {
+    logger({ event: "upstream_error", code: err.code || err.name });
+    if (!res.destroyed) res.destroy(err);
+  });
+
   if (!isSse) {
     res.writeHead(upstreamRes.statusCode || 502, upstreamRes.headers);
     upstreamRes.pipe(res);
@@ -186,6 +209,10 @@ function forwardResponse({ upstreamRes, res, isSse, keepaliveMs }) {
   // Belt-and-suspenders: hint to anything along the path that it must
   // not buffer this response. Cloudflare honors `text/event-stream` on
   // its own; nginx-shaped intermediaries also key off X-Accel-Buffering.
+  // SSE is inherently a "live, ephemeral, do not cache" payload, so we
+  // unconditionally force `no-cache, no-store` rather than respecting an
+  // upstream-set Cache-Control that would let intermediaries try to
+  // cache the stream.
   // Strip `transfer-encoding` and `content-length` so Node manages the
   // framing for the bytes we write (otherwise res.write payloads bypass
   // the chunked encoder and the client sees a corrupt stream).
@@ -193,41 +220,63 @@ function forwardResponse({ upstreamRes, res, isSse, keepaliveMs }) {
   delete headers["transfer-encoding"];
   delete headers["content-length"];
   headers["x-accel-buffering"] = "no";
-  headers["cache-control"] = headers["cache-control"] || "no-cache";
+  headers["cache-control"] = "no-cache, no-store";
   res.writeHead(upstreamRes.statusCode || 502, headers);
+
+  // Single guard for every write attempt — on the keepalive tick AND on
+  // the upstream data handler. Returns true if the write proceeded.
+  const safeWrite = (bytes) => {
+    if (res.writableEnded || res.destroyed) return false;
+    res.write(bytes);
+    return true;
+  };
 
   let lastByteAt = Date.now();
   let ended = false;
+  // Tick at ~1/3 of the keepalive interval so the worst-case delay
+  // between idle threshold crossing and an injected comment is bounded
+  // by one tick.
   const tick = setInterval(() => {
     if (ended) return;
     if (Date.now() - lastByteAt < keepaliveMs) return;
-    if (res.writableEnded || res.destroyed) {
+    if (!safeWrite(": keepalive\n\n")) {
       clearInterval(tick);
       return;
     }
-    res.write(": keepalive\n\n");
     lastByteAt = Date.now();
   }, Math.max(50, Math.floor(keepaliveMs / 3)));
 
+  // Single point that ends the per-request bookkeeping. Idempotent — the
+  // various lifecycle events all funnel through here. `destroyUpstream`
+  // is the key fix: when the client disconnects, we must stop pulling
+  // bytes from upstream, otherwise the data handler below keeps trying
+  // to write to a dead `res` (HIGH severity bug pre-fix).
+  const finish = ({ destroyUpstream }) => {
+    if (ended) return;
+    ended = true;
+    clearInterval(tick);
+    if (destroyUpstream && upstreamReq && !upstreamReq.destroyed) {
+      upstreamReq.destroy();
+    }
+  };
+
   upstreamRes.on("data", (chunk) => {
+    if (ended) return;
     lastByteAt = Date.now();
-    res.write(chunk);
+    if (!safeWrite(chunk)) {
+      // Client gone — stop pulling bytes from upstream.
+      finish({ destroyUpstream: true });
+    }
   });
   upstreamRes.on("end", () => {
-    ended = true;
-    clearInterval(tick);
-    res.end();
+    finish({ destroyUpstream: false });
+    if (!res.writableEnded) res.end();
   });
-  upstreamRes.on("error", (err) => {
-    ended = true;
-    clearInterval(tick);
-    if (!res.destroyed) res.destroy(err);
-  });
+  // Note: `upstreamRes.on("error")` is registered above (covers SSE +
+  // non-SSE). It calls `res.destroy(err)`, which fires `res.on("close")`
+  // below, which runs `finish({ destroyUpstream: true })`.
   res.on("close", () => {
-    if (!ended) {
-      ended = true;
-      clearInterval(tick);
-    }
+    finish({ destroyUpstream: true });
   });
 }
 

--- a/bridges/_lib/server.js
+++ b/bridges/_lib/server.js
@@ -24,6 +24,16 @@ import { request as httpsRequest } from "node:https";
 // token cannot exhaust host disk/memory by sending an unbounded stream.
 const MAX_BODY_BYTES = 512 * 1024 * 1024;
 
+// SSE keepalive cadence. When upstream goes silent on a `text/event-stream`
+// response (e.g. an LLM is in its reasoning phase before any visible
+// tokens), inject `: keepalive\n\n` SSE comments so intermediate proxies
+// (Cloudflare, cloudflared, nginx) don't trip their "idle response"
+// timeouts and tear the connection down. 15s is comfortably inside
+// Cloudflare's ~100s edge timeout.
+const SSE_KEEPALIVE_MS = 15_000;
+// Heuristic: treat any response whose content-type starts with this as SSE.
+const SSE_CT_PREFIX = "text/event-stream";
+
 // Headers that must NOT propagate end-to-end, per RFC 7230 §6.1 (hop-by-hop)
 // plus forwarding headers a client could lie about to influence upstream
 // routing/trust decisions. `authorization` and `host` are stripped separately
@@ -84,7 +94,7 @@ function sanitizedUpstreamHeaders(rawHeaders) {
  * Default is a console.warn writer; tests can override with a no-op or
  * collector. The token itself is never passed to the logger.
  */
-export function createBridgeServer({ target, token, logger = defaultLogger }) {
+export function createBridgeServer({ target, token, logger = defaultLogger, keepaliveMs = SSE_KEEPALIVE_MS }) {
   const targetUrl = new URL(target);
   const targetIsHttps = targetUrl.protocol === "https:";
   const proxyRequest = targetIsHttps ? httpsRequest : httpRequest;
@@ -117,8 +127,8 @@ export function createBridgeServer({ target, token, logger = defaultLogger }) {
           logger({ event: "upstream_error", code: err.code || err.name });
           res.destroy(err);
         });
-        res.writeHead(upstreamRes.statusCode || 502, upstreamRes.headers);
-        upstreamRes.pipe(res);
+        const isSse = (upstreamRes.headers["content-type"] || "").startsWith(SSE_CT_PREFIX);
+        forwardResponse({ upstreamRes, res, isSse, keepaliveMs });
       },
     );
 
@@ -160,6 +170,67 @@ export function createBridgeServer({ target, token, logger = defaultLogger }) {
   });
 }
 
+
+/**
+ * Forward an upstream response to the client. For SSE responses, inject
+ * keepalive comments during upstream silence so intermediate proxies
+ * don't time out. For everything else, this is a verbatim pipe.
+ */
+function forwardResponse({ upstreamRes, res, isSse, keepaliveMs }) {
+  if (!isSse) {
+    res.writeHead(upstreamRes.statusCode || 502, upstreamRes.headers);
+    upstreamRes.pipe(res);
+    return;
+  }
+
+  // Belt-and-suspenders: hint to anything along the path that it must
+  // not buffer this response. Cloudflare honors `text/event-stream` on
+  // its own; nginx-shaped intermediaries also key off X-Accel-Buffering.
+  // Strip `transfer-encoding` and `content-length` so Node manages the
+  // framing for the bytes we write (otherwise res.write payloads bypass
+  // the chunked encoder and the client sees a corrupt stream).
+  const headers = { ...upstreamRes.headers };
+  delete headers["transfer-encoding"];
+  delete headers["content-length"];
+  headers["x-accel-buffering"] = "no";
+  headers["cache-control"] = headers["cache-control"] || "no-cache";
+  res.writeHead(upstreamRes.statusCode || 502, headers);
+
+  let lastByteAt = Date.now();
+  let ended = false;
+  const tick = setInterval(() => {
+    if (ended) return;
+    if (Date.now() - lastByteAt < keepaliveMs) return;
+    if (res.writableEnded || res.destroyed) {
+      clearInterval(tick);
+      return;
+    }
+    res.write(": keepalive\n\n");
+    lastByteAt = Date.now();
+  }, Math.max(50, Math.floor(keepaliveMs / 3)));
+
+  upstreamRes.on("data", (chunk) => {
+    lastByteAt = Date.now();
+    res.write(chunk);
+  });
+  upstreamRes.on("end", () => {
+    ended = true;
+    clearInterval(tick);
+    res.end();
+  });
+  upstreamRes.on("error", (err) => {
+    ended = true;
+    clearInterval(tick);
+    if (!res.destroyed) res.destroy(err);
+  });
+  res.on("close", () => {
+    if (!ended) {
+      ended = true;
+      clearInterval(tick);
+    }
+  });
+}
+
 function defaultLogger(event) {
   // Single-line structured log so it shows up readably in launchd-stderr.log.
   // The caller can swap this for nothing in tests.
@@ -167,8 +238,8 @@ function defaultLogger(event) {
   console.warn(JSON.stringify({ ts: new Date().toISOString(), ...event }));
 }
 
-export function startBridgeServer({ port, bind, target, token, logger }) {
-  const server = createBridgeServer({ target, token, logger });
+export function startBridgeServer({ port, bind, target, token, logger, keepaliveMs }) {
+  const server = createBridgeServer({ target, token, logger, keepaliveMs });
   return new Promise((resolve, reject) => {
     server.once("error", reject);
     server.listen(port, bind, () => {

--- a/test/bridges-server.test.js
+++ b/test/bridges-server.test.js
@@ -64,6 +64,25 @@ function startStubUpstream() {
         setTimeout(() => res.destroy(), 30);
         return;
       }
+      if (url.searchParams.get("status") === "sse-stream") {
+        // Continuously emits an SSE event every `intervalMs` (default 10ms)
+        // until the response closes. Used to catch the race where the
+        // bridge data handler must guard against `res` already being
+        // destroyed by a client-side abort.
+        const intervalMs = Number(url.searchParams.get("interval") || "10");
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.flushHeaders();
+        let n = 0;
+        const i = setInterval(() => {
+          if (res.writableEnded || res.destroyed) {
+            clearInterval(i);
+            return;
+          }
+          res.write(`data: ${n++}\n\n`);
+        }, intervalMs);
+        res.on("close", () => clearInterval(i));
+        return;
+      }
       if (url.searchParams.get("status") === "sse-cached") {
         // Upstream tries to set Cache-Control: public, max-age=60 on an
         // SSE response. Bridge must override to no-cache, no-store —
@@ -261,6 +280,68 @@ describe("bridge server", () => {
     probe.close();
   });
 
+  it("destroys the upstream connection when the client aborts mid-stream", async () => {
+    // Direct observation of the leak fix: spin up a private stub that
+    // counts how many chunks it has *sent*. After the bridge call, we
+    // sample the counter, abort the client, wait, then sample again.
+    // If the bridge correctly calls upstreamReq.destroy() on
+    // res.on('close'), the stub's response fires its own 'close' event
+    // and stops the chunk loop within one tick. The counter delta
+    // post-abort should be small (last in-flight chunk + close
+    // propagation). Without the fix, the stub keeps streaming for the
+    // full wait window — the counter delta will be 25–30+.
+    let chunkCount = 0;
+    const trackingStub = createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.flushHeaders();
+      const i = setInterval(() => {
+        if (res.writableEnded || res.destroyed) {
+          clearInterval(i);
+          return;
+        }
+        chunkCount++;
+        res.write(`data: ${chunkCount}\n\n`);
+      }, 8);
+      res.on("close", () => clearInterval(i));
+    });
+    await new Promise((r) => trackingStub.listen(0, "127.0.0.1", r));
+    const probe = await startBridgeServer({
+      port: 0,
+      bind: "127.0.0.1",
+      target: `http://127.0.0.1:${trackingStub.address().port}`,
+      token: TOKEN,
+      logger: () => {},
+      keepaliveMs: 50,
+    });
+
+    const ac = new AbortController();
+    const promise = fetch(
+      `http://127.0.0.1:${probe.address().port}/sse`,
+      { headers: { Authorization: `Bearer ${TOKEN}` }, signal: ac.signal },
+    );
+    await new Promise((r) => setTimeout(r, 100));
+    ac.abort();
+    try {
+      await promise;
+    } catch (_e) {
+      /* expected */
+    }
+    const countAtAbort = chunkCount;
+    // Wait significantly longer than the 8ms tick — without the fix,
+    // 30 more chunks would arrive in this window. With the fix, the
+    // stub's res.on('close') fires within 1–2 ticks of abort and the
+    // counter freezes.
+    await new Promise((r) => setTimeout(r, 250));
+    const delta = chunkCount - countAtAbort;
+    assert.ok(
+      delta <= 5,
+      `upstream not torn down on client abort: stub sent ${delta} more chunks after client gave up (countAtAbort=${countAtAbort}, finalCount=${chunkCount})`,
+    );
+
+    probe.close();
+    trackingStub.close();
+  });
+
   it("forces no-cache, no-store on SSE responses, overriding upstream Cache-Control", async () => {
     const res = await fetch(
       `http://127.0.0.1:${bridgePort}/api/sse?status=sse-cached`,
@@ -334,17 +415,25 @@ describe("bridge server", () => {
       logger: () => {},
       keepaliveMs: NaN,
     });
-    const t0 = Date.now();
     const res = await fetch(
       `http://127.0.0.1:${probe.address().port}/api/sse?status=sse-silent&ms=80`,
       { headers: { Authorization: `Bearer ${TOKEN}` } },
     );
     assert.equal(res.status, 200);
     assert.equal(res.headers.get("content-type"), "text/event-stream");
-    await res.text();
-    // A clamp regression would either throw or produce sub-ms ticks that
-    // CPU-burn for the duration of the request. 2s is generous.
-    assert.ok(Date.now() - t0 < 2000, "SSE response took too long with NaN keepaliveMs");
+    const body = await res.text();
+    // The response body distinguishes clamped vs. unclamped behavior:
+    //   - With the clamp: keepaliveMs = 15000ms default. 80ms upstream
+    //     silence is way under threshold → 0 keepalive frames written.
+    //   - Without the clamp: setInterval(fn, NaN) → 1ms ticks. The
+    //     threshold check `Date.now() - lastByteAt < NaN` is always
+    //     false → keepalive frame written on every tick → ~80 frames.
+    // Anything above a small handful indicates the clamp was bypassed.
+    const keepaliveCount = (body.match(/:\s*keepalive/g) || []).length;
+    assert.ok(
+      keepaliveCount < 5,
+      `clamp regression: expected <5 keepalive frames in 80ms, got ${keepaliveCount}`,
+    );
     probe.close();
   });
 

--- a/test/bridges-server.test.js
+++ b/test/bridges-server.test.js
@@ -54,6 +54,33 @@ function startStubUpstream() {
         res.on("close", () => clearTimeout(t));
         return;
       }
+      if (url.searchParams.get("status") === "sse-error-mid") {
+        // Sends one SSE event then abruptly destroys the socket — used
+        // to confirm the bridge cleans up the keepalive timer and tears
+        // down the response without crashing on a write-after-error.
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.flushHeaders();
+        res.write('data: first\n\n');
+        setTimeout(() => res.destroy(), 30);
+        return;
+      }
+      if (url.searchParams.get("status") === "sse-cached") {
+        // Upstream tries to set Cache-Control: public, max-age=60 on an
+        // SSE response. Bridge must override to no-cache, no-store —
+        // intermediate caches cannot be allowed to capture a live stream.
+        res.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "public, max-age=60",
+        });
+        res.flushHeaders();
+        setTimeout(() => {
+          if (!res.writableEnded) {
+            res.write('data: ok\n\n');
+            res.end();
+          }
+        }, 20);
+        return;
+      }
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ ok: true }));
     });
@@ -184,24 +211,122 @@ describe("bridge server", () => {
     assert.equal(res.headers.get("x-accel-buffering"), null);
   });
 
-  it("stops the keepalive timer when the client disconnects mid-stream", async () => {
-    // Make a request and abort it before upstream sends its real event.
-    // The bridge should clean up its interval timer; if it leaks node's
-    // test runner exits with an open-handle warning. Coarse but cheap.
+  it("tears down upstream and the keepalive timer on client disconnect", async () => {
+    // Spin up a private bridge so we can capture logger events without
+    // racing other tests. Stub uses a 5s upstream silence so we can
+    // observe the disconnect cleanup *before* upstream would have ended
+    // on its own.
+    const events = [];
+    const probe = await startBridgeServer({
+      port: 0,
+      bind: "127.0.0.1",
+      target: `http://127.0.0.1:${stub.port}`,
+      token: TOKEN,
+      logger: (e) => events.push(e),
+      keepaliveMs: 50,
+    });
+    const probePort = probe.address().port;
+
     const ac = new AbortController();
     const promise = fetch(
-      `http://127.0.0.1:${bridgePort}/api/sse?status=sse-silent&ms=10000`,
+      `http://127.0.0.1:${probePort}/api/sse?status=sse-silent&ms=5000`,
       { headers: { Authorization: `Bearer ${TOKEN}` }, signal: ac.signal },
     );
-    await new Promise((r) => setTimeout(r, 60));
+    await new Promise((r) => setTimeout(r, 80));
     ac.abort();
     try {
       await promise;
     } catch (_e) {
-      // Aborted as expected.
+      /* expected */
     }
+    // Wait long enough that, if the bridge had failed to destroy
+    // upstream, the data handler would have fired write-after-destroy
+    // and emitted an upstream_error event.
+    await new Promise((r) => setTimeout(r, 250));
+    // ECONNRESET is the expected consequence of our deliberate
+    // upstreamReq.destroy() — upstream's socket gets RST'd. The bug we
+    // want to catch is the data handler writing to an already-destroyed
+    // `res`, which surfaces as ERR_STREAM_DESTROYED or
+    // ERR_STREAM_WRITE_AFTER_END.
+    const writeAfterDestroy = events.filter(
+      (e) =>
+        e.event === "upstream_error" &&
+        /ERR_STREAM_DESTROYED|ERR_STREAM_WRITE_AFTER_END/.test(e.code || ""),
+    );
+    assert.equal(
+      writeAfterDestroy.length,
+      0,
+      `expected no write-after-destroy errors after client disconnect, got: ${JSON.stringify(writeAfterDestroy)}`,
+    );
+    probe.close();
   });
 
+  it("forces no-cache, no-store on SSE responses, overriding upstream Cache-Control", async () => {
+    const res = await fetch(
+      `http://127.0.0.1:${bridgePort}/api/sse?status=sse-cached`,
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/event-stream");
+    // Must NOT preserve the upstream's public/max-age caching directive
+    // for a live stream.
+    const cc = res.headers.get("cache-control");
+    assert.match(cc, /no-cache/);
+    assert.match(cc, /no-store/);
+    assert.doesNotMatch(cc, /public/);
+    assert.doesNotMatch(cc, /max-age/);
+    await res.text(); // drain
+  });
+
+  it("survives upstream destroying the socket mid-stream", async () => {
+    const events = [];
+    const probe = await startBridgeServer({
+      port: 0,
+      bind: "127.0.0.1",
+      target: `http://127.0.0.1:${stub.port}`,
+      token: TOKEN,
+      logger: (e) => events.push(e),
+      keepaliveMs: 50,
+    });
+    const res = await fetch(
+      `http://127.0.0.1:${probe.address().port}/api/sse?status=sse-error-mid`,
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+    );
+    assert.equal(res.status, 200);
+    // Reading the body should either yield the partial event or throw —
+    // either way the bridge must not crash.
+    try {
+      await res.text();
+    } catch (_e) {
+      /* truncated streams may surface as a fetch read error; tolerable */
+    }
+    // Give the bridge a tick to settle its cleanup.
+    await new Promise((r) => setTimeout(r, 50));
+    probe.close();
+  });
+
+  it("rejects garbage keepaliveMs values by falling back to the default", async () => {
+    // NaN / negative values would otherwise cause sub-millisecond ticks
+    // (CPU burn). The defensive clamp inside createBridgeServer should
+    // map them to the default. We can't observe the value directly, but
+    // we can confirm the bridge still answers normal requests with the
+    // bad input.
+    const probe = await startBridgeServer({
+      port: 0,
+      bind: "127.0.0.1",
+      target: `http://127.0.0.1:${stub.port}`,
+      token: TOKEN,
+      logger: () => {},
+      keepaliveMs: NaN,
+    });
+    const res = await fetch(
+      `http://127.0.0.1:${probe.address().port}/api/tags`,
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+    );
+    assert.equal(res.status, 200);
+    await res.text();
+    probe.close();
+  });
 
   it("returns 502 when upstream is unreachable", async () => {
     const orphan = await startBridgeServer({

--- a/test/bridges-server.test.js
+++ b/test/bridges-server.test.js
@@ -35,6 +35,25 @@ function startStubUpstream() {
         }, 10);
         return;
       }
+      if (url.searchParams.get("status") === "sse-silent") {
+        // SSE upstream that stays silent for the requested duration before
+        // sending a single visible event, then ends. Used to verify the
+        // bridge injects keepalive comments while upstream is quiet.
+        const silentMs = Number(url.searchParams.get("ms") || "200");
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        // Flush headers so the bridge enters its silent-SSE keepalive
+        // phase before we send any real bytes (matches real LLM upstream
+        // behavior where headers land immediately and tokens come later).
+        res.flushHeaders();
+        const t = setTimeout(() => {
+          if (!res.writableEnded) {
+            res.write('data: {"x":1}\n\n');
+            res.end();
+          }
+        }, silentMs);
+        res.on("close", () => clearTimeout(t));
+        return;
+      }
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ ok: true }));
     });
@@ -78,6 +97,7 @@ describe("bridge server", () => {
       target: `http://127.0.0.1:${stub.port}`,
       token: TOKEN,
       logger: () => {}, // suppress test-time noise
+      keepaliveMs: 50,
     });
     bridgePort = bridge.address().port;
   });
@@ -135,6 +155,53 @@ describe("bridge server", () => {
     assert.ok(text.includes('"chunk":2'));
     assert.ok(text.includes('"done":true'));
   });
+
+  it("injects SSE keepalive comments while upstream is silent", async () => {
+    // Upstream stays quiet for 200ms, then sends one event. With
+    // keepaliveMs=50 the bridge should emit at least one `: keepalive`
+    // SSE comment before the real event arrives.
+    const res = await fetch(
+      `http://127.0.0.1:${bridgePort}/api/sse?status=sse-silent&ms=200`,
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/event-stream");
+    // Belt-and-suspenders header for nginx-shaped intermediaries.
+    assert.equal(res.headers.get("x-accel-buffering"), "no");
+    const text = await res.text();
+    assert.match(text, /:\s*keepalive/);
+    // Real event still arrives.
+    assert.match(text, /data:\s*\{"x":1\}/);
+  });
+
+  it("does NOT inject keepalive on non-SSE responses", async () => {
+    const res = await fetch(`http://127.0.0.1:${bridgePort}/api/tags`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    const text = await res.text();
+    assert.doesNotMatch(text, /keepalive/);
+    // Should not have added the buffering hint to a non-SSE response.
+    assert.equal(res.headers.get("x-accel-buffering"), null);
+  });
+
+  it("stops the keepalive timer when the client disconnects mid-stream", async () => {
+    // Make a request and abort it before upstream sends its real event.
+    // The bridge should clean up its interval timer; if it leaks node's
+    // test runner exits with an open-handle warning. Coarse but cheap.
+    const ac = new AbortController();
+    const promise = fetch(
+      `http://127.0.0.1:${bridgePort}/api/sse?status=sse-silent&ms=10000`,
+      { headers: { Authorization: `Bearer ${TOKEN}` }, signal: ac.signal },
+    );
+    await new Promise((r) => setTimeout(r, 60));
+    ac.abort();
+    try {
+      await promise;
+    } catch (_e) {
+      // Aborted as expected.
+    }
+  });
+
 
   it("returns 502 when upstream is unreachable", async () => {
     const orphan = await startBridgeServer({

--- a/test/bridges-server.test.js
+++ b/test/bridges-server.test.js
@@ -293,24 +293,39 @@ describe("bridge server", () => {
       { headers: { Authorization: `Bearer ${TOKEN}` } },
     );
     assert.equal(res.status, 200);
-    // Reading the body should either yield the partial event or throw —
-    // either way the bridge must not crash.
     try {
       await res.text();
     } catch (_e) {
       /* truncated streams may surface as a fetch read error; tolerable */
     }
     // Give the bridge a tick to settle its cleanup.
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((r) => setTimeout(r, 80));
+
+    // The bridge must NOT have thrown a write-after-destroy error inside
+    // the data handler — that would indicate the bug from Round 1 has
+    // regressed. We tolerate the upstream's own ECONNRESET / aborted
+    // signal, which is the legitimate "upstream gave up" telemetry.
+    const writeAfterDestroy = events.filter(
+      (e) =>
+        e.event === "upstream_error" &&
+        /ERR_STREAM_DESTROYED|ERR_STREAM_WRITE_AFTER_END/.test(e.code || ""),
+    );
+    assert.equal(
+      writeAfterDestroy.length,
+      0,
+      `expected no write-after-destroy errors, got: ${JSON.stringify(writeAfterDestroy)}`,
+    );
     probe.close();
   });
 
   it("rejects garbage keepaliveMs values by falling back to the default", async () => {
     // NaN / negative values would otherwise cause sub-millisecond ticks
     // (CPU burn). The defensive clamp inside createBridgeServer should
-    // map them to the default. We can't observe the value directly, but
-    // we can confirm the bridge still answers normal requests with the
-    // bad input.
+    // map them to the default. We exercise the *SSE* path here so the
+    // setInterval is actually constructed under the bad value — without
+    // the clamp, setInterval(fn, NaN) treats the delay as 1ms and pegs
+    // a CPU. The test would then time out or hang; with the clamp it
+    // completes promptly.
     const probe = await startBridgeServer({
       port: 0,
       bind: "127.0.0.1",
@@ -319,12 +334,17 @@ describe("bridge server", () => {
       logger: () => {},
       keepaliveMs: NaN,
     });
+    const t0 = Date.now();
     const res = await fetch(
-      `http://127.0.0.1:${probe.address().port}/api/tags`,
+      `http://127.0.0.1:${probe.address().port}/api/sse?status=sse-silent&ms=80`,
       { headers: { Authorization: `Bearer ${TOKEN}` } },
     );
     assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/event-stream");
     await res.text();
+    // A clamp regression would either throw or produce sub-ms ticks that
+    // CPU-burn for the duration of the request. 2s is generous.
+    assert.ok(Date.now() - t0 < 2000, "SSE response took too long with NaN keepaliveMs");
     probe.close();
   });
 


### PR DESCRIPTION
## Summary

When the bridge fronts an LLM (e.g. via the ollama bridge), long-running streaming responses can go silent for tens of seconds — the model is in its reasoning phase before any visible tokens are emitted. Cloudflare's edge cuts requests at ~100s with HTTP 524 when no bytes have reached it, killing the connection before the real tokens ever arrive.

This adds keepalive injection to the bridge's SSE pass-through:

- Detects `Content-Type: text/event-stream` responses from upstream.
- Sets up an idle-timer; if upstream goes silent for `keepaliveMs` (default 15s, well inside Cloudflare's 100s edge timeout), writes `: keepalive\n\n` SSE comments to the client.
- Sets `X-Accel-Buffering: no` and `Cache-Control: no-cache` on SSE responses for nginx-shaped intermediaries that key off those headers.
- Strips `Transfer-Encoding` and `Content-Length` on SSE pass-through so Node manages chunked framing for the bytes we write ourselves (otherwise `res.write` payloads bypass the chunk encoder and the client sees a corrupt stream).

Non-SSE responses are still piped verbatim — no behavior change.

## Why this matters

Today, sipag's research worker calls ollama through the bridge for synthesis. With gemma4:31b (a reasoning model) on a non-trivial prompt, the model spends 1-3 minutes thinking before emitting any visible content. Cloudflare returns 524 every time, even with `--protocol http2`. With this keepalive, the connection stays open for the full reasoning period and the actual tokens land.

The fix lives in the bridge so every client (sipag today, JS/WASM tomorrow, any future SSE consumer) gets reliable streaming "for free" without each implementing its own connection-keeper.

## Test plan

- [x] New unit test: keepalive bytes appear while upstream is silent (uses test stub that flushes headers then waits)
- [x] New unit test: non-SSE responses get no keepalive and no `x-accel-buffering` header
- [x] New unit test: keepalive timer is cleaned up when the client disconnects mid-stream
- [x] Existing tests still pass (auth gates, body forwarding, NDJSON streaming, hop-by-hop stripping, 502 handling)
- [ ] Deploy to mac2024 and verify a real ollama gemma4:31b synthesis through the tunnel completes without 524