### PR TITLE
finish-upgrade: verify version after handover; redundant unload before bootstrap

### DIFF
--- a/lib/cli/commands/_finish-upgrade.js
+++ b/lib/cli/commands/_finish-upgrade.js
@@ -263,19 +263,31 @@ export default async function finishUpgrade(args) {
   // one endpoint that does NOT touch deleted files, which is exactly why
   // the bug hides behind it. See lib/cli/safe-stop.js for the launchd-
   // unload-failure rationale.
+  //
+  // Sanitize the loopback /health response before interpolating into
+  // stderr: if a rogue local process squats 127.0.0.1:$port it can return
+  // arbitrary strings — including terminal escape sequences. We only
+  // accept conservative shapes (semver-ish for version, integer for pid).
+  const safeVersion = /^[0-9A-Za-z.+-]+$/.test(String(finalHealth.version ?? ""))
+    ? finalHealth.version : "(unparseable)";
+  const safePid = Number.isInteger(finalHealth.pid) ? finalHealth.pid : "(unparseable)";
   if (finalHealth.version !== newVersion) {
-    console.error(`✗ Upgrade verification failed`);
-    console.error(`  /health on port ${port} reports v${finalHealth.version}, expected v${newVersion}`);
-    console.error(`  PID ${finalHealth.pid} is still the old binary — the launchd handover did not complete.`);
+    // Exit code 2 (not 1) so update.js's catch can distinguish this from a
+    // smoke-test failure and avoid stacking its own "Post-upgrade smoke test
+    // failed / DO NOT run katulong start" recovery block on top of ours
+    // (the new binary IS running here, just not on the production port —
+    // very different recovery posture from a smoke-test failure).
+    console.error(`✗ Version mismatch after launchd handover — old binary still holds port ${port}`);
+    console.error(`  /health reports v${safeVersion} (PID ${safePid}), expected v${newVersion}`);
     console.error("");
     console.error("  Recovery (run on this host):");
     console.error("    launchctl bootout gui/$(id -u)/com.dorkyrobot.katulong");
     console.error(`    sudo lsof -ti:${port} | xargs kill -9   # if anything still holds the port`);
     console.error("    katulong service install                # bootstraps the agent fresh");
-    process.exit(1);
+    process.exit(2);
   }
 
-  console.log(`✓ Running v${finalHealth.version} (PID ${finalHealth.pid})`);
+  console.log(`✓ Running v${safeVersion} (PID ${safePid})`);
   console.log(`  Open: http://localhost:${port}`);
 
   // Clean up sentinel

--- a/lib/cli/commands/_finish-upgrade.js
+++ b/lib/cli/commands/_finish-upgrade.js
@@ -180,7 +180,7 @@ export default async function finishUpgrade(args) {
   // See lib/cli/safe-stop.js and commit 50773fc for the full lesson.
   if (existsSync(PLIST_PATH)) {
     console.log("Restarting via LaunchAgent...");
-    const { buildAndWritePlist, launchctlLoad } = await import("./service.js");
+    const { buildAndWritePlist, launchctlLoad, launchctlUnload } = await import("./service.js");
 
     // safeStopServer calls launchctlUnload internally via its default
     // injection, then polls the specific old PID (not the port).
@@ -198,6 +198,15 @@ export default async function finishUpgrade(args) {
     }
 
     buildAndWritePlist();
+    // Belt-and-suspenders: safeStopServer's launchctlUnload can silently
+    // fail (observed on mini during the v0.61.6 → v0.61.7 roll: bootout
+    // returned 0 but left the agent in launchd's job table). Without this
+    // second unload the bootstrap below collides with the stale entry and
+    // returns "Input/output error", then falls through to the legacy
+    // `load -w` which "succeeds" without doing anything — and the old
+    // server keeps the port. An extra unload here is a no-op when the
+    // agent is already gone.
+    try { launchctlUnload(); } catch { /* already unloaded */ }
     try {
       launchctlLoad();
     } catch {
@@ -242,6 +251,27 @@ export default async function finishUpgrade(args) {
   if (!finalHealth) {
     console.error(`✗ New server failed to start on port ${port}`);
     console.error("  Try: katulong start");
+    process.exit(1);
+  }
+
+  // The launchd handover can complete with /health responding 200 while
+  // an OLD process still holds the port — happens when bootout silently
+  // failed and the legacy `launchctl load -w` fallback did nothing useful.
+  // Without this check we'd declare success while the public port is held
+  // by a stale binary whose Cellar dir was just deleted by `brew cleanup`,
+  // so /health works but every static asset request 500s. /health is the
+  // one endpoint that does NOT touch deleted files, which is exactly why
+  // the bug hides behind it. See lib/cli/safe-stop.js for the launchd-
+  // unload-failure rationale.
+  if (finalHealth.version !== newVersion) {
+    console.error(`✗ Upgrade verification failed`);
+    console.error(`  /health on port ${port} reports v${finalHealth.version}, expected v${newVersion}`);
+    console.error(`  PID ${finalHealth.pid} is still the old binary — the launchd handover did not complete.`);
+    console.error("");
+    console.error("  Recovery (run on this host):");
+    console.error("    launchctl bootout gui/$(id -u)/com.dorkyrobot.katulong");
+    console.error(`    sudo lsof -ti:${port} | xargs kill -9   # if anything still holds the port`);
+    console.error("    katulong service install                # bootstraps the agent fresh");
     process.exit(1);
   }
 

--- a/lib/cli/commands/update.js
+++ b/lib/cli/commands/update.js
@@ -273,8 +273,18 @@ export default async function update(args) {
         `"${newBin}" _finish-upgrade --old-pid ${oldPid}`,
         { stdio: "inherit", encoding: "utf-8" },
       );
-    } catch {
+    } catch (err) {
       cleanupSentinel();
+      // _finish-upgrade exits 2 when the launchd handover left an old
+      // binary serving the production port (version-mismatch path). Its
+      // own stderr already named the failure and the exact recovery
+      // commands; printing the smoke-test-failure block on top would
+      // contradict that guidance ("DO NOT run katulong start" is wrong
+      // when the new binary is actually fine — it just hasn't taken over
+      // the port). Pass the exit through.
+      if (err && err.status === 2) {
+        process.exit(2);
+      }
       // By the time we reach this catch, `brew upgrade` has already
       // replaced the on-disk binary with v${newVersion} AND has typically
       // removed the old Cellar's libexec contents (including public/).


### PR DESCRIPTION
## Summary
Two correctness fixes for the `katulong update` LaunchAgent handover, both motivated by an observed outage on `mini` during the v0.61.6 → v0.61.7 mesh roll.

1. **Insert a redundant `launchctlUnload()` before `launchctlLoad()`.** `safeStopServer`'s unload can silently fail (`launchctl bootout` returns 0 while leaving the agent in launchd's job table). The follow-up bootstrap then collides with the stale entry, returns `Input/output error`, and falls through to the legacy `launchctl load -w` which is permissive — it "succeeds" without actually starting anything new. The redundant unload is a no-op when clean and self-heals when stale.
2. **Compare `finalHealth.version` to `newVersion` after `waitForHealth`.** /health doesn't load static files, so a stale process whose Cellar dir was just deleted by `brew cleanup` still reports `status: \"ok\"` — the version field was right there in the response but never checked. On mismatch, exit 1 with the actual recovery commands inline so the operator doesn't have to dig through commit history.

## Field report

```
✓ Smoke test passed (v0.61.7)
Restarting via LaunchAgent...
Load failed: 5: Input/output error
Try running \`launchctl bootstrap\` as root for richer errors.
✓ Running v0.61.6 (PID 67529)        ← script declared success
  Open: http://localhost:3001
```

The mesh-update HTTP probe then returned 500 because `/` 500'd on missing static assets. Without this PR, `_finish-upgrade` would happily print the wrong version forever.

## Why this is the right scope

The deeper fix — making `safeStopServer` verify that `launchctl unload` actually removed the entry before returning `stopped: true` — is intentionally **not** in this PR. That requires plumbing an `isLoaded` injection through `safe-stop.js` and updating its tests, and the redundant unload + version check above already arrests the user-visible outage. The deeper fix is filed in the commit message as the next follow-up.

## Test plan
- [x] `npm run test:unit` — 2714 pass, 0 fail
- [ ] After merge: simulate the failure mode by hand-corrupting the launchd entry, run `katulong update`, confirm the new error message + recovery steps appear (instead of a silent-success that lies about the version).