### PR TITLE
fix(test): stop unit tests from clobbering ~/.katulong

### DIFF
--- a/lib/drift-log.js
+++ b/lib/drift-log.js
@@ -19,7 +19,8 @@
  *                          bin/debug-drift.sh invocations and prior
  *                          documentation still work.
  *
- * Log location: ~/.katulong/drift.log (one JSON object per line).
+ * Log location: <KATULONG_DATA_DIR>/drift.log (one JSON object per line),
+ * defaulting to ~/.katulong/drift.log when no override is set.
  *
  * Event types emitted
  *   level 1:
@@ -41,7 +42,7 @@
  * Design notes
  * - Writes are fire-and-forget: failures never throw into the hot path.
  * - The stream is opened lazily on first log so a disabled logger does
- *   not create ~/.katulong at startup.
+ *   not create the data dir at startup.
  * - `driftLogLevel()` is a cheap getter callers can use to avoid
  *   building an expensive log payload (hex dumps, rolling-buffer
  *   stringification) when the level is below the threshold.
@@ -49,9 +50,9 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import envConfig from "./env-config.js";
 
-const LOG_PATH = path.join(os.homedir(), ".katulong", "drift.log");
+const LOG_PATH = path.join(envConfig.dataDir, "drift.log");
 
 function parseLevel() {
   const raw = process.env.KATULONG_DRIFT_LOG;

--- a/lib/env-filter.js
+++ b/lib/env-filter.js
@@ -15,6 +15,15 @@ export const SENSITIVE_ENV_VARS = new Set([
   // Trusted-proxy shared secret — anyone holding this can bypass auth
   // (server.js isTrustedProxy). Treat as a root credential.
   "KATULONG_TRUST_PROXY_SECRET",
+  // Server-internal pointers that must NOT leak into PTY shells. If a
+  // user runs `npm test` or any test runner from inside a katulong
+  // tile, an inherited value here would aim the test harness's
+  // setup-env.js straight at the live data dir / live tmux server.
+  // Stripping at the PTY boundary makes the inheritance impossible.
+  // setup-env.js also unconditionally overrides these as a second
+  // line of defense — both protections must remain in place.
+  "KATULONG_DATA_DIR",
+  "KATULONG_TMUX_SOCKET",
   // Outbound bridge token (when configured via env rather than the
   // settings UI). Prevents `env` / `printenv` inside a session from
   // surfacing the credential to shared LLM bridges.

--- a/test/data-dir-isolation.test.js
+++ b/test/data-dir-isolation.test.js
@@ -1,0 +1,80 @@
+/**
+ * Tripwire: tests must NEVER run against the developer's real ~/.katulong/.
+ *
+ * Background — see commit history.
+ * The daemon (LaunchAgent in lib/cli/commands/service.js, plus
+ * `katulong-stage`) exports `KATULONG_DATA_DIR=<live dir>` into every
+ * shell it spawns. Before this tripwire existed, running
+ * `npm run test:unit` from a katulong tile silently wrote test
+ * fixtures (id: "cred1", publicKey: "key1", user "user123" …) into
+ * the live auth state, deleted the real WebAuthn credentials, and
+ * booted every authenticated remote device.
+ *
+ * Two protections were added:
+ *   1. lib/env-filter.js strips KATULONG_DATA_DIR / _TMUX_SOCKET from
+ *      the env handed to PTY shells.
+ *   2. test/helpers/setup-env.js unconditionally overrides
+ *      KATULONG_DATA_DIR with a private mkdtemp() before any test
+ *      module loads.
+ *
+ * This file is the third line: a test that fails loud and red the
+ * moment either guard regresses, instead of silently corrupting state.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import envConfig from "../lib/env-config.js";
+
+describe("data dir isolation tripwire", () => {
+  it("KATULONG_DATA_DIR is set to a private temp dir", () => {
+    const value = process.env.KATULONG_DATA_DIR;
+    assert.ok(
+      value,
+      "KATULONG_DATA_DIR must be set by test/helpers/setup-env.js",
+    );
+    assert.notEqual(
+      value,
+      join(homedir(), ".katulong"),
+      "KATULONG_DATA_DIR must NOT point at the developer's real ~/.katulong",
+    );
+    assert.ok(
+      value.startsWith(tmpdir()),
+      `KATULONG_DATA_DIR must live under os.tmpdir() (got: ${value})`,
+    );
+  });
+
+  it("envConfig.dataDir resolved against the test override, not the home dir", () => {
+    assert.notEqual(
+      envConfig.dataDir,
+      join(homedir(), ".katulong"),
+      "envConfig.dataDir must NOT resolve to ~/.katulong during tests — " +
+        "if it does, KATULONG_DATA_DIR was unset at env-config import time " +
+        "(check that --import setup-env.js is on the test command line)",
+    );
+    assert.equal(
+      envConfig.dataDir,
+      process.env.KATULONG_DATA_DIR,
+      "envConfig.dataDir should mirror the env override exactly",
+    );
+  });
+
+  it("KATULONG_TMUX_SOCKET points at a per-PID test socket, not 'katulong'", () => {
+    const value = process.env.KATULONG_TMUX_SOCKET;
+    assert.ok(
+      value,
+      "KATULONG_TMUX_SOCKET must be set by test/helpers/setup-env.js",
+    );
+    assert.notEqual(
+      value,
+      "katulong",
+      "KATULONG_TMUX_SOCKET must not match the daemon's production socket name",
+    );
+    assert.match(
+      value,
+      /^katulong-test-\d+$/,
+      `KATULONG_TMUX_SOCKET should look like katulong-test-<pid> (got: ${value})`,
+    );
+  });
+});

--- a/test/env-filter.test.js
+++ b/test/env-filter.test.js
@@ -16,6 +16,15 @@ describe("SENSITIVE_ENV_VARS", () => {
     assert.ok(SENSITIVE_ENV_VARS.has("TMUX_PANE"));
     assert.ok(SENSITIVE_ENV_VARS.has("TMUX_TMPDIR"));
   });
+
+  // The daemon exports KATULONG_DATA_DIR and KATULONG_TMUX_SOCKET so its
+  // own subprocesses know where to read/write. If a PTY shell inherited
+  // those, running `npm test` from a katulong tile would point the test
+  // harness at the live data dir and live tmux server.
+  it("contains KATULONG_DATA_DIR and KATULONG_TMUX_SOCKET", () => {
+    assert.ok(SENSITIVE_ENV_VARS.has("KATULONG_DATA_DIR"));
+    assert.ok(SENSITIVE_ENV_VARS.has("KATULONG_TMUX_SOCKET"));
+  });
 });
 
 describe("getSafeEnv", () => {
@@ -105,5 +114,15 @@ describe("getSafeEnv", () => {
   it("filters TMUX_TMPDIR from the returned environment", () => {
     process.env.TMUX_TMPDIR = "/private/tmp";
     assert.ok(!("TMUX_TMPDIR" in getSafeEnv()));
+  });
+
+  it("filters KATULONG_DATA_DIR from the returned environment", () => {
+    process.env.KATULONG_DATA_DIR = "/Users/felixflores/.katulong";
+    assert.ok(!("KATULONG_DATA_DIR" in getSafeEnv()));
+  });
+
+  it("filters KATULONG_TMUX_SOCKET from the returned environment", () => {
+    process.env.KATULONG_TMUX_SOCKET = "katulong";
+    assert.ok(!("KATULONG_TMUX_SOCKET" in getSafeEnv()));
   });
 });

--- a/test/helpers/setup-env.js
+++ b/test/helpers/setup-env.js
@@ -9,9 +9,20 @@
  *
  * Two isolations are set up here:
  *
- * 1. **KATULONG_DATA_DIR** — each test process gets its own temp data dir
- *    so parallel auth tests don't stomp on each other's ~/.katulong/
- *    (which may be owned by root in CI/containers).
+ * 1. **KATULONG_DATA_DIR** — each test process gets its own temp data
+ *    dir so parallel auth tests don't stomp on each other's
+ *    ~/.katulong/ (which may be owned by root in CI/containers).
+ *
+ *    The override is unconditional and **must stay that way**. The
+ *    daemon (LaunchAgent in lib/cli/commands/service.js, and any
+ *    `katulong-stage` invocation) exports `KATULONG_DATA_DIR=<live dir>`
+ *    into the env of every shell it spawns. If we honored that
+ *    inherited value, running `npm run test:unit` from inside any
+ *    katulong tile would silently overwrite the developer's real
+ *    auth state with test fixtures — and has, see commit history.
+ *    `lib/env-filter.js` strips these vars from PTY shells as a
+ *    second line of defense, but the test harness must not rely on
+ *    that filtering being correct.
  *
  * 2. **KATULONG_TMUX_SOCKET** — each test process gets its own isolated
  *    tmux server, scoped by PID. Without this, every integration test
@@ -21,6 +32,10 @@
  *    (b) causes flaky cross-file races — e.g. `sessions-crud` and
  *    `credential-revoke` both creating sessions on the same shared
  *    socket while they run in parallel.
+ *
+ *    Same unconditional-override rule applies: the daemon's plist
+ *    sets `KATULONG_TMUX_SOCKET=katulong`, so an inherited value
+ *    would point us at the live tmux server.
  *
  *    See `lib/tmux.js:tmuxSocketArgs()` for the `-L <name>` wiring this
  *    hooks into. The socket name MUST match `/^[A-Za-z0-9_-]+$/`;
@@ -37,11 +52,26 @@
 
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { sweepOrphanTmuxSockets } from "../../lib/tmux-socket-sweep.js";
 
-if (!process.env.KATULONG_DATA_DIR) {
+// Refuse to run if anything has already set DATA_DIR to the developer's
+// real katulong directory. Surface it loudly so a regression in the
+// inheritance path (env-filter, plist, etc.) is impossible to miss.
+const realDataDir = join(homedir(), ".katulong");
+if (
+  process.env.KATULONG_DATA_DIR &&
+  process.env.KATULONG_DATA_DIR === realDataDir
+) {
+  process.stderr.write(
+    `\n[setup-env] WARNING: KATULONG_DATA_DIR was inherited as ${realDataDir} ` +
+    `(likely from a parent katulong shell). Overriding with a private ` +
+    `tmpdir to prevent test fixtures from clobbering live auth state.\n\n`,
+  );
+}
+
+{
   const dir = mkdtempSync(join(tmpdir(), "katulong-test-"));
   process.env.KATULONG_DATA_DIR = dir;
 
@@ -50,7 +80,7 @@ if (!process.env.KATULONG_DATA_DIR) {
   });
 }
 
-if (!process.env.KATULONG_TMUX_SOCKET) {
+{
   // Reap orphan sockets from prior test runs. Catches both
   //   (a) graceful exits where `kill-server` ran but did not unlink, and
   //   (b) hard kills (SIGKILL / CI or pre-push hook timeouts / OOM)


### PR DESCRIPTION
## Summary

- Test runs from inside a katulong tile silently overwrote the developer's real `~/.katulong/` with fixture data (`cred1`/`key1`/`user123`/etc.), wiping live WebAuthn credentials and booting authenticated remote devices. Reproduced today on my own setup — iPad lost its passkey, sessions empty.
- Three layers of defense: (1) `lib/env-filter.js` strips `KATULONG_DATA_DIR` + `KATULONG_TMUX_SOCKET` from the env handed to PTY shells, (2) `test/helpers/setup-env.js` always overrides them with a private tmpdir / per-PID socket regardless of inherited values, (3) a new `test/data-dir-isolation.test.js` tripwire fails red the moment any guard regresses.
- Drive-by: `lib/drift-log.js` had the same latent bug (hardcoded `os.homedir()/.katulong/drift.log`) — switched to `envConfig.dataDir`.

## Root cause

The daemon's LaunchAgent (`lib/cli/commands/service.js:66-69`) exports `KATULONG_DATA_DIR=~/.katulong` and `KATULONG_TMUX_SOCKET=katulong` so its subprocesses know where to read/write. `env-filter.js` did not strip them, so every PTY shell inherited them. `test/helpers/setup-env.js` then guarded its tmp override with `if (!process.env.KATULONG_DATA_DIR)` — saw an inherited value and respected it. `test/auth.test.js:11` captures `envConfig.dataDir` at module load, so `loadState`/`saveState` ran straight against the live data dir.

## What was tried and rejected

- Patching `auth.test.js` (and friends) to allocate their own tmpdirs — whack-a-mole; doesn't fix the inheritance root.
- Forcing `KATULONG_DATA_DIR=` empty before each test — `envConfig.dataDir` is captured at module-load time, before any test code runs.
- Only fixing `setup-env.js` — would protect `node:test` runs, but not ad-hoc `node test/auth.test.js` invocations or future test runners that don't `--import setup-env`. Filtering at the PTY boundary closes the whole class.

## Test plan

- [x] `npm run test:unit` — 2689/2689 pass
- [x] New tripwire suite (`test/data-dir-isolation.test.js`) passes
- [x] `env-filter.test.js` covers both new filters
- [x] Pre-push hook (full suite + smoke E2E + review agents) green
- [ ] After merge, recover live `~/.katulong/` state: revoke fixture token `tok1`, delete fake `cred1.json`, re-register Mac + iPad passkeys