### PR TITLE
mesh-update: pass -n to ssh so the read loop processes every peer

### DIFF
--- a/bin/katulong-mesh-update
+++ b/bin/katulong-mesh-update
@@ -193,10 +193,14 @@ cmd_roll() {
 
     echo "[$processed/$total] $id ($alias:$port): rolling update"
     local pre_version
+    # `-n` redirects ssh's stdin to /dev/null. Without it, ssh consumes the
+    # while-loop's piped input on the first iteration and the loop exits
+    # silently after one peer. (Symptom: summary reports total=3 but
+    # processed=1 with no failed_id — a green "rollout complete" lie.)
     # `--` ends ssh's option processing so a future mesh.json that somehow
     # smuggled a leading-dash alias through validation still can't inject
     # ssh options. Belt and suspenders against the parser regex above.
-    pre_version="$(ssh -- "$alias" "$REMOTE_PATH_PREFIX katulong --version" 2>/dev/null || true)"
+    pre_version="$(ssh -n -- "$alias" "$REMOTE_PATH_PREFIX katulong --version" 2>/dev/null || true)"
     echo "    before: ${pre_version:-(unknown — host unreachable or katulong missing)}"
 
     if [[ -z "$pre_version" ]]; then
@@ -205,15 +209,15 @@ cmd_roll() {
       break
     fi
 
-    if ! ssh -- "$alias" "$REMOTE_PATH_PREFIX katulong update"; then
+    if ! ssh -n -- "$alias" "$REMOTE_PATH_PREFIX katulong update"; then
       echo "    ✗ update failed on $id ($alias) — rollout halted" >&2
       failed_id="$id"
       break
     fi
 
     local post_version http_code
-    post_version="$(ssh -- "$alias" "$REMOTE_PATH_PREFIX katulong --version" 2>/dev/null || true)"
-    http_code="$(ssh -- "$alias" "$REMOTE_PATH_PREFIX curl -s -o /dev/null -w \"%{http_code}\" http://localhost:$port/" 2>/dev/null || true)"
+    post_version="$(ssh -n -- "$alias" "$REMOTE_PATH_PREFIX katulong --version" 2>/dev/null || true)"
+    http_code="$(ssh -n -- "$alias" "$REMOTE_PATH_PREFIX curl -s -o /dev/null -w \"%{http_code}\" http://localhost:$port/" 2>/dev/null || true)"
     echo "    after:  ${post_version:-(unknown)}  (HTTP ${http_code:-000})"
 
     if [[ "${http_code:-}" != "200" ]]; then
@@ -230,6 +234,15 @@ cmd_roll() {
     echo "rollout halted at $failed_id."
     echo "  updated: $updated   skipped (self): $skipped   not attempted: $remaining"
     echo "  fix $failed_id and re-run — already-updated peers will no-op."
+    return 1
+  fi
+  # Sanity check: if the loop exited without setting failed_id but didn't
+  # process every peer, something silently swallowed iterations (e.g. an ssh
+  # call inside the loop consuming its stdin without `-n`). Don't lie about
+  # "rollout complete" in that case — fail loudly so the bug surfaces.
+  if [[ "$processed" != "$total" ]]; then
+    echo "rollout incomplete: processed $processed of $total peers (no failure reported)" >&2
+    echo "  this is a script bug — please report it." >&2
     return 1
   fi
   echo "rollout complete."


### PR DESCRIPTION
## Summary
- `ssh -n` (read stdin from /dev/null) inside the `while read … <<< \"\$peers\"` loop. Without it, ssh consumes the loop's piped input on the first iteration and the loop exits silently after one peer.
- New `processed != total` sanity check that fails loudly when the loop drops iterations without setting `failed_id`.

## How we found it
Rolling out v0.61.6 to a 3-peer mesh (mac2019, mac2024-self, mini) processed only mac2019 and then printed:

```
rollout complete.
  updated: 1   skipped (self): 0   total: 3
```

`1 + 0 ≠ 3` was the only hint anything was wrong — `failed_id` stayed empty so the script declared success. Dry-run worked because that path doesn't shell out to ssh, which is why the bug only ever showed under a real roll.

## Verified
Re-ran the same mesh after the fix:
- mac2019 → `✓ Already up to date (v0.61.6)` (HTTP 200)
- mac2024 → `self — skipping`
- mini    → `✓ Already up to date (v0.61.6)` (HTTP 200)
- Summary: `updated: 2   skipped (self): 1   total: 3`

`katulong update` is itself idempotent (`decideUpgradeAction` returns `noop:already-up-to-date` when on-disk + running-server versions both match), so the re-run double-checked both the mesh-update fix and the underlying idempotency contract in one shot.

## Test plan
- [x] Dry-run still lists all peers (unchanged path)
- [x] Real roll on a 3-peer mesh visits all peers
- [x] Re-running on a fully-updated mesh is a no-op (each peer reports "Already up to date")
- [ ] Reviewer: confirm `-n` is the right knob vs. an FD-3 read loop. `-n` is simpler and matches what the rest of the script already assumes (no stdin to forward to remote commands).