### PR TITLE
fix(tile-status-bar): keep pills sticky across server restarts

### DIFF
--- a/public/lib/tiles/terminal-status-bar.js
+++ b/public/lib/tiles/terminal-status-bar.js
@@ -124,23 +124,35 @@ export function createTerminalStatusBar() {
      * mirrors the server's /status payload, which includes `pane` and
      * (when an agent is detected) `agent`.
      *
-     * Sticky semantics: only overwrite `pane`/`agent` when the server returns
-     * a truthy value. The status route emits `pane: meta.pane || null`, and
-     * `meta.pane` is only populated by the 5s server-side monitor tick (see
-     * lib/session-child-counter.js). After a server restart — notably the
-     * binary swap inside `katulong update` — meta.pane is unset for every
-     * session until the first post-restart tick lands, so every poll in
-     * that window returns `pane: null`. The previous "always assign" shape
-     * let that null clobber the last-known state, hiding the entire pill
-     * bar for ~5–10s after every release. The server only ever MERGES into
-     * meta.pane (never clears it back to null), so treating a null payload
-     * as "no update" is consistent with how the server actually mutates
-     * the data and removes the cold-start flicker.
+     * `pane` is sticky, `agent` is not — they have different server-side
+     * lifecycles and the client must mirror them.
+     *
+     * pane (sticky): the route emits `pane: meta.pane || null`, and the
+     * server-side reconcilers (reconcilePaneCwd / reconcilePaneGit in
+     * lib/session-child-counter.js) only ever MERGE into meta.pane via
+     * spread — nothing in the codebase sets it back to null after
+     * population. So a null payload always means "monitor hasn't ticked
+     * yet" (notably immediately after the binary swap inside `katulong
+     * update`), not "this session genuinely has no pane." Skipping the
+     * null assignment preserves the last-known cwd/branch through the
+     * cold-start window and removes the ~5–10s pill-bar flicker on every
+     * release.
+     *
+     * agent (NOT sticky): reconcileAgentPresence explicitly calls
+     * setMeta("agent", null) when the foreground command is no longer a
+     * recognized agent (Claude exited, etc.). That null is a real "agent
+     * gone" signal — skipping it would leave the robot pill stuck on
+     * indefinitely after the agent quits. The `!== undefined` guard
+     * accepts null (the explicit clear) while keeping forward-compat for
+     * a server that omits the key entirely.
+     *
+     * `!= null` on pane catches both null and undefined, matching the
+     * forward-compat intent for the omitted-key case there too.
      */
     updateFromStatus(status) {
       if (!status) return;
-      if (status.pane) state.pane = status.pane;
-      if (status.agent) state.agent = status.agent;
+      if (status.pane != null) state.pane = status.pane;
+      if (status.agent !== undefined) state.agent = status.agent;
       render();
     },
 

--- a/public/lib/tiles/terminal-status-bar.js
+++ b/public/lib/tiles/terminal-status-bar.js
@@ -121,13 +121,26 @@ export function createTerminalStatusBar() {
 
     /**
      * Accept a status event from SessionStatusWatcher. The `status` field
-     * mirrors the server's /status payload, which now includes `pane` and
-     * (when an agent is detected) `meta.agent`.
+     * mirrors the server's /status payload, which includes `pane` and
+     * (when an agent is detected) `agent`.
+     *
+     * Sticky semantics: only overwrite `pane`/`agent` when the server returns
+     * a truthy value. The status route emits `pane: meta.pane || null`, and
+     * `meta.pane` is only populated by the 5s server-side monitor tick (see
+     * lib/session-child-counter.js). After a server restart — notably the
+     * binary swap inside `katulong update` — meta.pane is unset for every
+     * session until the first post-restart tick lands, so every poll in
+     * that window returns `pane: null`. The previous "always assign" shape
+     * let that null clobber the last-known state, hiding the entire pill
+     * bar for ~5–10s after every release. The server only ever MERGES into
+     * meta.pane (never clears it back to null), so treating a null payload
+     * as "no update" is consistent with how the server actually mutates
+     * the data and removes the cold-start flicker.
      */
     updateFromStatus(status) {
       if (!status) return;
-      if (status.pane !== undefined) state.pane = status.pane;
-      if (status.agent !== undefined) state.agent = status.agent;
+      if (status.pane) state.pane = status.pane;
+      if (status.agent) state.agent = status.agent;
       render();
     },
 


### PR DESCRIPTION
## Summary

The bottom status pill bar on terminal tiles (folder / branch / worktree / agent chips) would disappear for ~5–10 seconds after every `katulong update` release. Reproducible every upgrade.

## Root cause

`terminal-status-bar.js#updateFromStatus` blindly assigned `state.pane = status.pane` whenever the field was `!== undefined`. The server's status route emits `pane: meta.pane || null`, and `meta.pane` is only populated by the 5s server-side monitor (`lib/session-child-counter.js`). After the binary swap inside `katulong update`, the new server boots with `meta.pane` unset for every session — so the very next poll returns `pane: null`, the client clobbers the previously-populated state back to null, and the bar's render sees zero pills and goes `display: none`. The bar comes back on the next successful tick, but the gap is what the user sees.

## Fix

Make the assignment sticky — only overwrite `state.pane` / `state.agent` when the server returns a truthy value. The server only ever MERGES into `meta.pane` (`reconcilePaneCwd` / `reconcilePaneGit` use spread to combine fields and never set the namespace back to null), so treating a null payload as "no update" matches how the data actually mutates server-side.

## Trade-off

If a future code path explicitly cleared `meta.pane = null` to mean "this session genuinely has no pane info," the bar wouldn't reflect that. There's no such path today, and the natural way to signal a dead session is `alive: false` (which the watcher exposes separately via the `exited` transition).

## Test plan

- [x] `npm test` passes (2702/2702, 3 pre-existing skips).
- [ ] Reviewer: stage this branch, observe the chip bar persists across a `katulong update` cycle on the staged instance.