### PR TITLE
fix(ipad): use overflow:clip on xterm viewport to stop trackpad scroll ghosts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -729,17 +729,18 @@
     .terminal-pane .xterm-screen { margin-left: auto; margin-right: auto; }
     /* Scroll is JS-driven (xterm's wheel handler + initTouchScroll's pointer
        bridge → term.scrollLines). Override xterm.css's overflow-y:scroll so
-       no native scroll container exists on iOS — native momentum scrolling
-       on this layer fights the WebGL canvas redraw and ghosts rows on iPad.
+       wheel events have no native layer to translate against the WebGL
+       canvas redraw — that race ghosts rows on iPad.
 
-       Why `clip` and not `hidden`: on iPadOS WebKit, `overflow: hidden` still
-       creates a scroll container — focus and trackpad-wheel events translate
-       its compositor layer even though no scrollbar shows. PR #677 used
-       `hidden` and fixed finger-touch (whose path is the pointer bridge), but
+       `clip`, not `hidden`: on iPadOS WebKit, `overflow: hidden` still
+       establishes a scroll container — wheel and focus events drive its
+       compositor layer even though no scrollbar shows. PR #677 used `hidden`
+       and fixed finger-touch (which goes through the pointer bridge), but
        trackpad wheel still ghosted rows because the container was alive.
-       `overflow: clip` does not create a scroll container at all (see prior
-       lessons in commits 88dc3a1 and a391a15), so wheel events have no native
-       layer to translate and only xterm's JS handler runs. */
+       `overflow: clip` does not create a scroll container at all, so only
+       xterm's JS handler runs. Prior fixes for the same WebKit quirk on
+       html/body (88dc3a1) and the carousel container (a391a15) reached
+       the same conclusion. */
     #terminal-container .xterm-viewport,
     #terminal-container .xterm-scrollable-element {
       overflow: clip;

--- a/public/index.html
+++ b/public/index.html
@@ -730,10 +730,19 @@
     /* Scroll is JS-driven (xterm's wheel handler + initTouchScroll's pointer
        bridge → term.scrollLines). Override xterm.css's overflow-y:scroll so
        no native scroll container exists on iOS — native momentum scrolling
-       on this layer fights the WebGL canvas redraw and ghosts rows on iPad. */
+       on this layer fights the WebGL canvas redraw and ghosts rows on iPad.
+
+       Why `clip` and not `hidden`: on iPadOS WebKit, `overflow: hidden` still
+       creates a scroll container — focus and trackpad-wheel events translate
+       its compositor layer even though no scrollbar shows. PR #677 used
+       `hidden` and fixed finger-touch (whose path is the pointer bridge), but
+       trackpad wheel still ghosted rows because the container was alive.
+       `overflow: clip` does not create a scroll container at all (see prior
+       lessons in commits 88dc3a1 and a391a15), so wheel events have no native
+       layer to translate and only xterm's JS handler runs. */
     #terminal-container .xterm-viewport,
     #terminal-container .xterm-scrollable-element {
-      overflow: hidden;
+      overflow: clip;
     }
     /* Transparent (not a fixed color) so whatever paints behind the viewport
        — card-face surface in carousel mode, --bg in non-carousel — shows

--- a/public/lib/scroll-utils.js
+++ b/public/lib/scroll-utils.js
@@ -9,8 +9,11 @@
  * away from bottom, cleared on arrival.
  *
  * Scroll architecture: native browser scroll is disabled on the terminal
- * pane (#terminal-container .xterm-viewport { overflow: hidden }) so all
- * viewport movement flows through `term.scrollLines()`:
+ * pane (#terminal-container .xterm-viewport { overflow: clip }) so all
+ * viewport movement flows through `term.scrollLines()`. `clip` is load-
+ * bearing on iPadOS WebKit — `hidden` still creates a scroll container
+ * whose compositor layer wheel events translate independently of xterm's
+ * redraw, ghosting rows on trackpad scroll.
  *   - wheel/trackpad → xterm's built-in wheel handler
  *   - touch drag    → initTouchScroll's pointer bridge
  *   - programmatic  → scrollToBottom, etc.


### PR DESCRIPTION
## Summary

- Trackpad two-finger scroll on iPad still produced ghost/duplicated rows after PR #677, because `overflow: hidden` on `.xterm-viewport` / `.xterm-scrollable-element` still leaves a scroll container that iPadOS WebKit translates the compositor layer for on wheel events — meanwhile xterm redraws the canvas with new content at the new viewport position. The two render paths race and ghost rows.
- Switching the override to `overflow: clip` removes the scroll container entirely (same lesson as 88dc3a1 / a391a15), so wheel events have no native layer to translate and only xterm's JS handler runs.
- Finger-touch scroll path is unaffected — it goes through `initTouchScroll`'s pointer bridge, which PR #677 already made the single source of truth.

## Test plan

- [ ] Reload on iPad, two-finger trackpad scroll up/down through Claude Code output, confirm no duplicated rows during or after the gesture
- [ ] Finger-touch scroll on iPad still works (regression check on PR #677's fix)
- [ ] Trackpad/wheel scroll on macOS still works
- [ ] Mouse wheel scroll on Linux/Windows still works