### PR TITLE
rewrite(web): slice 9r.5 — register UI for fresh-install users

### DIFF
--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -319,17 +319,19 @@ fn js_err(v: &JsValue) -> String {
     // Operator-side detail goes to the console; the user-side
     // string stays generic. Useful when triaging weird browser
     // / extension errors that don't follow the `Error` shape.
-    web_sys::console::warn_2(&JsValue::from_str("katulong: unstructured signin error"), v);
+    web_sys::console::warn_2(&JsValue::from_str("katulong: unstructured browser error"), v);
     "unexpected browser error".to_string()
 }
 
-/// Login phase — local to `<Login/>`. The three states form a
-/// minimal state machine: idle → in-flight → (idle | error).
-/// Encoded as an enum (rather than a pair of bool signals) so
-/// "in-flight" and "error" can never co-exist; `pending` would
-/// be ambiguous if both were independent.
+/// In-flight state machine for an auth ceremony component.
+/// Used by both `<Login/>` (sign-in + pair) and
+/// `<Register/>`. Three states form a minimal machine:
+/// idle → in-flight → (idle | error). Encoded as an enum
+/// (rather than a pair of bool signals) so "in-flight" and
+/// "error" can never co-exist; `pending` would be ambiguous
+/// if both were independent.
 #[derive(Clone, Debug, PartialEq, Eq)]
-enum LoginPhase {
+enum CeremonyPhase {
     Idle,
     InFlight,
     Error(String),
@@ -382,7 +384,7 @@ pub fn Login() -> impl IntoView {
 
     // Local state machine. `phase` drives the CTA copy +
     // disabled state and renders the error region.
-    let (phase, set_phase) = create_signal(LoginPhase::Idle);
+    let (phase, set_phase) = create_signal(CeremonyPhase::Idle);
 
     // Both ceremonies share the same post-resolve handler:
     // success flips global auth state (which unmounts this
@@ -393,7 +395,7 @@ pub fn Login() -> impl IntoView {
     // means changing one place, not two.
     let resolve = move |result: Result<(), String>| match result {
         Ok(()) => auth.set_phase.set(crate::AuthPhase::SignedIn),
-        Err(message) => set_phase.set(LoginPhase::Error(message)),
+        Err(message) => set_phase.set(CeremonyPhase::Error(message)),
     };
 
     // The ceremonies themselves are dispatched via
@@ -427,7 +429,7 @@ pub fn Login() -> impl IntoView {
     });
 
     let cta_label = move || match phase.get() {
-        LoginPhase::InFlight => if is_pair_mode {
+        CeremonyPhase::InFlight => if is_pair_mode {
             "Pairing…"
         } else {
             "Signing in…"
@@ -435,13 +437,13 @@ pub fn Login() -> impl IntoView {
         .to_string(),
         _ => cta_idle.to_string(),
     };
-    let cta_disabled = move || matches!(phase.get(), LoginPhase::InFlight);
+    let cta_disabled = move || matches!(phase.get(), CeremonyPhase::InFlight);
     // Signal: are we in the error state? Drives a conditional
     // <p class="error">. Reading the message directly out of
     // the signal would clone an empty string in the non-error
     // case, hence the `Show` + accessor split.
     let error_message = move || match phase.get() {
-        LoginPhase::Error(msg) => Some(msg),
+        CeremonyPhase::Error(msg) => Some(msg),
         _ => None,
     };
 
@@ -458,7 +460,7 @@ pub fn Login() -> impl IntoView {
         // synthetic double-click to fire a second concurrent
         // ceremony. The disabled re-render must happen before
         // the second click can be queued.
-        set_phase.set(LoginPhase::InFlight);
+        set_phase.set(CeremonyPhase::InFlight);
         match &setup_token {
             Some(token) => {
                 pair_action.dispatch(token.clone());
@@ -512,7 +514,7 @@ pub fn Login() -> impl IntoView {
 #[component]
 pub fn Register() -> impl IntoView {
     let auth = expect_context::<AuthState>();
-    let (phase, set_phase) = create_signal(LoginPhase::Idle);
+    let (phase, set_phase) = create_signal(CeremonyPhase::Idle);
 
     // Same resolve closure pattern as `<Login/>` — success
     // flips global auth state (which unmounts this component
@@ -520,7 +522,7 @@ pub fn Register() -> impl IntoView {
     // error renders in the local error region.
     let resolve = move |result: Result<(), String>| match result {
         Ok(()) => auth.set_phase.set(crate::AuthPhase::SignedIn),
-        Err(message) => set_phase.set(LoginPhase::Error(message)),
+        Err(message) => set_phase.set(CeremonyPhase::Error(message)),
     };
 
     let register_action = create_action(move |_: &()| async move {
@@ -528,12 +530,12 @@ pub fn Register() -> impl IntoView {
     });
 
     let cta_label = move || match phase.get() {
-        LoginPhase::InFlight => "Registering…".to_string(),
+        CeremonyPhase::InFlight => "Registering…".to_string(),
         _ => "Register first device".to_string(),
     };
-    let cta_disabled = move || matches!(phase.get(), LoginPhase::InFlight);
+    let cta_disabled = move || matches!(phase.get(), CeremonyPhase::InFlight);
     let error_message = move || match phase.get() {
-        LoginPhase::Error(msg) => Some(msg),
+        CeremonyPhase::Error(msg) => Some(msg),
         _ => None,
     };
 
@@ -544,7 +546,7 @@ pub fn Register() -> impl IntoView {
     // could fire two concurrent ceremonies. Setting InFlight
     // synchronously here closes that window.
     let on_click = move |_| {
-        set_phase.set(LoginPhase::InFlight);
+        set_phase.set(CeremonyPhase::InFlight);
         register_action.dispatch(());
     };
 

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -1,27 +1,37 @@
-//! Login component + sign-in / pair WebAuthn ceremonies.
+//! Login + Register components + their WebAuthn ceremonies.
 //!
 //! Slice 9r.1 landed the form shell + URL-based pair vs.
 //! sign-in mode swap. Slice 9r.2 wired the sign-in ceremony.
-//! Slice 9r.3 wires the pair (registration) ceremony,
-//! reusing the `LoginPhase` state machine.
+//! Slice 9r.3 wires the pair (additional-device registration)
+//! ceremony. Slice 9r.5 adds the first-device register
+//! ceremony as a sibling component, gated by
+//! `AuthPhase::Register` (which the App-root probe sets when
+//! the server reports authenticated-but-no-credentials, the
+//! fresh-install-on-localhost case).
 //!
-//! FP-leaning per memory `feedback_rewrite_fp_direction`:
-//! `signin()` and `pair()` are pure async pipelines (no shared
-//! state, no callbacks). They share shape but not types — the
-//! WebAuthn wire formats and the `web-sys` entry points
-//! diverge between get/create. We keep them as two parallel
-//! functions rather than a generic helper because the
-//! "different parts" (endpoint, request body, options type,
-//! navigator method, response type) outweigh the "same parts"
-//! (ok-check, JsFuture, dyn_into); a generic abstraction
-//! would obscure the flow without paying for itself.
-//! The component dispatches whichever applies via
-//! `create_action` and reacts to the resolved value.
+//! Three pure async ceremonies live here: `signin()`, `pair()`,
+//! `register()`. Their shapes are nearly identical (start
+//! request → options → credentials API → finish request) but
+//! the types diverge at every step (endpoint URL, request
+//! body, options type, navigator method, response type, finish
+//! body). A generic helper across the three would need ~6
+//! type parameters; three parallel functions reading top-to-
+//! bottom is easier to follow. The genuinely shared parts —
+//! HTTP-status guard, JsFuture-into-credential conversion,
+//! JsValue error rendering — are extracted as `check_ok`,
+//! `credential_from_promise`, and `js_err`.
+//!
+//! FP-leaning per memory `feedback_rewrite_fp_direction`: the
+//! ceremonies are side-effect-free in shape (Result-returning
+//! linear pipelines). The components dispatch them via
+//! `create_action` and react to the resolved value through a
+//! shared `resolve` closure that funnels success/error into
+//! the right signals.
 
 use crate::AuthState;
 use katulong_shared::wire::{
     LoginFinishRequest, LoginStartResponse, PairFinishRequest, PairStartRequest,
-    PairStartResponse,
+    PairStartResponse, RegisterFinishRequest, RegisterStartResponse,
 };
 use leptos::*;
 use wasm_bindgen::{JsCast, JsValue};
@@ -211,6 +221,69 @@ async fn pair(setup_token: String) -> Result<(), String> {
         .await
         .map_err(|e| format!("network error completing pair: {e}"))?;
     check_ok(&finish_resp, "server rejected pair")?;
+
+    Ok(())
+}
+
+/// Run the first-device WebAuthn registration ceremony.
+///
+/// Same shape as `pair()` (both produce a credential via
+/// `navigator.credentials.create()`), with the differences
+/// concentrated at the HTTP boundaries:
+///   - POST `/api/auth/register/start` with no body (the
+///     route is localhost-only and fresh-install-only on the
+///     server; no setup token to submit)
+///   - POST `/api/auth/register/finish` with just the
+///     credential — no `setup_token_id` to echo
+///
+/// The server's register routes refuse non-localhost callers
+/// and refuse a non-fresh install. The WASM doesn't pre-check
+/// either condition; the user only reaches this ceremony when
+/// the App-root probe has already classified the request as
+/// `AuthPhase::Register`, which by definition means
+/// authenticated (loopback peer) AND no credentials. If the
+/// server rejects anyway (race against another concurrent
+/// register, or a credential added between the probe and the
+/// click), the error renders in the standard error region.
+async fn register() -> Result<(), String> {
+    // 1. Ask for a registration challenge.
+    let start_resp = gloo_net::http::Request::post("/api/auth/register/start")
+        .send()
+        .await
+        .map_err(|e| format!("network error contacting server: {e}"))?;
+    check_ok(&start_resp, "server rejected register challenge")?;
+    let start: RegisterStartResponse = start_resp
+        .json()
+        .await
+        .map_err(|e| format!("server returned malformed challenge: {e}"))?;
+
+    // 2. Convert the wire challenge to the JS shape that
+    //    `navigator.credentials.create()` expects.
+    let options: web_sys::CredentialCreationOptions = start.options.into();
+
+    // 3. Run the platform registration ceremony.
+    let window = web_sys::window().ok_or("browser window unavailable")?;
+    let promise = window
+        .navigator()
+        .credentials()
+        .create_with_options(&options)
+        .map_err(|e| format!("browser refused credential creation: {}", js_err(&e)))?;
+    let credential = credential_from_promise(promise).await?;
+    let response: webauthn_rs_proto::RegisterPublicKeyCredential = credential.into();
+
+    // 4. Send the attestation back. No `setup_token_id` here —
+    //    register/finish only needs the challenge id and the
+    //    credential.
+    let finish_resp = gloo_net::http::Request::post("/api/auth/register/finish")
+        .json(&RegisterFinishRequest {
+            challenge_id: start.challenge_id,
+            response,
+        })
+        .map_err(|e| format!("could not encode register-finish payload: {e}"))?
+        .send()
+        .await
+        .map_err(|e| format!("network error completing register: {e}"))?;
+    check_ok(&finish_resp, "server rejected register")?;
 
     Ok(())
 }
@@ -406,6 +479,81 @@ pub fn Login() -> impl IntoView {
             // affordance before the wire type carries the
             // value would silently discard whatever the user
             // typed.
+            <button
+                type="button"
+                class="cta"
+                prop:disabled=cta_disabled
+                on:click=on_click
+            >
+                {cta_label}
+            </button>
+            {move || error_message().map(|msg| view! {
+                <p class="error" role="alert">{msg}</p>
+            })}
+        </section>
+    }
+}
+
+/// First-device register UI. Rendered when the App-root
+/// probe classifies the request as `AuthPhase::Register`
+/// (server: authenticated && !has_credentials, i.e., a
+/// fresh-install localhost session with no enrolled
+/// credentials).
+///
+/// The UX is deliberately minimal: one CTA, one explanatory
+/// blurb. Unlike `<Login/>` (which has two URL-driven modes
+/// and dispatches between two ceremonies), `<Register/>` has
+/// exactly one path — there's no setup token, no device-
+/// name input (the server doesn't carry a name field on
+/// register/finish either), no mode switch. A user reaching
+/// this view is by definition the operator setting up the
+/// first device; we don't need to clutter the screen with
+/// options.
+#[component]
+pub fn Register() -> impl IntoView {
+    let auth = expect_context::<AuthState>();
+    let (phase, set_phase) = create_signal(LoginPhase::Idle);
+
+    // Same resolve closure pattern as `<Login/>` — success
+    // flips global auth state (which unmounts this component
+    // when `<Main/>`'s match swaps to `<TerminalStub/>`),
+    // error renders in the local error region.
+    let resolve = move |result: Result<(), String>| match result {
+        Ok(()) => auth.set_phase.set(crate::AuthPhase::SignedIn),
+        Err(message) => set_phase.set(LoginPhase::Error(message)),
+    };
+
+    let register_action = create_action(move |_: &()| async move {
+        resolve(register().await);
+    });
+
+    let cta_label = move || match phase.get() {
+        LoginPhase::InFlight => "Registering…".to_string(),
+        _ => "Register first device".to_string(),
+    };
+    let cta_disabled = move || matches!(phase.get(), LoginPhase::InFlight);
+    let error_message = move || match phase.get() {
+        LoginPhase::Error(msg) => Some(msg),
+        _ => None,
+    };
+
+    // Same synchronous-InFlight pattern as `<Login/>`'s
+    // click handler. `create_action`'s first poll runs on a
+    // microtask, so a transition done inside the future
+    // would leave a window where a synthetic double-click
+    // could fire two concurrent ceremonies. Setting InFlight
+    // synchronously here closes that window.
+    let on_click = move |_| {
+        set_phase.set(LoginPhase::InFlight);
+        register_action.dispatch(());
+    };
+
+    view! {
+        <section id="kat-register" data-mode="register">
+            <h1 class="title">"Set up your first device"</h1>
+            <p class="blurb">
+                "Register a passkey for this device to get started. The first credential is created from this machine over localhost."
+            </p>
             <button
                 type="button"
                 class="cta"

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -209,8 +209,8 @@ fn Main() -> impl IntoView {
             {move || match auth.phase.get() {
                 AuthPhase::Restoring => view! { <SessionRestoring/> }.into_view(),
                 AuthPhase::Register => view! { <Register/> }.into_view(),
-                AuthPhase::SignedIn => view! { <TerminalStub/> }.into_view(),
                 AuthPhase::SignedOut => view! { <Login/> }.into_view(),
+                AuthPhase::SignedIn => view! { <TerminalStub/> }.into_view(),
             }}
         </main>
     }

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -28,7 +28,7 @@ use leptos::*;
 use wasm_bindgen_futures::spawn_local;
 
 mod login;
-use login::Login;
+use login::{Login, Register};
 
 fn main() {
     console_error_panic_hook::set_once();
@@ -48,23 +48,23 @@ struct ConnectionStatus(ReadSignal<bool>);
 ///   flight. `<Main/>` renders a small "restoring" view here,
 ///   NOT the login form, so a page reload of an already-authed
 ///   user doesn't flash through the sign-in screen.
-/// - `SignedOut` — probe resolved as unauthenticated. The
-///   login form renders.
-/// - `SignedIn` — probe resolved as authenticated, OR the
-///   sign-in/pair ceremony just succeeded. Post-auth view
+/// - `Register` — server says authenticated (typically via
+///   localhost auto-auth) but no credentials are registered
+///   yet. The first-device register UI renders. Distinct
+///   from `SignedOut` because the next user action differs:
+///   `Register` triggers `/api/auth/register/*` (localhost-
+///   only, fresh-install-only); `SignedOut` triggers
+///   `/api/auth/login/*`.
+/// - `SignedOut` — probe resolved as unauthenticated AND
+///   credentials exist on the server. The login form
 ///   renders.
-///
-/// Encoded as a typed enum (rather than `Option<bool>`) so
-/// each variant has a name at the match sites — the previous
-/// `Some(false)` / `Some(true)` shape leaned on a doc comment
-/// to spell out which boolean meant what. Also gives us a
-/// natural place to grow: when 9r.5 lands the register flow,
-/// a `SignedOutNoCredentials` variant captures the
-/// "authenticated-but-fresh-install" case that `Option<bool>`
-/// can't represent without splitting into a second signal.
+/// - `SignedIn` — probe resolved as authenticated AND
+///   credentials exist, OR a register/sign-in/pair ceremony
+///   just succeeded. Post-auth view renders.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum AuthPhase {
     Restoring,
+    Register,
     SignedOut,
     SignedIn,
 }
@@ -133,6 +133,19 @@ fn App() -> impl IntoView {
     // putting it in the user-visible string.
     spawn_local(async move {
         match probe_auth_status().await {
+            // Branch order matters: the `authenticated &&
+            // !has_credentials` case is the fresh-install-on-
+            // localhost path (auto-auth gives `authenticated`
+            // before any credential exists). Routing it to
+            // `SignedIn` would land the user on the terminal
+            // stub with no path back to the register flow;
+            // routing to `SignedOut` would show the login
+            // form with no credentials to sign in against.
+            // The dedicated `Register` phase is what makes
+            // this state representable.
+            Ok(status) if status.authenticated && !status.has_credentials => {
+                set_phase.set(AuthPhase::Register);
+            }
             Ok(status) if status.authenticated => set_phase.set(AuthPhase::SignedIn),
             Ok(_) => set_phase.set(AuthPhase::SignedOut),
             Err(message) => {
@@ -195,6 +208,7 @@ fn Main() -> impl IntoView {
         <main id="kat-main">
             {move || match auth.phase.get() {
                 AuthPhase::Restoring => view! { <SessionRestoring/> }.into_view(),
+                AuthPhase::Register => view! { <Register/> }.into_view(),
                 AuthPhase::SignedIn => view! { <TerminalStub/> }.into_view(),
                 AuthPhase::SignedOut => view! { <Login/> }.into_view(),
             }}

--- a/test/e2e-rust/webauthn.e2e.js
+++ b/test/e2e-rust/webauthn.e2e.js
@@ -51,6 +51,60 @@ import {
   mintSetupToken,
 } from "./lib/webauthn.js";
 
+test.describe("Register UI (first-device)", () => {
+  // Slice 9r.5 — fresh-install on localhost lands on a
+  // dedicated register UI rather than the login form. The
+  // App-root probe sees `authenticated: true` (loopback
+  // auto-auth) and `has_credentials: false` (fresh data
+  // dir) and resolves `AuthPhase::Register`.
+  //
+  // This test does NOT stub the status probe — the real
+  // probe behaviour IS what's under test. It runs against a
+  // freshly-wiped data dir so the server reports
+  // `has_credentials: false`. Because each ensure-fresh call
+  // tears down + restarts staging, we don't share data-dir
+  // state with the "WebAuthn UI happy paths" describe block
+  // below — that block's `beforeAll` does its own wipe.
+  test("a fresh-install localhost user registers their first device", async ({
+    browser,
+    baseURL,
+  }) => {
+    await ensureFreshStagingDataDir(baseURL);
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    // Attach the virtual authenticator BEFORE navigation so
+    // the page's `navigator.credentials.create()` can resolve
+    // when the user clicks the CTA.
+    await setupVirtualAuthenticator(page);
+    await page.goto("/");
+
+    // The probe should resolve the user to the Register
+    // phase, NOT the login form or the post-auth view. The
+    // CTA copy is the user-visible signal that we're in the
+    // right phase.
+    await expect(
+      page.getByRole("button", { name: /register first device/i }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByRole("button", { name: /sign in with passkey/i }),
+    ).toHaveCount(0);
+
+    await page
+      .getByRole("button", { name: /register first device/i })
+      .click();
+
+    // Successful registration: the WASM flips
+    // `AuthPhase::SignedIn`, `<Main/>` swaps to the
+    // post-auth view.
+    await expect(page.getByText(/signed in/i)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await context.close();
+  });
+});
+
 test.describe.serial("WebAuthn UI happy paths", () => {
   // Bootstrap output captured in `beforeAll` and read by
   // each test. The bootstrap registers a credential AND


### PR DESCRIPTION
## Summary

Slice 9r.4's status probe routed `authenticated && !has_credentials` (fresh-install on localhost) to `AuthPhase::SignedIn`, which rendered the post-auth stub with no path back to register a credential — a UX dead-end. This slice adds an `AuthPhase::Register` variant + a dedicated `<Register/>` component to close the loop.

## What changed

- `AuthPhase` gains a `Register` variant. Probe now classifies `authenticated && !has_credentials` as `Register`, distinct from both `SignedOut` (login form) and `SignedIn` (terminal stub).
- `<Register/>` component in `crates/web/src/login.rs` — sibling to `<Login/>`. Single CTA, single ceremony, no setup token, no device-name input.
- `register()` async fn parallel to `signin()` and `pair()`. POSTs to `/api/auth/register/start` and `/api/auth/register/finish`; reuses the existing `check_ok` and `credential_from_promise` helpers.
- New e2e test in its own `Register UI (first-device)` describe block: \"a fresh-install localhost user registers their first device\". No probe stub — real probe behaviour is what's under test.

## Why a separate `<Register/>` component

`<Login/>` switches between sign-in and pair modes via URL query string. `<Register/>` is reached via probe result, not URL. Folding it into `<Login/>` would mix two unrelated mode dimensions; a sibling component is cleaner.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release` green (292 tests)
- [x] `trunk build --release` clean (bundle 553 KB → 568 KB; +15 KB for the new component + ceremony)
- [x] Full Rust e2e (13 tests) green on a fresh data dir
- [x] Full Rust e2e green on a re-run with dirty data dir (register-UI test triggers the data-dir reset on re-run)
- [ ] Reviewer: confirm the `Register` branch ordering in the App probe (line 144-147 of `crates/web/src/main.rs`) — the `!has_credentials` case must come BEFORE the `authenticated`-only catch-all