### PR TITLE
service: launchd plist KeepAlive=true so a clean exit auto-restarts

### DIFF
--- a/lib/cli/commands/_finish-upgrade.js
+++ b/lib/cli/commands/_finish-upgrade.js
@@ -174,8 +174,9 @@ export default async function finishUpgrade(args) {
   // Both branches route through `safeStopServer`, which detects the
   // LaunchAgent plist and calls `launchctl unload` BEFORE any signals
   // when one exists. That's required because the plist has
-  // `KeepAlive.SuccessfulExit=false`, so direct SIGTERM causes launchd
-  // to immediately respawn the process — racing with the upgrade flow.
+  // `KeepAlive=true` (originally `KeepAlive.SuccessfulExit=false`), so
+  // direct SIGTERM causes launchd to immediately respawn the process —
+  // racing with the upgrade flow.
   // See lib/cli/safe-stop.js and commit 50773fc for the full lesson.
   if (existsSync(PLIST_PATH)) {
     console.log("Restarting via LaunchAgent...");

--- a/lib/cli/commands/service.js
+++ b/lib/cli/commands/service.js
@@ -75,10 +75,7 @@ function buildPlist() {
   <true/>
 
   <key>KeepAlive</key>
-  <dict>
-    <key>SuccessfulExit</key>
-    <false/>
-  </dict>
+  <true/>
 
   <key>StandardOutPath</key>
   <string>${xmlEscape(dataDir + "/launchd-stdout.log")}</string>

--- a/lib/cli/safe-stop.js
+++ b/lib/cli/safe-stop.js
@@ -4,9 +4,9 @@
  * The bug this helper exists to fix:
  *
  *   `katulong stop` sent SIGTERM directly to the server PID. When a
- *   LaunchAgent is installed, its plist has `KeepAlive.SuccessfulExit=false`,
- *   which tells launchd to treat any death as abnormal and IMMEDIATELY
- *   respawn the process. That respawn raced the stop command's own wait
+ *   LaunchAgent is installed, its plist has `KeepAlive=true` (originally
+ *   `KeepAlive.SuccessfulExit=false`), which tells launchd to IMMEDIATELY
+ *   respawn the process on any exit. That respawn raced the stop command's wait
  *   loop — by the time stop.js polled again, the port was occupied by a
  *   different PID, `isServerRunning()` reported running=true via its port
  *   probe, and stop.js then tried `SIGKILL` against the ORIGINAL (now-dead)

--- a/test/safe-stop.test.js
+++ b/test/safe-stop.test.js
@@ -5,7 +5,8 @@
  *
  *   1. Send SIGTERM to a LaunchAgent-managed PID
  *   2. Process exits
- *   3. launchd sees SuccessfulExit=false and IMMEDIATELY respawns the server
+ *   3. launchd sees KeepAlive (originally SuccessfulExit=false; now unconditional
+ *      true) and IMMEDIATELY respawns the server
  *   4. `isServerRunning()` falls back to its port probe and returns running=true
  *      (the respawn is now on the port)
  *   5. stop.js calls SIGKILL against the ORIGINAL PID → ESRCH, because the


### PR DESCRIPTION
## Summary
- `katulong service install` now writes `KeepAlive: <true/>` instead of `KeepAlive: { SuccessfulExit: false }`, so the LaunchAgent auto-restarts on **any** exit — including a clean SIGTERM/exit-0.
- Old policy left a quiescent agent after a graceful shutdown (formula post_install, upgrade flow, direct `katulong stop`); the formula's own caveats already flagged this as a footgun.
- Updated stale comments in `safe-stop.js` and `safe-stop.test.js` that referenced the old policy.

## Why this is safe
The CLI is already built on the assumption that any `KeepAlive` will respawn on raw signals:
- `lib/cli/safe-stop.js` (used by `stop.js`, `restart.js`, and `_finish-upgrade.js`) routes through `launchctl unload` *before* any signal precisely because direct signals trigger launchd respawn.
- `service.restart` and `service.uninstall` both unload the agent first, then act on the process.
- So `katulong stop` and `katulong service restart` continue to work; only direct `kill <pid>` now respawns, which is the desired behavior for a supervised service.

## Incident motivation
On mac2019 today, the launchd-managed katulong received SIGTERM (exit 0) and stayed down because `SuccessfulExit=false` only restarts on crashes. A later detached `katulong start` came up on PORT=3002, but the Cloudflare tunnel maps the public hostname to :3001, so the instance was unreachable externally.

## Rollout
This is the source-of-truth change. Each box picks up the new plist via `katulong update` (or `katulong service restart`) after merge; the brew formula's `post_install` does that automatically on `brew upgrade`. Mini also needs `katulong service install` since its agent isn't loaded right now.

Follow-up: the brew tap formula's caveats currently warn about the exact bug this PR fixes (`Formula/katulong.rb` lines 60-62 in `dorky-robot/homebrew-tap`). Worth dropping that paragraph in the next formula bump.

## Test plan
- [x] `npm run test:unit` — 2702 pass, 0 fail
- [ ] After release: `katulong update` on mac2019 / mac2024, `katulong service install` on mini; verify each plist has `<key>KeepAlive</key><true/>` and that `launchctl print gui/501/com.dorkyrobot.katulong | grep KeepAlive` shows the new shape.
- [ ] Manually `kill -TERM` the server on one box and confirm launchd respawns it within ~10s.