### PR TITLE
fix(ws): make tile activation tolerant of accumulated reconnect backoff

### DIFF
--- a/docs/connection-rewrite.md
+++ b/docs/connection-rewrite.md
@@ -384,7 +384,10 @@ in pull-manager.js.
 
 ```js
 const BACKOFF_INITIAL = 1000;    // 1s
-const BACKOFF_MAX     = 10000;   // 10s
+const BACKOFF_MAX     = 2000;    // 2s (low cap: self-hosted single-user,
+                                 // reconnect cost ~100ms; high cap made
+                                 // accumulated backoff visible as
+                                 // multi-second blank-tile lag)
 const BACKOFF_FACTOR  = 2;
 
 // On disconnect:

--- a/public/app.js
+++ b/public/app.js
@@ -1032,7 +1032,6 @@
         const anchorIdx = activeName ? priorTabs.indexOf(activeName) : -1;
         routeToSession(data.name);
         windowTabSet.addTab(data.name, anchorIdx >= 0 ? anchorIdx + 1 : undefined);
-        cm.reconnectNow();
       } catch (err) {
         console.error("Failed to create session:", err);
         showToast(`Failed to create session: ${err.message}`);

--- a/public/lib/connection-manager.js
+++ b/public/lib/connection-manager.js
@@ -19,7 +19,7 @@ import { basePath } from "./base-path.js";
 
 // ─── Constants ──────────────────────────────────────────────────────
 const BACKOFF_INITIAL    = 1000;
-const BACKOFF_MAX        = 10000;
+const BACKOFF_MAX        = 2000;
 const BACKOFF_FACTOR     = 2;
 const BACKGROUND_THRESHOLD = 5000; // 5s — after this long in background, force reconnect
 const WAKE_PROBE_TIMEOUT   = 2000; // 2s — probe deadline on focus/pageshow (laptop wake)

--- a/public/lib/connection-manager.js
+++ b/public/lib/connection-manager.js
@@ -19,7 +19,7 @@ import { basePath } from "./base-path.js";
 
 // ─── Constants ──────────────────────────────────────────────────────
 const BACKOFF_INITIAL    = 1000;
-const BACKOFF_MAX        = 2000;
+const BACKOFF_MAX        = 2000;  // low cap: self-hosted single-user, reconnect cost ~100ms
 const BACKOFF_FACTOR     = 2;
 const BACKGROUND_THRESHOLD = 5000; // 5s — after this long in background, force reconnect
 const WAKE_PROBE_TIMEOUT   = 2000; // 2s — probe deadline on focus/pageshow (laptop wake)


### PR DESCRIPTION
## Summary

- **Removes dead `cm.reconnectNow()`** from `createNewSession` in `public/app.js:1035`. Was a no-op on a healthy WS (the Apr 10 connection rewrite changed semantics so `connect()` bails when status !== "disconnected"), but it was misleading dead code on a sensitive path.
- **Lowers `BACKOFF_MAX`** from `10000` → `2000` in `public/lib/connection-manager.js`. Self-hosted single-user tool reached over a tunnel; reconnect cost is ~100ms; there's no upstream service to spare. Caps recovery from "10s blank tile" to "~2s banner flash" after accumulated transient disconnects.

## Why

User reported new-tile creation on iPad Safari shows a "Disconnected" banner and the new tile stays blank ~11s before content arrives. Reproducible on multiple host machines, so cause is client-side.

Server-side ruled out — POST /sessions completes in ~120ms even with `copyFrom`, and a CLI WebSocket against the running server during repeated POSTs never closed. The 11s is the iPad's WS reconnect after some transient disconnect, with backoff already pinned at the 10s ceiling from prior cycles (1s → 2s → 4s → 8s → 10s after ~5 cycles).

Why iPad's WS disconnects in the first place isn't fixable from our code (likely Safari throttling heartbeat on tap-induced focus changes, virtual keyboard pausing JS >8s, or Cloudflare hiccup). But recovery latency is a single tunable constant.

## Test plan

- [x] `npm run test:unit` — 2699 passing, 0 failing
- [ ] Manual: create new tile on iPad Safari via tunnel — blank period under ~2s instead of ~11s
- [ ] Manual: create new tile in desktop browser — no regression