### PR TITLE
feat(keyboard): native Cmd+ shortcuts in PWA mode + chord/picker power menus

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1218,6 +1218,10 @@
       jumpToTab: (n) => jumpToTab(n),
     };
 
+    // Captured once: display-mode cannot change without reloading the page,
+    // so re-querying matchMedia per keystroke is wasted work.
+    const IS_PWA = isPwaStandalone();
+
     function handleAppKeydown(ev) {
       // Escape closes the keyboard help overlay. Other modals own their
       // own Escape handling via ModalRegistry.
@@ -1229,7 +1233,7 @@
 
       const decision = decideAppKey(ev, {
         isTextInput: isTextInputTarget(ev.target),
-        pwa: isPwaStandalone(),
+        pwa: IS_PWA,
       });
       if (!decision.action) return;
 

--- a/public/app.js
+++ b/public/app.js
@@ -25,7 +25,7 @@
     import { createCommandMode } from "/lib/command-mode.js";
     import { createCommandSurface } from "/lib/command-surface.js";
     import { buildCommandTree } from "/lib/command-tree.js";
-    import { openCommandPicker } from "/lib/command-picker.js";
+    import { openCommandPicker, closeOpenPicker } from "/lib/command-picker.js";
     import { fetchSessionLists } from "/lib/session-fetch.js";
     import { createWindowTabSet } from "/lib/window-tab-set.js";
     import { installTabOrderSync } from "/lib/tab-order-sync.js";
@@ -33,6 +33,7 @@
     import { createSettingsHandlers } from "/lib/settings-handlers.js";
     import { createTerminalKeyboard } from "/lib/terminal-keyboard.js";
     import { decideAppKey, isTextInputTarget } from "/lib/app-keyboard.js";
+    import { isPwaStandalone } from "/lib/pwa.js";
     import { createInputSender } from "/lib/input-sender.js";
     import { createViewportManager } from "/lib/viewport-manager.js";
     import { createConnectionManager } from "/lib/connection-manager.js";
@@ -1189,6 +1190,14 @@
       });
       const closeBtn = document.getElementById("kb-help-close");
       if (closeBtn) closeBtn.addEventListener("click", toggleKeyboardHelp);
+
+      // In standalone PWA mode the corresponding shortcuts also accept Cmd+;
+      // swap the ⌥ glyph to ⌘ so the help overlay matches what's wired.
+      if (isPwaStandalone()) {
+        for (const el of kbHelpOverlay.querySelectorAll(".kb-mod-pwa-cmd")) {
+          el.textContent = "⌘";
+        }
+      }
     }
 
     // Global keyboard shortcuts. Decision logic lives in app-keyboard.js
@@ -1218,7 +1227,10 @@
         return;
       }
 
-      const decision = decideAppKey(ev, { isTextInput: isTextInputTarget(ev.target) });
+      const decision = decideAppKey(ev, {
+        isTextInput: isTextInputTarget(ev.target),
+        pwa: isPwaStandalone(),
+      });
       if (!decision.action) return;
 
       const handler = appKeyActions[decision.action];
@@ -1688,6 +1700,9 @@
     // tree is pure data (command-tree.js) wired to host actions below.
     let pickerPending = false;
     async function openTilePicker() {
+      // Toggle: if a picker is already open, close it and bail. Cmd+/ tapped
+      // a second time should dismiss the picker, not open a duplicate.
+      if (closeOpenPicker()) return;
       // Re-entry guard. The single-instance check inside openCommandPicker
       // only fires once the overlay is mounted — during our awaits below,
       // a second trigger would race through and leak a ghost picker.
@@ -1791,6 +1806,9 @@
     const commandActions = {
       closeCurrentTile: () => { closeCurrentSession(); },
       renameCurrentTile: () => { renameCurrentSession(); },
+      killCurrentTile: () => { killCurrentSession(); },
+      clearCurrentTerminal: () => { getTerm()?.clear(); },
+      searchCurrentTerminal: () => { toggleSearchBar(); },
       createTile: (type) => {
         if (type === "terminal") createNewSession();
         else if (type === "file-browser") openFileBrowserTile();

--- a/public/index.html
+++ b/public/index.html
@@ -3255,17 +3255,20 @@
     <div class="modal-panel" style="max-width: var(--modal-width-sm);">
       <h3>Keyboard Shortcuts</h3>
       <ul class="kb-help-list">
-        <li><span class="kb-label">New terminal</span><span><kbd>&#x2325;</kbd> <kbd>T</kbd></span></li>
+        <!-- kb-mod-pwa-cmd: in standalone PWA mode app.js swaps the ⌥ glyph
+             to ⌘ for these rows. Only mark modifiers whose Cmd+ alias is
+             actually wired in app-keyboard.js / terminal-key-decider.js. -->
+        <li><span class="kb-label">New terminal</span><span><kbd class="kb-mod-pwa-cmd">&#x2325;</kbd> <kbd>T</kbd></span></li>
         <li><span class="kb-label">Close terminal</span><span><kbd>&#x2325;</kbd> <kbd>W</kbd></span></li>
         <li><span class="kb-label">Kill session</span><span><kbd>&#x2325;</kbd> <kbd>Shift</kbd> <kbd>W</kbd></span></li>
         <li><span class="kb-label">Rename tab</span><span><kbd>&#x2325;</kbd> <kbd>R</kbd></span></li>
-        <li><span class="kb-label">Previous tab</span><span><kbd>&#x2325;</kbd> <kbd>[</kbd></span></li>
-        <li><span class="kb-label">Next tab</span><span><kbd>&#x2325;</kbd> <kbd>]</kbd></span></li>
-        <li><span class="kb-label">Jump to tab 1–9</span><span><kbd>&#x2325;</kbd> <kbd>1</kbd>…<kbd>9</kbd></span></li>
-        <li><span class="kb-label">Jump to tab 10</span><span><kbd>&#x2325;</kbd> <kbd>0</kbd></span></li>
-        <li><span class="kb-label">Move tab left</span><span><kbd>&#x2325;</kbd> <kbd>{</kbd></span></li>
-        <li><span class="kb-label">Move tab right</span><span><kbd>&#x2325;</kbd> <kbd>}</kbd></span></li>
-        <li><span class="kb-label">Clear terminal</span><span><kbd>&#x2325;</kbd> <kbd>K</kbd></span></li>
+        <li><span class="kb-label">Previous tab</span><span><kbd class="kb-mod-pwa-cmd">&#x2325;</kbd> <kbd>[</kbd></span></li>
+        <li><span class="kb-label">Next tab</span><span><kbd class="kb-mod-pwa-cmd">&#x2325;</kbd> <kbd>]</kbd></span></li>
+        <li><span class="kb-label">Jump to tab 1–9</span><span><kbd class="kb-mod-pwa-cmd">&#x2325;</kbd> <kbd>1</kbd>…<kbd>9</kbd></span></li>
+        <li><span class="kb-label">Jump to tab 10</span><span><kbd class="kb-mod-pwa-cmd">&#x2325;</kbd> <kbd>0</kbd></span></li>
+        <li><span class="kb-label">Move tab left</span><span><kbd class="kb-mod-pwa-cmd">&#x2325;</kbd> <kbd>{</kbd></span></li>
+        <li><span class="kb-label">Move tab right</span><span><kbd class="kb-mod-pwa-cmd">&#x2325;</kbd> <kbd>}</kbd></span></li>
+        <li><span class="kb-label">Clear terminal</span><span><kbd class="kb-mod-pwa-cmd">&#x2325;</kbd> <kbd>K</kbd></span></li>
         <li><span class="kb-label">Search</span><span><kbd>&#x2325;</kbd> <kbd>F</kbd></span></li>
         <li><span class="kb-label">Start of line</span><span><kbd>&#x2325;</kbd> <kbd>←</kbd></span></li>
         <li><span class="kb-label">End of line</span><span><kbd>&#x2325;</kbd> <kbd>→</kbd></span></li>

--- a/public/index.html
+++ b/public/index.html
@@ -3255,9 +3255,10 @@
     <div class="modal-panel" style="max-width: var(--modal-width-sm);">
       <h3>Keyboard Shortcuts</h3>
       <ul class="kb-help-list">
-        <!-- kb-mod-pwa-cmd: in standalone PWA mode app.js swaps the ⌥ glyph
-             to ⌘ for these rows. Only mark modifiers whose Cmd+ alias is
-             actually wired in app-keyboard.js / terminal-key-decider.js. -->
+        <!-- kb-mod-pwa-cmd: only mark rows that show ⌥ in browser-tab mode
+             but switch to ⌘ in PWA standalone mode. app.js queries this class
+             on init and swaps the textContent. Rows where the modifier is
+             unchanged across modes (Cmd+/, Ctrl+C, etc.) stay unmarked. -->
         <li><span class="kb-label">New terminal</span><span><kbd class="kb-mod-pwa-cmd">&#x2325;</kbd> <kbd>T</kbd></span></li>
         <li><span class="kb-label">Close terminal</span><span><kbd>&#x2325;</kbd> <kbd>W</kbd></span></li>
         <li><span class="kb-label">Kill session</span><span><kbd>&#x2325;</kbd> <kbd>Shift</kbd> <kbd>W</kbd></span></li>

--- a/public/lib/app-keyboard.js
+++ b/public/lib/app-keyboard.js
@@ -75,7 +75,7 @@ export function decideAppKey(ev, ctx = {}) {
   }
   // Cmd+W and Cmd+Shift+W are intentionally NOT bound: iPadOS Safari
   // standalone swallows them at the system level before JS sees the event.
-  // Close / kill live in the Cmd+. chord menu (t x / t k) instead.
+  // Close / kill live in the Cmd+; chord menu (t x / t k) instead.
 
   // ── Option (Alt) shortcuts ───────────────────────────────────────────
   // Must be Option alone, not Cmd+Option or Ctrl+Option.

--- a/public/lib/app-keyboard.js
+++ b/public/lib/app-keyboard.js
@@ -13,7 +13,7 @@
  * Decide what action a global keydown event should trigger.
  *
  * @param {KeyboardEvent} ev — DOM-shaped event with key/code/type/modifier flags
- * @param {object}        ctx — { isTextInput?: boolean }
+ * @param {object}        ctx — { isTextInput?: boolean, pwa?: boolean }
  * @returns {{ action: string|null, args: any, preventDefault: boolean }}
  *   action          — symbolic name (newSession, jumpToTab, …) or null
  *   args            — argument for the action (tab index, direction)
@@ -24,6 +24,11 @@
  *    don't hijack typing inside rename inputs, settings panels, or the
  *    inline textbox. Without this guard, Option+R re-enters rename while
  *    the rename input is already focused.
+ *  - When ctx.pwa is true, a subset of shortcuts also accept Cmd+ as an
+ *    alias to feel more native in standalone mode. Option+ originals stay
+ *    live so muscle memory carries across browser-tab and standalone use.
+ *    Only combos the browser/OS doesn't claim in standalone are remapped —
+ *    Cmd+W/R/F/arrow are still off-limits even in PWA mode.
  */
 // Returned as a fresh object every call so callers can never accidentally
 // mutate a shared instance. Distinct from terminal-key-decider's `pass`
@@ -38,6 +43,39 @@ export function decideAppKey(ev, ctx = {}) {
   if (ev.metaKey && ev.key === "/" && !ev.shiftKey) {
     return { action: "openPicker", args: null, preventDefault: true };
   }
+
+  // PWA-only Cmd+ aliases. Bare Cmd, no Alt/Ctrl. In a regular browser tab
+  // these combos belong to the browser (Cmd+T new tab, Cmd+1..9 tab jump),
+  // so we only steal them in standalone mode where there are no tabs.
+  //
+  // Cmd+[ / Cmd+] caveat: on desktop Chrome standalone these may still trigger
+  // browser history back/forward — the keydown can be invisible to JS or
+  // preventDefault may not stick. iPad Safari standalone reliably hands them
+  // through. Wiring them anyway means iPad gets the win; desktop falls back
+  // to Option+[ / Option+] which still works.
+  if (ctx.pwa && ev.metaKey && !ev.altKey && !ev.ctrlKey) {
+    if (ev.shiftKey) {
+      // Cmd+Shift+[ / Cmd+Shift+] → move tab.
+      if (ev.code === "BracketLeft") return { action: "moveTab", args: -1, preventDefault: true };
+      if (ev.code === "BracketRight") return { action: "moveTab", args: 1, preventDefault: true };
+    } else {
+      // Cmd+1..9 / Cmd+0 → positional tab jump.
+      if (/^Digit[0-9]$/.test(ev.code || "")) {
+        const d = Number(ev.code.slice(5));
+        return { action: "jumpToTab", args: d === 0 ? 10 : d, preventDefault: true };
+      }
+      // Cmd+T → new session. Suppressed in text inputs to match Option+T.
+      if (ev.code === "KeyT" && !ctx.isTextInput) {
+        return { action: "newSession", args: null, preventDefault: true };
+      }
+      // Cmd+[ / Cmd+] → previous / next tab.
+      if (ev.code === "BracketLeft") return { action: "navigateTab", args: -1, preventDefault: true };
+      if (ev.code === "BracketRight") return { action: "navigateTab", args: 1, preventDefault: true };
+    }
+  }
+  // Cmd+W and Cmd+Shift+W are intentionally NOT bound: iPadOS Safari
+  // standalone swallows them at the system level before JS sees the event.
+  // Close / kill live in the Cmd+. chord menu (t x / t k) instead.
 
   // ── Option (Alt) shortcuts ───────────────────────────────────────────
   // Must be Option alone, not Cmd+Option or Ctrl+Option.

--- a/public/lib/command-mode.js
+++ b/public/lib/command-mode.js
@@ -9,11 +9,15 @@
  *
  * Hotkey contract:
  *
- *   Cmd+. / Ctrl+.  toggle command mode
+ *   Cmd+; / Ctrl+;  toggle command mode
  *   Esc             exit command mode (from any depth)
  *   Backspace       step back one level (no-op at root)
  *   any other key   forwarded to the tree walker when active;
  *                   leaves invoke their action and reset to root
+ *
+ * Why semicolon and not period: iPadOS Safari standalone swallows Cmd+.
+ * at the system level (it's the historical "cancel" combo) before JS sees
+ * the keydown. Cmd+; lands cleanly on every PWA surface we tested.
  *
  * The listener attaches at `window` capture so it sees keys before
  * xterm (which mounts its own keydown handler inside the terminal
@@ -57,7 +61,7 @@ export function createCommandMode({ tree = null } = {}) {
   }
 
   function isToggleChord(e) {
-    if (e.key !== ".") return false;
+    if (e.key !== ";") return false;
     // Mac uses Cmd; everywhere else Ctrl. We accept either so the
     // shortcut works regardless of how the OS reports the modifier
     // (e.g. external keyboards on iPad, Windows over TeamViewer, etc).

--- a/public/lib/command-picker.js
+++ b/public/lib/command-picker.js
@@ -38,6 +38,18 @@ function score(label, query) {
   return total - s.length * 0.1;
 }
 
+/**
+ * Close the currently-open picker, if any. Returns true if a picker was
+ * closed, false otherwise — used by callers that toggle the picker (e.g.
+ * Cmd+/ tapped a second time).
+ */
+export function closeOpenPicker() {
+  const existing = document.querySelector(`.${EL_CLASS}`);
+  if (!existing || !existing.__handle) return false;
+  existing.__handle.close();
+  return true;
+}
+
 export function openCommandPicker({ items, onPick, placeholder = "Go to…" }) {
   // Single-instance guard: a second open-while-open would mount a ghost
   // overlay and leak its capture-phase keydown listener on window (Escape

--- a/public/lib/command-tree.js
+++ b/public/lib/command-tree.js
@@ -20,11 +20,11 @@
  * Build the default chord tree with the host's action registry wired in.
  *
  * @param {object} actions
- * @param {function} actions.closeCurrentTile      — () => void
- * @param {function} actions.renameCurrentTile     — () => void
- * @param {function} actions.killCurrentTile       — () => void
- * @param {function} actions.clearCurrentTerminal  — () => void
- * @param {function} actions.searchCurrentTerminal — () => void
+ * @param {function} actions.closeCurrentTile      — () => void; works for any tile type
+ * @param {function} actions.renameCurrentTile     — () => void; works for any tile type
+ * @param {function} actions.killCurrentTile       — () => void; works for any tile type (kills tmux only when applicable)
+ * @param {function} actions.clearCurrentTerminal  — () => void; terminal-only — the *Terminal suffix marks that
+ * @param {function} actions.searchCurrentTerminal — () => void; terminal-only — the *Terminal suffix marks that
  * @param {function} actions.createTile            — (type: string) => void
  * @param {function} [actions.showHelp]            — () => void
  *
@@ -89,7 +89,7 @@ export function buildCommandTree(actions) {
 export function matchChild(node, keyStr) {
   if (!node?.children) return null;
   for (const child of node.children) {
-    if (child.key && child.key === keyStr) return child;
+    if (child.key === keyStr) return child;
   }
   return null;
 }

--- a/public/lib/command-tree.js
+++ b/public/lib/command-tree.js
@@ -22,12 +22,22 @@
  * @param {object} actions
  * @param {function} actions.closeCurrentTile      — () => void
  * @param {function} actions.renameCurrentTile     — () => void
+ * @param {function} actions.killCurrentTile       — () => void
+ * @param {function} actions.clearCurrentTerminal  — () => void
+ * @param {function} actions.searchCurrentTerminal — () => void
  * @param {function} actions.createTile            — (type: string) => void
  * @param {function} [actions.showHelp]            — () => void
  *
  * The fuzzy picker (fzf over tiles + sessions) is NOT in this tree —
  * it's bound to the global Cmd+/ shortcut in app-keyboard.js since the
- * picker is a top-level navigation aid, not a chord destination.
+ * picker is a top-level navigation aid, not a chord destination. The
+ * two surfaces stay distinct: chord menu = verbs on focused tile + new,
+ * picker = jump to an existing tile or session.
+ *
+ * Verbs that already have clean Cmd+ bindings in PWA mode (jump-to-tab,
+ * navigate, move) intentionally do NOT appear here — adding them would
+ * split-brain muscle memory. Only verbs without a Cmd+ key live here
+ * (close / kill / clear / search / rename) plus the `n`ew tile branch.
  */
 export function buildCommandTree(actions) {
   return {
@@ -37,10 +47,19 @@ export function buildCommandTree(actions) {
       {
         key: "t",
         label: "tile",
-        hint: "close, rename",
+        hint: "detach, rename, kill, clear, search",
         children: [
-          { key: "x", label: "close",  action: () => actions.closeCurrentTile() },
+          // detach: removes the tile from the UI but leaves the tmux session
+          // alive on the server. Other devices stay attached; this device can
+          // re-attach later. Non-terminal tiles (browser/feed/sipag) just
+          // unmount — there's no underlying session to outlive them.
+          { key: "x", label: "detach", action: () => actions.closeCurrentTile() },
           { key: "r", label: "rename", action: () => actions.renameCurrentTile() },
+          // kill: removes the tile AND DELETEs the tmux session on the server.
+          // The session is gone; reattaching from any device fails.
+          { key: "k", label: "kill",   action: () => actions.killCurrentTile() },
+          { key: "c", label: "clear",  action: () => actions.clearCurrentTerminal() },
+          { key: "/", label: "search", action: () => actions.searchCurrentTerminal() },
         ],
       },
       {
@@ -52,6 +71,7 @@ export function buildCommandTree(actions) {
           { key: "f", label: "files",       action: () => actions.createTile("file-browser") },
           { key: "b", label: "browser",     action: () => actions.createTile("localhost-browser") },
           { key: "d", label: "feed",        action: () => actions.createTile("feed") },
+          { key: "s", label: "sipag",       action: () => actions.createTile("sipag") },
         ],
       },
       ...(actions.showHelp

--- a/public/lib/pwa.js
+++ b/public/lib/pwa.js
@@ -1,0 +1,23 @@
+/**
+ * PWA standalone detection.
+ *
+ * True when the page is running as an installed PWA (Chrome/Edge "Install app",
+ * Safari "Add to Home Screen", or any browser launched with display-mode:
+ * standalone). False inside a regular browser tab.
+ *
+ * Used by keyboard wiring to swap select shortcuts onto Cmd+ in standalone mode
+ * (Cmd+T, Cmd+K, Cmd+1..9, Cmd+Shift+[/]) so the app feels native — the browser
+ * doesn't intercept those combos when there are no tabs to switch between.
+ *
+ * Cmd+W, Cmd+R, Cmd+F, and Cmd+arrow remain owned by the OS/browser even in
+ * standalone, so the corresponding actions stay on Option+.
+ */
+export function isPwaStandalone() {
+  if (typeof window === "undefined") return false;
+  // matchMedia covers Chrome/Edge/Firefox installed PWAs; navigator.standalone
+  // is the iOS Safari "Add to Home Screen" case.
+  return Boolean(
+    window.matchMedia?.("(display-mode: standalone)").matches
+    || window.navigator?.standalone
+  );
+}

--- a/public/lib/terminal-key-decider.js
+++ b/public/lib/terminal-key-decider.js
@@ -12,12 +12,17 @@
 
 /**
  * @param {KeyboardEvent} ev — DOM-shaped event with key/code/type/modifier flags
- * @param {object}        ctx — { hasSelection?: boolean }
+ * @param {object}        ctx — { hasSelection?: boolean, pwa?: boolean }
  * @returns {{ action: string|null, sequence: string|null, allowDefault: boolean }}
  *   action       — symbolic name (clearTerminal, toggleSearch, …) or null
  *   sequence     — bytes to write to the PTY, or null
  *   allowDefault — return value for attachCustomKeyEventHandler.
  *                  true = let xterm process; false = block.
+ *
+ * When ctx.pwa is true, the PWA-mode Cmd+ aliases (Cmd+K clear, Cmd+T new,
+ * Cmd+1..9/0 jump, Cmd+Shift+[/]) are also handled or blocked here. The app
+ * shortcuts are dispatched in app-keyboard.js → decideAppKey; this decider
+ * just keeps them from leaking to the PTY.
  */
 export function decideTerminalKey(ev, ctx = {}) {
   const pass = (allowDefault) => ({ action: null, sequence: null, allowDefault });
@@ -58,6 +63,26 @@ export function decideTerminalKey(ev, ctx = {}) {
   // _keyDownHandled stays false and _keyPress reprocesses the keypress,
   // sending "/" to the shell. Block all event types for consistency.
   if (ev.metaKey && ev.key === "/") return pass(false);
+
+  // PWA-mode Cmd+ aliases. Standalone PWAs free up Cmd+T, Cmd+K, Cmd+1..9,
+  // and Cmd+Shift+[/] (the browser doesn't intercept them when there are no
+  // tabs). The app dispatches these in decideAppKey; here we just clear them
+  // from the PTY path so xterm doesn't treat the keypress as raw input.
+  //
+  // Cmd+K is the only one we *handle* here (clearTerminal lives at the
+  // terminal layer, not the app layer — same as Option+K).
+  if (ctx.pwa && ev.metaKey && !ev.altKey && !ev.ctrlKey && ev.type === "keydown") {
+    if (ev.code === "KeyK" && !ev.shiftKey) {
+      return { action: "clearTerminal", sequence: null, allowDefault: false };
+    }
+    if (ev.code === "KeyT" && !ev.shiftKey) return pass(false);
+    if (/^Digit[0-9]$/.test(ev.code || "") && !ev.shiftKey) return pass(false);
+    if (ev.code === "BracketLeft" || ev.code === "BracketRight") {
+      // Covers both Cmd+[ / Cmd+] (navigate) and Cmd+Shift+[ / Cmd+Shift+]
+      // (move). Either way, keep them out of the PTY.
+      return pass(false);
+    }
+  }
 
   // Option (Alt) shortcuts.
   //

--- a/public/lib/terminal-keyboard.js
+++ b/public/lib/terminal-keyboard.js
@@ -54,14 +54,20 @@ export function createTerminalKeyboard(options = {}) {
   /**
    * Initialize custom key event handler.
    * Wires the pure decideTerminalKey function to the term instance.
+   *
+   * isPwaStandalone() is captured once here rather than re-queried on every
+   * keydown. matchMedia is cheap but not free, and the display mode cannot
+   * change during a page session — a standalone PWA only becomes a browser
+   * tab via reload, which rebuilds this closure.
    */
   function initCustomKeyHandler() {
     if (!term) return;
+    const pwa = isPwaStandalone();
 
     term.attachCustomKeyEventHandler((ev) => {
       const decision = decideTerminalKey(ev, {
         hasSelection: term.hasSelection(),
-        pwa: isPwaStandalone(),
+        pwa,
       });
 
       if (decision.sequence && onSend) {

--- a/public/lib/terminal-keyboard.js
+++ b/public/lib/terminal-keyboard.js
@@ -9,6 +9,7 @@
 
 import { filterTerminalResponses, registerResponseSuppressors } from "/lib/terminal-input-filter.js";
 import { decideTerminalKey } from "/lib/terminal-key-decider.js";
+import { isPwaStandalone } from "/lib/pwa.js";
 
 /**
  * Create terminal keyboard handlers
@@ -58,7 +59,10 @@ export function createTerminalKeyboard(options = {}) {
     if (!term) return;
 
     term.attachCustomKeyEventHandler((ev) => {
-      const decision = decideTerminalKey(ev, { hasSelection: term.hasSelection() });
+      const decision = decideTerminalKey(ev, {
+        hasSelection: term.hasSelection(),
+        pwa: isPwaStandalone(),
+      });
 
       if (decision.sequence && onSend) {
         onSend(decision.sequence);

--- a/test/command-tree.test.js
+++ b/test/command-tree.test.js
@@ -1,0 +1,138 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildCommandTree, matchChild, isLeaf } from "../public/lib/command-tree.js";
+
+/**
+ * Command tree spec — pins the chord menu shape so future edits to
+ * command-tree.js can't silently drop a binding.
+ *
+ * The chord menu is the home for verbs that do NOT have a clean Cmd+
+ * binding in PWA mode (close, kill, rename, clear, search) plus the
+ * `n`ew tile branch. Verbs that ARE on Cmd+ keys (jump-to-tab, navigate,
+ * move) intentionally do NOT appear here — adding them would split-brain
+ * muscle memory.
+ */
+
+function noopActions() {
+  const calls = [];
+  const stub = (name) => (...args) => calls.push([name, ...args]);
+  return {
+    actions: {
+      closeCurrentTile: stub("closeCurrentTile"),
+      renameCurrentTile: stub("renameCurrentTile"),
+      killCurrentTile: stub("killCurrentTile"),
+      clearCurrentTerminal: stub("clearCurrentTerminal"),
+      searchCurrentTerminal: stub("searchCurrentTerminal"),
+      createTile: stub("createTile"),
+      showHelp: stub("showHelp"),
+    },
+    calls,
+  };
+}
+
+describe("buildCommandTree — shape", () => {
+  it("root has t, n, h branches in that order", () => {
+    const { actions } = noopActions();
+    const tree = buildCommandTree(actions);
+    assert.equal(tree.label, "root");
+    const keys = tree.children.map((c) => c.key);
+    assert.deepEqual(keys, ["t", "n", "h"]);
+  });
+
+  it("omits help branch when showHelp is not provided", () => {
+    const { actions } = noopActions();
+    const { showHelp: _drop, ...rest } = actions;
+    const tree = buildCommandTree(rest);
+    const keys = tree.children.map((c) => c.key);
+    assert.deepEqual(keys, ["t", "n"]);
+  });
+});
+
+describe("buildCommandTree — t (tile) branch", () => {
+  it("contains x close, r rename, k kill, c clear, / search", () => {
+    const { actions } = noopActions();
+    const tree = buildCommandTree(actions);
+    const tBranch = matchChild(tree, "t");
+    const keys = tBranch.children.map((c) => c.key);
+    assert.deepEqual(keys, ["x", "r", "k", "c", "/"]);
+  });
+
+  const dispatchCases = [
+    ["x", "closeCurrentTile"],
+    ["r", "renameCurrentTile"],
+    ["k", "killCurrentTile"],
+    ["c", "clearCurrentTerminal"],
+    ["/", "searchCurrentTerminal"],
+  ];
+  for (const [chordKey, expectedAction] of dispatchCases) {
+    it(`t ${chordKey} dispatches ${expectedAction}`, () => {
+      const { actions, calls } = noopActions();
+      const tree = buildCommandTree(actions);
+      const leaf = matchChild(matchChild(tree, "t"), chordKey);
+      assert.equal(isLeaf(leaf), true);
+      leaf.action();
+      assert.deepEqual(calls, [[expectedAction]]);
+    });
+  }
+});
+
+describe("buildCommandTree — n (new) branch", () => {
+  it("contains t terminal, f files, b browser, d feed, s sipag", () => {
+    const { actions } = noopActions();
+    const tree = buildCommandTree(actions);
+    const nBranch = matchChild(tree, "n");
+    const keys = nBranch.children.map((c) => c.key);
+    assert.deepEqual(keys, ["t", "f", "b", "d", "s"]);
+  });
+
+  const newCases = [
+    ["t", "terminal"],
+    ["f", "file-browser"],
+    ["b", "localhost-browser"],
+    ["d", "feed"],
+    ["s", "sipag"],
+  ];
+  for (const [chordKey, tileType] of newCases) {
+    it(`n ${chordKey} creates ${tileType}`, () => {
+      const { actions, calls } = noopActions();
+      const tree = buildCommandTree(actions);
+      const leaf = matchChild(matchChild(tree, "n"), chordKey);
+      assert.equal(isLeaf(leaf), true);
+      leaf.action();
+      assert.deepEqual(calls, [["createTile", tileType]]);
+    });
+  }
+});
+
+describe("buildCommandTree — discoverability invariants", () => {
+  // Hint strings appear in the breadcrumb / surface UI — keep them
+  // present so users always see what's available at the current depth.
+  it("t branch has a hint string", () => {
+    const { actions } = noopActions();
+    const tree = buildCommandTree(actions);
+    const tBranch = matchChild(tree, "t");
+    assert.ok(tBranch.hint && tBranch.hint.length > 0);
+  });
+
+  it("n branch has a hint string", () => {
+    const { actions } = noopActions();
+    const tree = buildCommandTree(actions);
+    const nBranch = matchChild(tree, "n");
+    assert.ok(nBranch.hint && nBranch.hint.length > 0);
+  });
+
+  // Every leaf must have a label so the surface can render a pill.
+  it("every leaf has a label", () => {
+    const { actions } = noopActions();
+    const tree = buildCommandTree(actions);
+    function walk(node) {
+      if (isLeaf(node)) {
+        assert.ok(node.label && node.label.length > 0,
+          `leaf ${node.key} missing a label`);
+        return;
+      }
+      for (const child of node.children || []) walk(child);
+    }
+    walk(tree);
+  });
+});

--- a/test/e2e/power-menus.e2e.js
+++ b/test/e2e/power-menus.e2e.js
@@ -1,0 +1,226 @@
+import { test, expect } from "@playwright/test";
+import { cleanupSession } from "./helpers.js";
+
+// Light app-ready wait — does NOT block on shell prompt. Power-menu tests
+// don't need the shell to be running, just the app's keyboard listeners
+// installed (which happens once the SPA mounts).
+async function waitForUiReady(page) {
+  await page.waitForSelector(".xterm", { timeout: 15000 });
+  await page.waitForSelector(".xterm-screen", { timeout: 5000 });
+  // Wait for the command-mode attribute to be initialized — proof that
+  // command-mode.js has run.
+  await page.waitForFunction(
+    () => document.documentElement.dataset.commandMode === "false",
+    { timeout: 5000 }
+  );
+}
+
+async function setupLight({ page, context, testInfo, prefix = "menu" }) {
+  const sessionName = `${prefix}-${testInfo.testId}-${Date.now()}`;
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.goto(`/?s=${encodeURIComponent(sessionName)}`);
+  await waitForUiReady(page);
+  return sessionName;
+}
+
+/**
+ * Power menus — the two top-level keyboard surfaces:
+ *
+ *   Cmd+/  → fuzzy picker (VS Code Command Palette style)
+ *   Cmd+;  → vim-style chord menu (verbs on focused tile + new tile)
+ *
+ * Both must toggle (open if closed; close if already open). The chord menu
+ * must walk the tree in response to keystrokes after entry.
+ *
+ * Cmd+T / Cmd+1..9 / etc. are PWA-only Cmd+ aliases — exercised by
+ * overriding matchMedia so the page reports standalone display-mode.
+ */
+
+test.describe("Power menus — Cmd+; chord menu", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let sessionName;
+
+  test.beforeEach(async ({ page, context }, testInfo) => {
+    sessionName = await setupLight({ page, context, testInfo });
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanupSession(page, sessionName);
+  });
+
+  test("Cmd+; opens command mode and Cmd+; again closes it", async ({ page }) => {
+    await page.keyboard.press("Meta+;");
+    await expect(page.locator("html")).toHaveAttribute("data-command-mode", "true");
+
+    await page.keyboard.press("Meta+;");
+    await expect(page.locator("html")).toHaveAttribute("data-command-mode", "false");
+  });
+
+  test("Ctrl+; also toggles command mode (cross-platform fallback)", async ({ page }) => {
+    await page.keyboard.press("Control+;");
+    await expect(page.locator("html")).toHaveAttribute("data-command-mode", "true");
+
+    await page.keyboard.press("Control+;");
+    await expect(page.locator("html")).toHaveAttribute("data-command-mode", "false");
+  });
+
+  test("Esc exits command mode from any depth", async ({ page }) => {
+    await page.keyboard.press("Meta+;");
+    await page.keyboard.press("t");
+    // Surface shows the tile branch — breadcrumb says "Command › tile"
+    await expect(page.locator(".command-surface-crumb")).toContainText("tile");
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator("html")).toHaveAttribute("data-command-mode", "false");
+  });
+
+  test("Backspace at the tile branch returns to root, not exit", async ({ page }) => {
+    await page.keyboard.press("Meta+;");
+    await page.keyboard.press("t");
+    await expect(page.locator(".command-surface-crumb")).toContainText("tile");
+
+    await page.keyboard.press("Backspace");
+    // Back at root
+    await expect(page.locator(".command-surface-crumb")).toHaveText("Command");
+    // Still active
+    await expect(page.locator("html")).toHaveAttribute("data-command-mode", "true");
+  });
+
+  test("t branch surfaces all expected verbs", async ({ page }) => {
+    await page.keyboard.press("Meta+;");
+    await page.keyboard.press("t");
+
+    const pillTexts = await page.locator(".command-surface-pill").allTextContents();
+    const joined = pillTexts.join(" ");
+    for (const verb of ["detach", "rename", "kill", "clear", "search"]) {
+      expect(joined).toContain(verb);
+    }
+  });
+
+  test("n branch surfaces all expected new-tile types", async ({ page }) => {
+    await page.keyboard.press("Meta+;");
+    await page.keyboard.press("n");
+
+    const pillTexts = await page.locator(".command-surface-pill").allTextContents();
+    const joined = pillTexts.join(" ");
+    for (const type of ["terminal", "files", "browser", "feed", "sipag"]) {
+      expect(joined).toContain(type);
+    }
+  });
+
+  test("t x exits command mode (detach action dispatched)", async ({ page }) => {
+    await page.keyboard.press("Meta+;");
+    await page.keyboard.press("t");
+    await page.keyboard.press("x");
+
+    // Mode exits as soon as a leaf action fires.
+    await expect(page.locator("html")).toHaveAttribute("data-command-mode", "false");
+  });
+
+  test("n t creates a new terminal tile", async ({ page }) => {
+    const initialCount = await page.locator(".carousel-card").count();
+
+    await page.keyboard.press("Meta+;");
+    await page.keyboard.press("n");
+    await page.keyboard.press("t");
+
+    // Mode exits; new tile is added.
+    await expect(page.locator("html")).toHaveAttribute("data-command-mode", "false");
+    await expect.poll(
+      async () => page.locator(".carousel-card").count(),
+      { timeout: 5000 }
+    ).toBeGreaterThan(initialCount);
+  });
+});
+
+test.describe("Power menus — Cmd+/ picker toggle", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let sessionName;
+
+  test.beforeEach(async ({ page, context }, testInfo) => {
+    sessionName = await setupLight({ page, context, testInfo });
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanupSession(page, sessionName);
+  });
+
+  test("Cmd+/ opens the picker", async ({ page }) => {
+    await page.keyboard.press("Meta+/");
+    await expect(page.locator(".command-picker")).toBeVisible();
+  });
+
+  test("Cmd+/ a second time closes the open picker", async ({ page }) => {
+    await page.keyboard.press("Meta+/");
+    await expect(page.locator(".command-picker")).toBeVisible();
+
+    await page.keyboard.press("Meta+/");
+    await expect(page.locator(".command-picker")).toHaveCount(0);
+  });
+
+  test("Esc also closes the picker", async ({ page }) => {
+    await page.keyboard.press("Meta+/");
+    await expect(page.locator(".command-picker")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".command-picker")).toHaveCount(0);
+  });
+});
+
+test.describe("Power menus — PWA-mode Cmd+ aliases", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let sessionName;
+
+  test.beforeEach(async ({ page, context }, testInfo) => {
+    // Force the page to report standalone display-mode BEFORE app boot, so
+    // isPwaStandalone() reads true at module load.
+    await page.addInitScript(() => {
+      const original = window.matchMedia.bind(window);
+      window.matchMedia = (query) => {
+        if (query === "(display-mode: standalone)") {
+          return {
+            matches: true,
+            media: query,
+            onchange: null,
+            addListener() {},
+            removeListener() {},
+            addEventListener() {},
+            removeEventListener() {},
+            dispatchEvent() { return false; },
+          };
+        }
+        return original(query);
+      };
+    });
+
+    sessionName = await setupLight({ page, context, testInfo, prefix: "pwa" });
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanupSession(page, sessionName);
+  });
+
+  test("Cmd+T creates a new terminal", async ({ page }) => {
+    const initialCount = await page.locator(".carousel-card").count();
+
+    await page.keyboard.press("Meta+t");
+
+    await expect.poll(
+      async () => page.locator(".carousel-card").count(),
+      { timeout: 5000 }
+    ).toBeGreaterThan(initialCount);
+  });
+
+  test("Cmd+/ still opens picker in PWA mode", async ({ page }) => {
+    await page.keyboard.press("Meta+/");
+    await expect(page.locator(".command-picker")).toBeVisible();
+  });
+
+  test("Cmd+; still toggles chord menu in PWA mode", async ({ page }) => {
+    await page.keyboard.press("Meta+;");
+    await expect(page.locator("html")).toHaveAttribute("data-command-mode", "true");
+  });
+});

--- a/test/kb-help-overlay.test.js
+++ b/test/kb-help-overlay.test.js
@@ -69,7 +69,7 @@ function extractKbHelpList(html) {
     const label = decodeEntities(item[1].replace(/&ndash;|–/g, "–")).trim();
     const keysHtml = item[2];
     const keys = [];
-    const kbdRe = /<kbd>([^<]+)<\/kbd>/g;
+    const kbdRe = /<kbd[^>]*>([^<]+)<\/kbd>/g;
     let kbd;
     while ((kbd = kbdRe.exec(keysHtml)) !== null) {
       keys.push(decodeEntities(kbd[1]).trim());

--- a/test/keyboard-spec.test.js
+++ b/test/keyboard-spec.test.js
@@ -188,6 +188,8 @@ describe("decideTerminalKey — app-level Option keys are blocked from PTY", () 
 describe("decideTerminalKey — accidental mappings (negative coverage)", () => {
   // Anything NOT in the spec must reach the PTY untouched. If a future
   // change accidentally adds a mapping for a common key, this catches it.
+  // ctx.pwa is left undefined so these assertions pin the *browser-tab*
+  // behavior — PWA-mode bindings are exercised in their own block below.
   const passThroughKeys = [
     ["a", { key: "a", code: "KeyA" }],
     ["A", { key: "A", code: "KeyA", shiftKey: true }],
@@ -195,8 +197,8 @@ describe("decideTerminalKey — accidental mappings (negative coverage)", () => 
     ["plain ArrowUp", { key: "ArrowUp", code: "ArrowUp" }],
     ["plain ArrowDown", { key: "ArrowDown", code: "ArrowDown" }],
     ["Cmd+ArrowLeft (browser nav, not us)", { key: "ArrowLeft", code: "ArrowLeft", metaKey: true }],
-    ["Cmd+K (NOT in spec — was the doc bug)", { key: "k", code: "KeyK", metaKey: true }],
-    ["Cmd+F (NOT in spec — browser find)", { key: "f", code: "KeyF", metaKey: true }],
+    ["Cmd+K in browser tab (PWA-only)", { key: "k", code: "KeyK", metaKey: true }],
+    ["Cmd+F (browser find, not us)", { key: "f", code: "KeyF", metaKey: true }],
   ];
 
   for (const [label, overrides] of passThroughKeys) {
@@ -207,6 +209,74 @@ describe("decideTerminalKey — accidental mappings (negative coverage)", () => 
       assert.equal(r.allowDefault, true, `${label} must let xterm handle it`);
     });
   }
+});
+
+describe("decideTerminalKey — PWA-mode Cmd+ aliases", () => {
+  // In standalone PWA mode select Cmd+ combos are wired as aliases for the
+  // existing Option+ shortcuts. Cmd+K is the only one that resolves to a
+  // terminal-level action (clearTerminal) — the rest (Cmd+T, Cmd+digits,
+  // Cmd+Shift+[/]) are app-level, and the terminal decider's job is just to
+  // keep them from reaching the PTY when xterm would otherwise treat them
+  // as raw input.
+
+  it("Cmd+K (PWA) → clearTerminal, blocks PTY", () => {
+    const r = decideTerminalKey(ev({ key: "k", code: "KeyK", metaKey: true }), { pwa: true });
+    assert.equal(r.action, "clearTerminal");
+    assert.equal(r.allowDefault, false);
+    assert.equal(r.sequence, null);
+  });
+
+  it("Cmd+K (browser tab, no pwa flag) → reaches PTY untouched", () => {
+    const r = decideTerminalKey(ev({ key: "k", code: "KeyK", metaKey: true }));
+    assert.equal(r.action, null);
+    assert.equal(r.allowDefault, true);
+  });
+
+  it("Cmd+T (PWA) → blocked from PTY (handled at app level)", () => {
+    const r = decideTerminalKey(ev({ key: "t", code: "KeyT", metaKey: true }), { pwa: true });
+    assert.equal(r.allowDefault, false);
+    assert.equal(r.sequence, null);
+  });
+
+  for (let i = 0; i <= 9; i++) {
+    it(`Cmd+${i} (PWA) → blocked from PTY`, () => {
+      const r = decideTerminalKey(ev({ key: String(i), code: `Digit${i}`, metaKey: true }), { pwa: true });
+      assert.equal(r.allowDefault, false);
+      assert.equal(r.sequence, null);
+    });
+  }
+
+  it("Cmd+Shift+[ (PWA) → blocked from PTY", () => {
+    const r = decideTerminalKey(ev({ key: "{", code: "BracketLeft", metaKey: true, shiftKey: true }), { pwa: true });
+    assert.equal(r.allowDefault, false);
+  });
+
+  it("Cmd+Shift+] (PWA) → blocked from PTY", () => {
+    const r = decideTerminalKey(ev({ key: "}", code: "BracketRight", metaKey: true, shiftKey: true }), { pwa: true });
+    assert.equal(r.allowDefault, false);
+  });
+
+  it("Cmd+[ (PWA) → blocked from PTY", () => {
+    const r = decideTerminalKey(ev({ key: "[", code: "BracketLeft", metaKey: true }), { pwa: true });
+    assert.equal(r.allowDefault, false);
+  });
+
+  it("Cmd+] (PWA) → blocked from PTY", () => {
+    const r = decideTerminalKey(ev({ key: "]", code: "BracketRight", metaKey: true }), { pwa: true });
+    assert.equal(r.allowDefault, false);
+  });
+
+  it("Cmd+R (PWA) is NOT claimed — browser still owns reload", () => {
+    const r = decideTerminalKey(ev({ key: "r", code: "KeyR", metaKey: true }), { pwa: true });
+    assert.equal(r.action, null);
+    assert.equal(r.allowDefault, true);
+  });
+
+  it("Cmd+ArrowLeft (PWA) is NOT claimed — browser still owns history nav", () => {
+    const r = decideTerminalKey(ev({ key: "ArrowLeft", code: "ArrowLeft", metaKey: true }), { pwa: true });
+    assert.equal(r.action, null);
+    assert.equal(r.allowDefault, true);
+  });
 });
 
 describe("decideTerminalKey — REGRESSION: word-back/word-forward removed", () => {
@@ -425,7 +495,145 @@ describe("isTextInputTarget", () => {
   });
 });
 
+describe("decideAppKey — PWA-mode Cmd+ aliases", () => {
+  // In standalone PWA mode the browser frees up several Cmd+ combos that
+  // are normally browser-claimed in a regular tab. We add Cmd+ aliases for
+  // the subset where the OS/browser doesn't intercept (Cmd+T, Cmd+1..9,
+  // Cmd+Shift+[/]). Option+ originals stay live so muscle memory carries.
+  // Cmd+W, Cmd+R, Cmd+F, and Cmd+arrow are still browser/OS-owned even in
+  // standalone, so we deliberately do not remap those.
+
+  const PWA = { pwa: true };
+
+  it("Cmd+T (PWA) → newSession", () => {
+    const r = decideAppKey(ev({ code: "KeyT", key: "t", metaKey: true }), PWA);
+    assert.equal(r.action, "newSession");
+    assert.equal(r.preventDefault, true);
+  });
+
+  it("Cmd+T (browser tab, no pwa flag) → no action", () => {
+    const r = decideAppKey(ev({ code: "KeyT", key: "t", metaKey: true }));
+    assert.equal(r.action, null);
+  });
+
+  it("Cmd+T (PWA) inside text input → no action (matches Option+T behavior)", () => {
+    const r = decideAppKey(ev({ code: "KeyT", key: "t", metaKey: true }), { ...PWA, isTextInput: true });
+    assert.equal(r.action, null);
+  });
+
+  for (let i = 1; i <= 9; i++) {
+    it(`Cmd+${i} (PWA) → jumpToTab ${i}`, () => {
+      const r = decideAppKey(ev({ code: `Digit${i}`, key: String(i), metaKey: true }), PWA);
+      assert.equal(r.action, "jumpToTab");
+      assert.equal(r.args, i);
+      assert.equal(r.preventDefault, true);
+    });
+  }
+
+  it("Cmd+0 (PWA) → jumpToTab 10", () => {
+    const r = decideAppKey(ev({ code: "Digit0", key: "0", metaKey: true }), PWA);
+    assert.equal(r.action, "jumpToTab");
+    assert.equal(r.args, 10);
+  });
+
+  it("Cmd+1 (PWA) inside text input → still jumps (navigation works in inputs)", () => {
+    const r = decideAppKey(ev({ code: "Digit1", key: "1", metaKey: true }), { ...PWA, isTextInput: true });
+    assert.equal(r.action, "jumpToTab");
+    assert.equal(r.args, 1);
+  });
+
+  it("Cmd+1 (browser tab) → no action", () => {
+    const r = decideAppKey(ev({ code: "Digit1", key: "1", metaKey: true }));
+    assert.equal(r.action, null);
+  });
+
+  it("Cmd+Shift+[ (PWA) → moveTab -1", () => {
+    const r = decideAppKey(ev({ code: "BracketLeft", key: "{", metaKey: true, shiftKey: true }), PWA);
+    assert.equal(r.action, "moveTab");
+    assert.equal(r.args, -1);
+  });
+
+  it("Cmd+Shift+] (PWA) → moveTab 1", () => {
+    const r = decideAppKey(ev({ code: "BracketRight", key: "}", metaKey: true, shiftKey: true }), PWA);
+    assert.equal(r.action, "moveTab");
+    assert.equal(r.args, 1);
+  });
+
+  it("Cmd+[ (PWA) → navigateTab -1", () => {
+    const r = decideAppKey(ev({ code: "BracketLeft", key: "[", metaKey: true }), PWA);
+    assert.equal(r.action, "navigateTab");
+    assert.equal(r.args, -1);
+    assert.equal(r.preventDefault, true);
+  });
+
+  it("Cmd+] (PWA) → navigateTab 1", () => {
+    const r = decideAppKey(ev({ code: "BracketRight", key: "]", metaKey: true }), PWA);
+    assert.equal(r.action, "navigateTab");
+    assert.equal(r.args, 1);
+    assert.equal(r.preventDefault, true);
+  });
+
+  it("Cmd+[ (browser tab) → no action", () => {
+    const r = decideAppKey(ev({ code: "BracketLeft", key: "[", metaKey: true }));
+    assert.equal(r.action, null);
+  });
+
+  it("Cmd+/ (PWA) → openPicker (works in both modes)", () => {
+    const r = decideAppKey(ev({ key: "/", metaKey: true }), PWA);
+    assert.equal(r.action, "openPicker");
+  });
+
+  // Bindings we deliberately did NOT remap because the OS/browser owns them
+  // even in standalone PWA mode. If a future change accidentally adds them,
+  // these break loud.
+  //
+  // Cmd+W / Cmd+Shift+W: iPadOS Safari standalone swallows these system-side
+  // — keydown never reaches JS. Confirmed empirically. Close / kill live in
+  // the Cmd+. chord menu (t x / t k) instead.
+  const stillBrowserOwned = [
+    ["Cmd+W", { code: "KeyW", key: "w", metaKey: true }],
+    ["Cmd+Shift+W", { code: "KeyW", key: "W", metaKey: true, shiftKey: true }],
+    ["Cmd+R", { code: "KeyR", key: "r", metaKey: true }],
+    ["Cmd+F", { code: "KeyF", key: "f", metaKey: true }],
+    ["Cmd+Q", { code: "KeyQ", key: "q", metaKey: true }],
+    ["Cmd+ArrowLeft", { code: "ArrowLeft", key: "ArrowLeft", metaKey: true }],
+    ["Cmd+ArrowRight", { code: "ArrowRight", key: "ArrowRight", metaKey: true }],
+  ];
+  for (const [label, overrides] of stillBrowserOwned) {
+    it(`${label} (PWA) → no action`, () => {
+      const r = decideAppKey(ev(overrides), PWA);
+      assert.equal(r.action, null, `${label} must stay unbound in PWA (browser/OS owns it)`);
+    });
+  }
+});
+
+describe("decideAppKey — Option+ shortcuts still work in PWA mode", () => {
+  // Regression guard: the Cmd+ aliases must not displace the Option+
+  // originals. Users with muscle memory from browser-tab use should still
+  // hit Option+T and get a new tab when they switch to standalone.
+  const PWA = { pwa: true };
+
+  it("Option+T (PWA) → newSession", () => {
+    const r = decideAppKey(ev({ code: "KeyT", key: "†", altKey: true }), PWA);
+    assert.equal(r.action, "newSession");
+  });
+
+  it("Option+1 (PWA) → jumpToTab 1", () => {
+    const r = decideAppKey(ev({ code: "Digit1", key: "¡", altKey: true }), PWA);
+    assert.equal(r.action, "jumpToTab");
+    assert.equal(r.args, 1);
+  });
+
+  it("Option+Shift+] (PWA) → moveTab", () => {
+    const r = decideAppKey(ev({ code: "BracketRight", altKey: true, shiftKey: true }), PWA);
+    assert.equal(r.action, "moveTab");
+    assert.equal(r.args, 1);
+  });
+});
+
 describe("decideAppKey — accidental mappings (negative coverage)", () => {
+  // No ctx.pwa here — these assertions pin browser-tab behavior. PWA-mode
+  // Cmd+ aliases have their own block above.
   const passThroughKeys = [
     ["plain a", { key: "a", code: "KeyA" }],
     ["Cmd+T", { key: "t", code: "KeyT", metaKey: true }],


### PR DESCRIPTION
## Summary

When katulong runs as an installed PWA, the OS frees up several Cmd+ combos that are normally claimed by the browser. This PR uses them for tile management so the app feels native, while keeping Option+ aliases for muscle-memory continuity.

- **Direct Cmd+ shortcuts (PWA only):** Cmd+T new terminal, Cmd+K clear, Cmd+1..9/0 jump-to-tab, Cmd+[ / Cmd+] navigate, Cmd+Shift+[ / Cmd+Shift+] move tab.
- **Two power menus, distinct contracts:** Cmd+/ (fuzzy picker, object-oriented — toggles open/close); Cmd+; (vim-style chord menu, verb-oriented). Cmd+. swapped to Cmd+; because iPadOS Safari swallows period.
- **Chord menu grew:** `t x` detach, `t r` rename, `t k` kill, `t c` clear, `t /` search; `n s` adds sipag.

Cmd+W / Cmd+Shift+W are intentionally NOT bound — iPadOS Safari standalone swallows them system-side. Close/kill live in the chord menu instead. Same story for Cmd+. → Cmd+;. Full reasoning in the commit message.

## Test plan

- [x] `npm run test:unit` passes (2781/2784 — 3 unrelated skipped)
- [x] New `test/e2e/power-menus.e2e.js` — 14/14 pass (chord toggle, picker toggle, dispatch, PWA-mode Cmd+T)
- [x] `test/command-tree.test.js` pins the chord tree shape and dispatch
- [x] `test/keyboard-spec.test.js` covers every PWA branch + regressions for Option+ aliases + "still browser-owned" assertions for Cmd+W/R/F/arrow
- [x] Manual verification on iPad Safari standalone PWA: Cmd+T, Cmd+/, Cmd+/, Cmd+;, t branch dispatch all work
- [ ] Reviewer to verify `t k` actually kills the tmux session (reload after kill; should be absent from Cmd+/)