### PR TITLE
feat(ui): show instance host on connection-dot tap

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2581,6 +2581,20 @@
       connTooltip.id = "connection-tooltip";
       document.body.appendChild(connTooltip);
     }
+    // Tooltip has two lines: state on top, host underneath. The host
+    // disambiguates which katulong instance you're on — mobile PWA hides the
+    // browser address bar, and the sidebar instance label is hidden in the
+    // collapsed/mobile sidebar (index.html line ~1629). Using
+    // window.location.host (not hostname) so a non-default port also shows.
+    connTooltip.replaceChildren();
+    const connTooltipState = document.createElement("span");
+    connTooltipState.className = "connection-tooltip-state";
+    const connTooltipHost = document.createElement("span");
+    connTooltipHost.className = "connection-tooltip-host";
+    connTooltipHost.textContent = window.location.host || "";
+    connTooltip.appendChild(connTooltipState);
+    if (connTooltipHost.textContent) connTooltip.appendChild(connTooltipHost);
+
     const dotIds = ["sidebar-connection-dot", "joystick-connection-dot"];
     let connTooltipText = "Disconnected";
 
@@ -2590,7 +2604,7 @@
     const wiredDots = new Set();
     function showTooltipAt(dot) {
       const r = dot.getBoundingClientRect();
-      connTooltip.textContent = connTooltipText;
+      connTooltipState.textContent = connTooltipText;
       connTooltip.style.left = `${r.left + r.width / 2}px`;
       connTooltip.style.top = `${r.top - 4}px`;
       connTooltip.style.transform = "translate(-50%, -100%)";
@@ -2646,7 +2660,7 @@
 
       // Update tooltip text live if it's currently visible
       if (connTooltip.classList.contains("visible")) {
-        connTooltip.textContent = connTooltipText;
+        connTooltipState.textContent = connTooltipText;
       }
 
       const overlay = document.getElementById("disconnect-overlay");

--- a/public/app.js
+++ b/public/app.js
@@ -2581,30 +2581,31 @@
       connTooltip.id = "connection-tooltip";
       document.body.appendChild(connTooltip);
     }
-    // Tooltip has two lines: state on top, host underneath. The host
-    // disambiguates which katulong instance you're on — mobile PWA hides the
-    // browser address bar, and the sidebar instance label is hidden in the
-    // collapsed/mobile sidebar (index.html line ~1629). Using
-    // window.location.host (not hostname) so a non-default port also shows.
+    // Tooltip has two lines: connection state on top, window.location.host
+    // underneath (host, not hostname — keeps non-default ports visible).
+    // Disambiguates which katulong instance you're on in PWA mode where the
+    // address bar is hidden and the sidebar instance label is also hidden
+    // (see .sidebar-instance-label in index.html).
     connTooltip.replaceChildren();
-    const connTooltipState = document.createElement("span");
-    connTooltipState.className = "connection-tooltip-state";
-    const connTooltipHost = document.createElement("span");
-    connTooltipHost.className = "connection-tooltip-host";
-    connTooltipHost.textContent = window.location.host || "";
-    connTooltip.appendChild(connTooltipState);
-    if (connTooltipHost.textContent) connTooltip.appendChild(connTooltipHost);
+    const connTooltipStateEl = document.createElement("span");
+    connTooltipStateEl.className = "connection-tooltip-state";
+    const connTooltipHostEl = document.createElement("span");
+    connTooltipHostEl.className = "connection-tooltip-host";
+    connTooltipHostEl.textContent = window.location.host || "";
+    connTooltip.appendChild(connTooltipStateEl);
+    if (connTooltipHostEl.textContent) connTooltip.appendChild(connTooltipHostEl);
 
     const dotIds = ["sidebar-connection-dot", "joystick-connection-dot"];
-    let connTooltipText = "Disconnected";
+    let connStatusLabel = "Disconnected";
 
-    // Wire hover listeners to all connection dots. Uses event delegation
-    // pattern: dots that don't exist yet (e.g. connection-indicator created
-    // by shortcut-bar.js) get wired when the subscriber first finds them.
+    // Wire hover/click/keyboard listeners to all connection dots. Uses
+    // event delegation pattern: dots that don't exist yet (e.g.
+    // joystick-connection-dot created lazily by joystick.js) get wired when
+    // the subscriber first finds them.
     const wiredDots = new Set();
     function showTooltipAt(dot) {
       const r = dot.getBoundingClientRect();
-      connTooltipState.textContent = connTooltipText;
+      connTooltipStateEl.textContent = connStatusLabel;
       connTooltip.style.left = `${r.left + r.width / 2}px`;
       connTooltip.style.top = `${r.top - 4}px`;
       connTooltip.style.transform = "translate(-50%, -100%)";
@@ -2612,6 +2613,10 @@
     }
     function hideTooltip() {
       connTooltip.classList.remove("visible");
+    }
+    function toggleTooltipAt(dot) {
+      if (connTooltip.classList.contains("visible")) hideTooltip();
+      else showTooltipAt(dot);
     }
     function wireDotTooltip(dot) {
       if (wiredDots.has(dot)) return;
@@ -2622,10 +2627,15 @@
       // Touch: tap to toggle, tap elsewhere to dismiss
       dot.addEventListener("click", (e) => {
         e.stopPropagation();
-        if (connTooltip.classList.contains("visible")) {
-          hideTooltip();
-        } else {
-          showTooltipAt(dot);
+        toggleTooltipAt(dot);
+      });
+      // Keyboard: Enter/Space activates the role="button" dot. Without this
+      // the role + tabindex on the dot are an incomplete contract — focusable
+      // but not operable.
+      dot.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          toggleTooltipAt(dot);
         }
       });
     }
@@ -2639,14 +2649,14 @@
 
     cm.subscribe((connState) => {
       let cssClass = "";
-      connTooltipText = "Disconnected";
+      connStatusLabel = "Disconnected";
 
       if (connState.status === "connecting") {
         cssClass = "connecting";
-        connTooltipText = "Connecting\u2026";
+        connStatusLabel = "Connecting\u2026";
       } else if (connState.status === "ready") {
         cssClass = connState.transport === "datachannel" ? "direct" : "relay";
-        connTooltipText = connState.transport === "datachannel" ? "Direct (P2P)" : "Relay (WebSocket)";
+        connStatusLabel = connState.transport === "datachannel" ? "Direct (P2P)" : "Relay (WebSocket)";
       }
 
       for (const id of dotIds) {
@@ -2660,7 +2670,7 @@
 
       // Update tooltip text live if it's currently visible
       if (connTooltip.classList.contains("visible")) {
-        connTooltipState.textContent = connTooltipText;
+        connTooltipStateEl.textContent = connStatusLabel;
       }
 
       const overlay = document.getElementById("disconnect-overlay");

--- a/public/index.html
+++ b/public/index.html
@@ -968,15 +968,28 @@
     }
 
     /* Connection dot tooltip — floating element positioned by JS to avoid
-       overflow:hidden clipping from parent containers (#shortcut-bar, sidebar) */
+       overflow:hidden clipping from parent containers (#shortcut-bar, sidebar).
+       Two lines: state on top, host (window.location.host) underneath so the
+       user can tell which katulong instance they're on without the browser
+       chrome (PWA / standalone mode hides the address bar). */
     #connection-tooltip {
       position: fixed; z-index: 9999; pointer-events: none;
       background: var(--bg-surface); color: var(--text);
       border: 1px solid var(--border); border-radius: var(--radius-sm);
       padding: 0.25rem 0.5rem; font-size: var(--text-xs);
-      white-space: nowrap; opacity: 0; transition: opacity 0.15s;
+      max-width: min(80vw, 22rem);
+      display: flex; flex-direction: column; align-items: center; gap: 1px;
+      opacity: 0; transition: opacity 0.15s;
     }
     #connection-tooltip.visible { opacity: 1; }
+    #connection-tooltip .connection-tooltip-state { white-space: nowrap; }
+    #connection-tooltip .connection-tooltip-host {
+      font-family: var(--font-mono);
+      font-size: 0.6875rem;
+      color: var(--text-dim);
+      max-width: 100%;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
 
     @keyframes connection-pulse {
       0%, 100% { opacity: 1; }
@@ -3157,7 +3170,7 @@
         <button class="sidebar-icon-btn" id="sidebar-settings-btn" aria-label="Settings" title="Settings">
           <i class="ph ph-gear"></i>
         </button>
-        <span id="sidebar-connection-dot" class="sidebar-connection-dot"></span>
+        <span id="sidebar-connection-dot" class="sidebar-connection-dot" role="button" tabindex="0" aria-label="Connection status — tap for instance host"></span>
         <span id="sidebar-instance-label" class="sidebar-instance-label" aria-label="Instance hostname"></span>
       </div>
     </aside>

--- a/public/lib/joystick.js
+++ b/public/lib/joystick.js
@@ -61,6 +61,9 @@ export function createJoystickManager(options = {}) {
     dotEl = document.createElement("div");
     dotEl.className = "joystick-dot";
     dotEl.id = "joystick-connection-dot";
+    dotEl.setAttribute("role", "button");
+    dotEl.setAttribute("tabindex", "0");
+    dotEl.setAttribute("aria-label", "Connection status — tap for instance host");
     island.appendChild(dotEl);
 
     joystick.appendChild(island);


### PR DESCRIPTION
## Summary

Mobile users running katulong as a PWA have no browser address bar, so when two staging instances are running on different tunnels there's no way to tell which one you're on. The sidebar already has an instance label that renders `window.location.hostname`, but it's explicitly hidden in the collapsed/mobile sidebar because the 56px rail has no room for it.

This piggy-backs on infrastructure that already exists: the connection dot's tooltip already supports desktop hover, mobile tap-to-toggle, and outside-tap dismiss. The tooltip used to only show the connection state ("Direct (P2P)" / "Relay (WebSocket)" / etc.) — now it's a two-line stack with `window.location.host` underneath the state. Host (not hostname) so a non-default port also disambiguates two local dev servers on 3001 vs 3002.

- Two-line tooltip: state on top, host underneath in monospace + dim color
- `role="button"` + `tabindex="0"` + `aria-label` on both connection dots (sidebar + joystick) so the interactive element is reachable by keyboard and AT
- Tooltip `max-width: min(80vw, 22rem)` so a long staging hostname doesn't run off a phone's screen edge; ellipsizes if it still overflows

### Why this surface and not another

- A permanent strip with the hostname would eat vertical pixels on a screen that's already cramped on mobile.
- Putting it in the settings panel costs two taps and the user has to remember to look.
- The connection dot is already the natural "where am I connected" affordance and is always visible (sidebar footer + joystick).

## Test plan

Code-side:
- [x] `npm run test:unit` — all 2689 tests pass
- [x] Pre-push hook (full suite + review agents) — passed

Visual verification I couldn't do from this environment — please confirm on your phone:
- [ ] Tap the green/yellow dot in the collapsed sidebar footer → tooltip appears showing connection state on top and the full hostname underneath
- [ ] Tap anywhere else → tooltip dismisses
- [ ] On desktop, hover the dot → same tooltip
- [ ] Tap the joystick connection dot (inside an active terminal) → same tooltip
- [ ] Long hostname (e.g. a staging tunnel with a UUID) ellipsizes instead of running off-screen