### PR TITLE
feat(scrollback): persist RingBuffer to disk across restarts

### DIFF
--- a/lib/ring-buffer.js
+++ b/lib/ring-buffer.js
@@ -60,6 +60,12 @@ export class RingBuffer {
     if (typeof data !== "string") return;
     if (!Number.isFinite(endOffset) || endOffset < 0) return;
     if (endOffset < data.length) return;
+    // Refuse a restore that would exceed the configured byte cap. Without
+    // this, a tampered or oversized file would bypass the eviction
+    // contract that push() enforces — the buffer would silently hold
+    // more bytes than it's supposed to. Combined with a size check at
+    // the file boundary this is defense in depth.
+    if (data.length > this.maxBytes) return;
     this.items = data.length > 0 ? [data] : [];
     this.offsets = data.length > 0 ? [endOffset - data.length] : [];
     this.bytes = data.length;

--- a/lib/ring-buffer.js
+++ b/lib/ring-buffer.js
@@ -43,6 +43,29 @@ export class RingBuffer {
     // totalBytes is NOT reset — sequence persists across clears
   }
 
+  /**
+   * Rehydrate the buffer from a persisted snapshot (lib/scrollback-store.js).
+   *
+   * `endOffset` is the cursor position at the END of `data` — i.e. the
+   * value `totalBytes` had when the snapshot was taken. The starting
+   * offset of the rehydrated item is therefore `endOffset - data.length`,
+   * which preserves the invariant that pre-restart `seq` cursors handed
+   * out to clients still resolve to the right slice via `sliceFrom()`.
+   *
+   * Existing buffer state is dropped — restore is meant for the empty
+   * post-construction RingBuffer on the restoreSessions() path. Calling
+   * it on a live buffer with already-streamed bytes would discard them.
+   */
+  restore(data, endOffset) {
+    if (typeof data !== "string") return;
+    if (!Number.isFinite(endOffset) || endOffset < 0) return;
+    if (endOffset < data.length) return;
+    this.items = data.length > 0 ? [data] : [];
+    this.offsets = data.length > 0 ? [endOffset - data.length] : [];
+    this.bytes = data.length;
+    this.totalBytes = endOffset;
+  }
+
   /** Returns the byte offset of the first buffered item, or totalBytes if empty. */
   getStartOffset() {
     return this.offsets.length > 0 ? this.offsets[0] : this.totalBytes;

--- a/lib/scrollback-store.js
+++ b/lib/scrollback-store.js
@@ -27,11 +27,23 @@
  * tokens printed by tools, file contents).
  */
 
-import { mkdirSync, readFileSync, writeFileSync, renameSync, unlinkSync, readdirSync } from "node:fs";
+import { mkdirSync, chmodSync, readFileSync, writeFileSync, renameSync, unlinkSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { log } from "./log.js";
 
 const SCROLLBACK_SUBDIR = "scrollback";
+
+// Refuse to load any file larger than the RingBuffer cap plus a small slack
+// for the header. Catches both corrupt/oversized files written by an older
+// (or buggy) server and tampered files planted by a same-user attacker that
+// would OOM the process at startup.
+const MAX_BUFFER_BYTES = 20 * 1024 * 1024;
+const MAX_FILE_SIZE = MAX_BUFFER_BYTES + 64 * 1024;
+
+// Stale-temp eviction threshold. .tmp.<pid> files normally vanish on
+// successful save (rename) or on the next save(). Anything older than this
+// belongs to a crashed writer whose pid is long gone — safe to GC.
+const STALE_TMP_AGE_MS = 60 * 60 * 1000; // 1 hour
 
 // Defense in depth: ids are produced by lib/id.js (alnum, length 21) but
 // adopted external tmux session names can also flow through here. The
@@ -55,7 +67,6 @@ function isValidId(id) {
  *   load: (sessionId: string) => { data: string, cursor: number } | null,
  *   remove: (sessionId: string) => void,
  *   pruneExcept: (activeIds: Iterable<string>) => void,
- *   enabled: boolean,
  * }}
  */
 export function createScrollbackStore({ dataDir }) {
@@ -65,13 +76,18 @@ export function createScrollbackStore({ dataDir }) {
       load: () => null,
       remove: () => {},
       pruneExcept: () => {},
-      enabled: false,
     };
   }
 
   const dir = join(dataDir, SCROLLBACK_SUBDIR);
   try {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
+    // mkdirSync with recursive:true does NOT enforce the mode on a dir
+    // that already exists — it silently no-ops. Re-apply explicitly so a
+    // directory carried over from a looser-permissioned install is locked
+    // down. Best-effort: a read-only volume or unowned dir will throw,
+    // which we accept (the file mode 0o600 is the primary defense).
+    try { chmodSync(dir, 0o700); } catch { /* readonly volume etc. */ }
   } catch (err) {
     log.warn("Failed to create scrollback dir", { dir, error: err.message });
   }
@@ -102,6 +118,22 @@ export function createScrollbackStore({ dataDir }) {
 
   function load(sessionId) {
     if (!isValidId(sessionId)) return null;
+    // Size-check via stat BEFORE readFileSync so a tampered or
+    // pathologically large file cannot OOM the process at startup. The
+    // ~20 MB cap matches the RingBuffer's maxBytes contract — anything
+    // larger could not have been written by a healthy server anyway.
+    let stat;
+    try {
+      stat = statSync(pathFor(sessionId));
+    } catch {
+      return null;
+    }
+    if (stat.size > MAX_FILE_SIZE) {
+      log.warn("Scrollback file exceeds size limit, refusing to load", {
+        sessionId, size: stat.size, limit: MAX_FILE_SIZE,
+      });
+      return null;
+    }
     let raw;
     try {
       raw = readFileSync(pathFor(sessionId), "utf-8");
@@ -131,14 +163,27 @@ export function createScrollbackStore({ dataDir }) {
     const active = new Set(activeIds);
     for (const entry of entries) {
       if (active.has(entry)) continue;
-      // Skip stray temp files (`.tmp.<pid>`) — they belong to a live or
-      // crashed write and will be cleaned up by the next save() or by
-      // the OS over time. Removing them here would race a concurrent
-      // shutdown writer.
-      if (entry.includes(".tmp.")) continue;
+      // Stray temp files (`.tmp.<pid>`) usually belong to a live writer or
+      // a crashed writer whose rename never landed. Keep recent ones (a
+      // concurrent shutdown might still own them); GC anything older than
+      // STALE_TMP_AGE_MS so a repeatedly-crashing server can't accumulate
+      // unbounded disk usage across restarts.
+      if (entry.includes(".tmp.")) {
+        try {
+          const ageMs = Date.now() - statSync(join(dir, entry)).mtimeMs;
+          if (ageMs > STALE_TMP_AGE_MS) {
+            unlinkSync(join(dir, entry));
+          }
+        } catch { /* concurrent unlink or stat failure */ }
+        continue;
+      }
+      // Defense in depth: only delete files matching our id format. A
+      // .gitkeep, manually placed file, or symlink should not be silently
+      // removed by the GC pass even though it isn't in the active set.
+      if (!isValidId(entry)) continue;
       try { unlinkSync(join(dir, entry)); } catch { /* concurrent unlink */ }
     }
   }
 
-  return { save, load, remove, pruneExcept, enabled: true };
+  return { save, load, remove, pruneExcept };
 }

--- a/lib/scrollback-store.js
+++ b/lib/scrollback-store.js
@@ -1,0 +1,144 @@
+/**
+ * Scrollback persistence store.
+ *
+ * Per-session terminal output history, written on graceful shutdown and
+ * rehydrated on restore. Without this the in-memory RingBuffer dies with
+ * the server process — a brief restart resets every client's `seq` cursor
+ * arithmetic, and `pullFrom` for any pre-restart offset returns null
+ * (treated as evicted) instead of the bytes the client missed.
+ *
+ * File layout: `<dataDir>/scrollback/<sessionId>` — one file per session,
+ * keyed by the immutable surrogate id (lib/id.js). The body is a single
+ * decimal cursor on the first line, then a newline, then the raw RingBuffer
+ * contents verbatim:
+ *
+ *   1234567\n
+ *   <escape sequences ...>
+ *
+ * The line-prefix format (vs JSON) avoids ~6× blow-up from JSON-encoding
+ * 0x1B and other sub-0x20 bytes that fill terminal output. A 20 MB
+ * RingBuffer JSON-encodes to ~120 MB; line-prefixed it's 20 MB plus a
+ * short header.
+ *
+ * Writes are atomic (temp + rename, mode 0o600) so a crash mid-write
+ * cannot leave a partial file that fails to parse on the next boot.
+ * Files are owner-only because terminal output may contain sensitive
+ * material echoed to the screen (passwords typed at non-noecho prompts,
+ * tokens printed by tools, file contents).
+ */
+
+import { mkdirSync, readFileSync, writeFileSync, renameSync, unlinkSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { log } from "./log.js";
+
+const SCROLLBACK_SUBDIR = "scrollback";
+
+// Defense in depth: ids are produced by lib/id.js (alnum, length 21) but
+// adopted external tmux session names can also flow through here. The
+// adopt path validates against /^[A-Za-z0-9_\-]+$/ with length ≤ 128;
+// match that here so a hostile sessions.json cannot path-traverse out
+// of the scrollback dir.
+const VALID_ID = /^[A-Za-z0-9_-]+$/;
+
+function isValidId(id) {
+  return typeof id === "string" && id.length > 0 && id.length <= 128 && VALID_ID.test(id);
+}
+
+/**
+ * Create a scrollback store bound to a data directory.
+ *
+ * @param {object} opts
+ * @param {string|null} opts.dataDir - Parent dir. If null/empty, the store is
+ *   a no-op (used by tests that don't want disk side effects).
+ * @returns {{
+ *   save: (sessionId: string, data: string, cursor: number) => void,
+ *   load: (sessionId: string) => { data: string, cursor: number } | null,
+ *   remove: (sessionId: string) => void,
+ *   pruneExcept: (activeIds: Iterable<string>) => void,
+ *   enabled: boolean,
+ * }}
+ */
+export function createScrollbackStore({ dataDir }) {
+  if (!dataDir) {
+    return {
+      save: () => {},
+      load: () => null,
+      remove: () => {},
+      pruneExcept: () => {},
+      enabled: false,
+    };
+  }
+
+  const dir = join(dataDir, SCROLLBACK_SUBDIR);
+  try {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  } catch (err) {
+    log.warn("Failed to create scrollback dir", { dir, error: err.message });
+  }
+
+  function pathFor(sessionId) {
+    return join(dir, sessionId);
+  }
+
+  function save(sessionId, data, cursor) {
+    if (!isValidId(sessionId)) return;
+    if (typeof data !== "string") return;
+    if (!Number.isFinite(cursor) || cursor < 0) return;
+    // Cursor must be at least data.length — it's the byte position of the
+    // last byte in `data`. A smaller value would imply we're claiming the
+    // buffer ends before its own contents start, which load() rejects.
+    if (cursor < data.length) return;
+
+    const filePath = pathFor(sessionId);
+    const tempPath = `${filePath}.tmp.${process.pid}`;
+    try {
+      writeFileSync(tempPath, `${cursor}\n${data}`, { encoding: "utf-8", mode: 0o600 });
+      renameSync(tempPath, filePath);
+    } catch (err) {
+      log.warn("Failed to save scrollback", { sessionId, error: err.message });
+      try { unlinkSync(tempPath); } catch { /* may not exist */ }
+    }
+  }
+
+  function load(sessionId) {
+    if (!isValidId(sessionId)) return null;
+    let raw;
+    try {
+      raw = readFileSync(pathFor(sessionId), "utf-8");
+    } catch {
+      return null;
+    }
+    const nl = raw.indexOf("\n");
+    if (nl < 0) return null;
+    const cursor = Number(raw.slice(0, nl));
+    if (!Number.isFinite(cursor) || cursor < 0 || !Number.isInteger(cursor)) return null;
+    const data = raw.slice(nl + 1);
+    // A file claiming cursor < data.length is structurally inconsistent —
+    // either the header was truncated or the file was tampered with.
+    // Refuse rather than restore a buffer with negative starting offset.
+    if (cursor < data.length) return null;
+    return { cursor, data };
+  }
+
+  function remove(sessionId) {
+    if (!isValidId(sessionId)) return;
+    try { unlinkSync(pathFor(sessionId)); } catch { /* missing is fine */ }
+  }
+
+  function pruneExcept(activeIds) {
+    let entries;
+    try { entries = readdirSync(dir); } catch { return; }
+    const active = new Set(activeIds);
+    for (const entry of entries) {
+      if (active.has(entry)) continue;
+      // Skip stray temp files (`.tmp.<pid>`) — they belong to a live or
+      // crashed write and will be cleaned up by the next save() or by
+      // the OS over time. Removing them here would race a concurrent
+      // shutdown writer.
+      if (entry.includes(".tmp.")) continue;
+      try { unlinkSync(join(dir, entry)); } catch { /* concurrent unlink */ }
+    }
+  }
+
+  return { save, load, remove, pruneExcept, enabled: true };
+}

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -217,25 +217,23 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
   /**
    * Restore a session's RingBuffer from the scrollback file, if any.
    *
-   * Call after adoptSession() but before sessions.set() — this is the only
-   * window where the buffer is guaranteed empty. Rehydrating later would
-   * silently discard any %output that arrived between adopt and rehydrate
-   * (the buffer is replaced wholesale, not appended to).
+   * Must be called BEFORE attachControlMode(), not after. Once the control
+   * client is wired up, %output starts streaming into outputBuffer
+   * synchronously through the parser. Calling restore() after that point
+   * would overwrite live bytes (restore replaces wholesale, not appends),
+   * silently dropping output and rolling totalBytes backwards.
    *
    * The cursor is restored too: clients that held a `seq` from before
-   * the restart will still resolve to the correct slice via pullFrom(),
+   * the restart still resolve to the correct slice via sliceFrom(),
    * instead of getting null (treated as evicted) for any pre-restart
-   * offset.
+   * offset. RingBuffer.restore() is total: it cannot throw, so no
+   * try/catch is needed here.
    */
-  function rehydrateScrollback(session) {
+  function restoreScrollback(session) {
     if (!session?.id) return;
     const saved = scrollbackStore.load(session.id);
     if (!saved) return;
-    try {
-      session.outputBuffer.restore(saved.data, saved.cursor);
-    } catch (err) {
-      log.warn("Failed to rehydrate scrollback", { session: session.name, error: err.message });
-    }
+    session.outputBuffer.restore(saved.data, saved.cursor);
   }
 
   // --- Shared helper: adopt an existing tmux session ---
@@ -283,6 +281,13 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
         });
       },
     });
+
+    // Restore the persisted RingBuffer (if any) BEFORE wiring up the
+    // control client. Once attachControlMode runs, %output begins flowing
+    // into outputBuffer synchronously — restoring after would overwrite
+    // those bytes. For freshly spawned sessions the file won't exist and
+    // this is a cheap statSync miss.
+    restoreScrollback(session);
 
     session.attachControlMode(cols, rows);
 
@@ -846,7 +851,6 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
           const exists = await tmuxHasSession(tmuxName);
           if (!exists) return;
           const session = await adoptSession(friendlyName, tmuxName, DEFAULT_COLS, DEFAULT_ROWS, { id: persistedId, meta: persistedMeta });
-          rehydrateScrollback(session);
           sessions.set(friendlyName, session);
           log.info("Restored session", { session: friendlyName, tmux: tmuxName });
         })
@@ -925,18 +929,21 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
       // Flush any pending debounced save and write final state
       store.cancelPendingSave();
       store.saveNow();
-      // Persist each session's RingBuffer BEFORE detach() — once the control
-      // process is closed the session won't be receiving more output, but
-      // the buffer contents and `cursor` are already final at this point and
-      // detach() runs the parser drain that could (rarely) push one last
-      // payload. Saving after detach would race that final flush.
+      // Detach FIRST. detach() → _closeControlProc() → _parser.drain(),
+      // and drain pushes any partial UTF-8 sequence still buffered in the
+      // tmux output parser into outputBuffer. Reading getBuffer() / cursor
+      // before detach would silently truncate the snapshot by up to 3
+      // bytes (the trailing carry of a multi-byte codepoint). Detach is
+      // synchronous on the buffer side — proc.stdin.write/end is queued
+      // but the buffer won't see new bytes after _onData is nulled.
+      for (const [, session] of sessions) {
+        session.detach();
+      }
+      // Now buffers are stable — persist each session's RingBuffer.
       for (const [, session] of sessions) {
         if (session.id) {
           scrollbackStore.save(session.id, session.getBuffer(), session.cursor);
         }
-      }
-      for (const [, session] of sessions) {
-        session.detach();
       }
     },
   };

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -19,6 +19,7 @@ import { createClientTracker } from "./client-tracker.js";
 import { createOutputCoalescer } from "./output-coalescer.js";
 import { driftLog, driftLogLevel } from "./drift-log.js";
 import { createSessionStore } from "./session-persistence.js";
+import { createScrollbackStore } from "./scrollback-store.js";
 import { startChildCountMonitor } from "./session-child-counter.js";
 import { Session } from "./session.js";
 import { sessionId, SESSION_ID_PATTERN } from "./id.js";
@@ -98,6 +99,14 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
     },
   });
   const scheduleSave = store.scheduleSave;
+
+  // Scrollback persistence — per-session RingBuffer contents written on
+  // graceful shutdown and rehydrated on restoreSessions(). Independent of
+  // the sessions.json store because the data is large (up to 20 MB/session)
+  // and binary-ish, so it gets its own per-id files rather than a single
+  // JSON blob. Falls back to a no-op store when dataDir isn't supplied
+  // (test fixtures, ephemeral runs).
+  const scrollbackStore = createScrollbackStore({ dataDir });
 
   // Multi-session subscriptions: clientId -> Set<sessionName>
   // Allows a client to receive output for multiple sessions simultaneously.
@@ -203,6 +212,30 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
       if (s.alive) count++;
     }
     return count;
+  }
+
+  /**
+   * Restore a session's RingBuffer from the scrollback file, if any.
+   *
+   * Call after adoptSession() but before sessions.set() — this is the only
+   * window where the buffer is guaranteed empty. Rehydrating later would
+   * silently discard any %output that arrived between adopt and rehydrate
+   * (the buffer is replaced wholesale, not appended to).
+   *
+   * The cursor is restored too: clients that held a `seq` from before
+   * the restart will still resolve to the correct slice via pullFrom(),
+   * instead of getting null (treated as evicted) for any pre-restart
+   * offset.
+   */
+  function rehydrateScrollback(session) {
+    if (!session?.id) return;
+    const saved = scrollbackStore.load(session.id);
+    if (!saved) return;
+    try {
+      session.outputBuffer.restore(saved.data, saved.cursor);
+    } catch (err) {
+      log.warn("Failed to rehydrate scrollback", { session: session.name, error: err.message });
+    }
   }
 
   // --- Shared helper: adopt an existing tmux session ---
@@ -311,6 +344,11 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
     } else {
       session.kill();
       detachedNames.delete(tmuxName);
+      // Hard-kill removes the tmux session — its scrollback file becomes
+      // unreachable (no future session will ever rehydrate from this id).
+      // Detach keeps the tmux session alive and re-adoptable on restart,
+      // so we keep the file in that case.
+      if (session.id) scrollbackStore.remove(session.id);
     }
     const action = detachOnly ? "detached" : "deleted";
     sessions.delete(name);
@@ -808,6 +846,7 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
           const exists = await tmuxHasSession(tmuxName);
           if (!exists) return;
           const session = await adoptSession(friendlyName, tmuxName, DEFAULT_COLS, DEFAULT_ROWS, { id: persistedId, meta: persistedMeta });
+          rehydrateScrollback(session);
           sessions.set(friendlyName, session);
           log.info("Restored session", { session: friendlyName, tmux: tmuxName });
         })
@@ -863,6 +902,16 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
       // ids — persisting now seals those ids into the file so subsequent
       // restarts keep them stable. No-op when the shape is already current.
       scheduleSave();
+
+      // Garbage-collect scrollback files for sessions that didn't make it
+      // back (their tmux session died, were renamed away, or the orphan
+      // adoption assigned a fresh id). Without this, every restart leaks
+      // up to 20 MB per dropped session into ~/.katulong/scrollback/.
+      const activeIds = [];
+      for (const s of sessions.values()) {
+        if (s.id) activeIds.push(s.id);
+      }
+      scrollbackStore.pruneExcept(activeIds);
     },
 
     /**
@@ -876,6 +925,16 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
       // Flush any pending debounced save and write final state
       store.cancelPendingSave();
       store.saveNow();
+      // Persist each session's RingBuffer BEFORE detach() — once the control
+      // process is closed the session won't be receiving more output, but
+      // the buffer contents and `cursor` are already final at this point and
+      // detach() runs the parser drain that could (rarely) push one last
+      // payload. Saving after detach would race that final flush.
+      for (const [, session] of sessions) {
+        if (session.id) {
+          scrollbackStore.save(session.id, session.getBuffer(), session.cursor);
+        }
+      }
       for (const [, session] of sessions) {
         session.detach();
       }

--- a/test/helpers/session-manager-fixture.js
+++ b/test/helpers/session-manager-fixture.js
@@ -76,7 +76,7 @@ export class BaseMockSession {
     this.external = options.external || false;
     this._options = options;
     this._childCount = 0;
-    this.outputBuffer = { totalBytes: 0, sliceFrom: () => "" };
+    this.outputBuffer = { totalBytes: 0, sliceFrom: () => "", restore: () => {} };
     this.meta = (options.meta && typeof options.meta === "object" && !Array.isArray(options.meta))
       ? { ...options.meta } : {};
     this._onChange = typeof options.onChange === "function" ? options.onChange : null;
@@ -110,6 +110,11 @@ export class BaseMockSession {
     const fromSeq = Math.max(cursor - maxBytes, 0);
     return { data: this.outputBuffer.sliceFrom(fromSeq) || "", cursor };
   }
+  // Stubbed for the scrollback persistence path: shutdown() reads each
+  // session's buffer + cursor and writes them via createScrollbackStore.
+  // The base mock has no real RingBuffer, so getBuffer() returns "" and
+  // cursor stays 0 — both safe inputs to scrollbackStore.save().
+  getBuffer() { return ""; }
   updateChildCount(count) { this._childCount = count; }
   write() {}
   resize() {}

--- a/test/ring-buffer.test.js
+++ b/test/ring-buffer.test.js
@@ -105,6 +105,78 @@ describe("RingBuffer", () => {
     });
   });
 
+  describe("restore", () => {
+    it("rehydrates data and totalBytes from a snapshot", () => {
+      const buffer = new RingBuffer();
+      buffer.restore("hello world", 1000);
+
+      assert.strictEqual(buffer.toString(), "hello world");
+      assert.strictEqual(buffer.totalBytes, 1000);
+      assert.strictEqual(buffer.getEndOffset(), 1000);
+      assert.strictEqual(buffer.getStartOffset(), 989, "start offset must be endOffset - data.length");
+    });
+
+    it("preserves pre-restart seq cursors via sliceFrom", () => {
+      // The whole point of restore: a client that held seq=995 from before
+      // the restart should get the last 5 bytes via pullFrom-style sliceFrom.
+      const buffer = new RingBuffer();
+      buffer.restore("hello world", 1000);
+
+      assert.strictEqual(buffer.sliceFrom(995), "world");
+      assert.strictEqual(buffer.sliceFrom(989), "hello world");
+      assert.strictEqual(buffer.sliceFrom(1000), "");
+      // Anything older than the start of the rehydrated buffer is treated as
+      // evicted — same contract as a long-running session.
+      assert.strictEqual(buffer.sliceFrom(900), null);
+    });
+
+    it("appends new pushes after the restored cursor", () => {
+      const buffer = new RingBuffer();
+      buffer.restore("abcd", 100);
+      buffer.push("efgh");
+
+      assert.strictEqual(buffer.totalBytes, 104);
+      assert.strictEqual(buffer.sliceFrom(96), "abcdefgh");
+      assert.strictEqual(buffer.sliceFrom(100), "efgh");
+    });
+
+    it("handles empty data with non-zero cursor", () => {
+      // Edge case: a session whose buffer was completely evicted but had
+      // pushed N bytes overall. We should still be able to advance from N.
+      const buffer = new RingBuffer();
+      buffer.restore("", 500);
+
+      assert.strictEqual(buffer.totalBytes, 500);
+      assert.strictEqual(buffer.toString(), "");
+      buffer.push("x");
+      assert.strictEqual(buffer.totalBytes, 501);
+      assert.strictEqual(buffer.sliceFrom(500), "x");
+    });
+
+    it("rejects structurally inconsistent input (cursor < data.length)", () => {
+      const buffer = new RingBuffer();
+      buffer.push("preexisting");
+      const before = buffer.totalBytes;
+
+      // cursor=3 with 11-char data would imply a negative starting offset.
+      buffer.restore("hello world", 3);
+
+      // Restore is a no-op on bad input — existing state is preserved.
+      assert.strictEqual(buffer.totalBytes, before);
+      assert.strictEqual(buffer.toString(), "preexisting");
+    });
+
+    it("rejects non-string data and non-finite cursors", () => {
+      const buffer = new RingBuffer();
+      buffer.restore(null, 100);
+      buffer.restore("data", NaN);
+      buffer.restore("data", -1);
+
+      assert.strictEqual(buffer.totalBytes, 0);
+      assert.strictEqual(buffer.toString(), "");
+    });
+  });
+
   describe("stats", () => {
     it("returns accurate statistics", () => {
       const buffer = new RingBuffer();

--- a/test/ring-buffer.test.js
+++ b/test/ring-buffer.test.js
@@ -175,6 +175,18 @@ describe("RingBuffer", () => {
       assert.strictEqual(buffer.totalBytes, 0);
       assert.strictEqual(buffer.toString(), "");
     });
+
+    it("rejects data larger than maxBytes (eviction-contract defense)", () => {
+      // push() enforces maxBytes via evict(). restore() must enforce the
+      // same cap or a tampered/oversized snapshot would silently bypass
+      // the buffer's memory contract.
+      const buffer = new RingBuffer(100);
+      const oversized = "x".repeat(200);
+      buffer.restore(oversized, 200);
+
+      assert.strictEqual(buffer.totalBytes, 0, "restore must no-op on oversize input");
+      assert.strictEqual(buffer.toString(), "");
+    });
   });
 
   describe("stats", () => {

--- a/test/scrollback-store.test.js
+++ b/test/scrollback-store.test.js
@@ -1,0 +1,230 @@
+/**
+ * Scrollback Store Tests
+ *
+ * Tests per-session terminal-history persistence: write-on-shutdown,
+ * read-on-restore, atomic temp+rename, file mode, id validation,
+ * and orphan pruning.
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { mkdtempSync, rmSync, readdirSync, statSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { createScrollbackStore } from "../lib/scrollback-store.js";
+
+let dataDir;
+let store;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "kat-scrollback-"));
+  store = createScrollbackStore({ dataDir });
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("scrollback store", () => {
+  describe("save / load round trip", () => {
+    it("persists data and cursor and reads them back identically", () => {
+      const data = "\x1b[2J\x1b[H$ ls\nfile1\nfile2\n";
+      store.save("session_id_abc", data, 12345);
+
+      const loaded = store.load("session_id_abc");
+      assert.deepStrictEqual(loaded, { data, cursor: 12345 });
+    });
+
+    it("survives terminal output containing newlines and control bytes", () => {
+      // The line-prefix format splits on the FIRST newline only; data after
+      // that may contain arbitrary bytes including more newlines and the
+      // 0x1B ESC byte that fills terminal output.
+      const data = "line1\nline2\n\x1b[31mred\x1b[0m\n\x00\x07\x1b[H";
+      store.save("session_id_xyz", data, data.length);
+
+      const loaded = store.load("session_id_xyz");
+      assert.strictEqual(loaded.data, data);
+      assert.strictEqual(loaded.cursor, data.length);
+    });
+
+    it("handles an empty buffer (session with totalBytes > 0 but fully evicted)", () => {
+      store.save("session_id_evicted", "", 999999);
+
+      const loaded = store.load("session_id_evicted");
+      assert.deepStrictEqual(loaded, { data: "", cursor: 999999 });
+    });
+
+    it("returns null for a session with no saved scrollback", () => {
+      assert.strictEqual(store.load("never_saved_id"), null);
+    });
+  });
+
+  describe("input validation", () => {
+    it("save rejects path-traversing ids without writing", () => {
+      store.save("../escape", "data", 4);
+      store.save("a/b", "data", 4);
+      store.save("with.dots", "data", 4);
+
+      // Nothing should land in the scrollback dir.
+      const entries = readdirSync(join(dataDir, "scrollback"));
+      assert.deepStrictEqual(entries, []);
+    });
+
+    it("load rejects bad ids without reading", () => {
+      assert.strictEqual(store.load("../escape"), null);
+      assert.strictEqual(store.load(""), null);
+      assert.strictEqual(store.load(null), null);
+      assert.strictEqual(store.load(123), null);
+    });
+
+    it("save rejects non-string data and bad cursors", () => {
+      store.save("session_id_a", null, 100);
+      store.save("session_id_a", "data", -1);
+      store.save("session_id_a", "data", NaN);
+      // Cursor smaller than data.length is structurally inconsistent.
+      store.save("session_id_a", "hello world", 3);
+
+      const entries = readdirSync(join(dataDir, "scrollback"));
+      assert.deepStrictEqual(entries, []);
+    });
+
+    it("load returns null on a corrupt file (missing newline header)", () => {
+      // Hand-write a file with no header newline. Should be rejected, not
+      // crash the restore path.
+      writeFileSync(join(dataDir, "scrollback", "corrupt_id"), "no header here");
+
+      assert.strictEqual(store.load("corrupt_id"), null);
+    });
+
+    it("load returns null on a non-numeric cursor", () => {
+      writeFileSync(join(dataDir, "scrollback", "bad_cursor_id"), "not_a_number\nactual data");
+
+      assert.strictEqual(store.load("bad_cursor_id"), null);
+    });
+
+    it("load returns null on a non-integer cursor", () => {
+      writeFileSync(join(dataDir, "scrollback", "fractional_id"), "1.5\nactual data");
+
+      assert.strictEqual(store.load("fractional_id"), null);
+    });
+
+    it("load returns null when cursor < data.length (truncated header)", () => {
+      writeFileSync(join(dataDir, "scrollback", "truncated_id"), "5\nthis_is_definitely_more_than_5_chars");
+
+      assert.strictEqual(store.load("truncated_id"), null);
+    });
+  });
+
+  describe("atomic write", () => {
+    it("writes via temp + rename, leaving no .tmp file on success", () => {
+      store.save("session_id_atomic", "data", 4);
+
+      const entries = readdirSync(join(dataDir, "scrollback"));
+      assert.deepStrictEqual(entries, ["session_id_atomic"]);
+    });
+
+    it("file is mode 0o600 (owner-only — terminal output may contain secrets)", () => {
+      store.save("session_id_perms", "data", 4);
+
+      const filePath = join(dataDir, "scrollback", "session_id_perms");
+      const mode = statSync(filePath).mode & 0o777;
+      assert.strictEqual(mode, 0o600);
+    });
+
+    it("save replaces existing file in place (cursor advances on restart)", () => {
+      store.save("session_id_replace", "old data", 8);
+      store.save("session_id_replace", "new data with more bytes", 100);
+
+      const loaded = store.load("session_id_replace");
+      assert.strictEqual(loaded.data, "new data with more bytes");
+      assert.strictEqual(loaded.cursor, 100);
+    });
+  });
+
+  describe("remove", () => {
+    it("deletes the scrollback file for a session", () => {
+      store.save("session_id_doomed", "data", 4);
+      assert.notStrictEqual(store.load("session_id_doomed"), null);
+
+      store.remove("session_id_doomed");
+      assert.strictEqual(store.load("session_id_doomed"), null);
+    });
+
+    it("is a no-op for a session with no saved file", () => {
+      // Should not throw.
+      store.remove("never_saved_id");
+    });
+  });
+
+  describe("pruneExcept", () => {
+    it("removes scrollback files for ids not in the active set", () => {
+      store.save("active_a", "a", 1);
+      store.save("active_b", "b", 1);
+      store.save("orphan_c", "c", 1);
+      store.save("orphan_d", "d", 1);
+
+      store.pruneExcept(["active_a", "active_b"]);
+
+      const remaining = readdirSync(join(dataDir, "scrollback")).sort();
+      assert.deepStrictEqual(remaining, ["active_a", "active_b"]);
+    });
+
+    it("preserves stray .tmp.<pid> files (a concurrent write may own them)", () => {
+      // Simulate a temp file from a live writer in another process.
+      writeFileSync(join(dataDir, "scrollback", "session_x.tmp.99999"), "in-flight");
+
+      store.pruneExcept([]);
+
+      // The tmp file is still there — pruning would race the other writer.
+      assert.ok(existsSync(join(dataDir, "scrollback", "session_x.tmp.99999")));
+    });
+
+    it("handles a missing scrollback dir without throwing", () => {
+      rmSync(join(dataDir, "scrollback"), { recursive: true, force: true });
+      // Should not throw.
+      store.pruneExcept(["anything"]);
+    });
+  });
+
+  describe("no-op store (no dataDir)", () => {
+    it("returns an enabled=false store that swallows all operations", () => {
+      const noop = createScrollbackStore({ dataDir: null });
+
+      assert.strictEqual(noop.enabled, false);
+      noop.save("id", "data", 4);  // no throw
+      assert.strictEqual(noop.load("id"), null);
+      noop.remove("id");           // no throw
+      noop.pruneExcept(["a"]);     // no throw
+    });
+  });
+
+  describe("session-restart simulation", () => {
+    it("a saved buffer can be loaded after the original store object is gone", () => {
+      // Save with one store instance; load with a fresh one. This is what
+      // happens across a real katulong restart.
+      store.save("restart_id", "scrollback contents", 1000);
+
+      const reborn = createScrollbackStore({ dataDir });
+      const loaded = reborn.load("restart_id");
+
+      assert.deepStrictEqual(loaded, { data: "scrollback contents", cursor: 1000 });
+    });
+
+    it("loading a file from disk that was hand-written matches the format spec", () => {
+      // This guards the file format itself: anyone debugging by writing
+      // a scrollback file by hand should be able to follow the documented
+      // shape. If someone changes the format without updating docs/tests,
+      // this fails first.
+      const filePath = join(dataDir, "scrollback", "manual_id");
+      writeFileSync(filePath, "42\nhello there");
+
+      const loaded = store.load("manual_id");
+      assert.deepStrictEqual(loaded, { data: "hello there", cursor: 42 });
+
+      // And the on-disk content can be inspected with cat or grep.
+      const raw = readFileSync(filePath, "utf-8");
+      assert.strictEqual(raw, "42\nhello there");
+    });
+  });
+});

--- a/test/scrollback-store.test.js
+++ b/test/scrollback-store.test.js
@@ -8,7 +8,7 @@
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { mkdtempSync, rmSync, readdirSync, statSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, readdirSync, statSync, writeFileSync, readFileSync, existsSync, openSync, ftruncateSync, closeSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -114,6 +114,23 @@ describe("scrollback store", () => {
 
       assert.strictEqual(store.load("truncated_id"), null);
     });
+
+    it("load refuses files larger than the RingBuffer cap (OOM defense)", () => {
+      // The store rejects anything > 20 MB + small slack. We simulate a
+      // tampered/oversized file without actually writing 21 MB by truncating
+      // a sparse file (stat.size reports the truncated size and triggers
+      // the gate before readFileSync runs).
+      const oversizePath = join(dataDir, "scrollback", "oversize_id");
+      const fd = openSync(oversizePath, "w");
+      try {
+        ftruncateSync(fd, 25 * 1024 * 1024); // 25 MB sparse file
+      } finally {
+        closeSync(fd);
+      }
+
+      assert.strictEqual(store.load("oversize_id"), null,
+        "oversized file must be refused before readFileSync runs");
+    });
   });
 
   describe("atomic write", () => {
@@ -170,14 +187,44 @@ describe("scrollback store", () => {
       assert.deepStrictEqual(remaining, ["active_a", "active_b"]);
     });
 
-    it("preserves stray .tmp.<pid> files (a concurrent write may own them)", () => {
+    it("preserves recent .tmp.<pid> files (a concurrent write may own them)", () => {
       // Simulate a temp file from a live writer in another process.
       writeFileSync(join(dataDir, "scrollback", "session_x.tmp.99999"), "in-flight");
 
       store.pruneExcept([]);
 
-      // The tmp file is still there — pruning would race the other writer.
+      // Recent tmp file is preserved — pruning would race the other writer.
       assert.ok(existsSync(join(dataDir, "scrollback", "session_x.tmp.99999")));
+    });
+
+    it("evicts stale .tmp.<pid> files older than the age threshold", () => {
+      // A repeatedly crashing server can otherwise accumulate 20 MB-sized
+      // temp files indefinitely. Anything older than the threshold belongs
+      // to a writer whose pid is long gone.
+      const stalePath = join(dataDir, "scrollback", "session_y.tmp.88888");
+      writeFileSync(stalePath, "stranded");
+      // Backdate the file 2 hours (well past the 1-hour threshold).
+      const twoHoursAgo = (Date.now() - 2 * 60 * 60 * 1000) / 1000;
+      utimesSync(stalePath, twoHoursAgo, twoHoursAgo);
+
+      store.pruneExcept([]);
+
+      assert.ok(!existsSync(stalePath), "stale .tmp file must be evicted");
+    });
+
+    it("preserves files whose names don't match the id format (.gitkeep, dotfiles, etc.)", () => {
+      // pruneExcept's id-format filter is path-traversal defense — it must
+      // skip anything in the dir that couldn't possibly be one of our files
+      // (names with `.`, `/`, etc.). Bare alnum names that happen to match
+      // the id format are still candidates for deletion; that's accepted
+      // behavior since we own the directory.
+      writeFileSync(join(dataDir, "scrollback", ".gitkeep"), "");
+      writeFileSync(join(dataDir, "scrollback", "with.dots"), "x");
+
+      store.pruneExcept([]);
+
+      assert.ok(existsSync(join(dataDir, "scrollback", ".gitkeep")));
+      assert.ok(existsSync(join(dataDir, "scrollback", "with.dots")));
     });
 
     it("handles a missing scrollback dir without throwing", () => {
@@ -188,10 +235,9 @@ describe("scrollback store", () => {
   });
 
   describe("no-op store (no dataDir)", () => {
-    it("returns an enabled=false store that swallows all operations", () => {
+    it("returns a store that silently swallows all operations", () => {
       const noop = createScrollbackStore({ dataDir: null });
 
-      assert.strictEqual(noop.enabled, false);
       noop.save("id", "data", 4);  // no throw
       assert.strictEqual(noop.load("id"), null);
       noop.remove("id");           // no throw

--- a/test/session-persistence.test.js
+++ b/test/session-persistence.test.js
@@ -7,9 +7,11 @@
 
 import { describe, it, before, beforeEach, mock } from "node:test";
 import assert from "node:assert";
-import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+
+import { RingBuffer } from "../lib/ring-buffer.js";
 
 // Mock tmux operations before importing session-manager
 const tmuxSessions = new Map(); // tmuxName -> true
@@ -29,13 +31,19 @@ class MockSession {
     this._cols = 0;
     this._rows = 0;
     this._resizeCalls = [];
-    this.outputBuffer = { totalBytes: 0 };
+    // Real RingBuffer so the scrollback round-trip tests can push data
+    // and assert that restore() rehydrates it correctly. Existing
+    // sessions.json tests don't push anything, so they see an empty
+    // buffer just like before.
+    this.outputBuffer = new RingBuffer();
     this.external = options.external || false;
     this.meta = (options.meta && typeof options.meta === "object" && !Array.isArray(options.meta))
       ? { ...options.meta } : {};
     this._onChange = options.onChange || null;
   }
   get alive() { return this._alive; }
+  get cursor() { return this.outputBuffer.totalBytes; }
+  getBuffer() { return this.outputBuffer.toString(); }
   attachControlMode(/* cols, rows */) { /* Real Session does NOT set _cols here */ }
   async seedScreen() {}
   updateChildCount() {}
@@ -220,6 +228,104 @@ describe("Session persistence", () => {
 
     mgr.shutdown();
     rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  describe("scrollback round trip", () => {
+    it("restores RingBuffer contents and cursor across a manager restart", async () => {
+      const mgr1 = createSessionManager({
+        bridge: makeBridge(), shell: "/bin/sh", home: "/tmp", dataDir,
+      });
+      const created = await mgr1.createSession("durable", 80, 24);
+      const session1 = mgr1.getSession("durable");
+
+      // Simulate live terminal output building up the RingBuffer.
+      session1.outputBuffer.push("line one\n");
+      session1.outputBuffer.push("\x1b[31mline two\x1b[0m\n");
+      const cursorAtShutdown = session1.cursor;
+      const bufferAtShutdown = session1.getBuffer();
+
+      mgr1.shutdown();
+
+      // Scrollback file should now exist on disk under the session id.
+      const scrollbackPath = join(dataDir, "scrollback", created.id);
+      assert.ok(existsSync(scrollbackPath), "scrollback file must be written on shutdown");
+
+      // Re-add the tmux session so restore() can re-adopt it.
+      tmuxSessions.set(`kat_${created.id}`, true);
+
+      const mgr2 = createSessionManager({
+        bridge: makeBridge(), shell: "/bin/sh", home: "/tmp", dataDir,
+      });
+      await mgr2.restoreSessions();
+
+      const session2 = mgr2.getSession("durable");
+      assert.ok(session2, "session must be restored");
+      assert.strictEqual(session2.cursor, cursorAtShutdown, "cursor must persist across restart");
+      assert.strictEqual(session2.getBuffer(), bufferAtShutdown, "buffer contents must persist across restart");
+
+      // Pre-restart seq cursors must still resolve to the right slice —
+      // the whole point of preserving cursor (clients reconnecting after a
+      // brief restart shouldn't see their seq become "evicted").
+      const slice = session2.outputBuffer.sliceFrom(cursorAtShutdown - 4);
+      assert.strictEqual(slice.length, 4);
+
+      mgr2.shutdown();
+      rmSync(dataDir, { recursive: true, force: true });
+    });
+
+    it("removes the scrollback file when the session is hard-deleted", async () => {
+      const mgr = createSessionManager({
+        bridge: makeBridge(), shell: "/bin/sh", home: "/tmp", dataDir,
+      });
+      const created = await mgr.createSession("doomed", 80, 24);
+      const session = mgr.getSession("doomed");
+      session.outputBuffer.push("about to die\n");
+      mgr.shutdown();
+
+      const scrollbackPath = join(dataDir, "scrollback", created.id);
+      assert.ok(existsSync(scrollbackPath), "scrollback file must exist after first shutdown");
+
+      // Re-add the tmux session and restart so we can hard-delete.
+      tmuxSessions.set(`kat_${created.id}`, true);
+      const mgr2 = createSessionManager({
+        bridge: makeBridge(), shell: "/bin/sh", home: "/tmp", dataDir,
+      });
+      await mgr2.restoreSessions();
+
+      mgr2.deleteSession("doomed");
+
+      assert.ok(!existsSync(scrollbackPath), "scrollback file must be removed on hard delete");
+
+      mgr2.shutdown();
+      rmSync(dataDir, { recursive: true, force: true });
+    });
+
+    it("prunes orphan scrollback files on restore", async () => {
+      // Lay down a scrollback file for a session id that nothing in
+      // sessions.json or tmux will reference. The first restoreSessions()
+      // call should garbage-collect it.
+      const orphanId = "abcdefghijklmnopqrstu"; // 21 chars, matches sessionId() shape
+      const orphanPath = join(dataDir, "scrollback");
+      // Force the dir to exist before we write into it.
+      const tmpStore = createSessionManager({
+        bridge: makeBridge(), shell: "/bin/sh", home: "/tmp", dataDir,
+      });
+      tmpStore.shutdown();
+
+      writeFileSync(join(orphanPath, orphanId), "100\norphan contents");
+      assert.ok(existsSync(join(orphanPath, orphanId)));
+
+      const mgr = createSessionManager({
+        bridge: makeBridge(), shell: "/bin/sh", home: "/tmp", dataDir,
+      });
+      await mgr.restoreSessions();
+
+      assert.ok(!existsSync(join(orphanPath, orphanId)),
+        "orphan scrollback file must be pruned after restoreSessions");
+
+      mgr.shutdown();
+      rmSync(dataDir, { recursive: true, force: true });
+    });
   });
 
   it("works without dataDir (no persistence)", async () => {


### PR DESCRIPTION
## Summary
- Persists each session's RingBuffer to `~/.katulong/scrollback/<sessionId>` on graceful shutdown and rehydrates it on `restoreSessions()`. Pre-restart `seq` cursors held by clients now resolve via `pullFrom`/`pullTail` instead of being treated as evicted.
- New `lib/scrollback-store.js` with atomic temp+rename writes (mode 0o600 — terminal output may contain echoed secrets), per-id files, line-prefix format (`<cursor>\n<raw bytes>`) chosen over JSON to avoid the ~6× blow-up that ``-encoding terminal escape bytes would cause on a 20 MB buffer.
- New `RingBuffer.restore(data, endOffset)` rehydrates `items` / `offsets` / `totalBytes` so the starting offset of the restored buffer matches its pre-restart `getStartOffset()`.
- `deleteSession()` removes the file on hard delete; detach (kept-alive tmux) intentionally preserves it for re-adoption. `restoreSessions()` calls `pruneExcept()` to GC orphans (sessions whose tmux died, fresh-id orphan adoption, etc.).

## What this does NOT yet give you
xterm.js scrollback after a browser reload. That requires changing the attach path to replay buffered bytes into the client, which has dimension-reflow concerns flagged in CLAUDE.md ("Multi-device terminal dimensions — inherent PTY limitation"). Worth a follow-up but a meaningfully bigger change.

## Test plan
- [x] `npm run test:unit` — 2745 pass / 0 fail
- [x] New unit tests: `test/scrollback-store.test.js` (round-trip, input validation, atomic write, mode 0o600, pruning, no-op store, hand-written file format)
- [x] New `RingBuffer.restore` tests in `test/ring-buffer.test.js` (rehydrate, pre-restart cursor resolution, append after restore, empty-data + non-zero-cursor edge case, structural validation)
- [x] New scrollback round-trip integration tests in `test/session-persistence.test.js` (full manager-shutdown → manager-restart cycle, hard-delete cleanup, orphan pruning)
- [ ] Manual smoke: start katulong, produce some output in a session, `Ctrl+C` the server, restart, verify the restored session has its pre-restart bytes available via the API