### PR TITLE
bridge: rotate structured logs per week

### DIFF
--- a/bridges/README.md
+++ b/bridges/README.md
@@ -67,7 +67,8 @@ katulong bridge <name> start             # foreground (used internally by launch
 Per-bridge state lives under `~/.katulong/bridges/<name>/`:
 
 - `config.json` (mode 0600) — `{ token, port?, bind?, target? }`. Operator overrides go here.
-- `stdout.log`, `stderr.log` — launchd output
+- `stdout.log`, `stderr.log` — launchd output (crashes, `console.log` lines)
+- `logs/<YYYY-MM-DD>.log` — structured per-week JSON-line logs (auth failures, upstream errors). The date is the UTC Sunday that begins the entry's week. Files are append-only; rotation happens lazily on the first write past a Sunday boundary. There is no automatic pruning — run `find ~/.katulong/bridges/<name>/logs -mtime +90 -delete` (or your retention of choice) on whatever cadence you like.
 
 The shared CLI handles atomic writes and 0600 enforcement. Don't write these files directly.
 

--- a/bridges/_lib/rotating-logger.js
+++ b/bridges/_lib/rotating-logger.js
@@ -42,12 +42,29 @@ export function sundayOfWeekUTC(date) {
 export function createRotatingLogger({ dir, now = () => new Date() } = {}) {
   const logger = (event) => {
     const ts = now();
-    const line = JSON.stringify({ ts: ts.toISOString(), ...event }) + "\n";
+    let line = "";
     try {
-      mkdirSync(dir, { recursive: true });
-      appendFileSync(join(dir, `${sundayOfWeekUTC(ts)}.log`), line, { mode: 0o644 });
-    } catch {
-      try { process.stderr.write(line); } catch { /* nothing left to do */ }
+      // JSON.stringify can throw on circular references; keep it inside
+      // the try so the contract holds even for misbehaving callers.
+      line = JSON.stringify({ ts: ts.toISOString(), ...event }) + "\n";
+      mkdirSync(dir, { recursive: true, mode: 0o700 });
+      appendFileSync(join(dir, `${sundayOfWeekUTC(ts)}.log`), line, { mode: 0o600 });
+    } catch (err) {
+      // Annotate the fallback so a future debugger seeing logs/ empty
+      // can grep stderr for `_log_fallback` and find the cause.
+      try {
+        const fallback = JSON.stringify({
+          ts: ts.toISOString(),
+          _log_fallback: true,
+          _log_error: err?.code || err?.name || "unknown",
+          ...event,
+        }) + "\n";
+        process.stderr.write(fallback);
+      } catch {
+        // Even JSON.stringify failed (event shape is hostile). Emit
+        // whatever we managed to build, falling back to a tag.
+        try { process.stderr.write(line || "{\"_log_fallback\":true}\n"); } catch { /* nothing left to do */ }
+      }
     }
   };
   // No-op kept for API symmetry — earlier stream-based draft exposed

--- a/bridges/_lib/rotating-logger.js
+++ b/bridges/_lib/rotating-logger.js
@@ -1,0 +1,57 @@
+/**
+ * Per-week rotating JSON-line logger for bridges.
+ *
+ * Writes events as one JSON object per line into `<dir>/<YYYY-MM-DD>.log`,
+ * where the date is the UTC Sunday that begins the entry's week.
+ *
+ * UTC was chosen for the filename — not local time — so it matches the
+ * `ts` field inside each line (UTC ISO). Opening `2026-04-26.log` shows a
+ * clean [Sun 00:00Z, next-Sun 00:00Z) window with no mental TZ conversion
+ * at grep time.
+ *
+ * The logger is synchronous (`appendFileSync`) on purpose: bridge log
+ * volume is low (handful of events per minute), and a sync append makes
+ * the contract dead simple — by the time `logger(event)` returns, the
+ * line is on disk. No stream lifecycle, no flush dance, no async handle
+ * to leak across rotation. The default console.warn logger this replaces
+ * is also synchronous.
+ *
+ * The logger never throws into the caller. On a write failure (disk
+ * full, EACCES, parent path is a regular file) the line is sent to
+ * `process.stderr` as a fallback so a logging failure can't break the
+ * bridge's request path.
+ */
+
+import { mkdirSync, appendFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * UTC-Sunday-of-the-week as `YYYY-MM-DD`. Weeks start on Sunday.
+ *
+ *   2026-05-03 (Sun, UTC)   → "2026-05-03"
+ *   2026-05-01 (Fri, UTC)   → "2026-04-26"
+ *   2027-01-01 (Fri, UTC)   → "2026-12-27"  (year boundary)
+ */
+export function sundayOfWeekUTC(date) {
+  const sunday = new Date(date.getTime());
+  sunday.setUTCDate(sunday.getUTCDate() - sunday.getUTCDay());
+  sunday.setUTCHours(0, 0, 0, 0);
+  return sunday.toISOString().slice(0, 10);
+}
+
+export function createRotatingLogger({ dir, now = () => new Date() } = {}) {
+  const logger = (event) => {
+    const ts = now();
+    const line = JSON.stringify({ ts: ts.toISOString(), ...event }) + "\n";
+    try {
+      mkdirSync(dir, { recursive: true });
+      appendFileSync(join(dir, `${sundayOfWeekUTC(ts)}.log`), line, { mode: 0o644 });
+    } catch {
+      try { process.stderr.write(line); } catch { /* nothing left to do */ }
+    }
+  };
+  // No-op kept for API symmetry — earlier stream-based draft exposed
+  // close(), and tests + future callers may rely on it being callable.
+  logger.close = () => {};
+  return logger;
+}

--- a/lib/cli/commands/bridge.js
+++ b/lib/cli/commands/bridge.js
@@ -23,12 +23,17 @@ import {
   generateToken,
 } from "../../../bridges/_lib/config-loader.js";
 import { startBridgeServer } from "../../../bridges/_lib/server.js";
+import { createRotatingLogger } from "../../../bridges/_lib/rotating-logger.js";
 import {
   bridgeLabel,
   bridgePlistPath,
   buildBridgePlist,
 } from "../../../bridges/_lib/launchd-template.js";
 import { DATA_DIR } from "../process-manager.js";
+
+function bridgeLogDir(bridgeName) {
+  return `${DATA_DIR}/bridges/${bridgeName}/logs`;
+}
 
 function usage() {
   console.log(`
@@ -103,7 +108,8 @@ async function actionList() {
 async function actionStart(name) {
   const manifest = await getBridge(name);
   const resolved = resolveBridge({ manifest, dataDir: DATA_DIR });
-  await startBridgeServer(resolved);
+  const logger = createRotatingLogger({ dir: bridgeLogDir(manifest.name) });
+  await startBridgeServer({ ...resolved, logger });
   console.log(
     `katulong bridge ${name}: listening on ${resolved.bind}:${resolved.port}, ` +
       `forwarding to ${resolved.target}`,

--- a/lib/cli/commands/bridge.js
+++ b/lib/cli/commands/bridge.js
@@ -14,7 +14,7 @@ import {
   renameSync,
   mkdirSync,
 } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { listBridges, getBridge } from "../../../bridges/_lib/registry.js";
 import {
   resolveBridge,
@@ -31,8 +31,12 @@ import {
 } from "../../../bridges/_lib/launchd-template.js";
 import { DATA_DIR } from "../process-manager.js";
 
+function bridgeDataDir(bridgeName) {
+  return join(DATA_DIR, "bridges", bridgeName);
+}
+
 function bridgeLogDir(bridgeName) {
-  return `${DATA_DIR}/bridges/${bridgeName}/logs`;
+  return join(bridgeDataDir(bridgeName), "logs");
 }
 
 function usage() {
@@ -165,7 +169,7 @@ async function actionInstall(name) {
   }
 
   // Make sure the log directory exists before launchd tries to write to it.
-  mkdirSync(`${DATA_DIR}/bridges/${manifest.name}`, { recursive: true });
+  mkdirSync(bridgeDataDir(manifest.name), { recursive: true });
 
   const xml = buildBridgePlist({
     bridgeName: manifest.name,
@@ -220,6 +224,7 @@ async function actionStatus(name) {
   console.log(`  Plist:    ${existsSync(plistPath) ? plistPath : "(not installed)"}`);
   console.log(`  Token:    ${config?.token ? "configured" : "(not set)"}`);
   console.log(`  Default:  port ${manifest.port}, target ${manifest.target}`);
+  console.log(`  Logs:     ${bridgeLogDir(manifest.name)}/<YYYY-MM-DD>.log`);
 
   let loaded = false;
   let pid = null;

--- a/test/bridges-rotating-logger.test.js
+++ b/test/bridges-rotating-logger.test.js
@@ -1,0 +1,141 @@
+/**
+ * Tests for bridges/_lib/rotating-logger.js — per-week JSON-line file
+ * rotation. Covers the Sunday math, the file-name handoff at week
+ * boundaries, and the never-throw fallback contract.
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  sundayOfWeekUTC,
+  createRotatingLogger,
+} from "../bridges/_lib/rotating-logger.js";
+
+// Tiny helper: drain any buffered writes so the file content is visible
+// to readFileSync. Node's writeStream.write() is async; ending the stream
+// is the simplest deterministic flush.
+function readLines(path) {
+  return readFileSync(path, "utf-8")
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+describe("sundayOfWeekUTC", () => {
+  it("returns the same date for a Sunday", () => {
+    // 2026-05-03 is a Sunday in UTC.
+    assert.equal(sundayOfWeekUTC(new Date("2026-05-03T00:00:00Z")), "2026-05-03");
+    assert.equal(sundayOfWeekUTC(new Date("2026-05-03T23:59:59Z")), "2026-05-03");
+  });
+
+  it("walks back to the previous Sunday for a Monday", () => {
+    assert.equal(sundayOfWeekUTC(new Date("2026-05-04T12:00:00Z")), "2026-05-03");
+  });
+
+  it("walks back to the previous Sunday for a Saturday", () => {
+    // 2026-05-02 is a Saturday — Sunday-of-week is Apr 26.
+    assert.equal(sundayOfWeekUTC(new Date("2026-05-02T23:59:59Z")), "2026-04-26");
+  });
+
+  it("crosses year boundaries correctly", () => {
+    // 2027-01-01 is a Friday; the Sunday that begins its week is 2026-12-27.
+    assert.equal(sundayOfWeekUTC(new Date("2027-01-01T08:00:00Z")), "2026-12-27");
+  });
+});
+
+describe("createRotatingLogger", () => {
+  let dir;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "bridge-log-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("creates the log directory lazily on first write", () => {
+    const logsDir = join(dir, "logs");
+    const logger = createRotatingLogger({
+      dir: logsDir,
+      now: () => new Date("2026-05-01T22:00:00Z"),
+    });
+    logger({ event: "hello" });
+    logger.close();
+
+    const files = readdirSync(logsDir);
+    assert.deepEqual(files, ["2026-04-26.log"]);
+  });
+
+  it("appends multiple entries within the same week to one file", () => {
+    let n = 0;
+    // Each call advances time by one second within the same week.
+    const logger = createRotatingLogger({
+      dir,
+      now: () => new Date(Date.UTC(2026, 3, 27, 0, 0, n++)),
+    });
+    logger({ event: "a" });
+    logger({ event: "b" });
+    logger({ event: "c" });
+    logger.close();
+
+    const files = readdirSync(dir);
+    assert.deepEqual(files, ["2026-04-26.log"]);
+    const lines = readLines(join(dir, "2026-04-26.log"));
+    assert.deepEqual(lines.map((l) => l.event), ["a", "b", "c"]);
+    // Timestamps are recorded as UTC ISO strings.
+    assert.ok(lines[0].ts.endsWith("Z"));
+  });
+
+  it("opens a fresh file when the entry crosses a week boundary", () => {
+    const stamps = [
+      new Date("2026-05-02T23:59:59Z"), // Saturday — week of Apr 26
+      new Date("2026-05-03T00:00:00Z"), // Sunday — new week
+      new Date("2026-05-09T22:00:00Z"), // following Saturday — same new week
+    ];
+    let i = 0;
+    const logger = createRotatingLogger({ dir, now: () => stamps[i++] });
+    logger({ event: "before" });
+    logger({ event: "boundary" });
+    logger({ event: "after" });
+    logger.close();
+
+    const files = readdirSync(dir).sort();
+    assert.deepEqual(files, ["2026-04-26.log", "2026-05-03.log"]);
+    assert.deepEqual(
+      readLines(join(dir, "2026-04-26.log")).map((l) => l.event),
+      ["before"],
+    );
+    assert.deepEqual(
+      readLines(join(dir, "2026-05-03.log")).map((l) => l.event),
+      ["boundary", "after"],
+    );
+  });
+
+  it("falls back to stderr without throwing when the dir cannot be created", () => {
+    // Point the logger at a path that exists as a *file* — mkdir on it
+    // throws ENOTDIR. The logger must swallow the error.
+    const blocker = join(dir, "blocker");
+    writeFileSync(blocker, "x");
+    const logger = createRotatingLogger({
+      dir: join(blocker, "logs"),
+      now: () => new Date("2026-05-01T22:00:00Z"),
+    });
+
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    let captured = "";
+    process.stderr.write = (chunk) => {
+      captured += chunk;
+      return true;
+    };
+    try {
+      assert.doesNotThrow(() => logger({ event: "fallback" }));
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+    assert.match(captured, /"event":"fallback"/);
+  });
+});

--- a/test/bridges-rotating-logger.test.js
+++ b/test/bridges-rotating-logger.test.js
@@ -137,5 +137,30 @@ describe("createRotatingLogger", () => {
       process.stderr.write = originalWrite;
     }
     assert.match(captured, /"event":"fallback"/);
+    // Fallback lines are tagged so operators can grep for them when
+    // logs/ is mysteriously empty.
+    assert.match(captured, /"_log_fallback":true/);
+    assert.match(captured, /"_log_error":/);
+  });
+
+  it("does not throw when an event contains a circular reference", () => {
+    const logger = createRotatingLogger({
+      dir,
+      now: () => new Date("2026-05-01T22:00:00Z"),
+    });
+    const cycle = { event: "loopy" };
+    cycle.self = cycle;
+
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    let captured = "";
+    process.stderr.write = (chunk) => { captured += chunk; return true; };
+    try {
+      assert.doesNotThrow(() => logger(cycle));
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+    // The catch path swallowed the TypeError; primary log file was never
+    // created; fallback either annotated or emitted the bare tag.
+    assert.match(captured, /_log_fallback/);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a per-week rotating JSON-line logger for bridges. Events land in `~/.katulong/bridges/<name>/logs/<YYYY-MM-DD>.log` where the date is the UTC Sunday that begins the entry's week.
- Wires the rotating logger into `actionStart` so launchd-managed bridges use it. `stderr.log` keeps catching crashes and the listening-on banner; structured `auth_failure` / `upstream_error` events move to the rotated files.
- Documents the new `logs/` dir + manual pruning option in `bridges/README.md`.

## Why this shape

- **UTC-named files.** The `ts` field inside each line is already UTC ISO; matching the filename means opening `2026-04-26.log` shows a clean `[Sun 00:00Z, next-Sun 00:00Z)` window with no mental TZ conversion at grep time. DST also stops mattering.
- **`appendFileSync`, not a cached writeStream.** Bridge volume is a handful of events per minute, so sync-append makes the contract trivial — the line is on disk by the time `logger()` returns. Tried first with a cached stream; tests caught that Node's `open()` is async so a freshly-created stream's file isn't visible to `readdirSync` immediately after `.end()`. Sync append sidesteps the whole class of bug.
- **Never throws into the caller.** On any I/O failure (disk full, parent path is a regular file, EACCES) the line falls back to `process.stderr`. The bridge proxies live LLM streams; logging must not break the request path.
- **No automatic pruning.** Files are local-only; users can `find ~/.katulong/bridges/<name>/logs -mtime +90 -delete` on whatever cadence suits them.

## Activating on an existing bridge

The change applies on next bridge process start. To pick it up immediately:

```
katulong bridge <name> uninstall && katulong bridge <name> install
```

…or just let `KeepAlive` cycle it.

## Test plan

- [x] `npm run test:unit` — 2722 pass / 0 fail (8 new cases for `sundayOfWeekUTC` + `createRotatingLogger`)
- [x] Pre-push hook (unit + integration + smoke E2E + review agents) green
- [ ] After merge: reinstall ollama bridge LaunchAgent and verify `~/.katulong/bridges/ollama/logs/<sunday>.log` appears on next request