### PR TITLE
fix(ollama): re-probe higher-priority backends quickly when on a fallback

### DIFF
--- a/lib/ollama-client.js
+++ b/lib/ollama-client.js
@@ -253,8 +253,7 @@ export function createOllamaClient({
     }
 
     let lastErr = null;
-    for (let i = 0; i < backends.length; i++) {
-      const backend = backends[i];
+    for (const [i, backend] of backends.entries()) {
       // Skip the backend that just failed the fast path (its probe may
       // still pass — /api/tags doesn't care if /api/chat is broken — and
       // we don't want a second chat-call attempt on the same cycle).
@@ -264,9 +263,6 @@ export function createOllamaClient({
       try {
         const result = await callChatOnce(backend, userPrompt, systemPrompt);
         cachedBackend = backend;
-        // If we landed on a fallback (anything past index 0), use the
-        // shorter TTL so we re-probe higher-priority backends quickly
-        // and migrate back when they recover.
         cacheUntil = Date.now() + (i === 0 ? probeTtlMs : fallbackTtlMs);
         noteActive(backend);
         return result;

--- a/lib/ollama-client.js
+++ b/lib/ollama-client.js
@@ -50,6 +50,12 @@ const DEFAULT_TIMEOUT_MS = 10 * 60_000;
 const DEFAULT_PROBE_TIMEOUT_MS = 3_000;
 const DEFAULT_PROBE_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_FAIL_TTL_MS = 30 * 1000;
+// When the active backend is a fallback (not the first/preferred entry),
+// re-probe much more often so we notice when the higher-priority backend
+// (e.g., a peer-bridge that just restarted) comes back online. Without
+// this, a downed bridge would leave us pinned to local-31b/local-cloud
+// for the full probeTtlMs (5 minutes).
+const DEFAULT_FALLBACK_TTL_MS = 30 * 1000;
 
 /**
  * Create a `callOllama` function. The returned function additionally
@@ -63,6 +69,7 @@ export function createOllamaClient({
   probeTimeoutMs = DEFAULT_PROBE_TIMEOUT_MS,
   probeTtlMs = DEFAULT_PROBE_TTL_MS,
   failTtlMs = DEFAULT_FAIL_TTL_MS,
+  fallbackTtlMs = DEFAULT_FALLBACK_TTL_MS,
   // Old API (single backend) — kept for tests + any pre-cascade callers
   host = DEFAULT_HOST,
   model = DEFAULT_MODEL,
@@ -246,7 +253,8 @@ export function createOllamaClient({
     }
 
     let lastErr = null;
-    for (const backend of backends) {
+    for (let i = 0; i < backends.length; i++) {
+      const backend = backends[i];
       // Skip the backend that just failed the fast path (its probe may
       // still pass — /api/tags doesn't care if /api/chat is broken — and
       // we don't want a second chat-call attempt on the same cycle).
@@ -256,7 +264,10 @@ export function createOllamaClient({
       try {
         const result = await callChatOnce(backend, userPrompt, systemPrompt);
         cachedBackend = backend;
-        cacheUntil = Date.now() + probeTtlMs;
+        // If we landed on a fallback (anything past index 0), use the
+        // shorter TTL so we re-probe higher-priority backends quickly
+        // and migrate back when they recover.
+        cacheUntil = Date.now() + (i === 0 ? probeTtlMs : fallbackTtlMs);
         noteActive(backend);
         return result;
       } catch (err) {

--- a/test/ollama-client-peer.test.js
+++ b/test/ollama-client-peer.test.js
@@ -204,6 +204,72 @@ describe("createOllamaClient — cascade (resolveBackends)", () => {
     assert.equal(probesAfterSecond, 1, "second call should reuse the cached active");
   });
 
+  it("re-probes higher-priority backends quickly when serving from a fallback", async () => {
+    // Simulates the peer-bridge being down at first call (so we cascade
+    // to local-31b), then coming back online. With the fallback-aware
+    // short TTL, the next call after fallbackTtlMs should re-probe and
+    // migrate back to peer-bridge.
+    let bridgeReachable = false;
+    const client = createOllamaClient({
+      resolveBackends: () => [
+        {
+          name: "peer-bridge",
+          host: bridgeReachable ? bridgeUrl : "http://127.0.0.1:1",
+          authToken: null,
+          model: "gemma4:31b",
+        },
+        { name: "local-31b", host: localUrl, authToken: null, model: "gemma4:31b" },
+      ],
+      probeTimeoutMs: 200,
+      fallbackTtlMs: 50,
+      probeTtlMs: 10 * 60 * 1000,
+    });
+
+    await client("first");
+    assert.equal(client.getActiveBackend().name, "local-31b");
+
+    // Bridge comes back. Within fallbackTtlMs we still trust the cached
+    // fallback (no probe storm).
+    bridgeReachable = true;
+    const localChatsBefore = localStub.requests.filter((r) => r.url === "/api/chat").length;
+    await client("second");
+    assert.equal(client.getActiveBackend().name, "local-31b", "stays on fallback within TTL");
+    const localChatsAfter = localStub.requests.filter((r) => r.url === "/api/chat").length;
+    assert.equal(localChatsAfter, localChatsBefore + 1, "second call served by local within TTL");
+
+    // After fallbackTtlMs expires, the next call should re-probe and find
+    // the now-healthy peer-bridge.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    await client("third");
+    assert.equal(client.getActiveBackend().name, "peer-bridge", "migrates back once TTL expires");
+    assert.ok(
+      bridgeStub.requests.some((r) => r.url === "/api/chat"),
+      "bridge served the third call",
+    );
+  });
+
+  it("uses the long TTL when the active backend is the highest-priority one", async () => {
+    // Counterpart to the fallback test: when we're already on the
+    // preferred backend, fallbackTtlMs must NOT shorten the cache —
+    // otherwise we'd probe-storm the happy path.
+    const client = createOllamaClient({
+      resolveBackends: () => [
+        { name: "peer-bridge", host: bridgeUrl, authToken: null, model: "gemma4:31b" },
+        { name: "local-31b",   host: localUrl,  authToken: null, model: "gemma4:31b" },
+      ],
+      fallbackTtlMs: 10,
+      probeTtlMs: 10 * 60 * 1000,
+    });
+    await client("first");
+    assert.equal(client.getActiveBackend().name, "peer-bridge");
+    const probesAfterFirst = bridgeStub.requests.filter((r) => r.url === "/api/tags").length;
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await client("second");
+    const probesAfterSecond = bridgeStub.requests.filter((r) => r.url === "/api/tags").length;
+    assert.equal(probesAfterFirst, 1, "first call probes once");
+    assert.equal(probesAfterSecond, 1, "preferred backend is not re-probed on the short TTL");
+  });
+
   it("invalidate() forces the next call to re-probe", async () => {
     const client = createOllamaClient({
       resolveBackends: () => [

--- a/test/ollama-client-peer.test.js
+++ b/test/ollama-client-peer.test.js
@@ -221,6 +221,8 @@ describe("createOllamaClient — cascade (resolveBackends)", () => {
         { name: "local-31b", host: localUrl, authToken: null, model: "gemma4:31b" },
       ],
       probeTimeoutMs: 200,
+      // Short TTL so the test can wait it out, with a generous 5x margin
+      // on the post-expiry sleep below to absorb GC pauses on loaded CI.
       fallbackTtlMs: 50,
       probeTtlMs: 10 * 60 * 1000,
     });
@@ -238,8 +240,8 @@ describe("createOllamaClient — cascade (resolveBackends)", () => {
     assert.equal(localChatsAfter, localChatsBefore + 1, "second call served by local within TTL");
 
     // After fallbackTtlMs expires, the next call should re-probe and find
-    // the now-healthy peer-bridge.
-    await new Promise((resolve) => setTimeout(resolve, 80));
+    // the now-healthy peer-bridge. 5x the TTL to tolerate scheduler jitter.
+    await new Promise((resolve) => setTimeout(resolve, 250));
     await client("third");
     assert.equal(client.getActiveBackend().name, "peer-bridge", "migrates back once TTL expires");
     assert.ok(
@@ -263,7 +265,10 @@ describe("createOllamaClient — cascade (resolveBackends)", () => {
     await client("first");
     assert.equal(client.getActiveBackend().name, "peer-bridge");
     const probesAfterFirst = bridgeStub.requests.filter((r) => r.url === "/api/tags").length;
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    // Wait well past fallbackTtlMs so the assertion below is a true
+    // negative — if the index-0 backend were incorrectly short-TTL'd,
+    // this delay would force a re-probe.
+    await new Promise((resolve) => setTimeout(resolve, 100));
     await client("second");
     const probesAfterSecond = bridgeStub.requests.filter((r) => r.url === "/api/tags").length;
     assert.equal(probesAfterFirst, 1, "first call probes once");


### PR DESCRIPTION
## Summary
- When the peer-bridge dies and the cascade falls through to `local-31b` / `local-cloud`, the cached active backend was held for the full `probeTtlMs` (5 min). Even after the bridge came back, the fast path kept using the local fallback for the remainder of that window — feed narration and per-tab summaries silently stayed on the wrong host.
- New behavior: when the chosen backend is anything other than the highest-priority entry in `resolveBackends()`, use a much shorter `fallbackTtlMs` (default **30s**, matching `failTtlMs`) so we re-probe higher-priority backends frequently and migrate back as soon as the bridge returns. The preferred backend keeps its long TTL — no probe storm on the happy path.
- Two regression tests in `test/ollama-client-peer.test.js`: one exercises bridge-down → fallback → bridge-back recovery within `fallbackTtlMs`; the other guards the inverse — that the preferred backend isn't accidentally short-TTL'd.

## Why the asymmetry mattered
- All backends down → `failTtlMs` (30s) → quick recovery.
- One fallback up → `probeTtlMs` (5 min) → slow recovery.
- That's backwards. Fallback-recovery is the case operators actually hit (bridge restarts), so it should be the *quicker* one.

## Test plan
- [x] `node --test test/ollama-client-peer.test.js` — 18/18 pass (16 prior + 2 new)
- [x] `npm run test:unit` — 2751 pass / 0 fail
- [x] Pre-push hook (full suite + smoke E2E + review agents) — all green
- [ ] Manual: kill the peer bridge mid-session, confirm narration falls through to local within one cycle, then bring the bridge back and confirm it migrates back within ~30s