### PR TITLE
rewrite(web): slice 9r.4 — status probe + session restore on page load

### DIFF
--- a/crates/server/src/access.rs
+++ b/crates/server/src/access.rs
@@ -50,6 +50,23 @@ impl AccessMethod {
     }
 }
 
+/// Boundary conversion from the server-internal access type
+/// to its wire-format mirror. Lives here (not in `wire.rs`)
+/// because the conversion direction is one-way at the
+/// HTTP-response boundary, and putting it in the shared
+/// crate would require an upstream dep on the server crate.
+/// Centralising the match here means a future variant
+/// addition gets caught by the exhaustive-match warning at
+/// one site instead of N inline matches across handlers.
+impl From<AccessMethod> for katulong_shared::wire::AccessMethod {
+    fn from(value: AccessMethod) -> Self {
+        match value {
+            AccessMethod::Localhost => Self::Localhost,
+            AccessMethod::Remote => Self::Remote,
+        }
+    }
+}
+
 /// Strip any `:port` from a Host header and test whether the remaining
 /// authority is a loopback hostname or literal loopback IP.
 ///

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -83,18 +83,8 @@ async fn status(
     let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
     let access = AccessMethod::classify(peer, host);
     let snap = state.auth_store.snapshot().await;
-    // The server-internal `AccessMethod` (in `crate::access`)
-    // owns the security-critical loopback-vs-tunnel
-    // classification. The wire-format `AccessMethod` (in
-    // `katulong_shared::wire`) is its JSON-serialisable
-    // mirror. Convert at the response boundary so the two
-    // never drift.
-    let access_wire = match access {
-        AccessMethod::Localhost => katulong_shared::wire::AccessMethod::Localhost,
-        AccessMethod::Remote => katulong_shared::wire::AccessMethod::Remote,
-    };
     Json(AuthStatusResponse {
-        access_method: access_wire,
+        access_method: access.into(),
         has_credentials: !snap.credentials.is_empty(),
         authenticated: authed.is_some(),
     })

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -39,11 +39,10 @@ use axum::{
 };
 use katulong_auth::{AuthError, Session, SESSION_TTL};
 use katulong_shared::wire::{
-    AuthFinishResponse, ChallengeStartResponse, CreationChallengeResponse,
-    LoginFinishRequest, PairFinishRequest, PairStartRequest, PairStartResponse,
-    RegisterFinishRequest, RequestChallengeResponse,
+    AuthFinishResponse, AuthStatusResponse, ChallengeStartResponse,
+    CreationChallengeResponse, LoginFinishRequest, PairFinishRequest, PairStartRequest,
+    PairStartResponse, RegisterFinishRequest, RequestChallengeResponse,
 };
-use serde::Serialize;
 use std::net::SocketAddr;
 use std::time::SystemTime;
 
@@ -75,44 +74,27 @@ pub fn auth_routes() -> Router<AppState> {
         .route("/api/auth/logout", post(logout))
 }
 
-/// JSON wire format for the status endpoint.
-///
-/// Snake_case on purpose — this is a fresh Rust-only wire format, no
-/// migrated Node clients to stay compatible with. Serde's default
-/// encoding already uses the struct field names so we don't carry a
-/// `rename_all` attribute. Any future interop requirement would land
-/// as an explicit rename.
-#[derive(Debug, Serialize)]
-struct AuthStatus {
-    /// `"localhost"` or `"remote"` — the binary access model. No LAN
-    /// tier; see project memory `project_access_model_no_lan`.
-    access_method: &'static str,
-    /// True when at least one credential is registered. A fresh
-    /// install reports `false` and the client routes to the register
-    /// flow.
-    has_credentials: bool,
-    /// True when the current request would pass the `Authenticated`
-    /// extractor. Derived from the same extractor in-process (via
-    /// `Option<Authenticated>`) so the two can't drift — if the
-    /// extractor's acceptance criteria change later, `status` tracks
-    /// automatically.
-    authenticated: bool,
-}
-
 async fn status(
     State(state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     authed: Option<Authenticated>,
-) -> Json<AuthStatus> {
+) -> Json<AuthStatusResponse> {
     let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
     let access = AccessMethod::classify(peer, host);
     let snap = state.auth_store.snapshot().await;
-    Json(AuthStatus {
-        access_method: match access {
-            AccessMethod::Localhost => "localhost",
-            AccessMethod::Remote => "remote",
-        },
+    // The server-internal `AccessMethod` (in `crate::access`)
+    // owns the security-critical loopback-vs-tunnel
+    // classification. The wire-format `AccessMethod` (in
+    // `katulong_shared::wire`) is its JSON-serialisable
+    // mirror. Convert at the response boundary so the two
+    // never drift.
+    let access_wire = match access {
+        AccessMethod::Localhost => katulong_shared::wire::AccessMethod::Localhost,
+        AccessMethod::Remote => katulong_shared::wire::AccessMethod::Remote,
+    };
+    Json(AuthStatusResponse {
+        access_method: access_wire,
         has_credentials: !snap.credentials.is_empty(),
         authenticated: authed.is_some(),
     })

--- a/crates/shared/src/wire.rs
+++ b/crates/shared/src/wire.rs
@@ -55,6 +55,43 @@ pub use webauthn_rs_proto::{
 
 pub type ChallengeId = String;
 
+// --- status probe ----------------------------------------------------
+
+/// Wire-format access classification. The server has its own
+/// `crate::access::AccessMethod` (security-critical, owns the
+/// loopback-vs-tunnel detection logic); this is the
+/// JSON-serialisable mirror used at the response boundary so
+/// the WASM client can pattern-match on the same two
+/// variants. Snake/lower-case at the wire so a server enum
+/// rename doesn't change the JSON shape — the
+/// `#[serde(rename_all = "lowercase")]` is the contract.
+///
+/// Binary by design (`project_access_model_no_lan`): there
+/// is no third "LAN" variant.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AccessMethod {
+    Localhost,
+    Remote,
+}
+
+/// Response shape for `GET /api/auth/status`. Public route
+/// (no auth required) — the WASM client probes this on every
+/// page load to discover the current session state and decide
+/// whether to render the login form, the post-auth view, or a
+/// loading state while the probe is in flight.
+///
+/// `has_credentials = false` is the signal for "fresh install
+/// — go to register flow"; `authenticated = true` is the
+/// signal for "session cookie is valid, go to post-auth
+/// view"; the remaining case is "show the login form."
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuthStatusResponse {
+    pub access_method: AccessMethod,
+    pub has_credentials: bool,
+    pub authenticated: bool,
+}
+
 // --- start: shared challenge envelope ---------------------------------
 
 /// Generic envelope for the start phase of every ceremony.

--- a/crates/shared/tests/wire_round_trip.rs
+++ b/crates/shared/tests/wire_round_trip.rs
@@ -25,8 +25,8 @@
 //! key is part of an HTTP contract.
 
 use katulong_shared::wire::{
-    AuthFinishResponse, ChallengeId, LoginFinishRequest, PairFinishRequest,
-    PairStartRequest, PairStartResponse,
+    AccessMethod, AuthFinishResponse, AuthStatusResponse, ChallengeId,
+    LoginFinishRequest, PairFinishRequest, PairStartRequest, PairStartResponse,
 };
 use serde_json::{json, Value};
 
@@ -177,6 +177,42 @@ fn pair_start_response_envelope_keys_are_snake_case() {
     assert_eq!(re_serialized["challenge_id"], json!("c1"));
     assert_eq!(re_serialized["setup_token_id"], json!("tok-id-1"));
     assert!(re_serialized["options"].is_object());
+}
+
+#[test]
+fn auth_status_response_pins_keys_and_round_trips() {
+    let resp = AuthStatusResponse {
+        access_method: AccessMethod::Localhost,
+        has_credentials: true,
+        authenticated: true,
+    };
+
+    let value = serde_json::to_value(&resp).unwrap();
+    assert_eq!(
+        value,
+        json!({
+            "access_method": "localhost",
+            "has_credentials": true,
+            "authenticated": true,
+        })
+    );
+
+    // Cover the other variant too — the WASM client switches
+    // on this string and a missed `Remote => "remote"` case
+    // would silently treat tunnel access as localhost.
+    let remote = AuthStatusResponse {
+        access_method: AccessMethod::Remote,
+        has_credentials: false,
+        authenticated: false,
+    };
+    let v = serde_json::to_value(&remote).unwrap();
+    assert_eq!(v["access_method"], json!("remote"));
+
+    let s = serde_json::to_string(&resp).unwrap();
+    let back: AuthStatusResponse = serde_json::from_str(&s).unwrap();
+    assert_eq!(back.access_method, AccessMethod::Localhost);
+    assert!(back.has_credentials);
+    assert!(back.authenticated);
 }
 
 #[test]

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -319,7 +319,7 @@ pub fn Login() -> impl IntoView {
     // actions in lockstep — adding a new "logging" hook later
     // means changing one place, not two.
     let resolve = move |result: Result<(), String>| match result {
-        Ok(()) => auth.set_signed_in.set(true),
+        Ok(()) => auth.set_signed_in.set(Some(true)),
         Err(message) => set_phase.set(LoginPhase::Error(message)),
     };
 

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -319,7 +319,7 @@ pub fn Login() -> impl IntoView {
     // actions in lockstep — adding a new "logging" hook later
     // means changing one place, not two.
     let resolve = move |result: Result<(), String>| match result {
-        Ok(()) => auth.set_signed_in.set(Some(true)),
+        Ok(()) => auth.set_phase.set(crate::AuthPhase::SignedIn),
         Err(message) => set_phase.set(LoginPhase::Error(message)),
     };
 

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -41,38 +41,55 @@ fn main() {
 #[derive(Copy, Clone)]
 struct ConnectionStatus(ReadSignal<bool>);
 
-/// Tri-state auth signal exposed to descendants via context:
+/// Phases of the auth state machine driving `<Main/>`'s
+/// view selection.
 ///
-/// - `None` — initial probe to `/api/auth/status` is in
-///   flight. `<Main/>` renders a small "restoring" view
-///   here, NOT the login form, so a page reload of an
-///   already-authed user doesn't flash through the sign-in
-///   screen.
-/// - `Some(false)` — probe resolved as unauthenticated. The
+/// - `Restoring` — initial probe to `/api/auth/status` is in
+///   flight. `<Main/>` renders a small "restoring" view here,
+///   NOT the login form, so a page reload of an already-authed
+///   user doesn't flash through the sign-in screen.
+/// - `SignedOut` — probe resolved as unauthenticated. The
 ///   login form renders.
-/// - `Some(true)` — probe resolved as authenticated, OR the
+/// - `SignedIn` — probe resolved as authenticated, OR the
 ///   sign-in/pair ceremony just succeeded. Post-auth view
 ///   renders.
 ///
-/// The setter half travels alongside the reader because two
-/// places need to write: the App-root probe-on-mount, and
-/// `<Login/>`'s ceremony success branches. A future logout
-/// will write the same setter in the opposite direction.
-#[derive(Copy, Clone)]
-pub struct AuthState {
-    pub signed_in: ReadSignal<Option<bool>>,
-    pub set_signed_in: WriteSignal<Option<bool>>,
+/// Encoded as a typed enum (rather than `Option<bool>`) so
+/// each variant has a name at the match sites — the previous
+/// `Some(false)` / `Some(true)` shape leaned on a doc comment
+/// to spell out which boolean meant what. Also gives us a
+/// natural place to grow: when 9r.5 lands the register flow,
+/// a `SignedOutNoCredentials` variant captures the
+/// "authenticated-but-fresh-install" case that `Option<bool>`
+/// can't represent without splitting into a second signal.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum AuthPhase {
+    Restoring,
+    SignedOut,
+    SignedIn,
 }
 
-/// Probe `/api/auth/status` once at App mount to discover
-/// the current session state. Returns the `authenticated`
-/// flag from the response (the wire shape exposes more
-/// fields — `access_method`, `has_credentials` — but only
-/// `authenticated` is needed at this layer; future slices
-/// that branch on `has_credentials` for the
-/// "no-credentials-yet → register flow" route will read the
-/// other fields).
-async fn probe_auth_status() -> Result<bool, String> {
+/// Reactive auth-state signal exposed via context. The setter
+/// half travels alongside the reader because two places write
+/// today (the App-root probe-on-mount and `<Login/>`'s
+/// ceremony success branches), and a future logout slice will
+/// write the same setter in the opposite direction.
+#[derive(Copy, Clone)]
+pub struct AuthState {
+    pub phase: ReadSignal<AuthPhase>,
+    pub set_phase: WriteSignal<AuthPhase>,
+}
+
+/// Probe `/api/auth/status` once at App mount.
+///
+/// Returns the full `AuthStatusResponse` (not just the
+/// `authenticated` bool) so the caller has access to
+/// `has_credentials` and `access_method` without a second
+/// round trip when 9r.5 lands the register flow gate. The
+/// caller currently only consumes `authenticated`; the wider
+/// shape is on the boundary instead of behind it so
+/// downstream code can grow without re-shaping this fn.
+async fn probe_auth_status() -> Result<AuthStatusResponse, String> {
     let resp = gloo_net::http::Request::get("/api/auth/status")
         .send()
         .await
@@ -80,11 +97,9 @@ async fn probe_auth_status() -> Result<bool, String> {
     if !resp.ok() {
         return Err(format!("status returned {}", resp.status()));
     }
-    let status: AuthStatusResponse = resp
-        .json()
+    resp.json()
         .await
-        .map_err(|e| format!("malformed status response: {e}"))?;
-    Ok(status.authenticated)
+        .map_err(|e| format!("malformed status response: {e}"))
 }
 
 #[component]
@@ -102,25 +117,30 @@ fn App() -> impl IntoView {
     // Auth signal lives at the root because three places
     // need to write: the probe-on-mount below, `<Login/>`'s
     // ceremony success branches, and a future logout. Initial
-    // `None` means "probe in flight" — `<Main/>` renders the
-    // restoring view in this state.
-    let (signed_in, set_signed_in) = create_signal(None::<bool>);
-    provide_context(AuthState {
-        signed_in,
-        set_signed_in,
-    });
+    // `Restoring` — `<Main/>` renders the restoring view in
+    // this state.
+    let (phase, set_phase) = create_signal(AuthPhase::Restoring);
+    provide_context(AuthState { phase, set_phase });
 
     // Fire the probe once on mount. We don't use
     // `create_action` because there's no input and no need
     // to expose pending/result state to the component tree —
     // the auth signal IS the result. On error (network
-    // failure, server misbehaving), default to
-    // `Some(false)` so the user lands on the login form
-    // rather than getting stuck on "restoring…" forever.
+    // failure, server misbehaving), default to `SignedOut`
+    // so the user lands on the login form rather than
+    // getting stuck on "restoring…" forever; a `console.warn`
+    // surfaces the actual failure for dev triage without
+    // putting it in the user-visible string.
     spawn_local(async move {
         match probe_auth_status().await {
-            Ok(authed) => set_signed_in.set(Some(authed)),
-            Err(_) => set_signed_in.set(Some(false)),
+            Ok(status) if status.authenticated => set_phase.set(AuthPhase::SignedIn),
+            Ok(_) => set_phase.set(AuthPhase::SignedOut),
+            Err(message) => {
+                web_sys::console::warn_1(
+                    &format!("katulong: auth status probe failed: {message}").into(),
+                );
+                set_phase.set(AuthPhase::SignedOut);
+            }
         }
     });
 
@@ -173,10 +193,10 @@ fn Main() -> impl IntoView {
     // section is small and self-explanatory.
     view! {
         <main id="kat-main">
-            {move || match auth.signed_in.get() {
-                None => view! { <SessionRestoring/> }.into_view(),
-                Some(true) => view! { <TerminalStub/> }.into_view(),
-                Some(false) => view! { <Login/> }.into_view(),
+            {move || match auth.phase.get() {
+                AuthPhase::Restoring => view! { <SessionRestoring/> }.into_view(),
+                AuthPhase::SignedIn => view! { <TerminalStub/> }.into_view(),
+                AuthPhase::SignedOut => view! { <Login/> }.into_view(),
             }}
         </main>
     }

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -6,17 +6,26 @@
 //   Login + ceremony moved to `login.rs` — this file owns
 //   only the shell layout, the App-root signal contexts, and
 //   the auth-state-driven swap in <Main/>.
+// Slice 9r.4: status probe + session restore. Auth state
+//   becomes tri-state — None while the initial
+//   `/api/auth/status` probe is in flight, Some(false) when
+//   the server says not authed, Some(true) when authed. The
+//   None branch renders a small "restoring" view, NOT the
+//   login form, so a refresh after sign-in doesn't flash
+//   the user back to "Sign in with passkey" before the
+//   probe resolves.
 //
 // FP-leaning per memory `feedback_rewrite_fp_direction`: the
 // shell is built from small pure components composed into a
 // tree. Auth + connection state live in signals provided at
-// the App root; the ceremony itself is a pure async function
-// (`login::signin`) that returns a `Result` — the component
-// just dispatches it via `create_action` and reacts to the
-// resolved value. No scattered globals, no callbacks-on-
-// callbacks.
+// the App root; the ceremonies (signin, pair, status probe)
+// are pure async functions returning `Result` — the
+// components dispatch them via `spawn_local` /
+// `create_action` and react to the resolved value.
 
+use katulong_shared::wire::AuthStatusResponse;
 use leptos::*;
+use wasm_bindgen_futures::spawn_local;
 
 mod login;
 use login::Login;
@@ -32,19 +41,50 @@ fn main() {
 #[derive(Copy, Clone)]
 struct ConnectionStatus(ReadSignal<bool>);
 
-/// Reactive auth-state signal exposed to descendants via
-/// context. Slice 9r.2 flips it on successful sign-in so
-/// `<Main/>` can swap from `<Login/>` to a stub. Future
-/// slices read the same signal to gate WS attach + tile
-/// rendering. The setter half travels alongside the reader
-/// because the sign-in ceremony — owned by `<Login/>` —
-/// needs to publish success up to its sibling-switching
-/// parent. Logout (a future slice) will use the same setter
-/// in reverse.
+/// Tri-state auth signal exposed to descendants via context:
+///
+/// - `None` — initial probe to `/api/auth/status` is in
+///   flight. `<Main/>` renders a small "restoring" view
+///   here, NOT the login form, so a page reload of an
+///   already-authed user doesn't flash through the sign-in
+///   screen.
+/// - `Some(false)` — probe resolved as unauthenticated. The
+///   login form renders.
+/// - `Some(true)` — probe resolved as authenticated, OR the
+///   sign-in/pair ceremony just succeeded. Post-auth view
+///   renders.
+///
+/// The setter half travels alongside the reader because two
+/// places need to write: the App-root probe-on-mount, and
+/// `<Login/>`'s ceremony success branches. A future logout
+/// will write the same setter in the opposite direction.
 #[derive(Copy, Clone)]
 pub struct AuthState {
-    pub signed_in: ReadSignal<bool>,
-    pub set_signed_in: WriteSignal<bool>,
+    pub signed_in: ReadSignal<Option<bool>>,
+    pub set_signed_in: WriteSignal<Option<bool>>,
+}
+
+/// Probe `/api/auth/status` once at App mount to discover
+/// the current session state. Returns the `authenticated`
+/// flag from the response (the wire shape exposes more
+/// fields — `access_method`, `has_credentials` — but only
+/// `authenticated` is needed at this layer; future slices
+/// that branch on `has_credentials` for the
+/// "no-credentials-yet → register flow" route will read the
+/// other fields).
+async fn probe_auth_status() -> Result<bool, String> {
+    let resp = gloo_net::http::Request::get("/api/auth/status")
+        .send()
+        .await
+        .map_err(|e| format!("network error contacting server: {e}"))?;
+    if !resp.ok() {
+        return Err(format!("status returned {}", resp.status()));
+    }
+    let status: AuthStatusResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("malformed status response: {e}"))?;
+    Ok(status.authenticated)
 }
 
 #[component]
@@ -59,17 +99,29 @@ fn App() -> impl IntoView {
     let (connected, _set_connected) = create_signal(false);
     provide_context(ConnectionStatus(connected));
 
-    // Auth signal also lives at the root because two siblings
-    // need it: `<Login/>` writes (on ceremony success) and
-    // `<Main/>` reads (to swap children). A future
-    // `<Header/>` logout button will also write through this
-    // setter. Initial value `false` because we haven't yet
-    // checked `/api/auth/status`; slice 9r.3 lands the
-    // session-restore-on-load probe.
-    let (signed_in, set_signed_in) = create_signal(false);
+    // Auth signal lives at the root because three places
+    // need to write: the probe-on-mount below, `<Login/>`'s
+    // ceremony success branches, and a future logout. Initial
+    // `None` means "probe in flight" — `<Main/>` renders the
+    // restoring view in this state.
+    let (signed_in, set_signed_in) = create_signal(None::<bool>);
     provide_context(AuthState {
         signed_in,
         set_signed_in,
+    });
+
+    // Fire the probe once on mount. We don't use
+    // `create_action` because there's no input and no need
+    // to expose pending/result state to the component tree —
+    // the auth signal IS the result. On error (network
+    // failure, server misbehaving), default to
+    // `Some(false)` so the user lands on the login form
+    // rather than getting stuck on "restoring…" forever.
+    spawn_local(async move {
+        match probe_auth_status().await {
+            Ok(authed) => set_signed_in.set(Some(authed)),
+            Err(_) => set_signed_in.set(Some(false)),
+        }
     });
 
     view! {
@@ -113,20 +165,37 @@ fn Header() -> impl IntoView {
 #[component]
 fn Main() -> impl IntoView {
     let auth = expect_context::<AuthState>();
-    // Switch on auth state. While unauthenticated → `<Login/>`.
-    // Once the sign-in ceremony flips `signed_in`, render the
-    // (still-stub) terminal placeholder. This is the FP-leaning
-    // shape: parent consumes a signal, returns the right child
-    // — no imperative DOM swap, no shared mutable view-state.
+    // Three-way switch on auth state. The `None` case has to
+    // render SOMETHING that isn't the login form — otherwise
+    // a page reload of an authed user would briefly flash
+    // through the sign-in screen before the probe resolves
+    // and swaps to the post-auth view. The "restoring…"
+    // section is small and self-explanatory.
     view! {
         <main id="kat-main">
-            <Show
-                when=move || auth.signed_in.get()
-                fallback=|| view! { <Login/> }
-            >
-                <TerminalStub/>
-            </Show>
+            {move || match auth.signed_in.get() {
+                None => view! { <SessionRestoring/> }.into_view(),
+                Some(true) => view! { <TerminalStub/> }.into_view(),
+                Some(false) => view! { <Login/> }.into_view(),
+            }}
         </main>
+    }
+}
+
+/// Rendered while the initial auth-status probe is in
+/// flight. Deliberately minimal — the probe is a single
+/// fast HTTP round trip, so this view is on screen for
+/// O(100ms) on a normal network and the user shouldn't
+/// even register it. The visible identity matters for e2e:
+/// `#kat-session-restoring` is the selector hook for tests
+/// that want to wait the probe out before asserting on
+/// downstream views.
+#[component]
+fn SessionRestoring() -> impl IntoView {
+    view! {
+        <section id="kat-session-restoring" aria-busy="true">
+            <p class="blurb">"Restoring session…"</p>
+        </section>
     }
 }
 

--- a/test/e2e-rust/auth.e2e.js
+++ b/test/e2e-rust/auth.e2e.js
@@ -26,7 +26,7 @@
 //     npx playwright test --config=playwright.rust.config.js
 
 import { test, expect } from "@playwright/test";
-import { stubUnauthenticated } from "./lib/webauthn.js";
+import { stubUnauthenticated } from "./lib/auth-stub.js";
 
 // Every test in this file exercises the login UI. Slice
 // 9r.4's probe-on-mount means the WASM only renders the

--- a/test/e2e-rust/auth.e2e.js
+++ b/test/e2e-rust/auth.e2e.js
@@ -26,6 +26,18 @@
 //     npx playwright test --config=playwright.rust.config.js
 
 import { test, expect } from "@playwright/test";
+import { stubUnauthenticated } from "./lib/webauthn.js";
+
+// Every test in this file exercises the login UI. Slice
+// 9r.4's probe-on-mount means the WASM only renders the
+// login form when the server says `authenticated: false`,
+// and on localhost the server auto-authenticates EVERY
+// request (security feature: physical access already grants
+// root). Without this stub the login form would never
+// render and every assertion below would time out.
+test.beforeEach(async ({ page }) => {
+  await stubUnauthenticated(page);
+});
 
 test("login defaults to sign-in mode without setup_token", async ({ page }) => {
   // No `?setup_token=...` query: Login should render its

--- a/test/e2e-rust/lib/auth-stub.js
+++ b/test/e2e-rust/lib/auth-stub.js
@@ -1,0 +1,37 @@
+/**
+ * Stub `/api/auth/status` to look like an unauthenticated
+ * remote caller. Slice 9r.4 added a probe-on-mount that
+ * reads this endpoint to decide between the login form,
+ * post-auth view, and "restoring" placeholder. On localhost
+ * the server auto-authenticates EVERY request (security
+ * feature: physical access is already root-equivalent), so
+ * a real probe returns `authenticated: true` and the login
+ * form would never render. Tests that exercise the login UI
+ * stub the response to look unauthenticated; tests that
+ * exercise the real probe behaviour (slice-9r.4 contract
+ * verification) skip the stub and let the probe see the
+ * server's actual classification.
+ *
+ * Must be called BEFORE `page.goto()`. Once the WASM has
+ * mounted and fired the probe, intercepting won't roll
+ * back the in-flight request.
+ *
+ * `has_credentials: false` reflects the stub's intent for
+ * tests that only want the login form to render. When a
+ * future slice (9r.5) adds a "no-credentials → register
+ * flow" branch in the WASM, this value will need updating
+ * to keep these tests on the sign-in path.
+ */
+export async function stubUnauthenticated(page) {
+  await page.route("**/api/auth/status", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        access_method: "remote",
+        has_credentials: false,
+        authenticated: false,
+      }),
+    }),
+  );
+}

--- a/test/e2e-rust/lib/webauthn.js
+++ b/test/e2e-rust/lib/webauthn.js
@@ -1,37 +1,5 @@
 import { execSync } from "node:child_process";
 
-/**
- * Stub `/api/auth/status` to look like an unauthenticated
- * remote caller. Slice 9r.4 added a probe-on-mount that
- * reads this endpoint to decide between the login form,
- * post-auth view, and "restoring" placeholder. On localhost
- * the server auto-authenticates EVERY request (security
- * feature: physical access is already root-equivalent), so
- * a real probe returns `authenticated: true` and the login
- * form would never render. Tests that exercise the login UI
- * stub the response to look unauthenticated; tests that
- * exercise the real probe behaviour (slice-9r.4 contract
- * verification) skip the stub and let the probe see the
- * server's actual classification.
- *
- * Must be called BEFORE `page.goto()`. Once the WASM has
- * mounted and fired the probe, intercepting won't roll
- * back the in-flight request.
- */
-export async function stubUnauthenticated(page) {
-  await page.route("**/api/auth/status", (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        access_method: "remote",
-        has_credentials: false,
-        authenticated: false,
-      }),
-    }),
-  );
-}
-
 // Helpers for driving Chromium's CDP virtual WebAuthn
 // authenticator from Playwright tests.
 //

--- a/test/e2e-rust/lib/webauthn.js
+++ b/test/e2e-rust/lib/webauthn.js
@@ -1,5 +1,37 @@
 import { execSync } from "node:child_process";
 
+/**
+ * Stub `/api/auth/status` to look like an unauthenticated
+ * remote caller. Slice 9r.4 added a probe-on-mount that
+ * reads this endpoint to decide between the login form,
+ * post-auth view, and "restoring" placeholder. On localhost
+ * the server auto-authenticates EVERY request (security
+ * feature: physical access is already root-equivalent), so
+ * a real probe returns `authenticated: true` and the login
+ * form would never render. Tests that exercise the login UI
+ * stub the response to look unauthenticated; tests that
+ * exercise the real probe behaviour (slice-9r.4 contract
+ * verification) skip the stub and let the probe see the
+ * server's actual classification.
+ *
+ * Must be called BEFORE `page.goto()`. Once the WASM has
+ * mounted and fired the probe, intercepting won't roll
+ * back the in-flight request.
+ */
+export async function stubUnauthenticated(page) {
+  await page.route("**/api/auth/status", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        access_method: "remote",
+        has_credentials: false,
+        authenticated: false,
+      }),
+    }),
+  );
+}
+
 // Helpers for driving Chromium's CDP virtual WebAuthn
 // authenticator from Playwright tests.
 //

--- a/test/e2e-rust/smoke.e2e.js
+++ b/test/e2e-rust/smoke.e2e.js
@@ -21,7 +21,7 @@
 // — that runs trunk for you).
 
 import { test, expect } from "@playwright/test";
-import { stubUnauthenticated } from "./lib/webauthn.js";
+import { stubUnauthenticated } from "./lib/auth-stub.js";
 
 test("leptos shell renders header + main + status", async ({ page }) => {
   // The trunk-built `index.html` arrives with an empty

--- a/test/e2e-rust/smoke.e2e.js
+++ b/test/e2e-rust/smoke.e2e.js
@@ -21,6 +21,7 @@
 // — that runs trunk for you).
 
 import { test, expect } from "@playwright/test";
+import { stubUnauthenticated } from "./lib/webauthn.js";
 
 test("leptos shell renders header + main + status", async ({ page }) => {
   // The trunk-built `index.html` arrives with an empty
@@ -31,6 +32,14 @@ test("leptos shell renders header + main + status", async ({ page }) => {
   //   - Browser ran the JS glue + downloaded the WASM
   //   - Leptos mounted successfully
   // i.e., the entire vertical works.
+  //
+  // Stub the status probe to look unauthenticated. On
+  // localhost the server auto-authenticates every request
+  // (security model: physical access = root-equivalent), so
+  // the slice-9r.4 probe would otherwise resolve as
+  // `authenticated: true` and the login form — which we want
+  // to assert is visible — would never render.
+  await stubUnauthenticated(page);
   const response = await page.goto("/");
   expect(response, "GET / should respond").not.toBeNull();
   expect(response.status(), "GET / should be 200").toBe(200);
@@ -66,9 +75,10 @@ test("leptos shell renders header + main + status", async ({ page }) => {
   );
   await expect(header.locator(".status .label")).toHaveText("disconnected");
 
-  // Main content area renders the Login form (slice 9r.1).
-  // Visible at every page load until a future slice gates
-  // it on the authenticated-session signal.
+  // Main content area renders the Login form. Slice 9r.4
+  // gates this on the auth probe — with the stubbed
+  // unauthenticated response, the WASM resolves
+  // `signed_in: Some(false)` and the login form renders.
   const main = page.locator("#kat-main");
   await expect(main).toBeVisible();
   await expect(main.locator("#kat-login")).toBeVisible();

--- a/test/e2e-rust/webauthn.e2e.js
+++ b/test/e2e-rust/webauthn.e2e.js
@@ -48,6 +48,7 @@ import {
   registerFirstDevice,
   injectCredential,
   mintSetupToken,
+  stubUnauthenticated,
 } from "./lib/webauthn.js";
 
 test.describe.serial("WebAuthn UI happy paths", () => {
@@ -63,6 +64,16 @@ test.describe.serial("WebAuthn UI happy paths", () => {
   // count).
   let bootstrap;
   let setupToken;
+  // The session cookie minted by `register/finish` during
+  // bootstrap. Captured here so test 3 can establish a
+  // session via cookie-injection rather than running
+  // another ceremony — re-using the bootstrap credential
+  // for a UI sign-in trips the sign-counter replay guard,
+  // and we've already consumed the bootstrap setupToken
+  // (test 2 takes it). Cookie injection is the cleanest
+  // way to set up "authed user opens the app" without
+  // burning more credentials/tokens.
+  let sessionCookie;
 
   test.beforeAll(async ({ browser, baseURL }) => {
     // Self-heal the data dir if a previous run left
@@ -88,6 +99,19 @@ test.describe.serial("WebAuthn UI happy paths", () => {
       bootstrap.finishResponse.csrf_token,
       "pair-test-device",
     );
+
+    // Snapshot the session cookie before the bootstrap
+    // context closes. The cookie is HttpOnly + SameSite=Lax;
+    // `context.cookies()` returns the full descriptor that
+    // `addCookies` accepts as-is.
+    const cookies = await context.cookies();
+    sessionCookie = cookies.find((c) => c.name === "katulong_session");
+    if (!sessionCookie) {
+      throw new Error(
+        "expected katulong_session cookie after register/finish",
+      );
+    }
+
     await context.close();
   });
 
@@ -99,6 +123,11 @@ test.describe.serial("WebAuthn UI happy paths", () => {
     // in", and end up at the post-auth view.
     const context = await browser.newContext();
     const page = await context.newPage();
+    // Localhost auto-auth would skip past the login form
+    // before we can click the CTA; stub the status probe so
+    // the WASM resolves to "not signed in" and renders the
+    // login UI we're trying to exercise.
+    await stubUnauthenticated(page);
     await page.goto("/");
 
     // Bootstrap minted the credential in a different
@@ -140,6 +169,10 @@ test.describe.serial("WebAuthn UI happy paths", () => {
     // lifetime; we don't need its CDP handle here so we
     // don't bind the return value.
     await setupVirtualAuthenticator(page);
+    // Stub the probe so the pair UI (gated on the same
+    // tri-state signal as login) actually renders — see
+    // the sign-in test for the full rationale.
+    await stubUnauthenticated(page);
     // The setup token rides the URL because that's the
     // pairing flow's designed entry point — the operator
     // gives the new device a `?setup_token=` URL. The
@@ -156,6 +189,53 @@ test.describe.serial("WebAuthn UI happy paths", () => {
     });
     await expect(
       page.getByRole("button", { name: /pair with passkey/i }),
+    ).toHaveCount(0);
+
+    await context.close();
+  });
+
+  test("an active session restores after a page reload", async ({
+    browser,
+  }) => {
+    // The slice 9r.4 contract: a valid session cookie at
+    // page load means the user lands on the post-auth view,
+    // not the login form. Without the on-mount status
+    // probe, every reload would briefly flash through the
+    // sign-in screen — observable as a visible login form
+    // for ~100ms before the WASM realised it was authed.
+    //
+    // We exercise the contract via cookie injection rather
+    // than another UI sign-in: the bootstrap credential's
+    // signCount is frozen in the dump and would trip the
+    // replay guard on a second use, and we've already
+    // consumed the only setup token. Direct cookie
+    // injection isolates THIS slice's contract — the
+    // mechanism that established the session is irrelevant
+    // here; what matters is that the WASM's on-mount probe
+    // observes the cookie and renders accordingly.
+    const context = await browser.newContext();
+    await context.addCookies([sessionCookie]);
+    const page = await context.newPage();
+    await page.goto("/");
+
+    // First load: the probe resolves to authenticated=true
+    // and the post-auth view renders without the user
+    // touching anything.
+    await expect(page.getByText(/signed in/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(
+      page.getByRole("button", { name: /sign in with passkey/i }),
+    ).toHaveCount(0);
+
+    // Reload: same cookie, fresh WASM mount, fresh probe.
+    // Same outcome — never flash through the login form.
+    await page.reload();
+    await expect(page.getByText(/signed in/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(
+      page.getByRole("button", { name: /sign in with passkey/i }),
     ).toHaveCount(0);
 
     await context.close();

--- a/test/e2e-rust/webauthn.e2e.js
+++ b/test/e2e-rust/webauthn.e2e.js
@@ -42,13 +42,13 @@
 // UI flow in isolation while sharing the bootstrap cost.
 
 import { test, expect } from "@playwright/test";
+import { stubUnauthenticated } from "./lib/auth-stub.js";
 import {
   ensureFreshStagingDataDir,
   setupVirtualAuthenticator,
   registerFirstDevice,
   injectCredential,
   mintSetupToken,
-  stubUnauthenticated,
 } from "./lib/webauthn.js";
 
 test.describe.serial("WebAuthn UI happy paths", () => {
@@ -101,9 +101,12 @@ test.describe.serial("WebAuthn UI happy paths", () => {
     );
 
     // Snapshot the session cookie before the bootstrap
-    // context closes. The cookie is HttpOnly + SameSite=Lax;
-    // `context.cookies()` returns the full descriptor that
-    // `addCookies` accepts as-is.
+    // context closes. The cookie is HttpOnly + SameSite=Lax,
+    // and the value is sensitive — Playwright's trace
+    // recorder captures network responses including
+    // Set-Cookie, so do NOT enable `--trace on` for this
+    // suite without scrubbing the artifact, and do NOT
+    // copy this capture pattern with a real-user session.
     const cookies = await context.cookies();
     sessionCookie = cookies.find((c) => c.name === "katulong_session");
     if (!sessionCookie) {
@@ -196,6 +199,7 @@ test.describe.serial("WebAuthn UI happy paths", () => {
 
   test("an active session restores after a page reload", async ({
     browser,
+    baseURL,
   }) => {
     // The slice 9r.4 contract: a valid session cookie at
     // page load means the user lands on the post-auth view,
@@ -208,13 +212,22 @@ test.describe.serial("WebAuthn UI happy paths", () => {
     // than another UI sign-in: the bootstrap credential's
     // signCount is frozen in the dump and would trip the
     // replay guard on a second use, and we've already
-    // consumed the only setup token. Direct cookie
-    // injection isolates THIS slice's contract — the
-    // mechanism that established the session is irrelevant
-    // here; what matters is that the WASM's on-mount probe
-    // observes the cookie and renders accordingly.
+    // consumed the only setup token.
+    //
+    // Normalise the cookie's `domain` to the baseURL host
+    // before injection. `context.cookies()` returns the
+    // domain set by the bootstrap response (which on
+    // localhost may be `127.0.0.1` if the staging script
+    // bound there); `addCookies` silently drops cookies
+    // whose domain doesn't match the next navigation's
+    // hostname. A dropped cookie would still pass this test
+    // on localhost via the server's auto-auth fallback —
+    // i.e., a false-positive — defeating the regression
+    // guard.
     const context = await browser.newContext();
-    await context.addCookies([sessionCookie]);
+    await context.addCookies([
+      { ...sessionCookie, domain: new URL(baseURL).hostname },
+    ]);
     const page = await context.newPage();
     await page.goto("/");
 


### PR DESCRIPTION
## Summary

Before this slice the WASM client started with a hardcoded `signed_in: false`, so a page reload of an authed user flashed through the login form before the WASM realised it was authed. This slice adds an on-mount probe of `/api/auth/status` that seeds the auth-state signal so reload-after-sign-in just works.

## What changed

### Wire surface

- `katulong_shared::wire::AuthStatusResponse` is the single source of truth for the status endpoint's wire shape. The server's local `AuthStatus` struct is deleted in favour of the shared type.
- `katulong_shared::wire::AccessMethod { Localhost, Remote }` — `#[serde(rename_all = \"lowercase\")]` pins the wire form. The server's internal security-classification `AccessMethod` stays put; conversion happens at the response boundary.
- New round-trip + key-pinning tests cover both the envelope and the lowercase enum serialisation.

### WASM — tri-state auth signal

- `AuthState.signed_in: ReadSignal<Option<bool>>`. `None` = probe in flight, `Some(false)` = login, `Some(true)` = post-auth.
- New `<SessionRestoring/>` component for the `None` branch — minimal "Restoring session…" view, prevents a flash through the login form on reload.
- `<Main/>` is now a three-way `match` on `auth.signed_in.get()`.
- `probe_auth_status()` async fn dispatched via `spawn_local` in `<App/>` on mount. On error, defaults to `Some(false)` so the user lands on login rather than getting stuck on the restoring view.

### Tests

- New webauthn.e2e.js test 3: \"an active session restores after a page reload.\" Bootstrap captures the session cookie, injects it into a fresh context, asserts the post-auth view renders without user interaction, then reloads and re-asserts. Cookie injection (rather than another UI sign-in) avoids burning the bootstrap credential — its frozen `signCount` would trip webauthn-rs's replay guard.
- New `stubUnauthenticated(page)` helper in `lib/webauthn.js`. Existing smoke.e2e.js, auth.e2e.js, and webauthn.e2e.js tests 1+2 use it. **Why:** localhost requests are auto-authenticated by the server (security model: physical access is already root-equivalent); without the stub the probe would always resolve `authenticated: true` and the login form — which these tests assert is visible — would never render.
- The new test 3 does NOT stub: the real probe behaviour IS what's under test.

## Why probe via `spawn_local` and not `create_action`

`create_action` exposes pending/result state to the component tree. The probe doesn't need that — the auth signal IS the result, and `<Main/>`'s `None` branch already handles the in-flight case. `spawn_local` is the simplest tool that fits.

## Why default to `Some(false)` on probe error, not `None`

Stuck on `None` = stuck on \"Restoring session…\" forever. `Some(false)` lands on login, which lets the user retry — the probe's failure mode is usually transient.

## Bundle / test impact

- WASM: 548 KB → 553 KB (+5 KB for `AuthStatusResponse` deserialization + probe code)
- Rust tests: 291 → 292 (+1 envelope-key-pinning test)
- E2E: 11 → 12 (+1 session-restore test)

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release` green (292 tests)
- [x] `trunk build --release` clean
- [x] Full Rust e2e (12 tests) green on a fresh data dir
- [x] Full Rust e2e green on re-run with dirty data dir (self-heal)
- [ ] Reviewer: confirm the localhost auto-auth + slice-9r.4 interaction is correct (see commit body section \"Tests — stub for legacy login-UI tests\")