### PR TITLE
fix(upgrade): unify caller- and server-side shutdown timeouts

### DIFF
--- a/lib/cli/safe-stop.js
+++ b/lib/cli/safe-stop.js
@@ -55,6 +55,7 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import envConfig from "../env-config.js";
 import { isProcessRunning } from "./process-manager.js";
 
 const PLIST_PATH = join(
@@ -81,7 +82,12 @@ function defaultSleep(ms) {
  *
  * @param {object} opts
  * @param {number|null} opts.pid           PID to stop. If null, no-op success.
- * @param {number}      [opts.timeoutMs=5000]     How long to wait for graceful exit.
+ * @param {number}      [opts.timeoutMs]          How long to wait for graceful
+ *   exit before SIGKILL. Defaults to envConfig.shutdownBudget, which is
+ *   derived from DRAIN_TIMEOUT so it always exceeds the server's own
+ *   self-imposed shutdown bound. A bespoke override here would silently
+ *   reintroduce the `katulong update`-races-graceful-shutdown bug — only
+ *   pass an override from tests that inject mock clocks.
  * @param {number}      [opts.pollIntervalMs=200] How often to poll isAlive.
  * @param {() => boolean}           [opts.plistExists] Injection: does the LaunchAgent plist exist?
  * @param {() => void}              [opts.unload]      Injection: launchctl unload.
@@ -98,7 +104,7 @@ function defaultSleep(ms) {
  */
 export async function safeStopServer({
   pid,
-  timeoutMs = 5000,
+  timeoutMs = envConfig.shutdownBudget,
   pollIntervalMs = 200,
   plistExists,
   unload,

--- a/lib/cli/safe-stop.js
+++ b/lib/cli/safe-stop.js
@@ -86,8 +86,8 @@ function defaultSleep(ms) {
  *   exit before SIGKILL. Defaults to envConfig.shutdownBudget, which is
  *   derived from DRAIN_TIMEOUT so it always exceeds the server's own
  *   self-imposed shutdown bound. A bespoke override here would silently
- *   reintroduce the `katulong update`-races-graceful-shutdown bug — only
- *   pass an override from tests that inject mock clocks.
+ *   reintroduce the `katulong update` race we hit on mac2019/mac2024 in
+ *   v0.61.3 — only pass an override from tests that inject mock clocks.
  * @param {number}      [opts.pollIntervalMs=200] How often to poll isAlive.
  * @param {() => boolean}           [opts.plistExists] Injection: does the LaunchAgent plist exist?
  * @param {() => void}              [opts.unload]      Injection: launchctl unload.

--- a/lib/env-config.js
+++ b/lib/env-config.js
@@ -30,6 +30,18 @@ const projectRoot = join(__dirname, "..");
  *                        bypass authentication. Used by abot's reverse proxy.
  */
 
+// Read DRAIN_TIMEOUT once so both the server-side drain wait and the
+// caller-side stop watchdog are derived from the same source. Without
+// this single read, `katulong update` could SIGKILL a server that was
+// still legitimately inside its drain window — see SHUTDOWN_TAIL_SLACK_MS.
+const drainTimeoutMs = parseInt(process.env.DRAIN_TIMEOUT || "30000", 10);
+
+// Upper bound on the synchronous tail of graceful shutdown after the
+// drain wait completes (sessionManager.shutdown → shutdownPlugins →
+// cleanupPidFile → process.exit). Plugins are user-defined so this is a
+// pessimistic budget, not a measured value.
+const SHUTDOWN_TAIL_SLACK_MS = 3000;
+
 const config = Object.freeze({
   // HTTP server
   port: parseInt(process.env.PORT || "3001", 10),
@@ -47,8 +59,18 @@ const config = Object.freeze({
   // Log level threshold
   logLevel: process.env.LOG_LEVEL || "info",
 
-  // Graceful shutdown drain timeout (ms)
-  drainTimeout: parseInt(process.env.DRAIN_TIMEOUT || "30000", 10),
+  // Graceful shutdown drain timeout (ms). Server-side: how long the
+  // shutdown handler waits for WebSocket clients to drain before
+  // force-terminating them.
+  drainTimeout: drainTimeoutMs,
+
+  // Caller-side watchdog budget for stopping a running server (ms).
+  // Must always exceed the server's own self-imposed shutdown bound
+  // (drainTimeout + synchronous tail) so a healthy graceful exit always
+  // wins the race against the SIGKILL fallback in safeStopServer.
+  // Derived from drainTimeout so DRAIN_TIMEOUT env overrides propagate
+  // to both sides automatically — there is no separate knob to forget.
+  shutdownBudget: drainTimeoutMs + SHUTDOWN_TAIL_SLACK_MS,
 
   // User home directory (used as initial cwd for PTY sessions)
   home: process.env.HOME || null,

--- a/lib/env-config.js
+++ b/lib/env-config.js
@@ -23,7 +23,10 @@ const projectRoot = join(__dirname, "..");
  *                        (default: "production")
  *   LOG_LEVEL          — Minimum log level: "debug" | "info" | "warn" | "error"
  *                        (default: "info")
- *   DRAIN_TIMEOUT      — Graceful shutdown drain timeout in ms (default: 30000)
+ *   DRAIN_TIMEOUT      — Graceful shutdown drain timeout in ms (default: 30000).
+ *                        Also derives `shutdownBudget`, the caller-side stop
+ *                        watchdog that `safeStopServer` uses — bumping this
+ *                        widens both sides automatically.
  *   HOME               — User home directory; used as the initial cwd for tmux sessions
  *   KATULONG_TRUST_PROXY_SECRET — Shared secret for trusted reverse proxy auth.
  *                        When set, requests with matching X-Katulong-Auth header
@@ -39,8 +42,11 @@ const drainTimeoutMs = parseInt(process.env.DRAIN_TIMEOUT || "30000", 10);
 // Upper bound on the synchronous tail of graceful shutdown after the
 // drain wait completes (sessionManager.shutdown → shutdownPlugins →
 // cleanupPidFile → process.exit). Plugins are user-defined so this is a
-// pessimistic budget, not a measured value.
-const SHUTDOWN_TAIL_SLACK_MS = 3000;
+// pessimistic budget, not a measured value. Exported so the contract
+// test in safe-stop.test.js can assert the structural invariant
+// (shutdownBudget - drainTimeout === SHUTDOWN_TAIL_SLACK_MS) instead of
+// a weaker positivity check.
+export const SHUTDOWN_TAIL_SLACK_MS = 3000;
 
 const config = Object.freeze({
   // HTTP server

--- a/test/safe-stop.test.js
+++ b/test/safe-stop.test.js
@@ -333,3 +333,20 @@ describe("safeStopServer — input validation", () => {
     assert.equal(calls.unload, 0);
   });
 });
+
+describe("safeStopServer — default timeout contract", () => {
+  it("default timeoutMs exceeds the server's drain timeout", async () => {
+    // The bug this guards against: if safeStopServer's caller-side
+    // watchdog fires before the server's own drain wait completes,
+    // a healthy graceful shutdown gets SIGKILLed mid-flight, skipping
+    // sessionManager.shutdown() (which sends in-band detach-client to
+    // each tmux control mode child to dodge the 3.6a UAF). Any future
+    // edit that uncouples these two values will silently re-introduce
+    // the `katulong update` race we hit on mac2019/mac2024 in v0.61.3.
+    const envConfig = (await import("../lib/env-config.js")).default;
+    assert.ok(
+      envConfig.shutdownBudget > envConfig.drainTimeout,
+      `shutdownBudget (${envConfig.shutdownBudget}ms) must exceed drainTimeout (${envConfig.drainTimeout}ms)`,
+    );
+  });
+});

--- a/test/safe-stop.test.js
+++ b/test/safe-stop.test.js
@@ -335,18 +335,27 @@ describe("safeStopServer — input validation", () => {
 });
 
 describe("safeStopServer — default timeout contract", () => {
-  it("default timeoutMs exceeds the server's drain timeout", async () => {
+  it("default budget = drainTimeout + named tail slack", async () => {
     // The bug this guards against: if safeStopServer's caller-side
     // watchdog fires before the server's own drain wait completes,
     // a healthy graceful shutdown gets SIGKILLed mid-flight, skipping
     // sessionManager.shutdown() (which sends in-band detach-client to
-    // each tmux control mode child to dodge the 3.6a UAF). Any future
-    // edit that uncouples these two values will silently re-introduce
-    // the `katulong update` race we hit on mac2019/mac2024 in v0.61.3.
-    const envConfig = (await import("../lib/env-config.js")).default;
-    assert.ok(
-      envConfig.shutdownBudget > envConfig.drainTimeout,
-      `shutdownBudget (${envConfig.shutdownBudget}ms) must exceed drainTimeout (${envConfig.drainTimeout}ms)`,
+    // each tmux control mode child to dodge the 3.6a UAF). The
+    // `katulong update` race we hit on mac2019/mac2024 in v0.61.3 was
+    // this exact failure mode.
+    //
+    // Asserting equality with SHUTDOWN_TAIL_SLACK_MS (rather than just
+    // shutdownBudget > drainTimeout) catches both regression vectors:
+    // someone reverting the derivation, AND someone shrinking the
+    // slack to a value too small to cover the synchronous tail
+    // (sessionManager.shutdown → shutdownPlugins → cleanupPidFile).
+    const { default: envConfig, SHUTDOWN_TAIL_SLACK_MS } = await import(
+      "../lib/env-config.js"
+    );
+    assert.equal(
+      envConfig.shutdownBudget - envConfig.drainTimeout,
+      SHUTDOWN_TAIL_SLACK_MS,
+      `shutdownBudget (${envConfig.shutdownBudget}ms) must equal drainTimeout (${envConfig.drainTimeout}ms) + SHUTDOWN_TAIL_SLACK_MS (${SHUTDOWN_TAIL_SLACK_MS}ms)`,
     );
   });
 });


### PR DESCRIPTION
## Summary

`katulong update` was SIGKILLing healthy graceful shutdowns on hosts with active remote WebSocket clients. We saw this on mac2019 and mac2024 during the v0.61.3 mesh rollout (mac2024 had also seen it during v0.61.2 — pattern, not flake). Both hosts had iPad/laptop sessions connected via Cloudflare tunnel; mac mini had none and shut down clean both times.

**Root cause:** two timeouts encoded the same concept in two places, with values that did not have to agree:
- `lib/env-config.js` — `DRAIN_TIMEOUT = 30000` (server's drain wait)
- `lib/cli/safe-stop.js` — `timeoutMs = 5000` (caller's SIGKILL watchdog)

The server's graceful shutdown waits up to `drainTimeout` for WebSocket clients to drain naturally, then runs `sessionManager.shutdown()` (which sends in-band `detach-client` to each `tmux -C` child to dodge the [tmux 3.6a UAF](lib/session.js#L507-L510)), `shutdownPlugins()`, pidfile cleanup, exit. With a real client connected, the close-frame round-trip through a tunnel can easily exceed 5s. The caller's watchdog fired before that finished, SIGKILL landed, `sessionManager.shutdown()` was skipped — silently exposing the host to the UAF.

**Fix:** single source of truth.

```js
// env-config.js
shutdownBudget: drainTimeoutMs + SHUTDOWN_TAIL_SLACK_MS  // 30000 + 3000
```

`safeStopServer`'s default `timeoutMs` is now `envConfig.shutdownBudget`. Bumping `DRAIN_TIMEOUT` propagates to both sides automatically — there is no second knob to forget. All four production callers (`stop`, `restart`, `_finish-upgrade` × 2) inherit the default; tests that override `timeoutMs` for fast-fail scenarios keep working via the existing options object.

## What was tried and ruled out

- **Reach into `~/.katulong/server.json` from the CLI** to discover the running server's `drainTimeout`. Bespoke cross-layer hack, IPC-shaped coupling. The single-constant approach makes the contract explicit and static.
- **Drop `DRAIN_TIMEOUT` default to ~3000ms.** Forces fast graceful exit but loses the close-frame window for real clients on slow networks.
- **Add a "fast shutdown" mode** triggered during upgrades that skips the drain wait. More moving parts. Worth keeping in mind if 30s + 3s proves too long in practice.

## Regression test

`test/safe-stop.test.js` gains a contract test asserting `shutdownBudget > drainTimeout`. Any future edit that uncouples the two trips this test.

## Test plan

- [x] `npm test` passes (2692/2692, +1 new test)
- [x] Smoke E2E + unit/integration tests pass via pre-push hook
- [ ] Verify on mac2019/mac2024 next mesh rollout — `Old server (PID …) did not exit, sent SIGKILL` should not appear when graceful shutdown completes within 33s