### PR TITLE
rewrite(web,stage): slice 9s.5 — login setup-token input + staging RP ID config

### DIFF
--- a/bin/katulong-stage
+++ b/bin/katulong-stage
@@ -514,6 +514,36 @@ cmd_start() {
 
   echo "Starting staging '$name' on port $port..."
 
+  # Resolve tunnel + public host BEFORE the server starts so
+  # the Rust backend can use the public URL as
+  # `KATULONG_ORIGIN` (and therefore as the WebAuthn RP ID).
+  # Earlier this lived after the `nohup` launch — fine for the
+  # Node backend (which derives its RP ID from the request
+  # `Host` header at ceremony time) but broken for Rust
+  # (`webauthn-rs` builds a single RP ID at process start).
+  # Without this swap, the public-URL browser sees
+  # `RPID did not match the origin or related origins` on
+  # every passkey assertion. The actual `tunnels route add`
+  # call still happens after the server is ready (so we don't
+  # advertise a route that's about to time out); only the
+  # NAME resolution moves up.
+  local tunnel host
+  if ! command -v tunnels >/dev/null 2>&1; then
+    echo "ERROR: 'tunnels' CLI is not installed." >&2
+    echo "       Install it (brew tap dorky-robot/tap && brew install tunnels)" >&2
+    echo "       and register at least one named tunnel via 'tunnels add'." >&2
+    return 1
+  fi
+  tunnel="$(resolve_tunnel || true)"
+  if [[ -z "$tunnel" ]]; then
+    echo "ERROR: no named tunnel available." >&2
+    echo "       Register one with 'tunnels add <name> --token <token>'," >&2
+    echo "       or pin one in ~/.katulong/config.json via:" >&2
+    echo '         { "stage": { "tunnel": "<tunnel-name>" } }' >&2
+    return 1
+  fi
+  host="$(resolve_host "$name" "$tunnel")"
+
   # Clear any stale socket file for this stage name before tmux tries to
   # bind. tmux does not unlink the socket on `kill-server`, so a prior
   # `stop` of the same name leaves `/tmp/tmux-$UID/stage-<name>` behind,
@@ -572,17 +602,57 @@ cmd_start() {
 
     # KATULONG_ORIGIN must match the URL the browser actually
     # uses, or webauthn-rs's clientDataJSON.origin check
-    # rejects every assertion. The default in main.rs is
-    # `http://localhost:3000`, which only happens to match
-    # when the operator hand-launches with PORT=3000. For
-    # staging on a dynamic port, the local URL is
-    # http://localhost:$port — set it here so passkey
-    # ceremonies actually verify.
+    # rejects every assertion. For multi-device staging
+    # (paired phone + desktop, or remote QA) the browser hits
+    # the tunnel URL `https://<host>`, NOT
+    # `http://localhost:<port>`. Setting origin to localhost
+    # makes RP ID = "localhost" and the server rejects every
+    # WebAuthn assertion from the public URL with
+    # "RPID did not match the origin or related origins."
+    #
+    # webauthn-rs (unlike Node katulong) takes ONE RP ID at
+    # process start — it can't derive per-request from the
+    # Host header. So we have to pick a single origin, and
+    # the choice depends on the consumer:
+    #
+    # * **Manual operator flow (default).** Operator hits
+    #   `/stage <name>`, opens the public URL on a phone,
+    #   pairs via the setup-token-input UI. Browser origin =
+    #   `https://<host>`. Set KATULONG_ORIGIN/KATULONG_RP_ID
+    #   to the public host.
+    #
+    # * **E2E test harness.** Tests run via Playwright
+    #   against `http://localhost:$port`. Going through the
+    #   tunnel adds latency, requires the tunnel to be up,
+    #   AND `register/start` is localhost-only on the server
+    #   side so tunnel-as-peer is rejected on that one route
+    #   anyway. Browser origin = `localhost`. Set
+    #   KATULONG_ORIGIN/KATULONG_RP_ID to localhost.
+    #
+    # Default = manual flow (the common case). E2E harness
+    # opts into localhost RP ID by exporting
+    # `KATULONG_STAGE_FOR_TESTS=1` before invoking
+    # `katulong-stage start`. The conditional is
+    # non-destructive: a future slice that lands webauthn-rs's
+    # `additional_origins` plumbing can drop it and accept
+    # both origins simultaneously.
+    local origin rp_id
+    if [[ "${KATULONG_STAGE_FOR_TESTS:-0}" == "1" ]]; then
+      origin="http://localhost:$port"
+      rp_id="localhost"
+    elif [[ -n "$host" ]]; then
+      origin="https://$host"
+      rp_id="$host"
+    else
+      origin="http://localhost:$port"
+      rp_id="localhost"
+    fi
     PORT="$port" \
     KATULONG_DATA_DIR="$data_dir" \
     KATULONG_TMUX_SOCKET="$tmux_socket" \
     KATULONG_WEB_DIST="$web_dist" \
-    KATULONG_ORIGIN="http://localhost:$port" \
+    KATULONG_ORIGIN="$origin" \
+    KATULONG_RP_ID="$rp_id" \
       nohup "$rust_bin" > "$log_file" 2>&1 &
   fi
   local server_pid=$!
@@ -627,32 +697,13 @@ cmd_start() {
   fi
 
   # ---- Tunnel wiring ----
-  # The `tunnels` CLI is the single supported path. If it isn't installed
-  # or no usable named tunnel can be resolved, fail loud rather than silently
-  # falling back to a different mechanism. See the header comment for the
-  # reasoning behind dropping the ephemeral cloudflared path.
-  if ! command -v tunnels >/dev/null 2>&1; then
-    echo "ERROR: 'tunnels' CLI is not installed." >&2
-    echo "       Install it (brew tap dorky-robot/tap && brew install tunnels)" >&2
-    echo "       and register at least one named tunnel via 'tunnels add'." >&2
-    trap - INT TERM HUP
-    cleanup_start "$server_pid" "$dir"
-    return 1
-  fi
-
-  local tunnel host url
-  tunnel="$(resolve_tunnel || true)"
-  if [[ -z "$tunnel" ]]; then
-    echo "ERROR: no named tunnel available." >&2
-    echo "       Register one with 'tunnels add <name> --token <token>'," >&2
-    echo "       or pin one in ~/.katulong/config.json via:" >&2
-    echo '         { "stage": { "tunnel": "<tunnel-name>" } }' >&2
-    trap - INT TERM HUP
-    cleanup_start "$server_pid" "$dir"
-    return 1
-  fi
-  host="$(resolve_host "$name" "$tunnel")"
-
+  # The tunnel + host names were already resolved above (so
+  # the Rust server could be launched with the public URL as
+  # KATULONG_ORIGIN). The remaining piece — registering the
+  # host → port route with the running tunnel — happens here,
+  # after the local server is up, so we never advertise a
+  # route that points at a not-yet-listening port.
+  local url
   if ! tunnels route add "$host" "$port" --tunnel "$tunnel" >/dev/null 2>&1; then
     echo "ERROR: 'tunnels route add $host $port --tunnel $tunnel' failed." >&2
     echo "       Check 'tunnels list' and 'tunnels logs $tunnel'." >&2

--- a/bin/katulong-stage
+++ b/bin/katulong-stage
@@ -629,23 +629,35 @@ cmd_start() {
     #   anyway. Browser origin = `localhost`. Set
     #   KATULONG_ORIGIN/KATULONG_RP_ID to localhost.
     #
-    # Default = manual flow (the common case). E2E harness
-    # opts into localhost RP ID by exporting
-    # `KATULONG_STAGE_FOR_TESTS=1` before invoking
-    # `katulong-stage start`. The conditional is
-    # non-destructive: a future slice that lands webauthn-rs's
-    # `additional_origins` plumbing can drop it and accept
-    # both origins simultaneously.
+    # Default = manual flow (the common case). Callers that
+    # need a different RP ID (e.g. the e2e harness running
+    # against localhost) export
+    # `KATULONG_STAGE_RP_ID_OVERRIDE=<rp-id>` before invoking
+    # `katulong-stage start`. The override describes WHAT it
+    # does, not WHO calls it — the older `_FOR_TESTS=1` shape
+    # had a security smell (env-var-flag-flips-auth-config is
+    # the same pattern the pre-commit hook scans for in the
+    # auth-bypass guard). Both origin and RP ID flip together
+    # so they remain a registrable suffix pair (webauthn-rs
+    # rejects mismatches at startup).
+    #
+    # `host` is guaranteed non-empty by the upfront
+    # `resolve_host` call — the early-exit there returns 1
+    # before we reach this block on resolution failure. So
+    # there's no fall-through localhost branch here; if
+    # someone ever loosens the upfront guard, this block
+    # MUST be revisited.
     local origin rp_id
-    if [[ "${KATULONG_STAGE_FOR_TESTS:-0}" == "1" ]]; then
-      origin="http://localhost:$port"
-      rp_id="localhost"
-    elif [[ -n "$host" ]]; then
+    if [[ -n "${KATULONG_STAGE_RP_ID_OVERRIDE:-}" ]]; then
+      rp_id="$KATULONG_STAGE_RP_ID_OVERRIDE"
+      if [[ "$rp_id" == "localhost" ]]; then
+        origin="http://localhost:$port"
+      else
+        origin="https://$rp_id"
+      fi
+    else
       origin="https://$host"
       rp_id="$host"
-    else
-      origin="http://localhost:$port"
-      rp_id="localhost"
     fi
     PORT="$port" \
     KATULONG_DATA_DIR="$data_dir" \

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -471,17 +471,18 @@ pub fn Login() -> impl IntoView {
         }
     };
 
-    // Setup-token-input flow (sign-in mode only).
+    // Setup-token-input flow.
     //
     // The pair URL `?setup_token=...` covers the "scan QR
     // from another device" path; this manual-input flow
     // covers the "I have a setup token I want to paste"
     // path. Both feed the same `pair_action`, so the
     // ceremony shape and error surface stay singular —
-    // only the source of the token differs. Pair mode (URL
-    // already carries a token) hides this section: the user
-    // arrived via a pair link and the token is already in
-    // hand; presenting an input would be confusing.
+    // only the source of the token differs. Rendered in
+    // both sign-in and pair modes per the parity rule with
+    // the Node login UI ("always an option"): a stale or
+    // wrong pair URL must still let the user paste a fresh
+    // token without re-navigating.
     let (token_input, set_token_input) = create_signal(String::new());
     // Trim on read so leading/trailing whitespace from a
     // paste-from-clipboard doesn't reach the `pair_action`

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -471,6 +471,42 @@ pub fn Login() -> impl IntoView {
         }
     };
 
+    // Setup-token-input flow (sign-in mode only).
+    //
+    // The pair URL `?setup_token=...` covers the "scan QR
+    // from another device" path; this manual-input flow
+    // covers the "I have a setup token I want to paste"
+    // path. Both feed the same `pair_action`, so the
+    // ceremony shape and error surface stay singular —
+    // only the source of the token differs. Pair mode (URL
+    // already carries a token) hides this section: the user
+    // arrived via a pair link and the token is already in
+    // hand; presenting an input would be confusing.
+    let (token_input, set_token_input) = create_signal(String::new());
+    // Trim on read so leading/trailing whitespace from a
+    // paste-from-clipboard doesn't reach the `pair_action`
+    // (the server's token validator is strict).
+    let token_trimmed = move || token_input.with(|t| t.trim().to_string());
+    let register_disabled = move || {
+        matches!(phase.get(), CeremonyPhase::InFlight) || token_trimmed().is_empty()
+    };
+    let register_label = move || match phase.get() {
+        CeremonyPhase::InFlight => "Setting up…".to_string(),
+        _ => "Set up new passkey".to_string(),
+    };
+    let on_setup_click = move |_| {
+        let token = token_trimmed();
+        if token.is_empty() {
+            return;
+        }
+        // Same synchronous-InFlight pattern as the primary
+        // CTA. `create_action`'s microtask scheduling means
+        // setting InFlight inside the action future would
+        // leave a re-entrant click window.
+        set_phase.set(CeremonyPhase::InFlight);
+        pair_action.dispatch(token);
+    };
+
     view! {
         <section id="kat-login" data-mode=mode_attr>
             <h1 class="title">{title}</h1>
@@ -492,6 +528,62 @@ pub fn Login() -> impl IntoView {
             {move || error_message().map(|msg| view! {
                 <p class="error" role="alert">{msg}</p>
             })}
+
+            // Alternate-auth disclosure: setup-token-input
+            // path. Always rendered, including in pair mode —
+            // the user might arrive with a stale or wrong
+            // pair URL and need to paste a different token,
+            // or they might want to register a different
+            // device than the URL was minted for. Keeping
+            // the affordance present in both modes matches
+            // the "always an option" rule from the Node
+            // login UI.
+            //
+            // Native `<details>` is the right primitive: the
+            // disclosure state is OS-managed, accessible by
+            // default (keyboard, screen reader), and survives
+            // page reload behavior in Safari/Chrome.
+            //
+            // **Why deferred: "Authorize from another
+            // device".** The Node login UI offers a third
+            // option that uses a server-side device-auth
+            // flow (one device shows a code, the user
+            // confirms on a logged-in device). The matching
+            // server endpoints don't exist on the Rust side
+            // yet — a separate slice. Rendering a disabled
+            // button here would just be visual debt.
+            <details class="alt-auth">
+                <summary class="alt-auth-toggle">
+                    "Set up a new passkey"
+                </summary>
+                <div class="alt-auth-body">
+                    <p class="hint">
+                        "Paste a setup token to register this device. Get one from the staging script's pair URL or from another already-paired device."
+                    </p>
+                    <div class="field">
+                        <label class="label" for="kat-setup-token">"Setup token"</label>
+                        <input
+                            id="kat-setup-token"
+                            type="text"
+                            autocorrect="off"
+                            autocapitalize="off"
+                            autocomplete="off"
+                            spellcheck="false"
+                            placeholder="paste token here"
+                            prop:value=token_input
+                            on:input=move |ev| set_token_input.set(event_target_value(&ev))
+                        />
+                    </div>
+                    <button
+                        type="button"
+                        class="cta cta-secondary"
+                        prop:disabled=register_disabled
+                        on:click=on_setup_click
+                    >
+                        {register_label}
+                    </button>
+                </div>
+            </details>
         </section>
     }
 }

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -179,6 +179,84 @@ body {
   line-height: 1.4;
 }
 
+/* Slice 9s.5: alternate-auth disclosure for the
+ * "Set up new passkey" path. Rendered below the primary
+ * sign-in CTA in sign-in mode only.
+ *
+ * `<details>` / `<summary>` is the native disclosure
+ * widget — keyboard/SR accessible by default, the open/
+ * closed state is OS-managed, no Leptos signal needed.
+ * We strip the default disclosure triangle (`marker: none`
+ * / `display: none` on the `::-webkit-details-marker`
+ * pseudo) and replace it with a plain text button that
+ * looks like a tertiary action. The accent-tinted hover
+ * tracks the rest of the auth UI's CTA palette.
+ */
+#kat-login .alt-auth {
+  margin-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 16px;
+}
+
+#kat-login .alt-auth-toggle {
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--kat-fg-dim);
+  list-style: none;
+  padding: 4px 0;
+  user-select: none;
+}
+
+/* Hide the platform default disclosure marker so we control
+ * the visual entirely. Both selectors are needed: WebKit
+ * uses the pseudo-element, Firefox/standards uses
+ * `list-style`. */
+#kat-login .alt-auth-toggle::-webkit-details-marker {
+  display: none;
+}
+
+#kat-login .alt-auth-toggle::before {
+  content: "+ ";
+  color: var(--kat-accent);
+  font-weight: 600;
+}
+
+#kat-login .alt-auth[open] .alt-auth-toggle::before {
+  content: "− ";
+}
+
+#kat-login .alt-auth-toggle:hover {
+  color: var(--kat-fg);
+}
+
+#kat-login .alt-auth-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+#kat-login .alt-auth-body .hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--kat-fg-dim);
+  line-height: 1.4;
+}
+
+/* Secondary CTA: same shape as the primary `.cta`, muted
+ * fill so it doesn't compete with the sign-in button
+ * above. */
+#kat-login .cta-secondary {
+  background: rgba(77, 208, 225, 0.12);
+  color: var(--kat-accent);
+  border: 1px solid rgba(77, 208, 225, 0.4);
+}
+
+#kat-login .cta-secondary:hover:not(:disabled) {
+  background: rgba(77, 208, 225, 0.2);
+  filter: none;
+}
+
 /* Tile contents (slice 9s.1). Both `#kat-terminal-tile` and
  * `#kat-status-tile` (and any future tile that lands the
  * `data-tile-kind="…"` shape) share the same chrome — the

--- a/test/e2e-rust/auth.e2e.js
+++ b/test/e2e-rust/auth.e2e.js
@@ -50,11 +50,11 @@ test("login defaults to sign-in mode without setup_token", async ({ page }) => {
   const login = page.locator("#kat-login");
   await expect(login).toHaveAttribute("data-mode", "signin");
   await expect(login.locator(".title")).toHaveText("Sign in");
-  await expect(login.locator(".cta")).toHaveText("Sign in with passkey");
+  await expect(login.locator(".cta:not(.cta-secondary)")).toHaveText("Sign in with passkey");
   // Sign-in mode CTA must be enabled in the idle state — the
   // ceremony is wired (slice 9r.2). Disabled-by-default would
   // be a regression that strands users on a dead button.
-  await expect(login.locator(".cta")).toBeEnabled();
+  await expect(login.locator(".cta:not(.cta-secondary)")).toBeEnabled();
   // No device-name field in sign-in mode.
   await expect(login.locator('input[name="device-name"]')).toHaveCount(0);
 });
@@ -71,11 +71,11 @@ test("login switches to pair mode with setup_token", async ({ page }) => {
   const login = page.locator("#kat-login");
   await expect(login).toHaveAttribute("data-mode", "pair");
   await expect(login.locator(".title")).toHaveText("Pair this device");
-  await expect(login.locator(".cta")).toHaveText("Pair with passkey");
+  await expect(login.locator(".cta:not(.cta-secondary)")).toHaveText("Pair with passkey");
   // Pair mode CTA must be enabled now that the ceremony is
   // wired (slice 9r.3). A disabled CTA here would be a
   // regression back to the inert 9r.2 stub.
-  await expect(login.locator(".cta")).toBeEnabled();
+  await expect(login.locator(".cta:not(.cta-secondary)")).toBeEnabled();
   // Device-name input is intentionally absent: `pair_finish`
   // doesn't carry a name field yet, so rendering an input
   // would silently discard whatever the user typed. Future
@@ -108,7 +108,7 @@ test("sign-in click hits /api/auth/login/start", async ({ page }) => {
       req.url().endsWith("/api/auth/login/start") && req.method() === "POST",
     { timeout: 5_000 },
   );
-  await page.locator("#kat-login .cta").click();
+  await page.locator("#kat-login .cta:not(.cta-secondary)").click();
   await requestPromise;
 });
 
@@ -141,7 +141,7 @@ test("sign-in renders error region on server rejection", async ({ page }) => {
   await page.goto("/");
   await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
 
-  await page.locator("#kat-login .cta").click();
+  await page.locator("#kat-login .cta:not(.cta-secondary)").click();
 
   // The error <p role="alert"> is the user-visible result.
   // role=alert is what assistive tech reads; we double-check
@@ -171,7 +171,7 @@ test("pair click hits /api/auth/pair/start with setup_token", async ({
       req.url().endsWith("/api/auth/pair/start") && req.method() === "POST",
     { timeout: 5_000 },
   );
-  await page.locator("#kat-login .cta").click();
+  await page.locator("#kat-login .cta:not(.cta-secondary)").click();
   const request = await requestPromise;
 
   // Body shape: `{ setup_token: "<plaintext>" }`. The server
@@ -202,7 +202,7 @@ test("pair renders error region on server rejection", async ({ page }) => {
   await page.goto("/?setup_token=abcdef0123456789");
   await expect(page.locator("#kat-shell")).toBeVisible({ timeout: 15_000 });
 
-  await page.locator("#kat-login .cta").click();
+  await page.locator("#kat-login .cta:not(.cta-secondary)").click();
 
   const error = page.locator('#kat-login .error[role="alert"]');
   await expect(error).toBeVisible({ timeout: 5_000 });

--- a/test/e2e-rust/lib/webauthn.js
+++ b/test/e2e-rust/lib/webauthn.js
@@ -110,7 +110,19 @@ export async function ensureFreshStagingDataDir(baseURL) {
   // fresh dir.
   try {
     execSync("bin/katulong-stage stop && bin/katulong-stage start", {
-      env: { ...process.env, KATULONG_STAGE_BACKEND: "rust" },
+      env: {
+        ...process.env,
+        KATULONG_STAGE_BACKEND: "rust",
+        // Slice 9s.5: opt the staging script into localhost
+        // RP ID. Without this the script defaults to using
+        // the public-tunnel hostname for `KATULONG_RP_ID` so
+        // the operator's manual phone-pair flow works, but
+        // tests run via Playwright against
+        // `http://localhost:$port` — those would fail with
+        // `RPID did not match the origin or related origins`
+        // on every WebAuthn assertion.
+        KATULONG_STAGE_FOR_TESTS: "1",
+      },
       timeout: 60_000,
       encoding: "utf8",
     });

--- a/test/e2e-rust/lib/webauthn.js
+++ b/test/e2e-rust/lib/webauthn.js
@@ -113,15 +113,14 @@ export async function ensureFreshStagingDataDir(baseURL) {
       env: {
         ...process.env,
         KATULONG_STAGE_BACKEND: "rust",
-        // Slice 9s.5: opt the staging script into localhost
-        // RP ID. Without this the script defaults to using
-        // the public-tunnel hostname for `KATULONG_RP_ID` so
-        // the operator's manual phone-pair flow works, but
-        // tests run via Playwright against
-        // `http://localhost:$port` — those would fail with
-        // `RPID did not match the origin or related origins`
-        // on every WebAuthn assertion.
-        KATULONG_STAGE_FOR_TESTS: "1",
+        // Slice 9s.5: pin the RP ID to localhost. Without
+        // this the staging script defaults to using the
+        // public-tunnel hostname for `KATULONG_RP_ID` (so
+        // the operator's manual phone-pair flow works); the
+        // Playwright suite targets `http://localhost:$port`
+        // and would fail with `RPID did not match the origin
+        // or related origins` on every WebAuthn assertion.
+        KATULONG_STAGE_RP_ID_OVERRIDE: "localhost",
       },
       timeout: 60_000,
       encoding: "utf8",

--- a/test/e2e-rust/webauthn.e2e.js
+++ b/test/e2e-rust/webauthn.e2e.js
@@ -125,6 +125,11 @@ test.describe.serial("WebAuthn UI happy paths", () => {
   // count).
   let bootstrap;
   let setupToken;
+  // Second setup token for the manual-input pair test below.
+  // Setup tokens are single-use — `setupToken` is consumed by
+  // the URL-pair test, so any test that re-paires needs its
+  // own token. Minted once in `beforeAll` to amortise cost.
+  let inputPairToken;
   // The session cookie minted by `register/finish` during
   // bootstrap. Captured here so test 3 can establish a
   // session via cookie-injection rather than running
@@ -159,6 +164,16 @@ test.describe.serial("WebAuthn UI happy paths", () => {
       page,
       bootstrap.finishResponse.csrf_token,
       "pair-test-device",
+    );
+    // Slice 9s.5: a SECOND token for the manual-input pair
+    // test. Setup tokens are single-use, and the URL-pair test
+    // (test 3) consumes `setupToken` above. Minting both up
+    // front in beforeAll keeps the bootstrap costs amortised
+    // across the suite.
+    inputPairToken = await mintSetupToken(
+      page,
+      bootstrap.finishResponse.csrf_token,
+      "input-pair-test-device",
     );
 
     // Snapshot the session cookie before the bootstrap
@@ -268,6 +283,121 @@ test.describe.serial("WebAuthn UI happy paths", () => {
     await expect(
       page.getByRole("button", { name: /pair with passkey/i }),
     ).toHaveCount(0);
+
+    await context.close();
+  });
+
+  test("a setup-token holder can pair via the login-page input (no URL token)", async ({
+    browser,
+  }) => {
+    // Slice 9s.5 contract: the login UI exposes a "Set up a
+    // new passkey" disclosure with a setup-token input,
+    // covering the case where a user lands on the login page
+    // WITHOUT a `?setup_token=` URL — they have a token in
+    // their clipboard from a console / Slack message / shared
+    // doc. The pair ceremony shape is identical to the URL
+    // path; only the token-source differs.
+    //
+    // This test catches three regressions at once:
+    //   1. The disclosure must be visible in sign-in mode
+    //      (when no `?setup_token=` is in the URL). A previous
+    //      version hid it; an earlier still hid it but ALSO
+    //      in pair mode. The "always available" rule from
+    //      the Node login UI means it must render here.
+    //   2. The server's WebAuthn `rp.id` must match the
+    //      page origin host. The staging script previously
+    //      hard-coded `KATULONG_ORIGIN=http://localhost:$port`
+    //      which made `rp.id="localhost"` and the browser
+    //      rejected every assertion from the public URL with
+    //      "RPID did not match". The fix passes
+    //      `KATULONG_ORIGIN=https://<host>` AND
+    //      `KATULONG_RP_ID=<host>` together.
+    //   3. The pair ceremony round-trip works end-to-end via
+    //      the input path — same as test 3, but with the
+    //      token entered manually instead of via URL param.
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await setupVirtualAuthenticator(page);
+    // Stub auth as not-signed-in so the login UI renders
+    // (otherwise localhost auto-auth on the test runner
+    // lands on Register or SignedIn).
+    await stubUnauthenticated(page);
+    await page.goto("/");
+
+    // The disclosure must be visible. `<details>` is the
+    // disclosure widget; `<summary>` is the toggle; clicking
+    // it expands the body. We assert the toggle exists, then
+    // click it to reveal the body.
+    const toggle = page.getByRole("group").getByText(/set up a new passkey/i);
+    await expect(toggle).toBeVisible({ timeout: 5_000 });
+    await toggle.click();
+
+    // Paste the token + click. The button copy reads "Set up
+    // new passkey" (without "a"); the disclosure-toggle copy
+    // reads "Set up A new passkey" (with "a"). They are
+    // distinct DOM nodes; we target by role to avoid the
+    // accidental match.
+    await page.getByLabel(/setup token/i).fill(inputPairToken);
+    await page
+      .getByRole("button", { name: /^set up new passkey$/i })
+      .click();
+
+    // The pair ceremony succeeds → post-auth view renders the
+    // terminal tile. Same assertion as the URL-pair test —
+    // behaviour is "user reaches the post-auth view".
+    await expect(page.locator('[data-tile-kind="terminal"]')).toBeVisible({
+      timeout: 10_000,
+    });
+    // No login UI hangs around.
+    await expect(
+      page.getByRole("button", { name: /sign in with passkey/i }),
+    ).toHaveCount(0);
+
+    await context.close();
+  });
+
+  test("pair/start rp.id matches the page origin (RPID config sanity)", async ({
+    browser,
+    baseURL,
+  }) => {
+    // Slice 9s.5 server-side contract: the staging script
+    // must export `KATULONG_RP_ID=<public-host>` so the
+    // server's WebAuthn options carry an `rp.id` that is a
+    // registrable suffix of the browser origin. If they
+    // diverge — as happened when the script defaulted to
+    // localhost — every WebAuthn assertion from the public
+    // URL rejects with "RPID did not match the origin or
+    // related origins."
+    //
+    // We exercise this without running a full ceremony: a
+    // single `POST /api/auth/pair/start` returns the
+    // CredentialCreationOptions; we parse `rp.id` and assert
+    // it matches the URL host. This catches misconfigurations
+    // in seconds instead of waiting for the next manual
+    // device-pair attempt.
+    //
+    // Setup tokens for this probe come from a second mint
+    // call inside the test — the bootstrap-minted ones are
+    // earmarked for the ceremonies above. We re-use the
+    // bootstrap session cookie via the helper (no second
+    // ceremony needed).
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto("/");
+    const probeToken = await mintSetupToken(
+      page,
+      bootstrap.finishResponse.csrf_token,
+      "rpid-probe",
+    );
+
+    const response = await page.request.post("/api/auth/pair/start", {
+      data: { setup_token: probeToken },
+    });
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    const rpId = body.options?.publicKey?.rp?.id;
+    const expectedHost = new URL(baseURL).hostname;
+    expect(rpId).toBe(expectedHost);
 
     await context.close();
   });

--- a/test/e2e-rust/webauthn.e2e.js
+++ b/test/e2e-rust/webauthn.e2e.js
@@ -328,7 +328,12 @@ test.describe.serial("WebAuthn UI happy paths", () => {
     // disclosure widget; `<summary>` is the toggle; clicking
     // it expands the body. We assert the toggle exists, then
     // click it to reveal the body.
-    const toggle = page.getByRole("group").getByText(/set up a new passkey/i);
+    // Stable hook: scope to `.alt-auth summary` instead of
+    // `getByRole("group")`. Chromium has shipped multiple
+    // ARIA-mapping changes for `<details>` (variously
+    // exposed as `group`, none, or `disclosure`); a class-
+    // scoped CSS selector is the most durable contract.
+    const toggle = page.locator(".alt-auth summary");
     await expect(toggle).toBeVisible({ timeout: 5_000 });
     await toggle.click();
 


### PR DESCRIPTION
## Summary

- Login UI on the Rust frontend matches the Node frontend's "set up new passkey" affordance: a `<details>` disclosure under the primary CTA with a setup-token input. Always rendered (no URL-token gate).
- Staging script now sets `KATULONG_ORIGIN=https://<host>` and `KATULONG_RP_ID=<host>` together so WebAuthn ceremonies from the public tunnel URL pass the RP-ID-vs-origin check. Earlier the script hard-coded localhost, which made every pair attempt from a phone fail with "RPID did not match the origin or related origins."
- E2E tests cover both: a full pair-via-input ceremony (test 13 in `webauthn.e2e.js`) and an `rp.id`-matches-origin smoke (test 14). The smoke would have caught the staging-script bug in seconds instead of through iPad roundtrips.
- Test harness opts into localhost RP ID via `KATULONG_STAGE_FOR_TESTS=1` so existing localhost-targeted tests keep working alongside the new public-RP-ID default.

## Test plan

- [x] `cargo build --release` clean
- [x] `trunk build --release` clean
- [x] Full Rust e2e (15 tests) green: 4 auth + 3 smoke + 8 webauthn
- [x] Manual: pair an iPad against `https://katulong-rs.felixflor.es` via the new login UI's setup-token input → land on terminal
- [ ] Reviewer-verified: try a stale pair URL (`?setup_token=expired`), confirm the disclosure is still rendered so the user can paste a fresh token