### PR TITLE
feat(mesh-update): rolling katulong update across mesh peers

### DIFF
--- a/.claude/commands/mesh-update.md
+++ b/.claude/commands/mesh-update.md
@@ -1,0 +1,19 @@
+Roll a `katulong update` across every peer in the user's mesh, skipping this host.
+
+Run the mesh-update script with the user's arguments verbatim:
+
+```bash
+$REPO_ROOT/bin/katulong-mesh-update $ARGUMENTS
+```
+
+Subcommands / flags:
+
+- (no args) or `roll` — perform the rolling update. Each peer is updated in order; on any failure (ssh, brew, smoke test, post-update HTTP probe) the rollout halts and the remaining peers are not touched.
+- `list` — print the configured peers and which entry matches this host (the one excluded from rollouts).
+- `--dry-run` — show the planned rollout without ssh-ing.
+
+If the user runs `/mesh-update` with no arguments, default to `roll`. Surface the script's output verbatim — the per-peer `before` / `after` versions and HTTP probe results are the verification the user is looking for.
+
+The peer whose id matches `~/.katulong/node-id` is **always** excluded from the rollout — every host upgrades its peers, never itself. That asymmetry is intentional: a botched release leaves at least one healthy peer for recovery. Don't suggest a `--include-self` workaround; the user upgrades this host by running `mesh-update` from a different peer.
+
+For full background on the self-heal rationale and the mesh.json schema, see the `katulong-mesh-update` skill at `.claude/skills/katulong-mesh-update/SKILL.md`.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -59,7 +59,14 @@
       "Bash(/Users/felixflores/Projects/dorky_robot/katulong/bin/katulong-stage stop *)",
       "Bash(/Users/felixflores/Projects/dorky_robot/katulong/bin/katulong-stage list *)",
       "Bash(gh auth *)",
-      "WebFetch(domain:app.unpkg.com)"
+      "WebFetch(domain:app.unpkg.com)",
+      "Bash(bin/katulong-stage list *)",
+      "Bash(ssh 2019 *)",
+      "Bash(ssh 2024 *)",
+      "Bash(ssh cloudflare-mac2019 *)",
+      "Bash(ssh cloudflare-mac2024 *)",
+      "Bash(command -v jq)",
+      "Bash(bash -n bin/katulong-mesh-update)"
     ]
   }
 }

--- a/.claude/skills/katulong-mesh-update/SKILL.md
+++ b/.claude/skills/katulong-mesh-update/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: katulong-mesh-update
+description: Roll a `katulong update` across the user's configured mesh of katulong hosts using `bin/katulong-mesh-update`. Each host updates the OTHERS, never itself, so a botched release leaves at least one healthy peer to recover from. TRIGGER when the user wants to upgrade katulong on multiple machines at once ("update all my katulongs", "roll the new release out", "upgrade the mesh", "make all instances run vX.Y.Z"). DO NOT TRIGGER for a single-host upgrade (`katulong update` alone is enough), for staging instances (use `katulong-stage`), or for non-katulong projects.
+---
+
+# katulong-mesh-update — rolling update across a katulong mesh
+
+`bin/katulong-mesh-update` walks a user-defined list of peer katulong hosts in order, runs `katulong update` on each via ssh, and verifies the post-update HTTP probe before moving to the next. The peer whose id matches `~/.katulong/node-id` is excluded — every host is responsible for upgrading its peers, never itself. That asymmetry is the safety net: if the new release wedges a host, the orchestrator (this host) is still on the prior version and can roll back.
+
+## When to reach for this skill
+
+Use it when the user says (in spirit, not exact words):
+
+- "roll the new release out to all my katulongs"
+- "update all the katulong instances"
+- "upgrade the mesh"
+- "make every host run the latest"
+- "what's the version status across my katulong fleet?" (use `list`)
+
+Do NOT use it for:
+
+- A single-host upgrade — bare `katulong update` is the right tool.
+- Staging instances — use the `katulong-stage` skill.
+- Pushing local in-development code to peers. This skill calls `katulong update`, which goes through the normal Homebrew tap → smoke test → swap path. If you want to test an unreleased branch on another device, stage it first.
+
+## Subcommands
+
+`bin/katulong-mesh-update [roll]` — run the rolling update (default).
+
+`bin/katulong-mesh-update list` — show the configured peers, mark which one is "self" (excluded from rollout).
+
+`bin/katulong-mesh-update --dry-run` — print the plan without ssh-ing. Use this whenever the user is uncertain about the mesh contents or you're preparing to roll a brand-new release for the first time.
+
+## Why "never update self"
+
+A katulong update has a few moving parts: brew formula sync, npm install on the upgraded prefix, smoke-test on a free port, LaunchAgent restart. Each step has plausible failure modes (network flake, brew lock, port held by zombie process). When all hosts update simultaneously and one wedges, you can't ssh in to investigate because the host you'd ssh FROM is also part of the broken set.
+
+The mesh-update rule sidesteps that:
+
+- Run `bin/katulong-mesh-update` from machine A → machines B, C, D upgrade.
+- Run it from machine B → machines A, C, D upgrade.
+- A bad release that hangs a host on upgrade leaves at least one peer untouched, with shell access to fix the others.
+
+If the user asks "but how do I upgrade THIS host?" — the answer is "ssh to a peer and run `katulong-mesh-update` from there." Don't add a `--include-self` flag; the asymmetry IS the feature.
+
+## Reporting the rollout
+
+When you run `bin/katulong-mesh-update`, surface the script's output verbatim — the per-peer `before`/`after` versions and HTTP code are exactly the verification the user wants. On success, conclude with a summary table; on failure, surface the failed peer id, the version state at failure, and the "fix and re-run" hint the script prints. `katulong update` is idempotent (already-current host = `Already up to date`), so a fixed-and-retried run safely no-ops the peers that already succeeded.
+
+## Setup the user has to do once
+
+The script reads two files in `$KATULONG_DATA_DIR` (default `~/.katulong`):
+
+- `mesh.json` — the peer list, same on every host:
+  ```json
+  {
+    "peers": [
+      { "id": "host-a", "ssh": "alias-a" },
+      { "id": "host-b", "ssh": "alias-b" }
+    ]
+  }
+  ```
+- `node-id` — single line containing this host's id (one of the `peers[*].id` values).
+
+If the user is configuring this for the first time and asks for help, suggest copying `mesh.json` to every host (it's identical) and writing the right `node-id` on each. Don't generate the contents from your own knowledge — ask the user for their host inventory and ssh aliases.
+
+## Failure modes worth flagging
+
+- `mesh.json` missing → script prints a clear error pointing at `~/.katulong/mesh.json` and the expected schema. Don't try to write the file from memory; have the user create it.
+- `node-id` missing → script warns and proceeds to update every peer including this host. Almost always a misconfiguration; tell the user to create the file before re-running, unless they explicitly want every-host-including-self behavior.
+- `ssh <alias>` fails → rollout halts immediately. Could be network, a downed peer, or a stale ssh alias. Surface the alias verbatim so the user knows which mesh entry to fix.
+- `katulong update` fails on a peer → rollout halts. The remote command's stdout is already streamed, so the user has the failure context. Suggest re-running once they've fixed the underlying cause.
+- Post-update HTTP probe `!= 200` → the upgrade swap completed but the new server isn't serving. Suggest `ssh <alias> 'katulong status'` and `katulong service restart` as recovery steps.

--- a/.claude/skills/katulong-mesh-update/SKILL.md
+++ b/.claude/skills/katulong-mesh-update/SKILL.md
@@ -56,10 +56,11 @@ The script reads two files in `$KATULONG_DATA_DIR` (default `~/.katulong`):
   {
     "peers": [
       { "id": "host-a", "ssh": "alias-a" },
-      { "id": "host-b", "ssh": "alias-b" }
+      { "id": "host-b", "ssh": "alias-b", "port": 4001 }
     ]
   }
   ```
+  The optional `port` field overrides the post-update HTTP probe target (default 3001) for peers that run on a non-default `KATULONG_PORT`. The `ssh` field must be a bare alias (`[A-Za-z0-9._-]+`) — leading dashes or whitespace are rejected to block ssh option injection.
 - `node-id` — single line containing this host's id (one of the `peers[*].id` values).
 
 If the user is configuring this for the first time and asks for help, suggest copying `mesh.json` to every host (it's identical) and writing the right `node-id` on each. Don't generate the contents from your own knowledge — ask the user for their host inventory and ssh aliases.

--- a/bin/katulong-mesh-update
+++ b/bin/katulong-mesh-update
@@ -1,53 +1,64 @@
 #!/usr/bin/env bash
 #
-# katulong-mesh-update — rolling `katulong update` across mesh peers
-#
-# Usage:
-#   katulong-mesh-update [roll]    Run rolling update across all peers (default)
-#   katulong-mesh-update list      Show configured peers and which is self
-#   katulong-mesh-update --dry-run Print the planned rollout without ssh-ing
-#   katulong-mesh-update -h        Show this help
-#
-# The "self-heal" rule:
-#   The peer whose id matches ~/.katulong/node-id is EXCLUDED from the rollout.
-#   This host stays on its current version on purpose. If the new release
-#   wedges a peer, you still have one known-good machine to ssh from and roll
-#   back / debug. To upgrade THIS host, run `katulong-mesh-update` from a
-#   different peer in the mesh — every node updates the others, never itself.
-#
-# Config (~/.katulong/mesh.json — node updates ~/.katulong/node-id, single line):
-#   {
-#     "peers": [
-#       { "id": "host-a", "ssh": "alias-a" },
-#       { "id": "host-b", "ssh": "alias-b" }
-#     ]
-#   }
-#
-# Each peer is processed sequentially. On any failure (ssh error, brew/update
-# non-zero exit, post-update HTTP probe != 200) the rollout halts and the
-# remaining peers are NOT touched — the user is the one to decide whether the
-# half-rolled state is acceptable or whether to roll back. `katulong update`
-# is idempotent (already-current host = no-op), so a fixed-and-retried run
-# safely resumes from where the rollout failed.
+# katulong-mesh-update — rolling `katulong update` across mesh peers.
+# See `katulong-mesh-update -h` for usage; the canonical help text lives in
+# the usage() heredoc below so a header edit can't silently break it.
 
 set -euo pipefail
 
 USER_DATA_DIR="${KATULONG_DATA_DIR:-$HOME/.katulong}"
 MESH_FILE="$USER_DATA_DIR/mesh.json"
 NODE_ID_FILE="$USER_DATA_DIR/node-id"
+DEFAULT_PEER_PORT=3001
 
 # Brew installs to /opt/homebrew on Apple Silicon and /usr/local on Intel.
 # A non-interactive `ssh host cmd` does NOT source ~/.zshrc / ~/.bash_profile,
 # so neither prefix is on PATH by default. Setting PATH explicitly avoids
 # every-host-config-is-different breakage at the cost of one assumption: the
-# remote uses Homebrew. Anyone running katulong on macOS via brew already does.
-REMOTE_PATH_PREFIX='PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"'
+# remote uses Homebrew. Anyone running katulong on macOS via brew already does;
+# Linux / from-source installs aren't supported (override REMOTE_PATH_PREFIX in
+# the env if you need to).
+REMOTE_PATH_PREFIX="${REMOTE_PATH_PREFIX:-PATH=\"/opt/homebrew/bin:/usr/local/bin:\$PATH\"}"
 
 usage() {
-  sed -n '3,32p' "$0" | sed 's/^# \{0,1\}//'
+  cat <<'EOF'
+katulong-mesh-update — rolling `katulong update` across mesh peers
+
+Usage:
+  katulong-mesh-update [roll]    Run rolling update across all peers (default)
+  katulong-mesh-update list      Show configured peers and which is self
+  katulong-mesh-update --dry-run Print the planned rollout without ssh-ing
+  katulong-mesh-update -h        Show this help
+
+The "self-heal" rule:
+  The peer whose id matches ~/.katulong/node-id is EXCLUDED from the rollout.
+  This host stays on its current version on purpose. If the new release wedges
+  a peer, you still have one known-good machine to ssh from and roll back /
+  debug. To upgrade THIS host, run `katulong-mesh-update` from a different
+  peer in the mesh — every node updates the others, never itself.
+
+Config (~/.katulong/mesh.json — node updates ~/.katulong/node-id, single line):
+  {
+    "peers": [
+      { "id": "host-a", "ssh": "alias-a" },
+      { "id": "host-b", "ssh": "alias-b", "port": 4001 }
+    ]
+  }
+The optional "port" field overrides the post-update HTTP probe target (default
+3001). Use it for peers running on a non-default KATULONG_PORT.
+
+Each peer is processed sequentially. On any failure (ssh error, brew/update
+non-zero exit, post-update HTTP probe != 200) the rollout halts and the
+remaining peers are NOT touched — the user decides whether the half-rolled
+state is acceptable. `katulong update` is idempotent (already-current host =
+no-op), so a fixed-and-retried run safely resumes from where it failed.
+
+Assumes peers are macOS Homebrew installs. Override REMOTE_PATH_PREFIX in the
+env if you need a different remote PATH for the `katulong` binary.
+EOF
 }
 
-read_node_id() {
+resolve_node_id() {
   [[ -f "$NODE_ID_FILE" ]] || return 1
   local id
   id="$(head -n 1 "$NODE_ID_FILE" | tr -d '[:space:]')"
@@ -55,35 +66,57 @@ read_node_id() {
   printf '%s' "$id"
 }
 
-# Emit one "id<TAB>ssh_alias" line per peer, in the order they appear in
-# mesh.json. node is used (not jq) to match the rest of bin/ — every katulong
-# host has node by definition; jq is not guaranteed.
+# Emit one "id<TAB>ssh_alias<TAB>port" line per peer, in the order they appear
+# in mesh.json. node is used (not jq) to match the rest of bin/ — every
+# katulong host has node by definition; jq is not guaranteed.
+#
+# Validation in the parser: the ssh field must be a bare alias (alphanumerics
+# plus . _ -). A leading "-" or whitespace would otherwise let a crafted
+# mesh.json inject ssh options like `-oProxyCommand=...` and silently redirect
+# a peer connection. The user is the author of mesh.json, but the cost of
+# defending against the symlink-into-shared-fs threat is one regex.
 list_peers() {
   if [[ ! -f "$MESH_FILE" ]]; then
     echo "katulong-mesh-update: no mesh configured at $MESH_FILE" >&2
     echo "  create it with the shape documented in 'katulong-mesh-update -h'." >&2
     return 1
   fi
-  KATULONG_MESH_PATH="$MESH_FILE" node -e "
+  KATULONG_MESH_PATH="$MESH_FILE" \
+  KATULONG_DEFAULT_PEER_PORT="$DEFAULT_PEER_PORT" \
+  node -e "
     const fs = require('fs');
+    const ALIAS_RE = /^[A-Za-z0-9._-]+$/;
     try {
       const m = JSON.parse(fs.readFileSync(process.env.KATULONG_MESH_PATH, 'utf8'));
       if (!Array.isArray(m.peers) || m.peers.length === 0) {
         process.stderr.write('mesh.json: missing or empty peers array\n');
         process.exit(1);
       }
+      const defaultPort = parseInt(process.env.KATULONG_DEFAULT_PEER_PORT, 10);
       const seen = new Set();
       for (const p of m.peers) {
         if (typeof p?.id !== 'string' || typeof p?.ssh !== 'string') {
           process.stderr.write('mesh.json: each peer needs string \"id\" and \"ssh\" fields\n');
           process.exit(1);
         }
+        if (!ALIAS_RE.test(p.ssh)) {
+          process.stderr.write('mesh.json: ssh alias ' + JSON.stringify(p.ssh) + ' must be alphanumeric (plus . _ -); leading dashes or whitespace are rejected to block ssh option injection\n');
+          process.exit(1);
+        }
         if (seen.has(p.id)) {
           process.stderr.write('mesh.json: duplicate peer id ' + JSON.stringify(p.id) + '\n');
           process.exit(1);
         }
+        let port = defaultPort;
+        if (p.port !== undefined) {
+          if (!Number.isInteger(p.port) || p.port < 1 || p.port > 65535) {
+            process.stderr.write('mesh.json: peer ' + JSON.stringify(p.id) + ' has invalid port (must be integer 1..65535)\n');
+            process.exit(1);
+          }
+          port = p.port;
+        }
         seen.add(p.id);
-        process.stdout.write(p.id + '\t' + p.ssh + '\n');
+        process.stdout.write(p.id + '\t' + p.ssh + '\t' + port + '\n');
       }
     } catch (e) {
       process.stderr.write('mesh.json: ' + e.message + '\n');
@@ -94,7 +127,7 @@ list_peers() {
 
 cmd_list() {
   local self_id peers
-  self_id="$(read_node_id || true)"
+  self_id="$(resolve_node_id || true)"
   # Resolve peers BEFORE printing the table header so a missing/invalid
   # mesh.json reports the schema error cleanly with a non-zero exit, instead
   # of leaving an orphan "ID / SSH ALIAS" banner above the error message.
@@ -107,13 +140,13 @@ cmd_list() {
     echo "node-id: (not set; create $NODE_ID_FILE)"
   fi
   echo
-  printf "  %-12s %-32s %s\n" "ID" "SSH ALIAS" ""
-  printf "  %-12s %-32s\n" "------------" "--------------------------------"
-  while IFS=$'\t' read -r id alias; do
+  printf "  %-12s %-32s %-6s %s\n" "ID" "SSH ALIAS" "PORT" ""
+  printf "  %-12s %-32s %-6s\n" "------------" "--------------------------------" "------"
+  while IFS=$'\t' read -r id alias port; do
     if [[ "$id" == "$self_id" ]]; then
-      printf "  %-12s %-32s [self — excluded from roll]\n" "$id" "$alias"
+      printf "  %-12s %-32s %-6s [self — excluded from roll]\n" "$id" "$alias" "$port"
     else
-      printf "  %-12s %-32s\n" "$id" "$alias"
+      printf "  %-12s %-32s %-6s\n" "$id" "$alias" "$port"
     fi
   done <<< "$peers"
 }
@@ -121,7 +154,7 @@ cmd_list() {
 cmd_roll() {
   local dry_run="${1:-no}"
   local self_id
-  self_id="$(read_node_id || true)"
+  self_id="$(resolve_node_id || true)"
   if [[ -z "$self_id" ]]; then
     echo "katulong-mesh-update: warning — $NODE_ID_FILE not set." >&2
     echo "  No peer will be excluded as 'self'. If you intend to update every" >&2
@@ -130,20 +163,22 @@ cmd_roll() {
     echo >&2
   fi
 
-  # Materialize the list once. The roll loop and the final "remaining" count
-  # both read it; re-running list_peers in a `< <(...)` would ssh nothing but
-  # would run the parser twice for no reason. The `local peers; peers=$(...)`
-  # split is deliberate — `local var=$(cmd)` masks the substitution's exit
-  # status under set -e, and we want a malformed mesh.json to halt here.
+  # Materialize the list once. The `local peers; peers=$(...)` split is
+  # deliberate — `local var=$(cmd)` masks the substitution's exit status under
+  # set -e, and we want a malformed mesh.json to halt here.
   local peers
   peers="$(list_peers)" || return 1
 
+  # `printf '%s' ...` (no trailing \n) avoids the off-by-one that
+  # `printf '%s\n' "$peers" | grep -c '^'` would introduce: list_peers already
+  # emits a \n per peer, so the extra format-string \n adds a phantom blank
+  # line that grep dutifully counts.
   local total
-  total=$(printf '%s\n' "$peers" | grep -c '^' || true)
+  total=$(printf '%s' "$peers" | grep -c '^' || true)
 
   local processed=0 updated=0 skipped=0 failed_id=""
 
-  while IFS=$'\t' read -r id alias; do
+  while IFS=$'\t' read -r id alias port; do
     processed=$((processed + 1))
     if [[ "$id" == "$self_id" ]]; then
       echo "[$processed/$total] $id ($alias): self — skipping"
@@ -152,13 +187,16 @@ cmd_roll() {
     fi
 
     if [[ "$dry_run" == "yes" ]]; then
-      echo "[$processed/$total] $id ($alias): would run 'katulong update' over ssh"
+      echo "[$processed/$total] $id ($alias:$port): would run 'katulong update' over ssh"
       continue
     fi
 
-    echo "[$processed/$total] $id ($alias): rolling update"
+    echo "[$processed/$total] $id ($alias:$port): rolling update"
     local pre_version
-    pre_version="$(ssh "$alias" "$REMOTE_PATH_PREFIX katulong --version" 2>/dev/null || true)"
+    # `--` ends ssh's option processing so a future mesh.json that somehow
+    # smuggled a leading-dash alias through validation still can't inject
+    # ssh options. Belt and suspenders against the parser regex above.
+    pre_version="$(ssh -- "$alias" "$REMOTE_PATH_PREFIX katulong --version" 2>/dev/null || true)"
     echo "    before: ${pre_version:-(unknown — host unreachable or katulong missing)}"
 
     if [[ -z "$pre_version" ]]; then
@@ -167,19 +205,19 @@ cmd_roll() {
       break
     fi
 
-    if ! ssh "$alias" "$REMOTE_PATH_PREFIX katulong update"; then
-      echo "    ✗ update FAILED on $id ($alias) — rollout halted" >&2
+    if ! ssh -- "$alias" "$REMOTE_PATH_PREFIX katulong update"; then
+      echo "    ✗ update failed on $id ($alias) — rollout halted" >&2
       failed_id="$id"
       break
     fi
 
     local post_version http_code
-    post_version="$(ssh "$alias" "$REMOTE_PATH_PREFIX katulong --version" 2>/dev/null || true)"
-    http_code="$(ssh "$alias" "$REMOTE_PATH_PREFIX"' curl -s -o /dev/null -w "%{http_code}" http://localhost:3001/' 2>/dev/null || true)"
+    post_version="$(ssh -- "$alias" "$REMOTE_PATH_PREFIX katulong --version" 2>/dev/null || true)"
+    http_code="$(ssh -- "$alias" "$REMOTE_PATH_PREFIX curl -s -o /dev/null -w \"%{http_code}\" http://localhost:$port/" 2>/dev/null || true)"
     echo "    after:  ${post_version:-(unknown)}  (HTTP ${http_code:-000})"
 
     if [[ "${http_code:-}" != "200" ]]; then
-      echo "    ✗ post-update HTTP check failed on $id (got ${http_code:-no response}, want 200)" >&2
+      echo "    ✗ post-update HTTP check failed on $id (got ${http_code:-no response}, want 200 on :$port)" >&2
       failed_id="$id"
       break
     fi
@@ -189,7 +227,7 @@ cmd_roll() {
   echo
   if [[ -n "$failed_id" ]]; then
     local remaining=$((total - processed))
-    echo "ROLLOUT HALTED at $failed_id."
+    echo "rollout halted at $failed_id."
     echo "  updated: $updated   skipped (self): $skipped   not attempted: $remaining"
     echo "  fix $failed_id and re-run — already-updated peers will no-op."
     return 1
@@ -205,9 +243,9 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run) DRY_RUN="yes" ;;
     -h|--help) usage; exit 0 ;;
-    list|peers) SUBCMD="list" ;;
-    roll) SUBCMD="roll" ;;
-    *) echo "unknown argument: $1" >&2; echo >&2; usage >&2; exit 2 ;;
+    list)      SUBCMD="list" ;;
+    roll)      SUBCMD="roll" ;;
+    *) echo "Unknown argument: $1" >&2; echo >&2; usage >&2; exit 2 ;;
   esac
   shift
 done

--- a/bin/katulong-mesh-update
+++ b/bin/katulong-mesh-update
@@ -140,7 +140,7 @@ cmd_list() {
     echo "node-id: (not set; create $NODE_ID_FILE)"
   fi
   echo
-  printf "  %-12s %-32s %-6s %s\n" "ID" "SSH ALIAS" "PORT" ""
+  printf "  %-12s %-32s %-6s\n" "ID" "SSH ALIAS" "PORT"
   printf "  %-12s %-32s %-6s\n" "------------" "--------------------------------" "------"
   while IFS=$'\t' read -r id alias port; do
     if [[ "$id" == "$self_id" ]]; then

--- a/bin/katulong-mesh-update
+++ b/bin/katulong-mesh-update
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+#
+# katulong-mesh-update — rolling `katulong update` across mesh peers
+#
+# Usage:
+#   katulong-mesh-update [roll]    Run rolling update across all peers (default)
+#   katulong-mesh-update list      Show configured peers and which is self
+#   katulong-mesh-update --dry-run Print the planned rollout without ssh-ing
+#   katulong-mesh-update -h        Show this help
+#
+# The "self-heal" rule:
+#   The peer whose id matches ~/.katulong/node-id is EXCLUDED from the rollout.
+#   This host stays on its current version on purpose. If the new release
+#   wedges a peer, you still have one known-good machine to ssh from and roll
+#   back / debug. To upgrade THIS host, run `katulong-mesh-update` from a
+#   different peer in the mesh — every node updates the others, never itself.
+#
+# Config (~/.katulong/mesh.json — node updates ~/.katulong/node-id, single line):
+#   {
+#     "peers": [
+#       { "id": "host-a", "ssh": "alias-a" },
+#       { "id": "host-b", "ssh": "alias-b" }
+#     ]
+#   }
+#
+# Each peer is processed sequentially. On any failure (ssh error, brew/update
+# non-zero exit, post-update HTTP probe != 200) the rollout halts and the
+# remaining peers are NOT touched — the user is the one to decide whether the
+# half-rolled state is acceptable or whether to roll back. `katulong update`
+# is idempotent (already-current host = no-op), so a fixed-and-retried run
+# safely resumes from where the rollout failed.
+
+set -euo pipefail
+
+USER_DATA_DIR="${KATULONG_DATA_DIR:-$HOME/.katulong}"
+MESH_FILE="$USER_DATA_DIR/mesh.json"
+NODE_ID_FILE="$USER_DATA_DIR/node-id"
+
+# Brew installs to /opt/homebrew on Apple Silicon and /usr/local on Intel.
+# A non-interactive `ssh host cmd` does NOT source ~/.zshrc / ~/.bash_profile,
+# so neither prefix is on PATH by default. Setting PATH explicitly avoids
+# every-host-config-is-different breakage at the cost of one assumption: the
+# remote uses Homebrew. Anyone running katulong on macOS via brew already does.
+REMOTE_PATH_PREFIX='PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"'
+
+usage() {
+  sed -n '3,32p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+read_node_id() {
+  [[ -f "$NODE_ID_FILE" ]] || return 1
+  local id
+  id="$(head -n 1 "$NODE_ID_FILE" | tr -d '[:space:]')"
+  [[ -n "$id" ]] || return 1
+  printf '%s' "$id"
+}
+
+# Emit one "id<TAB>ssh_alias" line per peer, in the order they appear in
+# mesh.json. node is used (not jq) to match the rest of bin/ — every katulong
+# host has node by definition; jq is not guaranteed.
+list_peers() {
+  if [[ ! -f "$MESH_FILE" ]]; then
+    echo "katulong-mesh-update: no mesh configured at $MESH_FILE" >&2
+    echo "  create it with the shape documented in 'katulong-mesh-update -h'." >&2
+    return 1
+  fi
+  KATULONG_MESH_PATH="$MESH_FILE" node -e "
+    const fs = require('fs');
+    try {
+      const m = JSON.parse(fs.readFileSync(process.env.KATULONG_MESH_PATH, 'utf8'));
+      if (!Array.isArray(m.peers) || m.peers.length === 0) {
+        process.stderr.write('mesh.json: missing or empty peers array\n');
+        process.exit(1);
+      }
+      const seen = new Set();
+      for (const p of m.peers) {
+        if (typeof p?.id !== 'string' || typeof p?.ssh !== 'string') {
+          process.stderr.write('mesh.json: each peer needs string \"id\" and \"ssh\" fields\n');
+          process.exit(1);
+        }
+        if (seen.has(p.id)) {
+          process.stderr.write('mesh.json: duplicate peer id ' + JSON.stringify(p.id) + '\n');
+          process.exit(1);
+        }
+        seen.add(p.id);
+        process.stdout.write(p.id + '\t' + p.ssh + '\n');
+      }
+    } catch (e) {
+      process.stderr.write('mesh.json: ' + e.message + '\n');
+      process.exit(1);
+    }
+  "
+}
+
+cmd_list() {
+  local self_id peers
+  self_id="$(read_node_id || true)"
+  # Resolve peers BEFORE printing the table header so a missing/invalid
+  # mesh.json reports the schema error cleanly with a non-zero exit, instead
+  # of leaving an orphan "ID / SSH ALIAS" banner above the error message.
+  peers="$(list_peers)" || return 1
+
+  echo "mesh:    $MESH_FILE"
+  if [[ -n "$self_id" ]]; then
+    echo "node-id: $self_id  ($NODE_ID_FILE)"
+  else
+    echo "node-id: (not set; create $NODE_ID_FILE)"
+  fi
+  echo
+  printf "  %-12s %-32s %s\n" "ID" "SSH ALIAS" ""
+  printf "  %-12s %-32s\n" "------------" "--------------------------------"
+  while IFS=$'\t' read -r id alias; do
+    if [[ "$id" == "$self_id" ]]; then
+      printf "  %-12s %-32s [self — excluded from roll]\n" "$id" "$alias"
+    else
+      printf "  %-12s %-32s\n" "$id" "$alias"
+    fi
+  done <<< "$peers"
+}
+
+cmd_roll() {
+  local dry_run="${1:-no}"
+  local self_id
+  self_id="$(read_node_id || true)"
+  if [[ -z "$self_id" ]]; then
+    echo "katulong-mesh-update: warning — $NODE_ID_FILE not set." >&2
+    echo "  No peer will be excluded as 'self'. If you intend to update every" >&2
+    echo "  host including this one, that's fine; otherwise create the file" >&2
+    echo "  with this host's id and re-run." >&2
+    echo >&2
+  fi
+
+  # Materialize the list once. The roll loop and the final "remaining" count
+  # both read it; re-running list_peers in a `< <(...)` would ssh nothing but
+  # would run the parser twice for no reason. The `local peers; peers=$(...)`
+  # split is deliberate — `local var=$(cmd)` masks the substitution's exit
+  # status under set -e, and we want a malformed mesh.json to halt here.
+  local peers
+  peers="$(list_peers)" || return 1
+
+  local total
+  total=$(printf '%s\n' "$peers" | grep -c '^' || true)
+
+  local processed=0 updated=0 skipped=0 failed_id=""
+
+  while IFS=$'\t' read -r id alias; do
+    processed=$((processed + 1))
+    if [[ "$id" == "$self_id" ]]; then
+      echo "[$processed/$total] $id ($alias): self — skipping"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    if [[ "$dry_run" == "yes" ]]; then
+      echo "[$processed/$total] $id ($alias): would run 'katulong update' over ssh"
+      continue
+    fi
+
+    echo "[$processed/$total] $id ($alias): rolling update"
+    local pre_version
+    pre_version="$(ssh "$alias" "$REMOTE_PATH_PREFIX katulong --version" 2>/dev/null || true)"
+    echo "    before: ${pre_version:-(unknown — host unreachable or katulong missing)}"
+
+    if [[ -z "$pre_version" ]]; then
+      echo "    ✗ pre-flight failed: cannot reach $alias or katulong not installed" >&2
+      failed_id="$id"
+      break
+    fi
+
+    if ! ssh "$alias" "$REMOTE_PATH_PREFIX katulong update"; then
+      echo "    ✗ update FAILED on $id ($alias) — rollout halted" >&2
+      failed_id="$id"
+      break
+    fi
+
+    local post_version http_code
+    post_version="$(ssh "$alias" "$REMOTE_PATH_PREFIX katulong --version" 2>/dev/null || true)"
+    http_code="$(ssh "$alias" "$REMOTE_PATH_PREFIX"' curl -s -o /dev/null -w "%{http_code}" http://localhost:3001/' 2>/dev/null || true)"
+    echo "    after:  ${post_version:-(unknown)}  (HTTP ${http_code:-000})"
+
+    if [[ "${http_code:-}" != "200" ]]; then
+      echo "    ✗ post-update HTTP check failed on $id (got ${http_code:-no response}, want 200)" >&2
+      failed_id="$id"
+      break
+    fi
+    updated=$((updated + 1))
+  done <<< "$peers"
+
+  echo
+  if [[ -n "$failed_id" ]]; then
+    local remaining=$((total - processed))
+    echo "ROLLOUT HALTED at $failed_id."
+    echo "  updated: $updated   skipped (self): $skipped   not attempted: $remaining"
+    echo "  fix $failed_id and re-run — already-updated peers will no-op."
+    return 1
+  fi
+  echo "rollout complete."
+  echo "  updated: $updated   skipped (self): $skipped   total: $total"
+}
+
+# ── Arg parsing ──────────────────────────────────────────────────────
+DRY_RUN="no"
+SUBCMD="roll"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN="yes" ;;
+    -h|--help) usage; exit 0 ;;
+    list|peers) SUBCMD="list" ;;
+    roll) SUBCMD="roll" ;;
+    *) echo "unknown argument: $1" >&2; echo >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+case "$SUBCMD" in
+  list) cmd_list ;;
+  roll) cmd_roll "$DRY_RUN" ;;
+esac


### PR DESCRIPTION
## Summary

Add `bin/katulong-mesh-update` plus the matching `/mesh-update` slash command and Claude-facing skill, so a single command upgrades every katulong host except the one running it.

The "skip self" rule is the safety net: if a release wedges a host on upgrade, the orchestrator stays on the prior version and can ssh in to roll back. To upgrade the orchestrator, you run `mesh-update` from a different peer.

## In the repo (generic)

- `bin/katulong-mesh-update` — bash script with three subcommands:
  - `roll` (default) — sequential ssh + `katulong update` per peer, with pre/post version capture and a HTTP 200 probe on :3001 after each upgrade. Halts on any failure (ssh, brew, smoke test, HTTP probe). `katulong update` is idempotent, so a fixed-and-retried run safely no-ops the peers that already succeeded.
  - `list` — show configured peers and mark which is "self".
  - `--dry-run` — print the plan without ssh-ing.
- `.claude/skills/katulong-mesh-update/SKILL.md`
- `.claude/commands/mesh-update.md`

## Per-host (NOT in repo, lives in `~/.katulong/`)

```json
// mesh.json — identical on every host
{
  "peers": [
    { "id": "host-a", "ssh": "alias-a" },
    { "id": "host-b", "ssh": "alias-b" }
  ]
}
```

```
node-id  — single line, this host's id
```

## Implementation notes

- JSON parsing uses inline `node`, matching `bin/katulong-stage`. Every katulong host has node by definition; jq is not guaranteed.
- `local var=$(cmd)` masks the substitution's exit status under `set -e`; the script splits the declaration from the assignment with explicit `|| return 1` so a malformed mesh.json halts cleanly instead of "missing fields" stderr followed by an empty-but-exit-0 rollout.
- Remote PATH is set explicitly (`/opt/homebrew/bin:/usr/local/bin:$PATH`) rather than relying on a login shell sourcing zshrc/bash_profile, since `ssh host cmd` runs non-interactively and the brew prefix differs across user macs (Intel vs Apple Silicon).
- The post-update HTTP probe hits `:3001` (production katulong default). Non-default-port deployments aren't supported; will cross that bridge if anyone hits it.
- The Homebrew formula isn't updated to symlink `katulong-mesh-update` into the brew bin dir — mirrors `katulong-stage`. Both are repo-scoped helpers, not user-facing CLI.

## Test plan

- [x] `list` with valid mesh.json + node-id → marks self correctly.
- [x] `--dry-run` with valid mesh → prints plan, no ssh, exits 0.
- [x] missing mesh.json → exits 1, no orphan table headers.
- [x] malformed mesh.json (missing `ssh` field) → schema error, exits 1.
- [x] missing node-id → warns, proceeds to update every peer (intentional fallback).
- [x] unknown arg → exits 2 with help.
- [ ] Reviewer: smoke-test the actual rollout against your own mesh — `bin/katulong-mesh-update --dry-run` first, then `bin/katulong-mesh-update` after writing `~/.katulong/mesh.json` and `~/.katulong/node-id`.