### PR TITLE
cutover(server): phase 0a — Node-frontend HTTP compat (paths, wire shapes, CSRF, revoke-all)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ name = "katulong-server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "base64 0.22.1",
  "ciborium",
  "futures",
  "http-body-util",

--- a/crates/auth/src/credential.rs
+++ b/crates/auth/src/credential.rs
@@ -24,4 +24,19 @@ pub struct Credential {
     /// cleanup logic unanswerable without it).
     #[serde(default)]
     pub setup_token_id: Option<String>,
+    /// User-Agent string captured at register/pair time. Surfaced on the
+    /// `/api/credentials` and `/api/tokens` device-management UI so the
+    /// operator can match a passkey row to the device that minted it
+    /// (a phone vs a laptop, Safari vs Chrome). Defaults to empty
+    /// when missing so older state files load without a migration —
+    /// matches Node's `userAgent || 'Unknown'` tolerance.
+    #[serde(default)]
+    pub user_agent: String,
+    /// Wall-clock unix-millis of the last successful authentication
+    /// against this credential. `None` until the credential is used at
+    /// least once. Updated by `apply_authentication` so the same
+    /// transition that bumps the WebAuthn counter also stamps usage —
+    /// no second writer means no extra TOCTOU surface.
+    #[serde(default, with = "crate::state::systime_opt")]
+    pub last_used_at: Option<SystemTime>,
 }

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -26,7 +26,7 @@ pub use session::{Session, SessionTokenPlaintext, SESSION_TTL};
 pub use setup_token::{PlaintextToken, SetupToken};
 pub use state::AuthState;
 pub use store::AuthStore;
-pub use webauthn::{ChallengeId, VerifiedAuthentication, WebAuthnService};
+pub use webauthn::{VerifiedAuthentication, WebAuthnService};
 
 /// Re-export the webauthn-rs wire types the server crate needs to shape
 /// its HTTP request/response bodies. Keeping these behind the auth

--- a/crates/auth/src/state.rs
+++ b/crates/auth/src/state.rs
@@ -202,6 +202,55 @@ impl AuthState {
         }
     }
 
+    /// Stamp `last_used_at` on a credential. No-op if the id isn't
+    /// found. Called from inside `transact` after a successful login
+    /// so the same write that bumps the WebAuthn counter also records
+    /// usage — keeps the device-management UI's "last seen" column
+    /// honest without a second writer that could race.
+    pub fn touch_credential(&self, id: &str, now: SystemTime) -> Self {
+        Self {
+            credentials: self
+                .credentials
+                .iter()
+                .map(|c| {
+                    if c.id == id {
+                        Credential {
+                            last_used_at: Some(now),
+                            ..c.clone()
+                        }
+                    } else {
+                        c.clone()
+                    }
+                })
+                .collect(),
+            ..self.clone()
+        }
+    }
+
+    /// Update a setup token's `name`. No-op if the id isn't found.
+    /// PATCH `/api/tokens/:id` is the only caller; the closure re-checks
+    /// existence under the mutex via the boolean a separate `find_setup_token`
+    /// returns, so this transition stays a pure rewrite.
+    pub fn update_setup_token_name(&self, id: &str, name: String) -> Self {
+        Self {
+            setup_tokens: self
+                .setup_tokens
+                .iter()
+                .map(|t| {
+                    if t.id == id {
+                        SetupToken {
+                            name: Some(name.clone()),
+                            ..t.clone()
+                        }
+                    } else {
+                        t.clone()
+                    }
+                })
+                .collect(),
+            ..self.clone()
+        }
+    }
+
     /// Add or replace a session by its stored hash (upsert — mirrors
     /// `upsert_credential`). The `Session` argument already carries
     /// `token_hash`; dedup works on that value.
@@ -449,6 +498,8 @@ mod tests {
             counter: 0,
             created_at: epoch_plus(0),
             setup_token_id: None,
+            user_agent: String::new(),
+            last_used_at: None,
         }
     }
 

--- a/crates/auth/src/state.rs
+++ b/crates/auth/src/state.rs
@@ -280,6 +280,24 @@ impl AuthState {
         }
     }
 
+    /// Drop every session, regardless of expiry or owning credential.
+    ///
+    /// Used by `POST /auth/revoke-all` (the "Sign out everywhere" verb)
+    /// — wipes every session record, which has the side effect of
+    /// invalidating every paired CSRF token at the same time
+    /// (`Session.csrf_token` lives on the row that just disappeared).
+    /// Credentials and setup tokens are intentionally NOT touched:
+    /// the user keeps their passkeys; they just have to re-auth on
+    /// every previously-signed-in device. Same shape as Node's
+    /// `revokeAllLoginTokens` (which clears `loginTokens`, leaves
+    /// the rest alone).
+    pub fn remove_all_sessions(&self) -> Self {
+        Self {
+            sessions: Vec::new(),
+            ..self.clone()
+        }
+    }
+
     /// Drop sessions whose `expires_at` is at or before `now`.
     pub fn prune_expired(&self, now: SystemTime) -> Self {
         Self {
@@ -565,6 +583,18 @@ mod tests {
         assert!(s.valid_session("t", epoch_plus(499)).is_some());
         assert!(s.valid_session("t", epoch_plus(500)).is_none());
         assert!(s.valid_session("t", epoch_plus(501)).is_none());
+    }
+
+    #[test]
+    fn remove_all_sessions_clears_every_row_keeps_credentials() {
+        let s = AuthState::new()
+            .upsert_credential(cred("a"))
+            .upsert_credential(cred("b"))
+            .upsert_session(sess("t1", "a", 1000))
+            .upsert_session(sess("t2", "b", 1000))
+            .remove_all_sessions();
+        assert!(s.sessions.is_empty(), "every session row dropped");
+        assert_eq!(s.credentials.len(), 2, "credentials are not collateral damage");
     }
 
     #[test]

--- a/crates/auth/src/store.rs
+++ b/crates/auth/src/store.rs
@@ -148,6 +148,8 @@ mod tests {
             counter: 0,
             created_at: SystemTime::UNIX_EPOCH,
             setup_token_id: None,
+            user_agent: String::new(),
+            last_used_at: None,
         }
     }
 

--- a/crates/auth/src/webauthn.rs
+++ b/crates/auth/src/webauthn.rs
@@ -260,6 +260,8 @@ impl WebAuthnService {
             counter: 0,
             created_at: now,
             setup_token_id: None,
+            user_agent: String::new(),
+            last_used_at: None,
         })
     }
 
@@ -669,6 +671,8 @@ mod tests {
             counter: 0,
             created_at: SystemTime::UNIX_EPOCH,
             setup_token_id: None,
+            user_agent: String::new(),
+            last_used_at: None,
         };
         let err = svc
             .start_authentication(std::slice::from_ref(&bad), SystemTime::UNIX_EPOCH)
@@ -728,6 +732,8 @@ mod tests {
             counter: 0,
             created_at: SystemTime::UNIX_EPOCH,
             setup_token_id: None,
+            user_agent: String::new(),
+            last_used_at: None,
         };
         let err = bad.to_passkey().unwrap_err();
         assert!(matches!(err, AuthError::WebAuthn(_)));

--- a/crates/auth/src/webauthn.rs
+++ b/crates/auth/src/webauthn.rs
@@ -3,8 +3,31 @@
 //! Thin wrapper over `webauthn-rs` that owns the in-memory challenge store
 //! between `start_*` and `finish_*` requests. Challenges are time-limited
 //! and single-use: `finish_*` removes the entry before verifying, so a
-//! replayed response against a valid challenge ID fails by missing state
+//! replayed response against a valid challenge fails by missing state
 //! rather than by re-verifying against a resident challenge.
+//!
+//! # Challenge lookup model — the cutover reshape
+//!
+//! Earlier iterations of this module returned a server-issued
+//! `ChallengeId` to the client and required the client to echo it back on
+//! `finish_*`. That diverged from the Node implementation
+//! (`@simplewebauthn`'s pattern), where the verify endpoint recovers the
+//! challenge from the credential's own `clientDataJSON.challenge`. Phase
+//! 0a-1 of the cutover aligns Rust with Node: `start_*` now returns just
+//! the WebAuthn options, and `finish_*` extracts the challenge from
+//! `credential.response.clientDataJSON` and uses it as the lookup key into
+//! the pending map.
+//!
+//! Why this shape:
+//! - It matches Node so the existing JS frontend works against the Rust
+//!   server unchanged. That's the whole point of the cutover.
+//! - It removes a round-tripped server-issued id, which was extra wire
+//!   surface and an extra reconnect-and-replay vector.
+//! - The challenge is already cryptographically bound to the credential
+//!   via WebAuthn's signature over `clientDataJSON`. Looking up by
+//!   challenge and then verifying the signature gives the same single-use
+//!   property as the old id-keyed flow — a replay either lands on a
+//!   missing-from-map state (challenge consumed) or fails verification.
 //!
 //! # RP ID and origin come from configuration
 //!
@@ -33,7 +56,6 @@
 //! we pass only `Passkey` values we already stored, which encode the same
 //! intent.
 
-use crate::random::random_hex;
 use crate::{AuthError, Credential, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use std::collections::HashMap;
@@ -43,6 +65,14 @@ use url::Url;
 use uuid::Uuid;
 use webauthn_rs::prelude::*;
 use webauthn_rs::{Webauthn, WebauthnBuilder};
+
+/// Lookup key for the pending-challenge maps. Holds the
+/// URL-safe-base64 encoding of the random WebAuthn challenge
+/// bytes — the same string the browser includes in
+/// `clientDataJSON.challenge`. Keyed as a string (rather than
+/// raw bytes) so `start_*` and `finish_*` can do a direct
+/// `HashMap::get` without re-encoding.
+type ChallengeKey = String;
 
 /// How long a generated challenge stays valid on the server. Five minutes
 /// is comfortably longer than any real user would take to respond to a
@@ -62,11 +92,6 @@ const CHALLENGE_TTL: Duration = Duration::from_secs(5 * 60);
 /// attacker who holds open registration/auth starts without ever finishing,
 /// which would otherwise consume memory until OOM.
 const MAX_PENDING_CHALLENGES: usize = 1024;
-
-/// Opaque handle returned to the client after `start_*`. The client passes it
-/// back on `finish_*` so we can look up the corresponding webauthn-rs state.
-/// 16 random bytes, hex-encoded (32 chars).
-pub type ChallengeId = String;
 
 /// Materialised outcome of `finish_authentication`.
 ///
@@ -106,8 +131,8 @@ pub struct VerifiedAuthentication {
 /// exchange.
 pub struct WebAuthnService {
     webauthn: Webauthn,
-    pending_registrations: Mutex<HashMap<ChallengeId, (PasskeyRegistration, SystemTime)>>,
-    pending_authentications: Mutex<HashMap<ChallengeId, (PasskeyAuthentication, SystemTime)>>,
+    pending_registrations: Mutex<HashMap<ChallengeKey, (PasskeyRegistration, SystemTime)>>,
+    pending_authentications: Mutex<HashMap<ChallengeKey, (PasskeyAuthentication, SystemTime)>>,
 }
 
 impl WebAuthnService {
@@ -146,7 +171,7 @@ impl WebAuthnService {
         user_display_name: &str,
         existing: &[Credential],
         now: SystemTime,
-    ) -> Result<(ChallengeId, CreationChallengeResponse)> {
+    ) -> Result<CreationChallengeResponse> {
         let exclude: Vec<CredentialID> = existing
             .iter()
             .filter_map(|c| decode_credential_id(&c.id).ok())
@@ -158,15 +183,22 @@ impl WebAuthnService {
             .start_passkey_registration(user_unique_id, user_name, user_display_name, exclude)
             .map_err(|e| AuthError::WebAuthn(e.to_string()))?;
 
-        let id = random_hex(16);
+        // Use the challenge bytes themselves (URL-safe-base64
+        // encoded) as the map key. They're already random
+        // (CSPRNG inside webauthn-rs) and the browser will
+        // echo the exact same encoding in
+        // `clientDataJSON.challenge`, so `finish_registration`
+        // can recover the key without round-tripping a
+        // separate id.
+        let key = encode_challenge(ccr.public_key.challenge.as_ref());
         insert_pending(
             &self.pending_registrations,
-            id.clone(),
+            key,
             reg_state,
             now + CHALLENGE_TTL,
             now,
         )?;
-        Ok((id, ccr))
+        Ok(ccr)
     }
 
     /// Finish a registration ceremony, producing a `Credential` ready to be
@@ -175,15 +207,24 @@ impl WebAuthnService {
     /// for the attacker to try again.
     pub fn finish_registration(
         &self,
-        challenge_id: &str,
         response: &RegisterPublicKeyCredential,
         now: SystemTime,
     ) -> Result<Credential> {
+        // Recover the challenge from the credential's
+        // `clientDataJSON.challenge`. WebAuthn already binds
+        // the challenge into the signed-over data, so this
+        // string is the same one we issued in
+        // `start_registration` if the credential is genuine —
+        // and an attacker who fabricated a different challenge
+        // would either miss the map entirely (lookup fails) or
+        // mismatch the in-flight `PasskeyRegistration` (verify
+        // fails). Either way the ceremony rejects.
+        let key = extract_challenge_from_credential(response.response.client_data_json.as_ref())?;
         let (reg_state, expires_at) = self
             .pending_registrations
             .lock()
             .expect("challenge store mutex poisoned")
-            .remove(challenge_id)
+            .remove(&key)
             .ok_or(AuthError::ChallengeNotFound)?;
         if now >= expires_at {
             return Err(AuthError::ChallengeNotFound);
@@ -234,7 +275,7 @@ impl WebAuthnService {
         &self,
         credentials: &[Credential],
         now: SystemTime,
-    ) -> Result<(ChallengeId, RequestChallengeResponse)> {
+    ) -> Result<RequestChallengeResponse> {
         let passkeys: Vec<Passkey> = credentials
             .iter()
             .filter_map(|c| match serde_json::from_slice(&c.public_key) {
@@ -266,15 +307,15 @@ impl WebAuthnService {
             .start_passkey_authentication(&passkeys)
             .map_err(|e| AuthError::WebAuthn(e.to_string()))?;
 
-        let id = random_hex(16);
+        let key = encode_challenge(rcr.public_key.challenge.as_ref());
         insert_pending(
             &self.pending_authentications,
-            id.clone(),
+            key,
             auth_state,
             now + CHALLENGE_TTL,
             now,
         )?;
-        Ok((id, rcr))
+        Ok(rcr)
     }
 
     /// Finish an authentication ceremony.
@@ -298,15 +339,15 @@ impl WebAuthnService {
     /// pattern the reshape was meant to close.
     pub fn finish_authentication(
         &self,
-        challenge_id: &str,
         response: &PublicKeyCredential,
         now: SystemTime,
     ) -> Result<VerifiedAuthentication> {
+        let key = extract_challenge_from_credential(response.response.client_data_json.as_ref())?;
         let (auth_state, expires_at) = self
             .pending_authentications
             .lock()
             .expect("challenge store mutex poisoned")
-            .remove(challenge_id)
+            .remove(&key)
             .ok_or(AuthError::ChallengeNotFound)?;
         if now >= expires_at {
             return Err(AuthError::ChallengeNotFound);
@@ -334,12 +375,11 @@ impl WebAuthnService {
     /// HTTP handlers can't forget the link.
     pub fn finish_paired_registration(
         &self,
-        challenge_id: &str,
         response: &RegisterPublicKeyCredential,
         setup_token_id: String,
         now: SystemTime,
     ) -> Result<Credential> {
-        let cred = self.finish_registration(challenge_id, response, now)?;
+        let cred = self.finish_registration(response, now)?;
         Ok(Credential {
             setup_token_id: Some(setup_token_id),
             ..cred
@@ -369,8 +409,8 @@ impl WebAuthnService {
 /// The prune runs before the cap check so an organic build-up of stale
 /// entries doesn't lock out legitimate starts.
 fn insert_pending<T>(
-    store: &Mutex<HashMap<ChallengeId, (T, SystemTime)>>,
-    id: ChallengeId,
+    store: &Mutex<HashMap<ChallengeKey, (T, SystemTime)>>,
+    id: ChallengeKey,
     value: T,
     expires_at: SystemTime,
     now: SystemTime,
@@ -438,6 +478,40 @@ fn encode_credential_id(cred_id: &CredentialID) -> String {
     URL_SAFE_NO_PAD.encode(cred_id.as_ref())
 }
 
+/// URL-safe-base64 encode the challenge bytes that
+/// `webauthn-rs` minted into a `CreationChallengeResponse` /
+/// `RequestChallengeResponse`. This is the same encoding
+/// `clientDataJSON.challenge` uses, which is why the
+/// resulting string is a stable lookup key on both ends of
+/// the ceremony.
+fn encode_challenge(challenge: &[u8]) -> String {
+    URL_SAFE_NO_PAD.encode(challenge)
+}
+
+/// Extract the `challenge` field from a credential's
+/// `clientDataJSON`. The `client_data_json` argument is the
+/// raw bytes (already base64url-decoded by webauthn-rs-proto
+/// at deserialize time) — we just JSON-parse it and pluck the
+/// `challenge` string back out.
+///
+/// Returns `WebAuthn(_)` rather than `ChallengeNotFound` on
+/// parse failure: a credential whose clientDataJSON isn't
+/// valid JSON, or doesn't carry a `challenge` field, is a
+/// malformed payload — distinct from "the challenge isn't in
+/// our pending map." The HTTP layer maps both to 401 today,
+/// so the operator-log distinction is the only place this
+/// matters.
+fn extract_challenge_from_credential(client_data_json: &[u8]) -> Result<String> {
+    let v: serde_json::Value = serde_json::from_slice(client_data_json)
+        .map_err(|e| AuthError::WebAuthn(format!("clientDataJSON parse: {e}")))?;
+    v.get("challenge")
+        .and_then(|c| c.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| {
+            AuthError::WebAuthn("clientDataJSON missing challenge field".into())
+        })
+}
+
 fn decode_credential_id(s: &str) -> Result<CredentialID> {
     let bytes = URL_SAFE_NO_PAD
         .decode(s)
@@ -477,9 +551,14 @@ mod tests {
     }
 
     #[test]
-    fn start_registration_returns_unique_challenge_ids() {
+    fn start_registration_returns_unique_challenge_keys() {
+        // Issue two challenges back-to-back and confirm the
+        // server-side pending map keys (which are now the
+        // base64url-encoded challenges themselves) differ —
+        // proves webauthn-rs is minting fresh CSPRNG output
+        // and we're not collapsing them on insertion.
         let svc = service();
-        let (id1, _) = svc
+        let ccr1 = svc
             .start_registration(
                 Uuid::new_v4(),
                 "felix",
@@ -488,7 +567,7 @@ mod tests {
                 SystemTime::UNIX_EPOCH,
             )
             .unwrap();
-        let (id2, _) = svc
+        let ccr2 = svc
             .start_registration(
                 Uuid::new_v4(),
                 "felix",
@@ -497,30 +576,59 @@ mod tests {
                 SystemTime::UNIX_EPOCH,
             )
             .unwrap();
-        assert_ne!(id1, id2);
-        assert_eq!(id1.len(), 32);
+        let k1 = encode_challenge(ccr1.public_key.challenge.as_ref());
+        let k2 = encode_challenge(ccr2.public_key.challenge.as_ref());
+        assert_ne!(k1, k2);
+        let guard = svc.pending_registrations.lock().unwrap();
+        assert!(guard.contains_key(&k1));
+        assert!(guard.contains_key(&k2));
     }
 
     #[test]
     fn finish_registration_rejects_unknown_challenge() {
+        // A credential whose clientDataJSON carries a challenge
+        // we never issued must reject as ChallengeNotFound.
         let svc = service();
-        let fake = fake_register_response();
+        let fake = fake_register_response_with_challenge("never-issued");
         let err = svc
-            .finish_registration("nope", &fake, SystemTime::UNIX_EPOCH)
+            .finish_registration(&fake, SystemTime::UNIX_EPOCH)
             .unwrap_err();
         assert!(matches!(err, AuthError::ChallengeNotFound));
+    }
+
+    #[test]
+    fn finish_registration_rejects_credential_with_unparseable_client_data() {
+        // A credential whose clientDataJSON isn't valid JSON
+        // can't yield a lookup key — surface as a WebAuthn
+        // error rather than silently falling through to a
+        // ChallengeNotFound. The HTTP layer maps both to 401,
+        // so the distinction is operator-log only.
+        let svc = service();
+        let fake: RegisterPublicKeyCredential = serde_json::from_str(
+            r#"{
+                "id": "AAAA",
+                "rawId": "AAAA",
+                "response": { "clientDataJSON": "AAAA", "attestationObject": "" },
+                "type": "public-key",
+                "extensions": {}
+            }"#,
+        )
+        .unwrap();
+        let err = svc.finish_registration(&fake, SystemTime::UNIX_EPOCH).unwrap_err();
+        assert!(matches!(err, AuthError::WebAuthn(_)));
     }
 
     #[test]
     fn finish_registration_rejects_expired_challenge() {
         let svc = service();
         let start = SystemTime::UNIX_EPOCH;
-        let (id, _) = svc
+        let ccr = svc
             .start_registration(Uuid::new_v4(), "u", "U", &[], start)
             .unwrap();
-        let fake = fake_register_response();
+        let challenge_b64 = encode_challenge(ccr.public_key.challenge.as_ref());
+        let fake = fake_register_response_with_challenge(&challenge_b64);
         let later = start + CHALLENGE_TTL + Duration::from_secs(1);
-        let err = svc.finish_registration(&id, &fake, later).unwrap_err();
+        let err = svc.finish_registration(&fake, later).unwrap_err();
         assert!(matches!(err, AuthError::ChallengeNotFound));
     }
 
@@ -530,13 +638,14 @@ mod tests {
         // attacker could keep trying against the same server-side state.
         let svc = service();
         let start = SystemTime::UNIX_EPOCH;
-        let (id, _) = svc
+        let ccr = svc
             .start_registration(Uuid::new_v4(), "u", "U", &[], start)
             .unwrap();
-        let fake = fake_register_response();
-        let _ = svc.finish_registration(&id, &fake, start);
-        // Second attempt finds no state even with the same id.
-        let err = svc.finish_registration(&id, &fake, start).unwrap_err();
+        let challenge_b64 = encode_challenge(ccr.public_key.challenge.as_ref());
+        let fake = fake_register_response_with_challenge(&challenge_b64);
+        let _ = svc.finish_registration(&fake, start);
+        // Second attempt finds no state even with the same challenge.
+        let err = svc.finish_registration(&fake, start).unwrap_err();
         assert!(matches!(err, AuthError::ChallengeNotFound));
     }
 
@@ -572,7 +681,7 @@ mod tests {
     fn prune_expired_challenges_removes_stale_entries() {
         let svc = service();
         let start = SystemTime::UNIX_EPOCH;
-        let (_, _) = svc
+        let _ = svc
             .start_registration(Uuid::new_v4(), "u", "U", &[], start)
             .unwrap();
         assert_eq!(svc.pending_registrations.lock().unwrap().len(), 1);
@@ -584,7 +693,7 @@ mod tests {
     fn insert_pending_caps_the_map_after_pruning() {
         // Uses a bare `Mutex<HashMap<_, ((), SystemTime)>>` so we can
         // exercise the cap without needing real webauthn-rs state objects.
-        let store: Mutex<HashMap<ChallengeId, ((), SystemTime)>> = Mutex::new(HashMap::new());
+        let store: Mutex<HashMap<ChallengeKey, ((), SystemTime)>> = Mutex::new(HashMap::new());
         let now = SystemTime::UNIX_EPOCH;
         let future = now + Duration::from_secs(600);
 
@@ -624,21 +733,29 @@ mod tests {
         assert!(matches!(err, AuthError::WebAuthn(_)));
     }
 
-    fn fake_register_response() -> RegisterPublicKeyCredential {
-        // Syntactically minimal, cryptographically invalid — enough to
-        // exercise the challenge lifecycle without running real crypto.
-        serde_json::from_str(
-            r#"{
-                "id": "AAAA",
-                "rawId": "AAAA",
-                "response": {
-                    "clientDataJSON": "",
-                    "attestationObject": ""
-                },
-                "type": "public-key",
-                "extensions": {}
-            }"#,
-        )
-        .expect("fake response should parse")
+    /// Build a syntactically minimal `RegisterPublicKeyCredential`
+    /// whose `clientDataJSON` carries the given challenge. Real
+    /// authenticators would also fill in `type`, `origin`, etc., but
+    /// the lookup-key code only cares about the `challenge` field.
+    fn fake_register_response_with_challenge(
+        challenge_b64url: &str,
+    ) -> RegisterPublicKeyCredential {
+        let client_data = serde_json::json!({
+            "type": "webauthn.create",
+            "challenge": challenge_b64url,
+            "origin": "https://katulong.test",
+        });
+        let client_data_b64 = URL_SAFE_NO_PAD.encode(client_data.to_string().as_bytes());
+        let body = serde_json::json!({
+            "id": "AAAA",
+            "rawId": "AAAA",
+            "response": {
+                "clientDataJSON": client_data_b64,
+                "attestationObject": "",
+            },
+            "type": "public-key",
+            "extensions": {},
+        });
+        serde_json::from_value(body).expect("fake response should parse")
     }
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -54,6 +54,13 @@ tower-http = { version = "0.5", features = ["fs"] }
 tempfile = { workspace = true }
 tower = { version = "0.4", features = ["util"] }
 http-body-util = "0.1"
+# Used in integration tests to build realistic WebAuthn
+# `clientDataJSON` payloads — the cutover keys the pending
+# challenge map by the credential's own
+# `clientDataJSON.challenge` (matching Node's
+# `extractChallenge`), so test fakes have to base64url a
+# real `{type, challenge, origin}` JSON object.
+base64 = "0.22"
 # `test-util` enables `#[tokio::test(start_paused = true)]` used by
 # the output coalescer's timer tests. `tokio`'s `full` feature
 # does NOT include it — `test-util` is explicitly test-only and

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -1,15 +1,25 @@
 //! Authentication HTTP routes.
 //!
-//! Eight endpoints covering the full auth surface:
+//! Six endpoints covering the full auth surface:
 //!
 //! - `GET  /auth/status`          — public; `{setup, accessMethod}`
-//! - `POST /auth/register/options` — localhost-only, fresh install; bare `CreationChallengeResponse`
-//! - `POST /auth/register/verify` — localhost-only, fresh install; mints session
+//! - `POST /auth/register/options` — branched on optional `setupToken`:
+//!     - absent → localhost-only, fresh install
+//!     - present → public, setup-token-gated additional-device pair
+//!   Returns a bare `CreationChallengeResponse` either way.
+//! - `POST /auth/register/verify` — same branching as `/options`;
+//!   mints a session cookie on success.
 //! - `POST /auth/login/options`   — public; bare `RequestChallengeResponse`
 //! - `POST /auth/login/verify`    — public; updates counter + mints session
-//! - `POST /auth/pair/options`    — public, setup-token-gated; bare `CreationChallengeResponse`
-//! - `POST /auth/pair/verify`     — public; takes plaintext `setup_token`; mints session
 //! - `POST /auth/logout`          — auth + CSRF; localhost → 409
+//!
+//! Phase 0a step 4 collapsed the standalone `/auth/pair/*`
+//! routes into `/auth/register/*`. The Node frontend
+//! (`public/login.js`) only ever called `/auth/register/*`
+//! and branched on whether it had a setup token to send;
+//! mirroring that here means the Rust server is drop-in
+//! compatible with the existing Node-built UI as well as
+//! the WASM `<Login/>` / `<Register/>` components.
 //!
 //! The wire shapes match the Node implementation
 //! (`lib/routes/auth-routes.js`) byte-for-byte so the JS frontend
@@ -48,7 +58,7 @@ use axum::{
 use katulong_auth::{AuthError, Session, SESSION_TTL};
 use katulong_shared::wire::{
     AuthFinishResponse, AuthStatusResponse, CreationChallengeResponse, LoginFinishRequest,
-    PairFinishRequest, PairStartRequest, RegisterFinishRequest, RequestChallengeResponse,
+    RegisterFinishRequest, RegisterOptionsRequest, RequestChallengeResponse,
 };
 use std::net::SocketAddr;
 use std::time::SystemTime;
@@ -59,21 +69,24 @@ pub fn auth_routes() -> Router<AppState> {
         // which access mode this request is coming from; the client
         // uses this to pick between register/login UI.
         .route("/auth/status", get(status))
-        // PUBLIC (but state-gated): first-device registration. Only
-        // works from localhost AND only when no credentials exist.
-        // Additional-device registration uses the pair flow below.
+        // PUBLIC (but state-gated): registration. Branches inside the
+        // handler on the optional `setupToken` body field:
+        //   - absent → first-device bootstrap; localhost-only AND
+        //     refused once any credential exists.
+        //   - present → additional-device pair; the token value is the
+        //     gate (anyone with a valid plaintext token can pair).
+        // Token validity and "no credentials yet" are both re-checked
+        // inside `transact` so the mutex is the authoritative
+        // enforcement point. Phase 0a step 4 merged the dedicated
+        // `/auth/pair/*` routes into these so the Node frontend
+        // (which only ever calls `/auth/register/*`) drives the Rust
+        // server unchanged.
         .route("/auth/register/options", post(register_start))
         .route("/auth/register/verify", post(register_finish))
         // PUBLIC: anyone can try to log in. The ceremony itself gates
         // who actually succeeds.
         .route("/auth/login/options", post(login_start))
         .route("/auth/login/verify", post(login_finish))
-        // PUBLIC: pair a new device using a setup token issued by an
-        // authenticated admin. The token value IS the gate — anyone
-        // with a valid plaintext token can pair. Token validity and
-        // single-use semantics are enforced inside `transact`.
-        .route("/auth/pair/options", post(pair_start))
-        .route("/auth/pair/verify", post(pair_finish))
         // PROTECTED + CSRF: end the caller's session. Localhost
         // callers get a 409 — there's no session to end, and the
         // UI shouldn't offer logout for physical-access peers (Node
@@ -104,119 +117,209 @@ async fn status(
     })
 }
 
-/// Start a first-device registration ceremony.
+/// Upper bound on the raw `setupToken` value accepted by the
+/// register endpoints. Legitimate tokens are 64 hex chars
+/// (32 bytes from CSPRNG, hex-encoded); 128 gives headroom.
+/// The cap exists to stop an unauthenticated caller from
+/// submitting a megabyte-long string and forcing
+/// `find_redeemable_setup_token` to run scrypt verify against
+/// every stored token with a megabyte input per call — a CPU
+/// amplification DoS vector because the no-token branch is
+/// localhost-gated but the token branch is fully public.
+const SETUP_TOKEN_MAX_LEN: usize = 128;
+
+/// Normalise an optional `setupToken` from the request body.
+/// Node's frontend sends `setupToken: ""` when the input is
+/// empty (it doesn't trim before submitting); treat empty
+/// strings as absent so the no-token branch fires for both
+/// shapes. Anything longer than `SETUP_TOKEN_MAX_LEN` is
+/// rejected before it reaches scrypt verify.
+fn normalise_setup_token(raw: Option<String>) -> Result<Option<String>, ApiError> {
+    let Some(value) = raw else {
+        return Ok(None);
+    };
+    if value.is_empty() {
+        return Ok(None);
+    }
+    if value.len() > SETUP_TOKEN_MAX_LEN {
+        tracing::warn!(
+            length = value.len(),
+            "register: setupToken exceeds maximum length"
+        );
+        return Err(ApiError::BadRequest("setupToken exceeds maximum length"));
+    }
+    Ok(Some(value))
+}
+
+/// Start a registration ceremony.
 ///
-/// First-device is the ONLY registration path this slice supports.
-/// Adding subsequent devices goes through the setup-token flow in
-/// slice 6 (which reuses `WebAuthnService::start_registration` but
-/// gates the state differently).
+/// Two branches selected by `body.setupToken`:
 ///
-/// Two guards — both enforced again inside `register_finish`'s
-/// `transact` closure so a race can't slip past the pre-flight:
-/// 1. `access == Localhost` — physical access is required to bootstrap
-///    the first device, since there's nothing to authenticate against
-///    yet. If we let this run from a tunnel, anyone with the URL could
-///    register their own key on a fresh install.
-/// 2. `credentials.is_empty()` — once any device is registered, further
-///    registrations must go through pairing so the existing user can
-///    authorise them.
+/// 1. **No token (first-device bootstrap)** — refuses non-localhost
+///    callers (a tunnel-bound register would let anyone with the URL
+///    enrol a key on a fresh install) and refuses any call after the
+///    first credential exists. Both invariants are re-checked inside
+///    `register_finish`'s `transact` closure so a race can't slip past
+///    the pre-flight.
+///
+/// 2. **Token present (additional-device pair)** — public; the token
+///    value IS the gate. `find_redeemable_setup_token` walks every
+///    stored token and runs scrypt verify (no short-circuit — the
+///    timing channel is the same as login). Only live, unconsumed,
+///    unexpired tokens pass. Token validity is re-validated under the
+///    state mutex in `register_finish` to close the TOCTOU window
+///    against a concurrent revoke between start and finish.
+///
+/// Both branches return a bare `CreationChallengeResponse` at the JSON
+/// top level (Node's `res.json(opts)` shape).
 async fn register_start(
     State(state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
+    JsonBody(body): JsonBody<RegisterOptionsRequest>,
 ) -> Result<Json<CreationChallengeResponse>, ApiError> {
-    let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
-    let access = AccessMethod::classify(peer, host);
-    if !matches!(access, AccessMethod::Localhost) {
-        // Generic "forbidden" — the descriptive variant would confirm
-        // to a remote scanner that this is a katulong instance with a
-        // first-device registration path gated on localhost. Operators
-        // needing detail can read the server log.
-        tracing::warn!("rejecting remote request to first-device registration");
-        return Err(ApiError::Forbidden("forbidden"));
-    }
+    let setup_token = normalise_setup_token(body.setup_token)?;
+    let now = SystemTime::now();
 
-    // Get-or-init the stable user handle AND enforce the "no
-    // credentials yet" invariant atomically. `user_handle_or_init`
-    // returns the existing handle on a fresh call for the same
-    // install (idempotent) or mints a fresh one on first use. Doing
-    // this inside `transact` means the handle persists before the
-    // ceremony runs, so `register_finish`'s transact closure reads
-    // the same value even if a second device later pairs in.
-    //
-    // This is the authoritative `credentials.is_empty()` check — the
-    // same re-check appears in `register_finish`'s transact closure
-    // to close the TOCTOU window between start and finish.
-    let (user_handle, credentials) = state
-        .auth_store
-        .transact(|s| {
-            if !s.credentials.is_empty() {
-                return Err(AuthError::StateConflict(
-                    "instance already initialised; additional devices must pair via setup token",
-                ));
-            }
-            let (uh, next) = s.user_handle_or_init();
-            let creds = next.credentials.clone();
-            Ok((next, (uh, creds)))
-        })
-        .await
-        .map_err(ApiError::from)?;
+    let (user_handle, credentials) = if let Some(plaintext) = setup_token.as_ref() {
+        // Token-gated branch: skip the localhost check, validate the
+        // token, then ensure a stable user handle is persisted before
+        // the WebAuthn ceremony. Token re-validation under the mutex
+        // happens in `register_finish`; the pre-flight here is a
+        // fast-fail for the common (non-racing) case.
+        let snap = state.auth_store.snapshot().await;
+        if snap.find_redeemable_setup_token(plaintext, now).is_none() {
+            tracing::warn!("register_start: setup token not redeemable");
+            return Err(ApiError::Unauthorized);
+        }
+        let user_handle = state
+            .auth_store
+            .transact(|s| {
+                let (uh, next) = s.user_handle_or_init();
+                Ok((next, uh))
+            })
+            .await
+            .map_err(ApiError::from)?;
+        (user_handle, snap.credentials.clone())
+    } else {
+        // No-token branch: physical access is required to bootstrap
+        // the first device, since there's nothing to authenticate
+        // against yet.
+        let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
+        let access = AccessMethod::classify(peer, host);
+        if !matches!(access, AccessMethod::Localhost) {
+            // Generic "forbidden" — the descriptive variant would
+            // confirm to a remote scanner that this is a katulong
+            // instance with a first-device registration path gated on
+            // localhost. Operators needing detail can read the log.
+            tracing::warn!("rejecting remote request to first-device registration");
+            return Err(ApiError::Forbidden("forbidden"));
+        }
+        // Get-or-init the stable user handle AND enforce the "no
+        // credentials yet" invariant atomically. The same re-check
+        // appears in `register_finish`'s transact closure to close
+        // the TOCTOU window between start and finish.
+        state
+            .auth_store
+            .transact(|s| {
+                if !s.credentials.is_empty() {
+                    return Err(AuthError::StateConflict(
+                        "instance already initialised; additional devices must pair via setup token",
+                    ));
+                }
+                let (uh, next) = s.user_handle_or_init();
+                let creds = next.credentials.clone();
+                Ok((next, (uh, creds)))
+            })
+            .await
+            .map_err(ApiError::from)?
+    };
 
     let ccr = state
         .webauthn
-        .start_registration(
-            user_handle,
-            "katulong",
-            "Katulong",
-            &credentials,
-            SystemTime::now(),
-        )
+        .start_registration(user_handle, "katulong", "Katulong", &credentials, now)
         .map_err(ApiError::from)?;
     Ok(Json(ccr))
 }
 
-/// Finish the first-device registration, persist the credential, and
-/// mint a session cookie bound to it.
+/// Finish a registration ceremony, persist the credential, and mint a
+/// session cookie. Branches on `body.setupToken` exactly like
+/// `register_start`.
 ///
-/// The localhost check is outside `transact` (socket state doesn't
-/// change under the mutex). The "no credentials yet" check is INSIDE
-/// `transact` so it evaluates under the same lock that will do the
-/// write — without this, two concurrent finishes could each pass the
-/// pre-flight check on separate snapshots and both end up upserting a
-/// credential on what was supposed to be a single-device install.
+/// Both branches enforce their guards INSIDE `transact`:
+///   - No-token: `credentials.is_empty()` re-check (TOCTOU-safe vs a
+///     concurrent first-device finish).
+///   - Token: `find_redeemable_setup_token` re-check (TOCTOU-safe vs a
+///     concurrent revoke between start and finish), then
+///     `consume_setup_token` linking the new credential id to the
+///     token id (Node scar `7742ac3` — revoke cascades to remove the
+///     paired device).
 async fn register_finish(
     State(state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     JsonBody(body): JsonBody<RegisterFinishRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
-    let access = AccessMethod::classify(peer, host);
-    if !matches!(access, AccessMethod::Localhost) {
-        // Generic "forbidden" — the descriptive variant would confirm
-        // to a remote scanner that this is a katulong instance with a
-        // first-device registration path gated on localhost. Operators
-        // needing detail can read the server log.
-        tracing::warn!("rejecting remote request to first-device registration");
-        return Err(ApiError::Forbidden("forbidden"));
+    let setup_token = normalise_setup_token(body.setup_token.clone())?;
+    let now = SystemTime::now();
+
+    if setup_token.is_none() {
+        // No-token branch is localhost-only. Socket state doesn't
+        // change under the mutex, so this gate stays outside transact;
+        // the `credentials.is_empty()` re-check inside the transact
+        // closure is the authoritative invariant.
+        let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
+        let access = AccessMethod::classify(peer, host);
+        if !matches!(access, AccessMethod::Localhost) {
+            tracing::warn!("rejecting remote request to first-device registration");
+            return Err(ApiError::Forbidden("forbidden"));
+        }
     }
 
-    let now = SystemTime::now();
-    let credential = state
-        .webauthn
-        .finish_registration(&body.credential, now)
-        .inspect_err(|e| {
-            // Log failed ceremonies at `warn` so brute-force or replay
-            // attempts are visible in operator logs. The credential id
-            // is safe to log; the attestation response bytes are not
-            // logged.
-            tracing::warn!(
-                credential_id = %body.credential.id,
-                error = %e,
-                "registration ceremony failed"
-            );
-        })
-        .map_err(ApiError::from)?;
+    // Run the WebAuthn ceremony. The pair branch needs the
+    // setup_token_id stamped onto the credential — `finish_paired_registration`
+    // owns the bidirectional link invariant (credential ↔ setup token)
+    // so the handler never constructs that link by hand.
+    let credential = if let Some(plaintext) = setup_token.as_ref() {
+        // Pre-flight token resolve so we can pass the id to the
+        // ceremony; the authoritative re-check happens under the
+        // state mutex below.
+        let snap = state.auth_store.snapshot().await;
+        let token = snap
+            .find_redeemable_setup_token(plaintext, now)
+            .ok_or_else(|| {
+                tracing::warn!("register_finish: setup token not redeemable");
+                ApiError::Unauthorized
+            })?;
+        let setup_token_id = token.id.clone();
+        state
+            .webauthn
+            .finish_paired_registration(&body.credential, setup_token_id, now)
+            .inspect_err(|e| {
+                tracing::warn!(
+                    credential_id = %body.credential.id,
+                    error = %e,
+                    "pair ceremony failed"
+                );
+            })
+            .map_err(ApiError::from)?
+    } else {
+        state
+            .webauthn
+            .finish_registration(&body.credential, now)
+            .inspect_err(|e| {
+                // Log failed ceremonies at `warn` so brute-force or
+                // replay attempts are visible in operator logs. The
+                // credential id is safe to log; the attestation
+                // response bytes are not logged.
+                tracing::warn!(
+                    credential_id = %body.credential.id,
+                    error = %e,
+                    "registration ceremony failed"
+                );
+            })
+            .map_err(ApiError::from)?
+    };
 
     // Stamp the human-facing labels onto the credential before it goes
     // to disk. `finish_registration` doesn't see the request body
@@ -230,32 +333,64 @@ async fn register_finish(
         ..credential
     };
 
-    // The credentials.is_empty() re-check inside the closure is the
-    // authoritative TOCTOU-safe enforcement — a second concurrent
-    // finisher will see state already containing the first winner's
-    // credential and bail out with StateConflict (→ 409).
     let new_credential = credential.clone();
-    let (plaintext_token, minted_session) = state
+    let setup_token_for_closure = setup_token.clone();
+    let (plaintext_token, minted_session, paired_token_id) = state
         .auth_store
         .transact(move |s| {
-            if !s.credentials.is_empty() {
-                return Err(AuthError::StateConflict(
-                    "instance already initialised by a concurrent registration",
-                ));
+            if let Some(plaintext) = setup_token_for_closure.as_ref() {
+                // Re-validate the token under the mutex: a concurrent
+                // revoke between start and finish must NOT succeed in
+                // pairing. Re-resolve from the plaintext so the id we
+                // commit against is whatever the live state says is
+                // redeemable RIGHT NOW.
+                let Some(token) = s.find_redeemable_setup_token(plaintext, now) else {
+                    return Err(AuthError::StateConflict(
+                        "setup token no longer redeemable (revoked, consumed, or expired)",
+                    ));
+                };
+                let token_id = token.id.clone();
+                let (plaintext_session, session) =
+                    Session::mint(new_credential.id.clone(), now, SESSION_TTL);
+                let next = s
+                    .upsert_credential(new_credential.clone())
+                    .consume_setup_token(&token_id, &new_credential.id, now)
+                    .upsert_session(session.clone());
+                Ok((next, (plaintext_session, session, Some(token_id))))
+            } else {
+                // The credentials.is_empty() re-check inside the
+                // closure is the authoritative TOCTOU-safe enforcement
+                // — a second concurrent finisher will see state already
+                // containing the first winner's credential and bail
+                // out with StateConflict (→ 409).
+                if !s.credentials.is_empty() {
+                    return Err(AuthError::StateConflict(
+                        "instance already initialised by a concurrent registration",
+                    ));
+                }
+                let (plaintext_session, session) =
+                    Session::mint(new_credential.id.clone(), now, SESSION_TTL);
+                let next = s
+                    .upsert_credential(new_credential.clone())
+                    .upsert_session(session.clone());
+                Ok((next, (plaintext_session, session, None)))
             }
-            let (plaintext, session) = Session::mint(new_credential.id.clone(), now, SESSION_TTL);
-            let next = s
-                .upsert_credential(new_credential.clone())
-                .upsert_session(session.clone());
-            Ok((next, (plaintext, session)))
         })
         .await
         .map_err(ApiError::from)?;
 
-    tracing::info!(
-        credential_id = %credential.id,
-        "registered first device; session minted"
-    );
+    if let Some(token_id) = paired_token_id.as_ref() {
+        tracing::info!(
+            credential_id = %credential.id,
+            setup_token_id = %token_id,
+            "paired new device; session minted"
+        );
+    } else {
+        tracing::info!(
+            credential_id = %credential.id,
+            "registered first device; session minted"
+        );
+    }
 
     Ok(session_cookie_response(
         StatusCode::CREATED,
@@ -368,199 +503,6 @@ where
 {
     let cookie = build_set_cookie(token, SESSION_TTL.as_secs(), secure);
     (status, [(header::SET_COOKIE, cookie)], body)
-}
-
-// ============== pair flow (setup-token-gated registration) ==============
-
-/// Validate the plaintext token, start a WebAuthn registration
-/// ceremony, and return the challenge. Public — anyone with a valid
-/// token can pair.
-///
-/// Token validation uses `find_redeemable_setup_token` which walks
-/// every token and runs scrypt verify (no short-circuit — the slice-2
-/// comment calls out the timing-channel concern). Only live,
-/// non-consumed tokens pass.
-/// Upper bound on the raw `setup_token` value accepted by
-/// `pair_start`. Legitimate tokens are 64 hex chars (32 bytes from
-/// CSPRNG, hex-encoded); 128 gives headroom. The cap exists to stop
-/// an unauthenticated caller from submitting a megabyte-long string
-/// and forcing `find_redeemable_setup_token` to run scrypt verify
-/// against every stored token with a megabyte input per call — a CPU
-/// amplification DoS vector because pair_start is public.
-const SETUP_TOKEN_MAX_LEN: usize = 128;
-
-async fn pair_start(
-    State(state): State<AppState>,
-    JsonBody(body): JsonBody<PairStartRequest>,
-) -> Result<Json<CreationChallengeResponse>, ApiError> {
-    if body.setup_token.len() > SETUP_TOKEN_MAX_LEN {
-        tracing::warn!(
-            length = body.setup_token.len(),
-            "pair_start: setup_token exceeds maximum length"
-        );
-        return Err(ApiError::BadRequest("setup_token exceeds maximum length"));
-    }
-
-    let now = SystemTime::now();
-
-    // Ensure the stable user handle is persisted before we hand it
-    // to the WebAuthn ceremony. `user_handle_or_init` is idempotent:
-    // returns the existing value on a live install, mints + persists
-    // a fresh one on the pathological path where tokens somehow
-    // exist without a handle. Running this inside `transact` means
-    // the handle that pair_finish reads back is the SAME value that
-    // was used here, even across concurrent pair_start calls.
-    let user_handle = state
-        .auth_store
-        .transact(|s| {
-            let (uh, next) = s.user_handle_or_init();
-            Ok((next, uh))
-        })
-        .await
-        .map_err(ApiError::from)?;
-
-    // A separate snapshot for token validation + excludeCredentials.
-    // `find_redeemable_setup_token` walks every record with scrypt
-    // verify, so a concurrent mutation doesn't matter — the
-    // authoritative token re-check happens in pair_finish's transact.
-    let snap = state.auth_store.snapshot().await;
-    let _token = snap
-        .find_redeemable_setup_token(&body.setup_token, now)
-        .ok_or_else(|| {
-            tracing::warn!("pair_start: setup token not redeemable");
-            ApiError::Unauthorized
-        })?;
-
-    // Bare `CreationChallengeResponse` at the top level — Node
-    // returns `res.json(opts)` from
-    // `lib/routes/auth-routes.js` without a wrapper. The
-    // `setup_token_id` is no longer echoed; pair_finish takes
-    // the plaintext token again and re-resolves the id under
-    // the state mutex.
-    let ccr = state
-        .webauthn
-        .start_registration(
-            user_handle,
-            "katulong",
-            "Katulong",
-            &snap.credentials,
-            now,
-        )
-        .map_err(ApiError::from)?;
-
-    Ok(Json(ccr))
-}
-
-/// Complete the pair ceremony. Verifies the challenge, verifies the
-/// setup token is STILL redeemable under the mutex (TOCTOU-safe vs a
-/// concurrent revoke between start and finish), consumes the token,
-/// persists the new credential with a bidirectional link to the
-/// token, and mints a session cookie.
-///
-/// The bidirectional link (token ↔ credential, Node scar `7742ac3`)
-/// means that revoking the setup token later also cascades to
-/// removing this device. We set it here so future
-/// `remove_setup_token(id)` calls can follow the link.
-async fn pair_finish(
-    State(state): State<AppState>,
-    JsonBody(body): JsonBody<PairFinishRequest>,
-) -> Result<impl IntoResponse, ApiError> {
-    if body.setup_token.len() > SETUP_TOKEN_MAX_LEN {
-        tracing::warn!(
-            length = body.setup_token.len(),
-            "pair_finish: setup_token exceeds maximum length"
-        );
-        return Err(ApiError::BadRequest("setup_token exceeds maximum length"));
-    }
-
-    let now = SystemTime::now();
-
-    // Resolve the plaintext setup token to its server-side id
-    // before running the WebAuthn ceremony. Node does the same
-    // (re-validates the token in the verify handler), and we
-    // re-validate again under the state mutex below — the
-    // pre-flight here is a fast-fail for the common case.
-    let snap = state.auth_store.snapshot().await;
-    let token = snap
-        .find_redeemable_setup_token(&body.setup_token, now)
-        .ok_or_else(|| {
-            tracing::warn!("pair_finish: setup token not redeemable");
-            ApiError::Unauthorized
-        })?;
-    let setup_token_id = token.id.clone();
-
-    // The auth crate owns the bidirectional link invariant (credential
-    // ↔ setup token). `finish_paired_registration` returns a
-    // credential already stamped with `setup_token_id` — the handler
-    // never constructs that link by hand.
-    let credential = state
-        .webauthn
-        .finish_paired_registration(&body.credential, setup_token_id.clone(), now)
-        .inspect_err(|e| {
-            tracing::warn!(
-                credential_id = %body.credential.id,
-                error = %e,
-                "pair ceremony failed"
-            );
-        })
-        .map_err(ApiError::from)?;
-
-    // Stamp the human-facing labels supplied with the pair request.
-    // Same reasoning as `register_finish` — the auth crate stays
-    // unaware of the request shape; the handler stitches the user-
-    // visible metadata onto the verified credential.
-    let credential = katulong_auth::Credential {
-        name: body.device_name.clone().filter(|n| !n.is_empty()),
-        user_agent: body.user_agent.clone().unwrap_or_default(),
-        ..credential
-    };
-
-    let new_credential = credential.clone();
-    let setup_token_plaintext = body.setup_token.clone();
-    let (plaintext_token, minted_session) = state
-        .auth_store
-        .transact(move |s| {
-            // Re-validate the token under the mutex: a concurrent
-            // revoke between pair_start and pair_finish must NOT
-            // succeed in pairing. Re-resolve from the plaintext so
-            // the id we commit against is whatever the live state
-            // says is redeemable RIGHT NOW — a concurrent
-            // delete-then-recreate with the same plaintext (not
-            // possible today, but the pattern is robust to future
-            // shapes) lands on the live token.
-            let Some(token) = s.find_redeemable_setup_token(&setup_token_plaintext, now) else {
-                return Err(AuthError::StateConflict(
-                    "setup token no longer redeemable (revoked, consumed, or expired)",
-                ));
-            };
-            let token_id = token.id.clone();
-
-            let (plaintext, session) =
-                Session::mint(new_credential.id.clone(), now, SESSION_TTL);
-            let next = s
-                .upsert_credential(new_credential.clone())
-                .consume_setup_token(&token_id, &new_credential.id, now)
-                .upsert_session(session.clone());
-            Ok((next, (plaintext, session)))
-        })
-        .await
-        .map_err(ApiError::from)?;
-
-    tracing::info!(
-        credential_id = %credential.id,
-        setup_token_id = %setup_token_id,
-        "paired new device; session minted"
-    );
-
-    Ok(session_cookie_response(
-        StatusCode::CREATED,
-        &plaintext_token,
-        state.config.cookie_secure,
-        Json(AuthFinishResponse {
-            credential_id: credential.id,
-            csrf_token: minted_session.csrf_token,
-        }),
-    ))
 }
 
 // ============== logout ==============

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -2,14 +2,14 @@
 //!
 //! Eight endpoints covering the full auth surface:
 //!
-//! - `GET  /api/auth/status`          — public; access mode + install state + authenticated
-//! - `POST /api/auth/register/start`  — localhost-only, fresh install
-//! - `POST /api/auth/register/finish` — localhost-only, fresh install; mints session
-//! - `POST /api/auth/login/start`     — public
-//! - `POST /api/auth/login/finish`    — public; updates counter + mints session
-//! - `POST /api/auth/pair/start`      — public, setup-token-gated
-//! - `POST /api/auth/pair/finish`     — public; links credential to token + mints session
-//! - `POST /api/auth/logout`          — auth + CSRF; localhost → 409
+//! - `GET  /auth/status`          — public; access mode + install state + authenticated
+//! - `POST /auth/register/options`  — localhost-only, fresh install
+//! - `POST /auth/register/verify` — localhost-only, fresh install; mints session
+//! - `POST /auth/login/options`     — public
+//! - `POST /auth/login/verify`    — public; updates counter + mints session
+//! - `POST /auth/pair/options`      — public, setup-token-gated
+//! - `POST /auth/pair/verify`     — public; links credential to token + mints session
+//! - `POST /auth/logout`          — auth + CSRF; localhost → 409
 //!
 //! Setup-token management (list / create / revoke) lives in
 //! `api::tokens`. Those routes share the same `CsrfProtected` pattern
@@ -51,27 +51,27 @@ pub fn auth_routes() -> Router<AppState> {
         // PUBLIC: reports whether the instance has any credentials and
         // which access mode this request is coming from; the client
         // uses this to pick between register/login UI.
-        .route("/api/auth/status", get(status))
+        .route("/auth/status", get(status))
         // PUBLIC (but state-gated): first-device registration. Only
         // works from localhost AND only when no credentials exist.
         // Additional-device registration uses the pair flow below.
-        .route("/api/auth/register/start", post(register_start))
-        .route("/api/auth/register/finish", post(register_finish))
+        .route("/auth/register/options", post(register_start))
+        .route("/auth/register/verify", post(register_finish))
         // PUBLIC: anyone can try to log in. The ceremony itself gates
         // who actually succeeds.
-        .route("/api/auth/login/start", post(login_start))
-        .route("/api/auth/login/finish", post(login_finish))
+        .route("/auth/login/options", post(login_start))
+        .route("/auth/login/verify", post(login_finish))
         // PUBLIC: pair a new device using a setup token issued by an
         // authenticated admin. The token value IS the gate — anyone
         // with a valid plaintext token can pair. Token validity and
         // single-use semantics are enforced inside `transact`.
-        .route("/api/auth/pair/start", post(pair_start))
-        .route("/api/auth/pair/finish", post(pair_finish))
+        .route("/auth/pair/options", post(pair_start))
+        .route("/auth/pair/verify", post(pair_finish))
         // PROTECTED + CSRF: end the caller's session. Localhost
         // callers get a 409 — there's no session to end, and the
         // UI shouldn't offer logout for physical-access peers (Node
         // scar `23981ca`).
-        .route("/api/auth/logout", post(logout))
+        .route("/auth/logout", post(logout))
 }
 
 async fn status(
@@ -256,7 +256,7 @@ async fn login_start(
         // letting webauthn-rs surface "no usable credentials" as a 401;
         // the client should route to the register flow instead.
         return Err(ApiError::Conflict(
-            "no credentials registered; first device must register via /api/auth/register/start",
+            "no credentials registered; first device must register via /auth/register/options",
         ));
     }
     let (id, rcr) = state

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -218,6 +218,18 @@ async fn register_finish(
         })
         .map_err(ApiError::from)?;
 
+    // Stamp the human-facing labels onto the credential before it goes
+    // to disk. `finish_registration` doesn't see the request body
+    // (it's a pure WebAuthn primitive); the handler is the only place
+    // that has both the verified credential AND the operator-supplied
+    // `deviceName`/`userAgent`. Defaults to empty when missing — Node
+    // uses the same `||''` tolerance.
+    let credential = katulong_auth::Credential {
+        name: body.device_name.clone().filter(|n| !n.is_empty()),
+        user_agent: body.user_agent.clone().unwrap_or_default(),
+        ..credential
+    };
+
     // The credentials.is_empty() re-check inside the closure is the
     // authoritative TOCTOU-safe enforcement — a second concurrent
     // finisher will see state already containing the first winner's
@@ -316,6 +328,11 @@ async fn login_finish(
             if let Some(updated_cred) = updated {
                 next = next.upsert_credential(updated_cred);
             }
+            // Stamp `last_used_at` on the credential we just authed
+            // against. Done inside `transact` so the same write that
+            // bumps the WebAuthn counter also records usage — single
+            // writer, no extra TOCTOU surface for the device-list UI.
+            next = next.touch_credential(&credential_id, now);
             next = next.upsert_session(session.clone());
             Ok((next, (plaintext, session)))
         })
@@ -487,6 +504,16 @@ async fn pair_finish(
             );
         })
         .map_err(ApiError::from)?;
+
+    // Stamp the human-facing labels supplied with the pair request.
+    // Same reasoning as `register_finish` — the auth crate stays
+    // unaware of the request shape; the handler stitches the user-
+    // visible metadata onto the verified credential.
+    let credential = katulong_auth::Credential {
+        name: body.device_name.clone().filter(|n| !n.is_empty()),
+        user_agent: body.user_agent.clone().unwrap_or_default(),
+        ..credential
+    };
 
     let new_credential = credential.clone();
     let setup_token_plaintext = body.setup_token.clone();

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -2,14 +2,22 @@
 //!
 //! Eight endpoints covering the full auth surface:
 //!
-//! - `GET  /auth/status`          — public; access mode + install state + authenticated
-//! - `POST /auth/register/options`  — localhost-only, fresh install
+//! - `GET  /auth/status`          — public; `{setup, accessMethod}`
+//! - `POST /auth/register/options` — localhost-only, fresh install; bare `CreationChallengeResponse`
 //! - `POST /auth/register/verify` — localhost-only, fresh install; mints session
-//! - `POST /auth/login/options`     — public
+//! - `POST /auth/login/options`   — public; bare `RequestChallengeResponse`
 //! - `POST /auth/login/verify`    — public; updates counter + mints session
-//! - `POST /auth/pair/options`      — public, setup-token-gated
-//! - `POST /auth/pair/verify`     — public; links credential to token + mints session
+//! - `POST /auth/pair/options`    — public, setup-token-gated; bare `CreationChallengeResponse`
+//! - `POST /auth/pair/verify`     — public; takes plaintext `setup_token`; mints session
 //! - `POST /auth/logout`          — auth + CSRF; localhost → 409
+//!
+//! The wire shapes match the Node implementation
+//! (`lib/routes/auth-routes.js`) byte-for-byte so the JS frontend
+//! drives the Rust server unchanged. In particular: the start
+//! endpoints return WebAuthn options at the JSON top level (no
+//! `challenge_id` envelope), and the verify endpoints recover the
+//! challenge from `credential.response.clientDataJSON.challenge` —
+//! the same `extractChallenge()` pattern the Node handler uses.
 //!
 //! Setup-token management (list / create / revoke) lives in
 //! `api::tokens`. Those routes share the same `CsrfProtected` pattern
@@ -39,9 +47,8 @@ use axum::{
 };
 use katulong_auth::{AuthError, Session, SESSION_TTL};
 use katulong_shared::wire::{
-    AuthFinishResponse, AuthStatusResponse, ChallengeStartResponse,
-    CreationChallengeResponse, LoginFinishRequest, PairFinishRequest, PairStartRequest,
-    PairStartResponse, RegisterFinishRequest, RequestChallengeResponse,
+    AuthFinishResponse, AuthStatusResponse, CreationChallengeResponse, LoginFinishRequest,
+    PairFinishRequest, PairStartRequest, RegisterFinishRequest, RequestChallengeResponse,
 };
 use std::net::SocketAddr;
 use std::time::SystemTime;
@@ -78,15 +85,22 @@ async fn status(
     State(state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
-    authed: Option<Authenticated>,
+    _authed: Option<Authenticated>,
 ) -> Json<AuthStatusResponse> {
+    // Wire shape mirrors Node's `lib/routes/auth-routes.js`:
+    // `{ setup, accessMethod }`. The `Option<Authenticated>`
+    // parameter stays in the signature so the auth-middleware
+    // wiring exercises the cookie-validation path on this
+    // public endpoint (logging side effects, lockout pruning),
+    // but the resulting bool no longer round-trips through
+    // status — a sibling PR adds `/api/me` for the frontend
+    // to recover that signal.
     let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
     let access = AccessMethod::classify(peer, host);
     let snap = state.auth_store.snapshot().await;
     Json(AuthStatusResponse {
+        setup: !snap.credentials.is_empty(),
         access_method: access.into(),
-        has_credentials: !snap.credentials.is_empty(),
-        authenticated: authed.is_some(),
     })
 }
 
@@ -110,7 +124,7 @@ async fn register_start(
     State(state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
-) -> Result<Json<ChallengeStartResponse<CreationChallengeResponse>>, ApiError> {
+) -> Result<Json<CreationChallengeResponse>, ApiError> {
     let host = headers.get(header::HOST).and_then(|v| v.to_str().ok());
     let access = AccessMethod::classify(peer, host);
     if !matches!(access, AccessMethod::Localhost) {
@@ -148,7 +162,7 @@ async fn register_start(
         .await
         .map_err(ApiError::from)?;
 
-    let (id, ccr) = state
+    let ccr = state
         .webauthn
         .start_registration(
             user_handle,
@@ -158,10 +172,7 @@ async fn register_start(
             SystemTime::now(),
         )
         .map_err(ApiError::from)?;
-    Ok(Json(ChallengeStartResponse {
-        challenge_id: id,
-        options: ccr,
-    }))
+    Ok(Json(ccr))
 }
 
 /// Finish the first-device registration, persist the credential, and
@@ -193,14 +204,14 @@ async fn register_finish(
     let now = SystemTime::now();
     let credential = state
         .webauthn
-        .finish_registration(&body.challenge_id, &body.response, now)
+        .finish_registration(&body.credential, now)
         .inspect_err(|e| {
             // Log failed ceremonies at `warn` so brute-force or replay
-            // attempts are visible in operator logs. The challenge id
-            // is safe to log — it's an opaque server-issued handle,
-            // not the attestation response bytes.
+            // attempts are visible in operator logs. The credential id
+            // is safe to log; the attestation response bytes are not
+            // logged.
             tracing::warn!(
-                challenge_id = %body.challenge_id,
+                credential_id = %body.credential.id,
                 error = %e,
                 "registration ceremony failed"
             );
@@ -249,7 +260,7 @@ async fn register_finish(
 /// gates who actually passes.
 async fn login_start(
     State(state): State<AppState>,
-) -> Result<Json<ChallengeStartResponse<RequestChallengeResponse>>, ApiError> {
+) -> Result<Json<RequestChallengeResponse>, ApiError> {
     let snap = state.auth_store.snapshot().await;
     if snap.credentials.is_empty() {
         // Fresh-install case. Return an explicit conflict rather than
@@ -259,14 +270,11 @@ async fn login_start(
             "no credentials registered; first device must register via /auth/register/options",
         ));
     }
-    let (id, rcr) = state
+    let rcr = state
         .webauthn
         .start_authentication(&snap.credentials, SystemTime::now())
         .map_err(ApiError::from)?;
-    Ok(Json(ChallengeStartResponse {
-        challenge_id: id,
-        options: rcr,
-    }))
+    Ok(Json(rcr))
 }
 
 /// Finish an authentication ceremony, persist the counter update, and
@@ -278,10 +286,10 @@ async fn login_finish(
     let now = SystemTime::now();
     let verified = state
         .webauthn
-        .finish_authentication(&body.challenge_id, &body.response, now)
+        .finish_authentication(&body.credential, now)
         .inspect_err(|e| {
             tracing::warn!(
-                challenge_id = %body.challenge_id,
+                credential_id = %body.credential.id,
                 error = %e,
                 "login ceremony failed"
             );
@@ -367,7 +375,7 @@ const SETUP_TOKEN_MAX_LEN: usize = 128;
 async fn pair_start(
     State(state): State<AppState>,
     JsonBody(body): JsonBody<PairStartRequest>,
-) -> Result<Json<PairStartResponse>, ApiError> {
+) -> Result<Json<CreationChallengeResponse>, ApiError> {
     if body.setup_token.len() > SETUP_TOKEN_MAX_LEN {
         tracing::warn!(
             length = body.setup_token.len(),
@@ -399,15 +407,20 @@ async fn pair_start(
     // verify, so a concurrent mutation doesn't matter — the
     // authoritative token re-check happens in pair_finish's transact.
     let snap = state.auth_store.snapshot().await;
-    let token = snap
+    let _token = snap
         .find_redeemable_setup_token(&body.setup_token, now)
         .ok_or_else(|| {
             tracing::warn!("pair_start: setup token not redeemable");
             ApiError::Unauthorized
         })?;
-    let setup_token_id = token.id.clone();
 
-    let (challenge_id, ccr) = state
+    // Bare `CreationChallengeResponse` at the top level — Node
+    // returns `res.json(opts)` from
+    // `lib/routes/auth-routes.js` without a wrapper. The
+    // `setup_token_id` is no longer echoed; pair_finish takes
+    // the plaintext token again and re-resolves the id under
+    // the state mutex.
+    let ccr = state
         .webauthn
         .start_registration(
             user_handle,
@@ -418,11 +431,7 @@ async fn pair_start(
         )
         .map_err(ApiError::from)?;
 
-    Ok(Json(PairStartResponse {
-        challenge_id,
-        setup_token_id,
-        options: ccr,
-    }))
+    Ok(Json(ccr))
 }
 
 /// Complete the pair ceremony. Verifies the challenge, verifies the
@@ -439,22 +448,40 @@ async fn pair_finish(
     State(state): State<AppState>,
     JsonBody(body): JsonBody<PairFinishRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
+    if body.setup_token.len() > SETUP_TOKEN_MAX_LEN {
+        tracing::warn!(
+            length = body.setup_token.len(),
+            "pair_finish: setup_token exceeds maximum length"
+        );
+        return Err(ApiError::BadRequest("setup_token exceeds maximum length"));
+    }
+
     let now = SystemTime::now();
+
+    // Resolve the plaintext setup token to its server-side id
+    // before running the WebAuthn ceremony. Node does the same
+    // (re-validates the token in the verify handler), and we
+    // re-validate again under the state mutex below — the
+    // pre-flight here is a fast-fail for the common case.
+    let snap = state.auth_store.snapshot().await;
+    let token = snap
+        .find_redeemable_setup_token(&body.setup_token, now)
+        .ok_or_else(|| {
+            tracing::warn!("pair_finish: setup token not redeemable");
+            ApiError::Unauthorized
+        })?;
+    let setup_token_id = token.id.clone();
+
     // The auth crate owns the bidirectional link invariant (credential
     // ↔ setup token). `finish_paired_registration` returns a
     // credential already stamped with `setup_token_id` — the handler
     // never constructs that link by hand.
     let credential = state
         .webauthn
-        .finish_paired_registration(
-            &body.challenge_id,
-            &body.response,
-            body.setup_token_id.clone(),
-            now,
-        )
+        .finish_paired_registration(&body.credential, setup_token_id.clone(), now)
         .inspect_err(|e| {
             tracing::warn!(
-                challenge_id = %body.challenge_id,
+                credential_id = %body.credential.id,
                 error = %e,
                 "pair ceremony failed"
             );
@@ -462,32 +489,30 @@ async fn pair_finish(
         .map_err(ApiError::from)?;
 
     let new_credential = credential.clone();
-    let setup_token_id = body.setup_token_id.clone();
+    let setup_token_plaintext = body.setup_token.clone();
     let (plaintext_token, minted_session) = state
         .auth_store
         .transact(move |s| {
             // Re-validate the token under the mutex: a concurrent
             // revoke between pair_start and pair_finish must NOT
-            // succeed in pairing. `find_setup_token` by id because at
-            // this point we're committing against the specific token
-            // the client referenced; we also require it to still be
-            // redeemable.
-            let Some(token) = s.find_setup_token(&setup_token_id) else {
+            // succeed in pairing. Re-resolve from the plaintext so
+            // the id we commit against is whatever the live state
+            // says is redeemable RIGHT NOW — a concurrent
+            // delete-then-recreate with the same plaintext (not
+            // possible today, but the pattern is robust to future
+            // shapes) lands on the live token.
+            let Some(token) = s.find_redeemable_setup_token(&setup_token_plaintext, now) else {
                 return Err(AuthError::StateConflict(
-                    "setup token revoked during pair ceremony",
+                    "setup token no longer redeemable (revoked, consumed, or expired)",
                 ));
             };
-            if !token.is_redeemable(now) {
-                return Err(AuthError::StateConflict(
-                    "setup token no longer redeemable (consumed or expired)",
-                ));
-            }
+            let token_id = token.id.clone();
 
             let (plaintext, session) =
                 Session::mint(new_credential.id.clone(), now, SESSION_TTL);
             let next = s
                 .upsert_credential(new_credential.clone())
-                .consume_setup_token(&setup_token_id, &new_credential.id, now)
+                .consume_setup_token(&token_id, &new_credential.id, now)
                 .upsert_session(session.clone());
             Ok((next, (plaintext, session)))
         })
@@ -496,7 +521,7 @@ async fn pair_finish(
 
     tracing::info!(
         credential_id = %credential.id,
-        setup_token_id = %body.setup_token_id,
+        setup_token_id = %setup_token_id,
         "paired new device; session minted"
     );
 

--- a/crates/server/src/api/auth.rs
+++ b/crates/server/src/api/auth.rs
@@ -12,6 +12,11 @@
 //! - `POST /auth/login/options`   — public; bare `RequestChallengeResponse`
 //! - `POST /auth/login/verify`    — public; updates counter + mints session
 //! - `POST /auth/logout`          — auth + CSRF; localhost → 409
+//! - `POST /auth/revoke-all`      — auth + CSRF; wipes every
+//!   session row, broadcasts close-all, clears caller's cookie.
+//!   "Sign out everywhere" verb. Localhost may call without a
+//!   prior cookie — the CSRF extractor's localhost bypass means
+//!   the call is admissible without auth credentials.
 //!
 //! Phase 0a step 4 collapsed the standalone `/auth/pair/*`
 //! routes into `/auth/register/*`. The Node frontend
@@ -55,6 +60,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
+use serde_json::json;
 use katulong_auth::{AuthError, Session, SESSION_TTL};
 use katulong_shared::wire::{
     AuthFinishResponse, AuthStatusResponse, CreationChallengeResponse, LoginFinishRequest,
@@ -92,6 +98,20 @@ pub fn auth_routes() -> Router<AppState> {
         // UI shouldn't offer logout for physical-access peers (Node
         // scar `23981ca`).
         .route("/auth/logout", post(logout))
+        // PROTECTED + CSRF: "Sign out everywhere." Wipes every
+        // session row (which collaterally invalidates every
+        // paired CSRF token, since those live on the session),
+        // broadcasts the close-all variant on the revocation
+        // channel so every active long-lived transport tears
+        // down, and clears the caller's cookie. Returns 400 on a
+        // fresh install with no credentials, mirroring Node's
+        // `loadState() === null` short-circuit. Localhost is
+        // admissible (the CSRF extractor's bypass passes through
+        // an `AuthContext::Localhost`) and doesn't carry a
+        // session cookie to invalidate, but the broadcast still
+        // closes localhost-bound WebSockets — same contract as
+        // remote.
+        .route("/auth/revoke-all", post(revoke_all))
 }
 
 async fn status(
@@ -539,4 +559,76 @@ async fn logout(
         "logout succeeded; session removed"
     );
     Ok((StatusCode::NO_CONTENT, [(header::SET_COOKIE, clear)]))
+}
+
+// ============== revoke-all ==============
+
+/// `POST /auth/revoke-all` — "Sign out everywhere."
+///
+/// Wipes every session row in `AuthState` (collaterally invalidates
+/// every CSRF token, since those live on the session itself), then
+/// emits a close-all broadcast that tears down every active
+/// long-lived transport. The caller's cookie is cleared in the
+/// response so a remote caller observes the effect immediately
+/// rather than continuing to send a now-dead cookie.
+///
+/// 400 on a fresh install (no credentials registered). Mirrors
+/// Node's `loadState() === null` short-circuit at
+/// `lib/routes/auth-routes.js:248-249` — the user-observable shape
+/// is the same: an instance that hasn't been set up has nothing to
+/// revoke. Sessions and setup-tokens existing without credentials is
+/// not a state we expect (they cascade-clean), so checking only
+/// `credentials.is_empty()` is the right gate.
+///
+/// Credentials and setup tokens are intentionally NOT removed — the
+/// user keeps their passkeys; they just have to re-auth on every
+/// previously-signed-in device. Same shape as Node's
+/// `revokeAllLoginTokens` (which clears `loginTokens`, leaves the
+/// rest alone).
+///
+/// CSRF: required (state-changing). Localhost callers pass the
+/// extractor's bypass and reach this handler with
+/// `AuthContext::Localhost`; the broadcast still closes localhost-
+/// bound WebSockets via the `RevocationEvent::All` variant.
+async fn revoke_all(
+    State(state): State<AppState>,
+    CsrfProtected(_): CsrfProtected,
+) -> Result<impl IntoResponse, ApiError> {
+    // Pre-flight: refuse on a fresh install. The mutex-locked
+    // closure below would happily wipe an empty `sessions` table
+    // and return 200, but Node returns 400 here so a misbehaving
+    // client can't loop revoke-all against an unconfigured
+    // instance and trigger broadcast traffic for no reason. The
+    // re-check inside `transact` would be redundant: even with a
+    // race where credentials appear between the snapshot and the
+    // closure, wiping an empty session list is a no-op the
+    // operator doesn't care about.
+    let snap = state.auth_store.snapshot().await;
+    if snap.credentials.is_empty() {
+        return Err(ApiError::BadRequest("Not set up"));
+    }
+
+    state
+        .auth_store
+        .transact(|s| Ok((s.remove_all_sessions(), ())))
+        .await
+        .map_err(ApiError::from)?;
+
+    // Emit AFTER the auth-state commit. Subscribers that race
+    // ahead and tear down before we've cleared the table would
+    // see a torn state where the WS is gone but the cookie is
+    // still nominally valid until disk persistence completes.
+    // Order matters here: the channel is unblocking, so this
+    // doesn't pin the request inside `transact`.
+    state.revocations.emit_all();
+
+    let clear = build_clear_cookie(state.config.cookie_secure);
+    tracing::info!("revoke-all: every session dropped, broadcast emitted");
+    // Body shape `{"ok": true}` matches Node
+    // `lib/routes/auth-routes.js:258` byte-for-byte.
+    Ok((
+        StatusCode::OK,
+        [(header::SET_COOKIE, clear)],
+        Json(json!({ "ok": true })),
+    ))
 }

--- a/crates/server/src/api/devices.rs
+++ b/crates/server/src/api/devices.rs
@@ -5,9 +5,10 @@
 //!
 //! - `GET    /api/credentials`      — auth required, list with
 //!   per-device metadata
-//! - `DELETE /api/credentials/:id`  — auth + CSRF required; removes
-//!   the credential AND its sessions; blocked for remote callers if
-//!   it's the last credential on the instance
+//! - `DELETE /api/credentials/:id`  — auth required (CSRF added in
+//!   Phase 0a step 5); removes the credential AND its sessions;
+//!   blocked for remote callers if it's the last credential on the
+//!   instance
 //!
 //! The last-credential guard (Node scar `f25855f`) applies only to
 //! remote callers. A localhost caller has physical access regardless
@@ -17,21 +18,26 @@
 //! Revoking a credential cascades to its sessions via
 //! `AuthState::remove_credential`. Active WebSocket connections
 //! aren't torn down here — that's a WS-layer concern (Node scar
-//! `c073ec7`), and WS isn't in the Rust port yet. When it lands, the
-//! WS upgrade path should revalidate the session on every message
-//! and close on missing-credential.
+//! `c073ec7`).
+//!
+//! Wire shapes match Node `lib/routes/auth-routes.js:263-310`
+//! byte-for-byte: list returns `{ credentials: [...] }` (NOT a bare
+//! array) with camelCase fields; revoke returns `200 {"ok": true}`
+//! (NOT 204). The earlier shape — bare array, snake_case — was the
+//! pre-cutover Rust convention; Phase 0a step 3 reshapes it because
+//! the JS frontend reads `data.credentials`, not `data` directly,
+//! and parses `createdAt` not `created_at_millis`.
 
-use crate::api::csrf::CsrfProtected;
 use crate::api::error::ApiError;
 use crate::auth_middleware::{AuthContext, Authenticated};
 use crate::state::AppState;
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
     routing::{delete, get},
     Json, Router,
 };
 use serde::Serialize;
+use serde_json::{json, Value};
 use std::time::SystemTime;
 
 pub fn device_routes() -> Router<AppState> {
@@ -40,104 +46,126 @@ pub fn device_routes() -> Router<AppState> {
         .route("/api/credentials/:id", delete(revoke_device))
 }
 
+/// Per-credential row on the device-management UI.
+///
+/// Field set is the Node intersection — `id`, `name`, `createdAt`,
+/// `lastUsedAt`, `userAgent`, `setupTokenId`. Deliberately drops
+/// `counter` and `is_current`: Node never exposed them and the
+/// frontend doesn't read them. `counter` stays in `Credential` for
+/// internal clone-detection bookkeeping; `is_current` was a Rust-only
+/// addition that turned out to be redundant — the client already
+/// knows its own credential id from `/api/me` (or from the post-login
+/// response).
 #[derive(Debug, Serialize)]
-struct DeviceEntry {
+#[serde(rename_all = "camelCase")]
+struct CredentialEntry {
     id: String,
-    name: Option<String>,
-    /// Unix-millis of registration. `u64` for JSON integer safety —
-    /// `u128` would serialize as a string past 2^53.
-    created_at_millis: u64,
-    /// Last counter observed from the authenticator. Zero is normal
-    /// for counterless synced passkeys.
-    counter: u32,
+    /// Always emitted as a string. `Credential.name` is `Option<String>`
+    /// internally; absent or empty maps to the empty string on the
+    /// wire — Node uses `c.name` directly which JSON-serializes
+    /// `undefined` as missing, but the frontend reads it with
+    /// `c.name || ''` so empty-string is the safe canonical form.
+    name: String,
+    /// Unix-millis. `u64` for JSON safe-integer range.
+    created_at: u64,
+    /// Unix-millis of the last successful auth. `null` until the
+    /// credential is used at least once.
+    last_used_at: Option<u64>,
+    /// User-Agent captured at register/pair time.
+    user_agent: String,
     /// `Some` when this device was paired via a setup token. Mirrors
-    /// `TokenListEntry.credential_id` from the opposite side of the
-    /// bidirectional link (Node scar `7742ac3`). Name matches the
-    /// `Credential.setup_token_id` field directly.
+    /// `TokenEntry.credential` from the opposite side of the
+    /// bidirectional link (Node scar `7742ac3`).
     setup_token_id: Option<String>,
-    /// True when this entry is the credential the caller is
-    /// currently authenticated as. `Localhost` callers have no
-    /// current credential; all entries report `false`. Server-side
-    /// resolution (Node scar `c44bef3`): identity flows authority →
-    /// client, never inferred by localStorage or similar heuristics.
-    is_current: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ListResponse {
+    credentials: Vec<CredentialEntry>,
 }
 
 async fn list_devices(
     State(state): State<AppState>,
-    Authenticated(ctx): Authenticated,
-) -> Result<Json<Vec<DeviceEntry>>, ApiError> {
-    let current_id = match &ctx {
-        AuthContext::Remote { credential, .. } => Some(credential.id.clone()),
-        AuthContext::Localhost => None,
-    };
+    Authenticated(_): Authenticated,
+) -> Result<Json<ListResponse>, ApiError> {
     let snap = state.auth_store.snapshot().await;
-    let entries: Vec<DeviceEntry> = snap
+    let credentials: Vec<CredentialEntry> = snap
         .credentials
         .iter()
-        .map(|c| DeviceEntry {
+        .map(|c| CredentialEntry {
             id: c.id.clone(),
-            name: c.name.clone(),
-            created_at_millis: c
-                .created_at
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0),
-            counter: c.counter,
+            name: c.name.clone().unwrap_or_default(),
+            created_at: to_millis(c.created_at),
+            last_used_at: c.last_used_at.map(to_millis),
+            user_agent: c.user_agent.clone(),
             setup_token_id: c.setup_token_id.clone(),
-            is_current: current_id.as_deref() == Some(c.id.as_str()),
         })
         .collect();
-    Ok(Json(entries))
+    Ok(Json(ListResponse { credentials }))
 }
 
+/// DELETE `/api/credentials/:id`.
+///
+/// Returns `200 {"ok": true}` on success, matching Node. The earlier
+/// 204-no-content shape was a Rust convenience — switching to a JSON
+/// body matches every other Node DELETE handler in this surface
+/// (`/api/tokens/:id`, `/api/api-keys/:id`).
+///
+/// TODO: CSRF in Phase 0a step 5. The handler today is auth-only.
 async fn revoke_device(
     State(state): State<AppState>,
-    CsrfProtected(ctx): CsrfProtected,
+    Authenticated(ctx): Authenticated,
     Path(id): Path<String>,
-) -> Result<StatusCode, ApiError> {
+) -> Result<Json<Value>, ApiError> {
     let is_localhost = matches!(ctx, AuthContext::Localhost);
     let revoked_by = match &ctx {
         AuthContext::Localhost => "localhost".to_string(),
         AuthContext::Remote { credential, .. } => credential.id.clone(),
     };
 
-    // The last-credential check runs inside `transact` so a
-    // concurrent registration (or revocation) cannot slip past on a
-    // stale snapshot. Remote callers fail with `LastCredentialRemoval`
-    // → 409 `last_credential` if the state would hit zero
-    // credentials; localhost callers bypass the check entirely
-    // (physical access = no lockout risk). `LastCredentialRemoval`
-    // is a dedicated `AuthError` variant so the HTTP layer's mapping
-    // is compiler-enforced rather than string-matched.
     let credential_id = id.clone();
-    // `transact` returns whether the credential actually existed —
-    // used below to decide whether to emit the revocation broadcast.
-    // Unknown id → no state change → no signal (no one has a
-    // live connection bound to an id that never existed).
+    // The closure decides three things atomically: (a) whether the
+    // credential exists at all (404 outside if not), (b) whether the
+    // remote-caller last-credential guard fires (`LastCredential` →
+    // 403 with the literal Node message), (c) whether the cascade
+    // emits a revocation broadcast (only when something actually
+    // changed). Localhost callers bypass the last-credential check
+    // entirely — physical access trumps the lockout concern.
     let existed = state
         .auth_store
         .transact(move |s| {
             let target_exists = s.find_credential(&id).is_some();
-            if !is_localhost && target_exists && s.credentials.len() == 1 {
+            if !target_exists {
+                // Signal "not found" via Ok(false) so the closure stays
+                // in the success path; the handler maps that to 404
+                // outside. Using StateConflict here would route to 409
+                // and lose the not-found semantic.
+                return Ok((s.clone(), false));
+            }
+            if !is_localhost && s.credentials.len() == 1 {
                 return Err(katulong_auth::AuthError::LastCredentialRemoval);
             }
-            // `remove_credential` cascades to the credential's
-            // sessions (slice 1+2 transition). Unknown id is a no-op
-            // — idempotent DELETE.
-            Ok((s.remove_credential(&id), target_exists))
+            // `remove_credential` cascades to the credential's sessions.
+            Ok((s.remove_credential(&id), true))
         })
         .await
         .map_err(ApiError::from)?;
 
-    if existed {
-        state.revocations.emit(&credential_id);
+    if !existed {
+        return Err(ApiError::NotFound("Credential not found"));
     }
+    state.revocations.emit(&credential_id);
 
     tracing::info!(
         credential_id = %credential_id,
         revoked_by = %revoked_by,
         "device revoked"
     );
-    Ok(StatusCode::NO_CONTENT)
+    Ok(Json(json!({ "ok": true })))
+}
+
+fn to_millis(t: SystemTime) -> u64 {
+    t.duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }

--- a/crates/server/src/api/devices.rs
+++ b/crates/server/src/api/devices.rs
@@ -3,9 +3,9 @@
 //! Registered credentials are the user-facing view of "devices"
 //! paired with this instance. Two endpoints:
 //!
-//! - `GET    /api/auth/devices`      — auth required, list with
+//! - `GET    /api/credentials`      — auth required, list with
 //!   per-device metadata
-//! - `DELETE /api/auth/devices/:id`  — auth + CSRF required; removes
+//! - `DELETE /api/credentials/:id`  — auth + CSRF required; removes
 //!   the credential AND its sessions; blocked for remote callers if
 //!   it's the last credential on the instance
 //!
@@ -36,8 +36,8 @@ use std::time::SystemTime;
 
 pub fn device_routes() -> Router<AppState> {
     Router::new()
-        .route("/api/auth/devices", get(list_devices))
-        .route("/api/auth/devices/:id", delete(revoke_device))
+        .route("/api/credentials", get(list_devices))
+        .route("/api/credentials/:id", delete(revoke_device))
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/server/src/api/devices.rs
+++ b/crates/server/src/api/devices.rs
@@ -5,10 +5,9 @@
 //!
 //! - `GET    /api/credentials`      — auth required, list with
 //!   per-device metadata
-//! - `DELETE /api/credentials/:id`  — auth required (CSRF added in
-//!   Phase 0a step 5); removes the credential AND its sessions;
-//!   blocked for remote callers if it's the last credential on the
-//!   instance
+//! - `DELETE /api/credentials/:id`  — auth + CSRF required;
+//!   removes the credential AND its sessions; blocked for remote
+//!   callers if it's the last credential on the instance
 //!
 //! The last-credential guard (Node scar `f25855f`) applies only to
 //! remote callers. A localhost caller has physical access regardless
@@ -28,6 +27,7 @@
 //! the JS frontend reads `data.credentials`, not `data` directly,
 //! and parses `createdAt` not `created_at_millis`.
 
+use crate::api::csrf::CsrfProtected;
 use crate::api::error::ApiError;
 use crate::auth_middleware::{AuthContext, Authenticated};
 use crate::state::AppState;
@@ -111,10 +111,13 @@ async fn list_devices(
 /// body matches every other Node DELETE handler in this surface
 /// (`/api/tokens/:id`, `/api/api-keys/:id`).
 ///
-/// TODO: CSRF in Phase 0a step 5. The handler today is auth-only.
+/// CSRF: required (state-changing). The `CsrfProtected` extractor
+/// internally runs `Authenticated` and returns the same `AuthContext`
+/// the handler needs for the localhost-vs-remote last-credential
+/// guard, so taking it directly avoids re-extracting auth.
 async fn revoke_device(
     State(state): State<AppState>,
-    Authenticated(ctx): Authenticated,
+    CsrfProtected(ctx): CsrfProtected,
     Path(id): Path<String>,
 ) -> Result<Json<Value>, ApiError> {
     let is_localhost = matches!(ctx, AuthContext::Localhost);

--- a/crates/server/src/api/error.rs
+++ b/crates/server/src/api/error.rs
@@ -62,7 +62,15 @@ pub enum ApiError {
     /// first-device registration flow. Node hit this exact bug
     /// (`f25855f`); the two-tier access model means the guard must
     /// apply to remote callers only.
+    ///
+    /// Maps to `403` with the literal Node message — the frontend
+    /// renders `err.error` unchanged, so the wording is part of the
+    /// wire contract.
     LastCredential,
+    /// The id in the URL path doesn't match any record. Surfaces as
+    /// `404` with the supplied message — matches Node's
+    /// `{"error": "Credential not found"}` / `"Token not found"`.
+    NotFound(&'static str),
     /// State-changing request reached us without an `X-Csrf-Token`
     /// header. Maps to 403 with code `csrf_missing`. Distinct from
     /// `CsrfMismatch` so a client can distinguish "never sent" from
@@ -104,10 +112,13 @@ impl ApiError {
             ),
             Self::Conflict(why) => (StatusCode::CONFLICT, "conflict", (*why).into()),
             Self::LastCredential => (
-                StatusCode::CONFLICT,
+                StatusCode::FORBIDDEN,
                 "last_credential",
-                "cannot remove the last remote-access credential from a non-localhost session".into(),
+                // Literal Node message — the frontend renders this
+                // verbatim. Changing the wording would diverge.
+                "Cannot remove the last credential — would lock you out".into(),
             ),
+            Self::NotFound(msg) => (StatusCode::NOT_FOUND, "not_found", (*msg).into()),
             Self::CsrfMissing => (
                 StatusCode::FORBIDDEN,
                 "csrf_missing",

--- a/crates/server/src/api/error.rs
+++ b/crates/server/src/api/error.rs
@@ -2,12 +2,25 @@
 //!
 //! One error type. Every handler returns `Result<Json<T>, ApiError>`
 //! and this module owns the status-code + response-body mapping. The
-//! response body is deliberately terse — a client gets a stable
-//! `code` string and a short human-readable message, never stack
-//! traces or server-side error chains. `AuthError`'s own `Display`
-//! carries operator-facing context (paths, library detail) and is
-//! suitable for server logs only; see the caller-obligation comment
-//! in `crates/auth/src/error.rs`.
+//! response body is `{"error": "<message>"}` — a single string,
+//! matching the Node implementation (`json(res, status, { error:
+//! "..." })`). The JS frontend reads `err.error` directly:
+//!     `loginError.innerHTML = err.error || "fallback"`
+//! so the body shape is part of the wire contract.
+//!
+//! Phase 0a-1 of the cutover flipped the body from the previous
+//! `{"error": {"code": ..., "message": ...}}` envelope to the
+//! Node-compatible flat string. The `code` string still exists
+//! internally — it's wired through `Display` and tracing so
+//! operator logs distinguish "csrf_missing" from "csrf_mismatch"
+//! without parsing the message — but it does NOT appear on the
+//! wire. A future client that needs typed discrimination can
+//! recover it from the HTTP status + the message text; pulling
+//! `code` back into the body would diverge from Node again.
+//!
+//! `AuthError`'s own `Display` carries operator-facing context
+//! (paths, library detail) and is suitable for server logs only;
+//! see the caller-obligation comment in `crates/auth/src/error.rs`.
 
 use axum::{
     http::StatusCode,
@@ -70,6 +83,10 @@ pub enum ApiError {
 }
 
 impl ApiError {
+    /// Internal triple: `(status, code, message)`. The `code` string
+    /// is operator-log-only (emitted via `tracing` in
+    /// `IntoResponse`); the `message` is the body. Kept colocated so
+    /// adding a new variant forces both to be specified at once.
     fn as_pieces(&self) -> (StatusCode, &'static str, String) {
         match self {
             Self::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized", "unauthorized".into()),
@@ -113,9 +130,13 @@ impl ApiError {
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let (status, code, message) = self.as_pieces();
-        let body = Json(json!({
-            "error": { "code": code, "message": message },
-        }));
+        // Operator-log discriminator. The body keeps only the
+        // human-readable message (Node-compatible), but
+        // operators tailing the server log still see the
+        // typed code so "csrf_missing" vs "csrf_mismatch" is
+        // greppable without parsing message strings.
+        tracing::debug!(status = %status.as_u16(), code, "api error response");
+        let body = Json(json!({ "error": message }));
         (status, body).into_response()
     }
 }

--- a/crates/server/src/api/tokens.rs
+++ b/crates/server/src/api/tokens.rs
@@ -4,14 +4,14 @@
 //! the currently-authenticated user mints a token (carrying a short
 //! name for audit) and hands the plaintext to the new device's
 //! operator. The new device posts the plaintext to
-//! `/api/auth/pair/start` + `/finish` (in `auth.rs`), which consumes
+//! `/auth/pair/options` + `/finish` (in `auth.rs`), which consumes
 //! the token, registers a credential linked to the token, and mints
 //! a session cookie.
 //!
 //! Three endpoints here:
-//! - `GET    /api/auth/setup-tokens`       — list (auth)
-//! - `POST   /api/auth/setup-tokens`       — create (auth + CSRF)
-//! - `DELETE /api/auth/setup-tokens/:id`   — revoke (auth + CSRF)
+//! - `GET    /api/tokens`       — list (auth)
+//! - `POST   /api/tokens`       — create (auth + CSRF)
+//! - `DELETE /api/tokens/:id`   — revoke (auth + CSRF)
 //!
 //! Revocation cascades to the paired device AND its sessions via
 //! `AuthState::remove_setup_token` (Node scar `7742ac3`: bidirectional
@@ -45,10 +45,10 @@ const SETUP_TOKEN_TTL: Duration = Duration::from_secs(60 * 60);
 pub fn token_routes() -> Router<AppState> {
     Router::new()
         // PROTECTED: list requires auth but not CSRF (GET is safe).
-        .route("/api/auth/setup-tokens", get(list_tokens))
+        .route("/api/tokens", get(list_tokens))
         // PROTECTED + CSRF: state-changing.
-        .route("/api/auth/setup-tokens", post(create_token))
-        .route("/api/auth/setup-tokens/:id", delete(revoke_token))
+        .route("/api/tokens", post(create_token))
+        .route("/api/tokens/:id", delete(revoke_token))
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/server/src/api/tokens.rs
+++ b/crates/server/src/api/tokens.rs
@@ -3,10 +3,13 @@
 //! Setup tokens are the remote-device pairing primitive. Admin flow:
 //! the currently-authenticated user mints a token (carrying a short
 //! name for audit) and hands the plaintext to the new device's
-//! operator. The new device posts the plaintext to
-//! `/auth/pair/options` + `/finish` (in `auth.rs`), which consumes
-//! the token, registers a credential linked to the token, and mints
-//! a session cookie.
+//! operator. The new device posts the plaintext as `setupToken`
+//! to `/auth/register/options` + `/verify` (in `auth.rs`), which
+//! consumes the token, registers a credential linked to the
+//! token, and mints a session cookie. (Phase 0a step 4 merged the
+//! former `/auth/pair/*` routes into `/auth/register/*` — the
+//! same endpoint serves first-device bootstrap when `setupToken`
+//! is absent.)
 //!
 //! Four endpoints:
 //! - `GET    /api/tokens`       — list (auth)

--- a/crates/server/src/api/tokens.rs
+++ b/crates/server/src/api/tokens.rs
@@ -8,150 +8,194 @@
 //! the token, registers a credential linked to the token, and mints
 //! a session cookie.
 //!
-//! Three endpoints here:
+//! Four endpoints:
 //! - `GET    /api/tokens`       — list (auth)
-//! - `POST   /api/tokens`       — create (auth + CSRF)
-//! - `DELETE /api/tokens/:id`   — revoke (auth + CSRF)
+//! - `POST   /api/tokens`       — create (auth)
+//! - `DELETE /api/tokens/:id`   — revoke (auth)
+//! - `PATCH  /api/tokens/:id`   — rename (auth)
 //!
-//! Revocation cascades to the paired device AND its sessions via
-//! `AuthState::remove_setup_token` (Node scar `7742ac3`: bidirectional
-//! link between tokens and credentials was added specifically so
-//! "revoke this token" could also pull its device without a separate
-//! API call).
+//! TODO: CSRF on the three state-mutating handlers in Phase 0a step 5.
+//! The handlers stay auth-only for this commit so the wire reshape
+//! lands in isolation.
+//!
+//! Wire shapes match Node `lib/routes/auth-routes.js:347-476`
+//! byte-for-byte: list returns `{ tokens: [...] }` with each entry
+//! carrying a nested `credential` object (or null) — the cross-cut
+//! between setup tokens and the credentials they paired. Create
+//! returns 200 (NOT 201) with `{id, name, token, createdAt,
+//! expiresAt}` — the plaintext field is named `token`, not
+//! `plaintext`. Revoke + PATCH both return `200 {"ok": true}`.
 
-use crate::api::csrf::CsrfProtected;
 use crate::api::error::ApiError;
 use crate::api::extract::JsonBody;
 use crate::auth_middleware::Authenticated;
 use crate::state::AppState;
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
-    response::IntoResponse,
-    routing::{delete, get, post},
+    routing::{delete, get, patch, post},
     Json, Router,
 };
-use katulong_auth::{PlaintextToken, SetupToken};
+use katulong_auth::{Credential, SetupToken};
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 use std::time::{Duration, SystemTime};
 
 /// Default setup-token lifetime. One hour is long enough for a user
 /// to copy the plaintext, walk to the other device, and paste it in;
 /// short enough that a lost token doesn't sit redeemable overnight.
-/// Not currently overridable at the API level — operator tuning would
-/// go through an env var or config file, not per-token.
 const SETUP_TOKEN_TTL: Duration = Duration::from_secs(60 * 60);
+
+/// Max length for the human-readable `name` field. Node enforces 128;
+/// match it so the same client-side validation message lands.
+const TOKEN_NAME_MAX_LEN: usize = 128;
 
 pub fn token_routes() -> Router<AppState> {
     Router::new()
-        // PROTECTED: list requires auth but not CSRF (GET is safe).
         .route("/api/tokens", get(list_tokens))
-        // PROTECTED + CSRF: state-changing.
         .route("/api/tokens", post(create_token))
         .route("/api/tokens/:id", delete(revoke_token))
+        .route("/api/tokens/:id", patch(rename_token))
+}
+
+// ---------------- list ----------------
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TokenEntry {
+    id: String,
+    name: String,
+    created_at: u64,
+    last_used_at: Option<u64>,
+    /// `null` when the token has no expiry. Tokens minted via this
+    /// crate always carry one, but the field stays nullable to mirror
+    /// Node's union type and remain forward-compatible with a future
+    /// "perma-token" mode.
+    expires_at: Option<u64>,
+    /// Nested credential row when this token has been redeemed and
+    /// the paired credential still exists. `None` when the token is
+    /// live (not yet used) OR when it was used and the resulting
+    /// credential was later revoked. Mirrors Node's
+    /// `tokenData.credential = null` default + conditional fill.
+    credential: Option<NestedCredential>,
 }
 
 #[derive(Debug, Serialize)]
-struct TokenListEntry {
+#[serde(rename_all = "camelCase")]
+struct NestedCredential {
     id: String,
-    name: Option<String>,
-    /// Unix millis. Clients compute "expires in" locally.
-    /// Unix-millis encoded as `u64`. `u128` would overflow
-    /// `serde_json`'s 2^53 safe-integer range into a string, which
-    /// JS clients parsing `v.as_u64()` would then drop. u64 holds
-    /// unix-ms out to year 584,554,051 — ample.
-    expires_at_millis: u64,
-    /// Stable semantic tag:
-    /// - `"live"` — not used, not expired, redeemable by a new device
-    /// - `"used"` — already consumed; linked credential still paired
-    /// - `"expired"` — past TTL, never used
-    status: &'static str,
-    /// When `status == "used"`, the id of the device this token
-    /// created. Populated from the bidirectional link set in
-    /// `AuthState::consume_setup_token` (Node scar `7742ac3`).
-    credential_id: Option<String>,
+    name: String,
+    created_at: u64,
+    last_used_at: Option<u64>,
+    user_agent: String,
 }
 
-/// List setup tokens. Auth-only (no CSRF) because GET is a safe
-/// method — no state change to protect against cross-site replay.
-/// Write-path handlers in this module use `CsrfProtected`; the
-/// distinction is intentional and consistent with axum/HTTP norms.
+#[derive(Debug, Serialize)]
+struct ListResponse {
+    tokens: Vec<TokenEntry>,
+}
+
 async fn list_tokens(
     State(state): State<AppState>,
     Authenticated(_): Authenticated,
-) -> Result<Json<Vec<TokenListEntry>>, ApiError> {
-    let now = SystemTime::now();
+) -> Result<Json<ListResponse>, ApiError> {
     let snap = state.auth_store.snapshot().await;
-    let entries: Vec<TokenListEntry> = snap
+    let tokens: Vec<TokenEntry> = snap
         .setup_tokens
         .iter()
-        .map(|t| TokenListEntry {
-            id: t.id.clone(),
-            name: t.name.clone(),
-            expires_at_millis: t
-                .expires_at
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0),
-            status: if t.is_consumed() {
-                "used"
-            } else if t.is_expired(now) {
-                "expired"
-            } else {
-                "live"
-            },
-            credential_id: t.credential_id.clone(),
+        .map(|t| {
+            // Resolve the paired credential, if any, by walking the
+            // snapshot's credential list. Read-time only — no
+            // persistence change here. The `credentialId` field on
+            // the setup token is the authoritative pointer; if a
+            // post-pair credential revoke removed the row, the
+            // lookup returns `None` and the wire shows `credential:
+            // null`, which Node's frontend already handles ("token
+            // used, device revoked" path).
+            let credential = t.credential_id.as_deref().and_then(|cid| {
+                snap.credentials
+                    .iter()
+                    .find(|c| c.id == cid)
+                    .map(nested_credential)
+            });
+            TokenEntry {
+                id: t.id.clone(),
+                name: t.name.clone().unwrap_or_default(),
+                created_at: to_millis(t.created_at),
+                last_used_at: t.used_at.map(to_millis),
+                expires_at: Some(to_millis(t.expires_at)),
+                credential,
+            }
         })
         .collect();
-    Ok(Json(entries))
+    Ok(Json(ListResponse { tokens }))
 }
+
+fn nested_credential(c: &Credential) -> NestedCredential {
+    NestedCredential {
+        id: c.id.clone(),
+        name: c.name.clone().unwrap_or_default(),
+        created_at: to_millis(c.created_at),
+        last_used_at: c.last_used_at.map(to_millis),
+        user_agent: c.user_agent.clone(),
+    }
+}
+
+// ---------------- create ----------------
 
 #[derive(Debug, Deserialize)]
 struct CreateTokenRequest {
-    /// Optional human-readable tag, shown in the device-management
-    /// UI. Clipped server-side to avoid unbounded storage from a
-    /// malicious caller (who, to be clear, is already authenticated —
-    /// this is defence in depth, not a boundary control).
+    /// Required, non-empty after trim, ≤ 128 chars. Node treats name
+    /// as mandatory on this route (the device-management UI prompts
+    /// for it before submitting); match that contract so a frontend
+    /// mistake surfaces as 400 here rather than getting silently
+    /// stored as an empty label.
     name: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct CreateTokenResponse {
     id: String,
-    /// Hand this to the user. Once the HTTP response is sent, the
-    /// server holds only the scrypt hash — recovery is impossible.
-    plaintext: PlaintextToken,
-    /// Unix-millis encoded as `u64`. `u128` would overflow
-    /// `serde_json`'s 2^53 safe-integer range into a string, which
-    /// JS clients parsing `v.as_u64()` would then drop. u64 holds
-    /// unix-ms out to year 584,554,051 — ample.
-    expires_at_millis: u64,
+    name: String,
+    /// Plaintext token. Once the HTTP response is sent, the server
+    /// holds only the scrypt hash — recovery is impossible. Field is
+    /// named `token` (NOT `plaintext`) to match Node's wire shape;
+    /// the frontend reads `data.token`.
+    token: String,
+    created_at: u64,
+    expires_at: u64,
 }
 
-/// Max length for the human-readable `name` field. Chosen so a
-/// label comfortably holds a device nickname ("Felix iPad") without
-/// giving an authenticated caller a vector to grow the state file.
-const TOKEN_NAME_MAX_LEN: usize = 64;
-
+/// POST `/api/tokens` returns 200, NOT 201. Node uses 200 for create
+/// here; the previous Rust 201 was a REST-purist convenience.
+/// Matching Node means the JS frontend's `if (resp.ok)` keeps
+/// working unchanged.
+///
+/// TODO: CSRF in Phase 0a step 5.
 async fn create_token(
     State(state): State<AppState>,
-    CsrfProtected(_): CsrfProtected,
+    Authenticated(_): Authenticated,
     JsonBody(body): JsonBody<CreateTokenRequest>,
-) -> Result<impl IntoResponse, ApiError> {
-    let name = body
+) -> Result<Json<CreateTokenResponse>, ApiError> {
+    let trimmed = body
         .name
-        .map(|n| n.trim().to_string())
-        .filter(|n| !n.is_empty());
-    if let Some(ref n) = name {
-        if n.chars().count() > TOKEN_NAME_MAX_LEN {
-            return Err(ApiError::BadRequest("name exceeds 64 characters"));
-        }
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .ok_or(ApiError::BadRequest("Token name is required"))?;
+    if trimmed.chars().count() > TOKEN_NAME_MAX_LEN {
+        return Err(ApiError::BadRequest(
+            "Token name too long (max 128 characters)",
+        ));
     }
+
     let now = SystemTime::now();
     let (plaintext, token) =
-        SetupToken::issue(name, now, SETUP_TOKEN_TTL).map_err(ApiError::from)?;
+        SetupToken::issue(Some(trimmed.clone()), now, SETUP_TOKEN_TTL).map_err(ApiError::from)?;
     let id = token.id.clone();
     let expires_at = token.expires_at;
+    let created_at = token.created_at;
     state
         .auth_store
         .transact(|s| Ok((s.add_setup_token(token.clone()), ())))
@@ -159,68 +203,128 @@ async fn create_token(
         .map_err(ApiError::from)?;
 
     tracing::info!(token_id = %id, "setup token minted");
-    Ok((
-        StatusCode::CREATED,
-        Json(CreateTokenResponse {
-            id,
-            plaintext,
-            expires_at_millis: expires_at
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0),
-        }),
-    ))
+    Ok(Json(CreateTokenResponse {
+        id,
+        name: trimmed,
+        token: plaintext.into(),
+        created_at: to_millis(created_at),
+        expires_at: to_millis(expires_at),
+    }))
 }
 
+// ---------------- revoke ----------------
+
+/// DELETE `/api/tokens/:id` — returns `200 {"ok": true}`. Cascades to
+/// the paired credential (if any) and emits the revocation broadcast.
+/// Idempotent on unknown ids: returns 404 instead of 200 — Node
+/// distinguishes "never existed" with a 404 here (unlike the
+/// credential delete path, which it ALSO 404s).
+///
+/// TODO: CSRF in Phase 0a step 5.
 async fn revoke_token(
     State(state): State<AppState>,
-    CsrfProtected(_): CsrfProtected,
+    Authenticated(_): Authenticated,
     Path(id): Path<String>,
-) -> Result<StatusCode, ApiError> {
-    // `remove_setup_token` is a no-op on unknown ids — we treat that
-    // as idempotent success (204). The caller can't tell "never
-    // existed" from "already revoked," which is fine: both answers
-    // mean "this id is not redeemable from here forward."
-    //
-    // Revoking a token cascades (via `AuthState::remove_setup_token`)
-    // to removing the credential it paired and that credential's
-    // sessions. Any transport currently holding a connection bound
-    // to that credential needs the revocation broadcast, same as
-    // direct device-revoke. We read the paired credential id BEFORE
-    // the transact closure runs so we know what to emit afterwards.
+) -> Result<Json<Value>, ApiError> {
     let token_id = id.clone();
-    let paired_credential_id = state
+    // Resolve "did the token exist" + "what credential did it pair"
+    // inside the closure so a concurrent revoke can't race past the
+    // pre-flight. The handler emits the broadcast outside the mutex
+    // — tokio::broadcast is intentionally unblocking so we never
+    // hold the auth-state mutex across an await on a slow receiver.
+    let outcome = state
         .auth_store
         .transact(move |s| {
-            let paired = s
-                .find_setup_token(&id)
-                .and_then(|t| t.credential_id.clone());
-            Ok((s.remove_setup_token(&id), paired))
+            let Some(t) = s.find_setup_token(&id) else {
+                return Ok((s.clone(), TokenRevokeOutcome::NotFound));
+            };
+            let paired = t.credential_id.clone();
+            Ok((s.remove_setup_token(&id), TokenRevokeOutcome::Removed(paired)))
         })
         .await
         .map_err(ApiError::from)?;
 
-    // Two distinct log messages so a log-aggregation query can
-    // cleanly separate "revoked a live paired device" from "revoked
-    // an unused token" for incident response. A single message with
-    // an optional field makes the two cases structurally identical
-    // at query time, which is exactly what incident responders want
-    // to avoid.
-    match paired_credential_id {
-        Some(cred_id) => {
-            state.revocations.emit(&cred_id);
-            tracing::info!(
-                token_id = %token_id,
-                credential_id = %cred_id,
-                "setup token revoked; paired credential removed"
-            );
-        }
-        None => {
-            tracing::info!(
-                token_id = %token_id,
-                "setup token revoked (no paired credential)"
-            );
+    match outcome {
+        TokenRevokeOutcome::NotFound => Err(ApiError::NotFound("Token not found")),
+        TokenRevokeOutcome::Removed(paired) => {
+            if let Some(cred_id) = paired {
+                state.revocations.emit(&cred_id);
+                tracing::info!(
+                    token_id = %token_id,
+                    credential_id = %cred_id,
+                    "setup token revoked; paired credential removed"
+                );
+            } else {
+                tracing::info!(
+                    token_id = %token_id,
+                    "setup token revoked (no paired credential)"
+                );
+            }
+            Ok(Json(json!({ "ok": true })))
         }
     }
-    Ok(StatusCode::NO_CONTENT)
+}
+
+enum TokenRevokeOutcome {
+    NotFound,
+    Removed(Option<String>),
+}
+
+// ---------------- rename (PATCH) ----------------
+
+#[derive(Debug, Deserialize)]
+struct PatchTokenRequest {
+    name: Option<String>,
+}
+
+/// PATCH `/api/tokens/:id` — rename. Returns `200 {"ok": true}` on
+/// success, `404` on unknown id, `400` on missing/empty/oversized name.
+/// Mirrors Node `auth-routes.js:452-476` exactly.
+///
+/// TODO: CSRF in Phase 0a step 5.
+async fn rename_token(
+    State(state): State<AppState>,
+    Authenticated(_): Authenticated,
+    Path(id): Path<String>,
+    JsonBody(body): JsonBody<PatchTokenRequest>,
+) -> Result<Json<Value>, ApiError> {
+    let trimmed = body
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .ok_or(ApiError::BadRequest("Token name is required"))?;
+    if trimmed.chars().count() > TOKEN_NAME_MAX_LEN {
+        return Err(ApiError::BadRequest(
+            "Token name too long (max 128 characters)",
+        ));
+    }
+
+    let token_id = id.clone();
+    let new_name = trimmed.clone();
+    let existed = state
+        .auth_store
+        .transact(move |s| {
+            if s.find_setup_token(&id).is_none() {
+                return Ok((s.clone(), false));
+            }
+            Ok((s.update_setup_token_name(&id, new_name.clone()), true))
+        })
+        .await
+        .map_err(ApiError::from)?;
+
+    if !existed {
+        return Err(ApiError::NotFound("Token not found"));
+    }
+    tracing::info!(token_id = %token_id, name = %trimmed, "setup token renamed");
+    Ok(Json(json!({ "ok": true })))
+}
+
+// ---------------- helpers ----------------
+
+fn to_millis(t: SystemTime) -> u64 {
+    t.duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }

--- a/crates/server/src/api/tokens.rs
+++ b/crates/server/src/api/tokens.rs
@@ -17,9 +17,13 @@
 //! - `DELETE /api/tokens/:id`   — revoke (auth)
 //! - `PATCH  /api/tokens/:id`   — rename (auth)
 //!
-//! TODO: CSRF on the three state-mutating handlers in Phase 0a step 5.
-//! The handlers stay auth-only for this commit so the wire reshape
-//! lands in isolation.
+//! Phase 0a step 5 reinstated CSRF protection on the three
+//! state-mutating verbs (POST/DELETE/PATCH). Step 3 dropped it
+//! while reshaping the wire to the Node format; step 5 restores
+//! it via the same `CsrfProtected` extractor that gates
+//! `/auth/logout`. The list endpoint stays auth-only — reads
+//! don't mutate state, so a stolen cookie reading the token
+//! list isn't a CSRF concern.
 //!
 //! Wire shapes match Node `lib/routes/auth-routes.js:347-476`
 //! byte-for-byte: list returns `{ tokens: [...] }` with each entry
@@ -29,6 +33,7 @@
 //! expiresAt}` — the plaintext field is named `token`, not
 //! `plaintext`. Revoke + PATCH both return `200 {"ok": true}`.
 
+use crate::api::csrf::CsrfProtected;
 use crate::api::error::ApiError;
 use crate::api::extract::JsonBody;
 use crate::auth_middleware::Authenticated;
@@ -174,10 +179,14 @@ struct CreateTokenResponse {
 /// Matching Node means the JS frontend's `if (resp.ok)` keeps
 /// working unchanged.
 ///
-/// TODO: CSRF in Phase 0a step 5.
+/// CSRF: required (state-changing). Localhost callers skip the
+/// header check via the extractor's built-in bypass — they have
+/// no session and therefore no paired CSRF token to compare
+/// against, which is consistent with the physical-access trust
+/// model the auth middleware applies on the same peer class.
 async fn create_token(
     State(state): State<AppState>,
-    Authenticated(_): Authenticated,
+    CsrfProtected(_): CsrfProtected,
     JsonBody(body): JsonBody<CreateTokenRequest>,
 ) -> Result<Json<CreateTokenResponse>, ApiError> {
     let trimmed = body
@@ -223,10 +232,10 @@ async fn create_token(
 /// distinguishes "never existed" with a 404 here (unlike the
 /// credential delete path, which it ALSO 404s).
 ///
-/// TODO: CSRF in Phase 0a step 5.
+/// CSRF: required (state-changing).
 async fn revoke_token(
     State(state): State<AppState>,
-    Authenticated(_): Authenticated,
+    CsrfProtected(_): CsrfProtected,
     Path(id): Path<String>,
 ) -> Result<Json<Value>, ApiError> {
     let token_id = id.clone();
@@ -284,10 +293,10 @@ struct PatchTokenRequest {
 /// success, `404` on unknown id, `400` on missing/empty/oversized name.
 /// Mirrors Node `auth-routes.js:452-476` exactly.
 ///
-/// TODO: CSRF in Phase 0a step 5.
+/// CSRF: required (state-changing).
 async fn rename_token(
     State(state): State<AppState>,
-    Authenticated(_): Authenticated,
+    CsrfProtected(_): CsrfProtected,
     Path(id): Path<String>,
     JsonBody(body): JsonBody<PatchTokenRequest>,
 ) -> Result<Json<Value>, ApiError> {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -20,10 +20,17 @@ use api::auth::auth_routes;
 use api::devices::device_routes;
 use api::tokens::token_routes;
 use auth_middleware::Authenticated;
-use axum::{extract::DefaultBodyLimit, routing::get, Json, Router};
+use axum::{
+    extract::{DefaultBodyLimit, State},
+    http::{header, HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use cookie::extract_session_token;
 use serde_json::json;
 use state::AppState;
-use std::path::PathBuf;
+use std::time::SystemTime;
 use tower_http::services::ServeDir;
 
 /// Hard ceiling on request body bytes. 1 MiB matches the Node
@@ -52,12 +59,35 @@ const REQUEST_BODY_LIMIT: usize = 1024 * 1024;
 /// comments ARE the contract.
 ///
 /// Currently public: `/health` (k8s/uptime probe, returns static
-/// "ok"), and the static-asset fallback at `/` (the Leptos
-/// frontend bundle — `katulong-web`'s `dist/`).
+/// "ok"), `/` (SPA shell with conditional CSRF meta-tag
+/// injection — see `index_html`), and the static-asset fallback
+/// (the Leptos frontend bundle — `katulong-web`'s `dist/`, served
+/// for every path not explicitly routed above).
 pub fn app(state: AppState) -> Router {
+    let dist = state.config.web_dist.clone();
     Router::new()
         // PUBLIC: liveness probe. Returns static "ok".
         .route("/health", get(health))
+        // PUBLIC: SPA shell. Reads `crates/web/dist/index.html`
+        // and — if the request carries a valid session cookie —
+        // injects `<meta name="csrf-token" content="...">` into
+        // the `<head>`. The frontend reads this meta on boot and
+        // mirrors the token into `X-Csrf-Token` on every
+        // state-changing fetch.
+        //
+        // The injection is conditional on a valid session cookie
+        // because the login page (no cookie yet) doesn't make
+        // CSRF-protected calls — the auth ceremonies are
+        // CSRF-exempt by their own challenge-response design.
+        // Adding a meta tag with no token would be wrong; adding
+        // one with a fake token would be worse.
+        //
+        // ServeDir keeps catching every OTHER path
+        // (`/index.html`, the hashed JS/WASM bundle filenames
+        // trunk emits, `/style.css`, etc.) — only the literal
+        // root route gets the meta-tag treatment, mirroring the
+        // Node port (`lib/routes/app-routes.js:251-260`).
+        .route("/", get(index_html))
         // PROTECTED: smoke-test endpoint that exercises the full
         // auth extractor chain (access classification, cookie
         // extraction, store lookup) in a single round-trip.
@@ -103,20 +133,9 @@ pub fn app(state: AppState) -> Router {
         // 0.6 behavior). So the `DefaultBodyLimit` below
         // covers ServeDir requests too — no need to wrap
         // ServeDir separately.
-        .fallback_service(ServeDir::new(web_dist_path()))
+        .fallback_service(ServeDir::new(dist))
         .layer(DefaultBodyLimit::max(REQUEST_BODY_LIMIT))
         .with_state(state)
-}
-
-/// Resolve the trunk-output directory for the Leptos frontend.
-/// Operator-overridable via `KATULONG_WEB_DIST`; default is
-/// `crates/web/dist` relative to the binary's working
-/// directory. The staging script always sets the env var so
-/// production paths don't depend on cwd.
-fn web_dist_path() -> PathBuf {
-    std::env::var_os("KATULONG_WEB_DIST")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("crates/web/dist"))
 }
 
 async fn health() -> &'static str {
@@ -131,4 +150,106 @@ async fn me(Authenticated(ctx): Authenticated) -> Json<serde_json::Value> {
         },
         "credential_id": ctx.credential_id(),
     }))
+}
+
+/// Serve `index.html`, optionally injecting a `<meta name="csrf-token">`
+/// when the request carries a valid session cookie.
+///
+/// The Node port (`lib/routes/app-routes.js:251-260`) does the
+/// same string-replace on `<head>` to land the meta tag. We
+/// match that approach byte-for-byte rather than reach for an
+/// HTML parser — both servers agree the `<head>` literal lives
+/// in `index.html` and breaking that contract would already
+/// break ServeDir-based static deployments anyway.
+///
+/// Failure modes:
+///
+/// - File missing → 500. trunk should always produce
+///   `dist/index.html`; absence indicates a deployment bug.
+/// - Cookie present but unknown/expired → no injection. Treated
+///   the same as no cookie: the frontend will need to log in to
+///   pick up a fresh token.
+async fn index_html(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    let path = state.config.web_dist.join("index.html");
+    let html = match tokio::fs::read_to_string(&path).await {
+        Ok(s) => s,
+        Err(err) => {
+            tracing::error!(?path, %err, "index_html: failed to read dist/index.html");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response();
+        }
+    };
+
+    let html = if let Some(token) = csrf_token_for_request(&state, &headers).await {
+        // Inject before the FIRST `</head>` so we don't
+        // accidentally hit a literal inside a `<script>` body.
+        // Searching for the bare `</head>` literal (without
+        // surrounding whitespace) survives trunk's HTML
+        // minification, which collapses indentation in release
+        // builds. The Node port (`app-routes.js:251-260`) does
+        // the equivalent with `.replace("<head>", ...)`; we go
+        // before `</head>` because the dist HTML may have
+        // injected `<link data-trunk>` derivatives between the
+        // open tag and our intended insertion point.
+        //
+        // The token itself is 64 hex chars from the CSPRNG, so
+        // there's nothing to escape — but `escape_attr` runs
+        // unconditionally to preserve the contract that any
+        // value going into an HTML attribute is escaped at the
+        // point of injection. A future schema where the CSRF
+        // value gets a wider alphabet wouldn't silently produce
+        // a quote-injection.
+        let meta = format!(
+            "<meta name=\"csrf-token\" content=\"{}\"></head>",
+            escape_attr(&token)
+        );
+        html.replacen("</head>", &meta, 1)
+    } else {
+        html
+    };
+
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        html,
+    )
+        .into_response()
+}
+
+/// Resolve the CSRF token paired with the request's session
+/// cookie, if any. Returns `None` for unauthenticated requests
+/// (no cookie, unknown token, expired session) — the meta tag
+/// is then omitted entirely so the frontend sees `null` from
+/// `document.querySelector('meta[name="csrf-token"]')` rather
+/// than a fake value. Localhost peers also get `None`: there's
+/// no session and no CSRF pairing there (physical-access trust
+/// model), and the `CsrfProtected` extractor's localhost bypass
+/// makes the meta tag unnecessary for state-changing calls.
+async fn csrf_token_for_request(state: &AppState, headers: &HeaderMap) -> Option<String> {
+    let token = headers
+        .get(header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(extract_session_token)?;
+    let snap = state.auth_store.snapshot().await;
+    let session = snap.valid_session(&token, SystemTime::now())?;
+    Some(session.csrf_token.clone())
+}
+
+/// Minimal HTML attribute escape: the five characters that can
+/// break out of a double-quoted attribute value
+/// (`& < > " '`). Token format today is hex-only so this is a
+/// belt-and-braces guard for forward compatibility — see the
+/// inline comment at the call site.
+fn escape_attr(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            c => out.push(c),
+        }
+    }
+    out
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -17,6 +17,7 @@ async fn main() {
         .init();
 
     let config = load_config_from_env();
+    let web_dist = config.web_dist.clone();
     let auth_store = AuthStore::open(&config_data_file())
         .await
         .expect("open auth store");
@@ -89,17 +90,14 @@ async fn main() {
     //      (e.g., `/etc` — operator misconfiguration that
     //      would otherwise turn the server into an open file
     //      browser).
-    let dist = std::env::var_os("KATULONG_WEB_DIST")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("crates/web/dist"));
-    if !dist.exists() {
+    if !web_dist.exists() {
         tracing::warn!(
-            path = %dist.display(),
+            path = %web_dist.display(),
             "KATULONG_WEB_DIST does not exist; static assets will 404 (run `trunk build` in crates/web?)"
         );
-    } else if !dist.join("index.html").exists() {
+    } else if !web_dist.join("index.html").exists() {
         tracing::warn!(
-            path = %dist.display(),
+            path = %web_dist.display(),
             "KATULONG_WEB_DIST does not contain index.html; this doesn't look like a trunk dist directory — check the env var or run `trunk build` in crates/web"
         );
     }
@@ -128,11 +126,15 @@ fn load_config_from_env() -> ServerConfig {
     // Secure cookies only make sense when the public origin is https.
     // Flipping this for loopback deployments so dev-over-http still works.
     let cookie_secure = public_origin.starts_with("https://");
+    let web_dist = std::env::var_os("KATULONG_WEB_DIST")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("crates/web/dist"));
     ServerConfig {
         public_origin,
         rp_id,
         rp_name,
         cookie_secure,
+        web_dist,
     }
 }
 

--- a/crates/server/src/revocation.rs
+++ b/crates/server/src/revocation.rs
@@ -1,7 +1,7 @@
 //! Credential-revocation broadcast channel.
 //!
-//! When a credential is removed (directly via `/api/auth/devices/:id`
-//! or transitively via `/api/auth/setup-tokens/:id` cascading to its
+//! When a credential is removed (directly via `/api/credentials/:id`
+//! or transitively via `/api/tokens/:id` cascading to its
 //! paired device), every long-lived connection bound to that
 //! credential must tear down immediately. Without that, a
 //! WebSocket — or a future WebRTC peer-link — continues streaming

--- a/crates/server/src/revocation.rs
+++ b/crates/server/src/revocation.rs
@@ -73,13 +73,40 @@ use tokio::sync::broadcast::{self, error::SendError, Receiver, Sender};
 /// operator would have to be revoking credentials in a tight loop.
 const REVOCATION_CHANNEL_CAPACITY: usize = 64;
 
-/// Event published when a credential is revoked. Carries only the
-/// credential id, because that's all any subscriber needs — they
-/// compare against the credential their connection is bound to and
-/// tear down on match.
+/// Event published on the revocation channel.
+///
+/// Two shapes:
+///
+/// - `Credential` — a single credential was revoked (direct delete,
+///   or cascade from a setup-token revoke). Subscribers compare the
+///   carried `credential_id` to the one their connection is bound to
+///   and tear down on match. The single-credential case is the
+///   overwhelming common path.
+///
+/// - `All` — every active long-lived connection must close,
+///   regardless of which credential (or none, for localhost) it's
+///   bound to. Emitted by `POST /auth/revoke-all` ("Sign out
+///   everywhere"). The Node implementation expressed the same
+///   intent via a separate `close-all-websockets` bridge event,
+///   keeping the credential-revocation broadcast strictly
+///   per-credential. Folding it into this same channel keeps
+///   transport handlers reading from one source of truth: a
+///   future WebRTC peer-link gets close-all behaviour for free
+///   without re-plumbing a second broadcast.
+///
+/// Adding a third variant later (e.g., per-session revoke when
+/// "log out this device" lands separate from credential delete)
+/// stays a non-breaking change because subscribers exhaustively
+/// match — the compiler will flag every receiver that needs an
+/// update.
 #[derive(Debug, Clone)]
-pub struct RevocationEvent {
-    pub credential_id: String,
+pub enum RevocationEvent {
+    /// A single credential was revoked. Connections bound to it
+    /// must tear down; others continue.
+    Credential { credential_id: String },
+    /// Every active long-lived connection must close. The
+    /// "Sign out everywhere" admin action.
+    All,
 }
 
 /// Sender half of the broadcast channel, held by `AppState`. Cheap
@@ -95,16 +122,16 @@ impl RevocationPublisher {
         Self { sender }
     }
 
-    /// Publish a revocation. The `Result` conveys whether any
-    /// subscribers received it, which callers are free to ignore:
-    /// with zero subscribers the channel drops the event, and
-    /// that's correct — nothing is currently holding a connection
-    /// against that credential.
+    /// Publish a single-credential revocation. The `Result` conveys
+    /// whether any subscribers received it, which callers are free
+    /// to ignore: with zero subscribers the channel drops the
+    /// event, and that's correct — nothing is currently holding a
+    /// connection against that credential.
     pub fn emit(&self, credential_id: impl Into<String>) {
-        let event = RevocationEvent {
-            credential_id: credential_id.into(),
+        let credential_id = credential_id.into();
+        let event = RevocationEvent::Credential {
+            credential_id: credential_id.clone(),
         };
-        let credential_id = event.credential_id.clone();
         match self.sender.send(event) {
             Ok(receiver_count) => {
                 tracing::debug!(
@@ -121,6 +148,27 @@ impl RevocationPublisher {
                     credential_id = %credential_id,
                     "revocation broadcast: no subscribers"
                 );
+            }
+        }
+    }
+
+    /// Publish a "close every active connection" event. Used by
+    /// `POST /auth/revoke-all` after the auth-state mutex commits
+    /// the session wipe. Same broadcast channel as `emit` — every
+    /// subscriber sees the variant and tears down regardless of
+    /// the credential it's bound to (including localhost-bound
+    /// connections, which are otherwise immune to per-credential
+    /// events because they have no credential id).
+    pub fn emit_all(&self) {
+        match self.sender.send(RevocationEvent::All) {
+            Ok(receiver_count) => {
+                tracing::debug!(
+                    subscribers = receiver_count,
+                    "revoke-all broadcast emitted"
+                );
+            }
+            Err(SendError(_)) => {
+                tracing::trace!("revoke-all broadcast: no subscribers");
             }
         }
     }
@@ -152,10 +200,28 @@ mod tests {
         let mut b = pub_.subscribe();
         pub_.emit("cred-1");
 
-        let got_a = a.recv().await.expect("subscriber a received");
-        assert_eq!(got_a.credential_id, "cred-1");
-        let got_b = b.recv().await.expect("subscriber b received");
-        assert_eq!(got_b.credential_id, "cred-1");
+        match a.recv().await.expect("subscriber a received") {
+            RevocationEvent::Credential { credential_id } => assert_eq!(credential_id, "cred-1"),
+            other => panic!("expected Credential variant, got {other:?}"),
+        }
+        match b.recv().await.expect("subscriber b received") {
+            RevocationEvent::Credential { credential_id } => assert_eq!(credential_id, "cred-1"),
+            other => panic!("expected Credential variant, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn emit_all_publishes_close_everything_variant() {
+        // The revoke-all path: every subscriber sees `All`, which
+        // their handler interprets as "tear down regardless of
+        // bound credential."
+        let pub_ = RevocationPublisher::new();
+        let mut rx = pub_.subscribe();
+        pub_.emit_all();
+        match rx.recv().await.expect("subscriber received") {
+            RevocationEvent::All => {}
+            other => panic!("expected All variant, got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -175,11 +241,13 @@ mod tests {
         let mut late = pub_.subscribe();
 
         pub_.emit("cred-later");
-        let got = late.recv().await.expect("late subscriber gets only post-subscribe events");
-        assert_eq!(
-            got.credential_id, "cred-later",
-            "late subscriber must not see 'cred-earlier' — it connected after that revocation"
-        );
+        match late.recv().await.expect("late subscriber gets only post-subscribe events") {
+            RevocationEvent::Credential { credential_id } => assert_eq!(
+                credential_id, "cred-later",
+                "late subscriber must not see 'cred-earlier' — it connected after that revocation"
+            ),
+            other => panic!("expected Credential variant, got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -188,7 +256,9 @@ mod tests {
         let pub_b = pub_a.clone();
         let mut rx = pub_a.subscribe();
         pub_b.emit("cred-1");
-        let got = rx.recv().await.unwrap();
-        assert_eq!(got.credential_id, "cred-1");
+        match rx.recv().await.unwrap() {
+            RevocationEvent::Credential { credential_id } => assert_eq!(credential_id, "cred-1"),
+            other => panic!("expected Credential variant, got {other:?}"),
+        }
     }
 }

--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -1333,10 +1333,25 @@ fn handle_revoke(
     bound_credential: Option<&str>,
 ) -> Action {
     match revoke {
-        Ok(event) => match bound_credential {
-            Some(mine) if mine == event.credential_id => {
+        // The revoke-all path. Every connection closes,
+        // including localhost-bound ones (`bound_credential ==
+        // None`) — those carry no credential id to compare
+        // against, but the user-observable contract for "Sign
+        // out everywhere" is "every WebSocket dies."
+        Ok(RevocationEvent::All) => {
+            tracing::info!(
+                cause = "revoke_all",
+                "session connection terminating"
+            );
+            Action::Close {
+                code: error_code::CONNECTION_TERMINATED,
+                message: "connection terminated".into(),
+            }
+        }
+        Ok(RevocationEvent::Credential { credential_id }) => match bound_credential {
+            Some(mine) if mine == credential_id => {
                 tracing::info!(
-                    credential_id = %event.credential_id,
+                    credential_id = %credential_id,
                     cause = "credential_revoked",
                     "session connection terminating"
                 );
@@ -1659,7 +1674,7 @@ mod tests {
 
     #[test]
     fn revoke_matching_credential_closes_with_terminated_code() {
-        let event = RevocationEvent {
+        let event = RevocationEvent::Credential {
             credential_id: "cred-1".into(),
         };
         let action = handle_revoke(Ok(event), Some("cred-1"));
@@ -1671,7 +1686,7 @@ mod tests {
 
     #[test]
     fn revoke_other_credential_continues() {
-        let event = RevocationEvent {
+        let event = RevocationEvent::Credential {
             credential_id: "other-cred".into(),
         };
         assert_eq!(handle_revoke(Ok(event), Some("cred-1")), Action::Continue);
@@ -1679,10 +1694,36 @@ mod tests {
 
     #[test]
     fn revoke_when_localhost_bound_continues() {
-        let event = RevocationEvent {
+        let event = RevocationEvent::Credential {
             credential_id: "cred-1".into(),
         };
         assert_eq!(handle_revoke(Ok(event), None), Action::Continue);
+    }
+
+    #[test]
+    fn revoke_all_closes_remote_bound_connection() {
+        // The revoke-all path applies regardless of which
+        // credential the connection is bound to — that's the
+        // whole point of the variant.
+        let action = handle_revoke(Ok(RevocationEvent::All), Some("cred-1"));
+        match action {
+            Action::Close { code, .. } => assert_eq!(code, error_code::CONNECTION_TERMINATED),
+            other => panic!("expected close on revoke-all, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn revoke_all_closes_localhost_bound_connection() {
+        // A localhost-bound connection has `bound_credential =
+        // None` and is therefore immune to the per-credential
+        // event. The All variant has to close it anyway —
+        // "Sign out everywhere" promises to terminate every
+        // active connection.
+        let action = handle_revoke(Ok(RevocationEvent::All), None);
+        match action {
+            Action::Close { code, .. } => assert_eq!(code, error_code::CONNECTION_TERMINATED),
+            other => panic!("expected close on revoke-all (localhost), got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -9,6 +9,7 @@
 use crate::revocation::RevocationPublisher;
 use crate::session::{OutputRouter, SessionManager};
 use katulong_auth::{AuthStore, WebAuthnService};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::broadcast::Receiver;
 
@@ -27,6 +28,18 @@ pub struct ServerConfig {
     /// Whether remote cookies should carry the `Secure` flag. True for
     /// tunnel/TLS deployments, false for plain-http dev over loopback.
     pub cookie_secure: bool,
+    /// Path to the trunk-built Leptos frontend bundle. Resolved at
+    /// startup from the `KATULONG_WEB_DIST` env var (or the default
+    /// `crates/web/dist`) and threaded through state so the `/`
+    /// handler can read `index.html` for CSRF meta-tag injection
+    /// without re-reading the env var on every request.
+    ///
+    /// Plumbing the dist path through state instead of resolving
+    /// it lazily inside the handler makes integration tests cleanly
+    /// parallelizable — each test points its own `AppState` at a
+    /// scratch dist directory, where lazy env-var resolution would
+    /// race across `cargo test`'s default thread pool.
+    pub web_dist: PathBuf,
 }
 
 /// The handle threaded through every handler and extractor.

--- a/crates/server/tests/auth_routes.rs
+++ b/crates/server/tests/auth_routes.rs
@@ -5,7 +5,7 @@
 //! a browser-signed assertion, which an in-process test can't produce.
 //! So the tests here cover:
 //!
-//! - `/api/auth/status` in all four cases (install × access)
+//! - `/auth/status` in all four cases (install × access)
 //! - `register_start` guards: non-localhost → 403; fresh localhost → 200
 //!   with a challenge id + options; already-initialised → 409
 //! - `register_finish` guards: non-localhost → 403
@@ -32,7 +32,7 @@ use katulong_server::app;
 use serde_json::{json, Value};
 use tower::util::ServiceExt;
 
-// ---------------- /api/auth/status ----------------
+// ---------------- /auth/status ----------------
 
 #[tokio::test]
 async fn status_fresh_install_from_localhost() {
@@ -41,7 +41,7 @@ async fn status_fresh_install_from_localhost() {
         .oneshot(
             req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
                 .method(Method::GET)
-                .uri("/api/auth/status")
+                .uri("/auth/status")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -61,7 +61,7 @@ async fn status_fresh_install_from_remote() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::GET)
-                .uri("/api/auth/status")
+                .uri("/auth/status")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -86,7 +86,7 @@ async fn status_after_credential_registered() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::GET)
-                .uri("/api/auth/status")
+                .uri("/auth/status")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -97,7 +97,7 @@ async fn status_after_credential_registered() {
     assert_eq!(v["authenticated"], false);
 }
 
-// ---------------- /api/auth/register/start ----------------
+// ---------------- /auth/register/options ----------------
 
 #[tokio::test]
 async fn register_start_from_remote_is_forbidden() {
@@ -106,7 +106,7 @@ async fn register_start_from_remote_is_forbidden() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/register/start")
+                .uri("/auth/register/options")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from("{}"))
                 .unwrap(),
@@ -125,7 +125,7 @@ async fn register_start_localhost_fresh_install_returns_challenge() {
         .oneshot(
             req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
                 .method(Method::POST)
-                .uri("/api/auth/register/start")
+                .uri("/auth/register/options")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from("{}"))
                 .unwrap(),
@@ -153,7 +153,7 @@ async fn register_start_localhost_after_init_is_conflict() {
         .oneshot(
             req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
                 .method(Method::POST)
-                .uri("/api/auth/register/start")
+                .uri("/auth/register/options")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from("{}"))
                 .unwrap(),
@@ -165,7 +165,7 @@ async fn register_start_localhost_after_init_is_conflict() {
     assert_eq!(v["error"]["code"], "conflict");
 }
 
-// ---------------- /api/auth/register/finish ----------------
+// ---------------- /auth/register/verify ----------------
 
 #[tokio::test]
 async fn register_finish_from_remote_is_forbidden() {
@@ -178,7 +178,7 @@ async fn register_finish_from_remote_is_forbidden() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/register/finish")
+                .uri("/auth/register/verify")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(json_body(&body))
                 .unwrap(),
@@ -199,7 +199,7 @@ async fn register_finish_with_unknown_challenge_id_returns_challenge_not_found()
         .oneshot(
             req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
                 .method(Method::POST)
-                .uri("/api/auth/register/finish")
+                .uri("/auth/register/verify")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(json_body(&body))
                 .unwrap(),
@@ -227,7 +227,7 @@ async fn register_finish_with_real_challenge_but_bogus_response_returns_401() {
         .oneshot(
             req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
                 .method(Method::POST)
-                .uri("/api/auth/register/start")
+                .uri("/auth/register/options")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from("{}"))
                 .unwrap(),
@@ -248,7 +248,7 @@ async fn register_finish_with_real_challenge_but_bogus_response_returns_401() {
         .oneshot(
             req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
                 .method(Method::POST)
-                .uri("/api/auth/register/finish")
+                .uri("/auth/register/verify")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(json_body(&body))
                 .unwrap(),
@@ -267,7 +267,7 @@ async fn register_finish_with_bad_json_returns_400() {
         .oneshot(
             req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
                 .method(Method::POST)
-                .uri("/api/auth/register/finish")
+                .uri("/auth/register/verify")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from("not json"))
                 .unwrap(),
@@ -277,7 +277,7 @@ async fn register_finish_with_bad_json_returns_400() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 
-// ---------------- /api/auth/login/start ----------------
+// ---------------- /auth/login/options ----------------
 
 #[tokio::test]
 async fn login_start_on_fresh_install_is_conflict() {
@@ -286,7 +286,7 @@ async fn login_start_on_fresh_install_is_conflict() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/login/start")
+                .uri("/auth/login/options")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from("{}"))
                 .unwrap(),
@@ -298,7 +298,7 @@ async fn login_start_on_fresh_install_is_conflict() {
     assert_eq!(v["error"]["code"], "conflict");
 }
 
-// ---------------- /api/auth/login/finish ----------------
+// ---------------- /auth/login/verify ----------------
 
 #[tokio::test]
 async fn login_finish_with_unknown_challenge_id_returns_challenge_not_found() {
@@ -316,7 +316,7 @@ async fn login_finish_with_unknown_challenge_id_returns_challenge_not_found() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/login/finish")
+                .uri("/auth/login/verify")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(json_body(&body))
                 .unwrap(),

--- a/crates/server/tests/auth_routes.rs
+++ b/crates/server/tests/auth_routes.rs
@@ -7,16 +7,14 @@
 //!
 //! - `/auth/status` in all four cases (install × access)
 //! - `register_start` guards: non-localhost → 403; fresh localhost → 200
-//!   with a challenge id + options; already-initialised → 409
+//!   with a bare WebAuthn options object; already-initialised → 409
 //! - `register_finish` guards: non-localhost → 403
-//! - `register_finish` with unknown challenge id → 401
-//!   `challenge_not_found`
-//! - `register_finish` with a real challenge id but cryptographically
-//!   bogus response → 401 `unauthorized` (exercises the crypto-reject
-//!   path through the route handler)
+//! - `register_finish` with a credential whose clientDataJSON challenge
+//!   isn't in the pending map → 401 (Node-compatible flat error envelope)
+//! - `register_finish` with a real challenge but cryptographically
+//!   bogus response → 401 (exercises the crypto-reject path)
 //! - `login_start` on a fresh install → 409 Conflict
-//! - `login_finish` with unknown challenge id → 401
-//! - `login_finish` with a real challenge id + bogus response → 401
+//! - `login_finish` with unknown challenge → 401
 //!
 //! A separate end-to-end test that drives an actual browser passkey
 //! belongs in the e2e layer (Playwright, slice 8-ish), not here.
@@ -27,6 +25,7 @@ use axum::{
     body::Body,
     http::{header, Method, StatusCode},
 };
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use common::{body_json, ephemeral_state, json_body, req, stub_credential};
 use katulong_server::app;
 use serde_json::{json, Value};
@@ -49,9 +48,14 @@ async fn status_fresh_install_from_localhost() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let v = body_json(resp).await;
-    assert_eq!(v["access_method"], "localhost");
-    assert_eq!(v["has_credentials"], false);
-    assert_eq!(v["authenticated"], true, "localhost is always authed");
+    // Wire shape mirrors Node: `{setup, accessMethod}`. The
+    // `authenticated` field is gone (Node never returned it);
+    // the `accessMethod` key is camelCase on the wire.
+    assert_eq!(v["accessMethod"], "localhost");
+    assert_eq!(v["setup"], false);
+    assert!(v.get("authenticated").is_none(), "no authenticated field on the wire");
+    assert!(v.get("access_method").is_none(), "access_method renamed to accessMethod");
+    assert!(v.get("has_credentials").is_none(), "has_credentials renamed to setup");
 }
 
 #[tokio::test]
@@ -69,9 +73,8 @@ async fn status_fresh_install_from_remote() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let v = body_json(resp).await;
-    assert_eq!(v["access_method"], "remote");
-    assert_eq!(v["has_credentials"], false);
-    assert_eq!(v["authenticated"], false, "no cookie + remote = unauthed");
+    assert_eq!(v["accessMethod"], "remote");
+    assert_eq!(v["setup"], false);
 }
 
 #[tokio::test]
@@ -93,8 +96,7 @@ async fn status_after_credential_registered() {
         .await
         .unwrap();
     let v = body_json(resp).await;
-    assert_eq!(v["has_credentials"], true);
-    assert_eq!(v["authenticated"], false);
+    assert_eq!(v["setup"], true);
 }
 
 // ---------------- /auth/register/options ----------------
@@ -115,7 +117,8 @@ async fn register_start_from_remote_is_forbidden() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     let v = body_json(resp).await;
-    assert_eq!(v["error"]["code"], "forbidden");
+    // Node-compatible flat envelope: `{"error": "<message>"}`.
+    assert!(v["error"].is_string(), "error must be a flat string");
 }
 
 #[tokio::test]
@@ -134,11 +137,26 @@ async fn register_start_localhost_fresh_install_returns_challenge() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let v = body_json(resp).await;
+    // Bare `CreationChallengeResponse` at the top level — no
+    // `challenge_id` envelope. Node returns `res.json(opts)`
+    // and the JS frontend reads `opts.challenge`,
+    // `opts.user.id`, etc., directly. Match that shape.
     assert!(
-        v["challenge_id"].as_str().is_some_and(|s| s.len() == 32),
-        "challenge_id should be 32 hex chars"
+        v.get("challenge_id").is_none(),
+        "no challenge_id wrapper field"
     );
-    assert!(v["options"].is_object(), "options should be a JSON object");
+    assert!(
+        v.get("options").is_none(),
+        "no options wrapper field — the options ARE the body"
+    );
+    assert!(
+        v["publicKey"].is_object(),
+        "body should be a CreationChallengeResponse with a publicKey field"
+    );
+    assert!(
+        v["publicKey"]["challenge"].is_string(),
+        "publicKey.challenge must be present at the top of the bare response"
+    );
 }
 
 #[tokio::test]
@@ -162,7 +180,7 @@ async fn register_start_localhost_after_init_is_conflict() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::CONFLICT);
     let v = body_json(resp).await;
-    assert_eq!(v["error"]["code"], "conflict");
+    assert!(v["error"].is_string());
 }
 
 // ---------------- /auth/register/verify ----------------
@@ -171,8 +189,7 @@ async fn register_start_localhost_after_init_is_conflict() {
 async fn register_finish_from_remote_is_forbidden() {
     let (state, _dir) = ephemeral_state().await;
     let body = json!({
-        "challenge_id": "deadbeef",
-        "response": fake_register_response(),
+        "credential": fake_register_response_with_challenge("never-issued"),
     });
     let resp = app(state)
         .oneshot(
@@ -189,11 +206,12 @@ async fn register_finish_from_remote_is_forbidden() {
 }
 
 #[tokio::test]
-async fn register_finish_with_unknown_challenge_id_returns_challenge_not_found() {
+async fn register_finish_with_unknown_challenge_returns_challenge_not_found() {
+    // The credential's clientDataJSON references a challenge
+    // that was never issued — pending map miss → 401.
     let (state, _dir) = ephemeral_state().await;
     let body = json!({
-        "challenge_id": "deadbeef-never-issued",
-        "response": fake_register_response(),
+        "credential": fake_register_response_with_challenge("deadbeef-never-issued"),
     });
     let resp = app(state)
         .oneshot(
@@ -208,7 +226,7 @@ async fn register_finish_with_unknown_challenge_id_returns_challenge_not_found()
         .unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     let v = body_json(resp).await;
-    assert_eq!(v["error"]["code"], "challenge_not_found");
+    assert!(v["error"].is_string());
 }
 
 #[tokio::test]
@@ -235,14 +253,18 @@ async fn register_finish_with_real_challenge_but_bogus_response_returns_401() {
         .await
         .unwrap();
     assert_eq!(start.status(), StatusCode::OK);
-    let challenge_id = body_json(start).await["challenge_id"]
+    // Recover the issued challenge from the bare CCR — it
+    // lives at `publicKey.challenge` (URL-safe-base64 string).
+    // We echo it inside the credential's clientDataJSON so
+    // the server's lookup hits the pending map; the bogus
+    // attestationObject still trips webauthn-rs's verify.
+    let issued_challenge = body_json(start).await["publicKey"]["challenge"]
         .as_str()
         .unwrap()
         .to_string();
 
     let body = json!({
-        "challenge_id": challenge_id,
-        "response": fake_register_response(),
+        "credential": fake_register_response_with_challenge(&issued_challenge),
     });
     let resp = router
         .oneshot(
@@ -257,7 +279,7 @@ async fn register_finish_with_real_challenge_but_bogus_response_returns_401() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     let v = body_json(resp).await;
-    assert_eq!(v["error"]["code"], "unauthorized");
+    assert!(v["error"].is_string());
 }
 
 #[tokio::test]
@@ -295,13 +317,13 @@ async fn login_start_on_fresh_install_is_conflict() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::CONFLICT);
     let v = body_json(resp).await;
-    assert_eq!(v["error"]["code"], "conflict");
+    assert!(v["error"].is_string());
 }
 
 // ---------------- /auth/login/verify ----------------
 
 #[tokio::test]
-async fn login_finish_with_unknown_challenge_id_returns_challenge_not_found() {
+async fn login_finish_with_unknown_challenge_returns_challenge_not_found() {
     let (state, _dir) = ephemeral_state().await;
     state
         .auth_store
@@ -309,8 +331,7 @@ async fn login_finish_with_unknown_challenge_id_returns_challenge_not_found() {
         .await
         .unwrap();
     let body = json!({
-        "challenge_id": "deadbeef",
-        "response": fake_login_response(),
+        "credential": fake_login_response_with_challenge("deadbeef-never-issued"),
     });
     let resp = app(state)
         .oneshot(
@@ -325,29 +346,47 @@ async fn login_finish_with_unknown_challenge_id_returns_challenge_not_found() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     let v = body_json(resp).await;
-    assert_eq!(v["error"]["code"], "challenge_not_found");
+    assert!(v["error"].is_string());
 }
 
 // Syntactically minimal WebAuthn response payloads. Not
 // cryptographically valid — they exercise the challenge-lookup path
 // without running real verification. Real crypto validation belongs
 // in the browser-driven e2e tests.
-fn fake_register_response() -> Value {
+//
+// The cutover lifted the lookup key from a server-issued
+// `challenge_id` to the credential's own
+// `clientDataJSON.challenge`, so test fakes must embed a
+// realistic clientDataJSON (base64url-encoded JSON with a
+// `challenge` field) rather than an empty string.
+fn fake_register_response_with_challenge(challenge_b64: &str) -> Value {
+    let client_data = json!({
+        "type": "webauthn.create",
+        "challenge": challenge_b64,
+        "origin": "https://katulong.test",
+    });
+    let cdj = URL_SAFE_NO_PAD.encode(client_data.to_string().as_bytes());
     json!({
         "id": "AAAA",
         "rawId": "AAAA",
-        "response": {"clientDataJSON": "", "attestationObject": ""},
+        "response": {"clientDataJSON": cdj, "attestationObject": ""},
         "type": "public-key",
         "extensions": {}
     })
 }
 
-fn fake_login_response() -> Value {
+fn fake_login_response_with_challenge(challenge_b64: &str) -> Value {
+    let client_data = json!({
+        "type": "webauthn.get",
+        "challenge": challenge_b64,
+        "origin": "https://katulong.test",
+    });
+    let cdj = URL_SAFE_NO_PAD.encode(client_data.to_string().as_bytes());
     json!({
         "id": "AAAA",
         "rawId": "AAAA",
         "response": {
-            "clientDataJSON": "",
+            "clientDataJSON": cdj,
             "authenticatorData": "",
             "signature": "",
             "userHandle": null

--- a/crates/server/tests/common/mod.rs
+++ b/crates/server/tests/common/mod.rs
@@ -62,6 +62,8 @@ pub fn stub_credential(id: &str) -> Credential {
         counter: 0,
         created_at: SystemTime::UNIX_EPOCH,
         setup_token_id: None,
+        user_agent: String::new(),
+        last_used_at: None,
     }
 }
 

--- a/crates/server/tests/common/mod.rs
+++ b/crates/server/tests/common/mod.rs
@@ -28,13 +28,18 @@ use tempfile::TempDir;
 
 /// Canonical test config. `cookie_secure = true` matches a remote
 /// deployment; tests that specifically need the plain-http loopback
-/// path construct their own.
+/// path construct their own. `web_dist` points at a non-existent
+/// path by default — tests that exercise `/` build their own state
+/// pointing at a tempdir-rooted dist directory; everything else
+/// hits ServeDir's 404 path which is tolerated since no test in
+/// the existing suite asserts against a static asset response.
 pub fn cfg() -> ServerConfig {
     ServerConfig {
         public_origin: "https://katulong.test".into(),
         rp_id: "katulong.test".into(),
         rp_name: "Katulong Test".into(),
         cookie_secure: true,
+        web_dist: std::path::PathBuf::from("/tmp/katulong-test-no-dist"),
     }
 }
 

--- a/crates/server/tests/devices.rs
+++ b/crates/server/tests/devices.rs
@@ -1,8 +1,11 @@
 //! Integration tests for `/api/credentials`.
 //!
-//! Covers listing, current-device marking, CSRF enforcement, revoke
-//! cascade to sessions, idempotent delete, and the last-credential
-//! guard (remote-only; localhost bypasses it).
+//! Covers listing, CSRF-deferred behaviour (CSRF lands in step 5),
+//! revoke cascade to sessions, the 404-on-unknown-id response shape,
+//! and the last-credential guard (remote callers → 403; localhost
+//! bypasses it). Wire shape mirrors Node — list returns `{credentials:
+//! [...]}`, revoke returns `200 {"ok": true}`, last-credential guard
+//! returns 403 with the literal Node message.
 
 mod common;
 
@@ -34,16 +37,12 @@ async fn list_devices_requires_auth() {
 }
 
 #[tokio::test]
-async fn list_devices_returns_is_current_for_remote_caller() {
+async fn list_devices_returns_node_shape() {
+    // Wrapped object `{credentials: [...]}` with camelCase fields:
+    // `id`, `name`, `createdAt`, `lastUsedAt`, `userAgent`,
+    // `setupTokenId`. The pre-cutover bare-array shape is gone.
     let (state, _dir) = ephemeral_state().await;
     let (cookie, _csrf) = seeded_auth(&state, "my-device").await;
-    // Seed another device so we can verify ONLY one row has is_current=true.
-    state
-        .auth_store
-        .clone()
-        .transact(|s| Ok((s.upsert_credential(stub_credential("other-device")), ())))
-        .await
-        .unwrap();
 
     let resp = app(state)
         .oneshot(
@@ -58,49 +57,31 @@ async fn list_devices_returns_is_current_for_remote_caller() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let v = body_json(resp).await;
-    let entries = v.as_array().expect("array response");
-    assert_eq!(entries.len(), 2);
-
-    let current: Vec<&Value> = entries
-        .iter()
-        .filter(|e| e["is_current"].as_bool() == Some(true))
-        .collect();
-    assert_eq!(current.len(), 1, "exactly one entry should be current");
-    assert_eq!(current[0]["id"], "my-device");
-}
-
-#[tokio::test]
-async fn list_devices_from_localhost_shows_no_current() {
-    // Localhost has no paired credential — every entry reports is_current=false.
-    let (state, _dir) = ephemeral_state().await;
-    state
-        .auth_store
-        .clone()
-        .transact(|s| Ok((s.upsert_credential(stub_credential("c1")), ())))
-        .await
-        .unwrap();
-
-    let resp = app(state)
-        .oneshot(
-            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
-                .method(Method::GET)
-                .uri("/api/credentials")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-    let v = body_json(resp).await;
-    assert_eq!(v.as_array().unwrap().len(), 1);
-    assert_eq!(v[0]["is_current"], false);
+    let entries = v["credentials"].as_array().expect("credentials array");
+    assert_eq!(entries.len(), 1);
+    let entry = &entries[0];
+    assert_eq!(entry["id"], "my-device");
+    assert!(entry["name"].is_string(), "name present (empty allowed)");
+    assert!(entry["createdAt"].is_u64(), "camelCase createdAt");
+    assert!(
+        entry["lastUsedAt"].is_null() || entry["lastUsedAt"].is_u64(),
+        "lastUsedAt is null or unix-millis"
+    );
+    assert!(entry["userAgent"].is_string());
+    assert!(
+        entry.get("counter").is_none(),
+        "counter must NOT appear (Node never exposed it)"
+    );
+    assert!(
+        entry.get("is_current").is_none() && entry.get("isCurrent").is_none(),
+        "is_current dropped — frontend doesn't read it"
+    );
 }
 
 #[tokio::test]
 async fn list_devices_surfaces_setup_token_id() {
-    // Bidirectional link: Credential.setup_token_id surfaces on the
-    // DTO under the same field name. Set it directly via state
-    // mutation since we can't run a real pair ceremony inline.
+    // Bidirectional link: `Credential.setup_token_id` surfaces under
+    // camelCase `setupTokenId` to match Node.
     let (state, _dir) = ephemeral_state().await;
     let (cookie, _csrf) = seeded_auth(&state, "admin").await;
     state
@@ -126,47 +107,23 @@ async fn list_devices_surfaces_setup_token_id() {
         .await
         .unwrap();
     let v = body_json(resp).await;
-    let paired = v
+    let paired = v["credentials"]
         .as_array()
         .unwrap()
         .iter()
         .find(|e| e["id"] == "paired-device")
         .expect("paired device should appear in list");
-    assert_eq!(paired["setup_token_id"], "token-abc");
+    assert_eq!(paired["setupTokenId"], "token-abc");
 }
 
 // ---------------- revoke ----------------
 
 #[tokio::test]
-async fn revoke_device_requires_csrf() {
+async fn revoke_device_returns_200_ok_envelope() {
+    // Node returns `200 {"ok": true}`; the pre-cutover Rust 204 is
+    // gone. Keeps the JS frontend's `data.ok` check honest.
     let (state, _dir) = ephemeral_state().await;
-    let (cookie, _csrf) = seeded_auth(&state, "c1").await;
-    state
-        .auth_store
-        .clone()
-        .transact(|s| Ok((s.upsert_credential(stub_credential("other")), ())))
-        .await
-        .unwrap();
-    let resp = app(state)
-        .oneshot(
-            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
-                .method(Method::DELETE)
-                .uri("/api/credentials/other")
-                .header(header::COOKIE, format!("katulong_session={cookie}"))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-}
-
-#[tokio::test]
-async fn revoke_device_cascades_to_sessions() {
-    let (state, _dir) = ephemeral_state().await;
-    let (admin_cookie, csrf) = seeded_auth(&state, "admin").await;
-    // Seed another credential + session; revoking the credential
-    // should cascade to its sessions.
+    let (admin_cookie, _csrf) = seeded_auth(&state, "admin").await;
     let (target_cookie, _target_csrf) = seeded_auth(&state, "target-device").await;
 
     let router = app(state.clone());
@@ -176,13 +133,14 @@ async fn revoke_device_cascades_to_sessions() {
                 .method(Method::DELETE)
                 .uri("/api/credentials/target-device")
                 .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
-                .header("x-csrf-token", &csrf)
                 .body(Body::empty())
                 .unwrap(),
         )
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v["ok"], true);
 
     let snap = state.auth_store.snapshot().await;
     assert!(
@@ -200,12 +158,13 @@ async fn revoke_device_cascades_to_sessions() {
 }
 
 #[tokio::test]
-async fn revoke_device_is_idempotent() {
-    // Unknown or already-gone id: 204. Caller can't distinguish
-    // "never existed" from "already removed," which matches the
-    // idempotent-DELETE semantics of the setup-token path.
+async fn revoke_device_unknown_id_is_404() {
+    // Node 404s on unknown id (`{"error": "Credential not found"}`).
+    // The pre-cutover Rust path was idempotent-204; matching Node
+    // means the frontend can distinguish "already gone" from
+    // "successfully removed."
     let (state, _dir) = ephemeral_state().await;
-    let (cookie, csrf) = seeded_auth(&state, "admin").await;
+    let (cookie, _csrf) = seeded_auth(&state, "admin").await;
     state
         .auth_store
         .clone()
@@ -218,42 +177,47 @@ async fn revoke_device_is_idempotent() {
                 .method(Method::DELETE)
                 .uri("/api/credentials/never-existed")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
-                .header("x-csrf-token", &csrf)
                 .body(Body::empty())
                 .unwrap(),
         )
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let v: Value = body_json(resp).await;
+    assert_eq!(v["error"], "Credential not found");
 }
 
 #[tokio::test]
-async fn revoke_last_credential_from_remote_is_blocked() {
-    // Single credential + remote caller. Guard fires → 409
-    // last_credential.
+async fn revoke_last_credential_from_remote_is_403_with_literal_message() {
+    // Single credential + remote caller. Last-credential guard fires
+    // → 403 with the literal Node message ("Cannot remove the last
+    // credential — would lock you out"). The frontend renders
+    // `err.error` verbatim, so the wording is part of the wire.
     let (state, _dir) = ephemeral_state().await;
-    let (cookie, csrf) = seeded_auth(&state, "only-device").await;
+    let (cookie, _csrf) = seeded_auth(&state, "only-device").await;
     let resp = app(state)
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::DELETE)
                 .uri("/api/credentials/only-device")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
-                .header("x-csrf-token", &csrf)
                 .body(Body::empty())
                 .unwrap(),
         )
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     let v = body_json(resp).await;
-    assert!(v["error"].is_string(), "flat error envelope per Node shape");
+    assert_eq!(
+        v["error"],
+        "Cannot remove the last credential — would lock you out"
+    );
 }
 
 #[tokio::test]
 async fn revoke_last_credential_from_localhost_is_allowed() {
-    // Same last-credential scenario, but caller is localhost. Physical
-    // access trumps the lockout concern — Node scar f25855f.
+    // Localhost bypasses the guard — physical access trumps lockout
+    // concern (Node scar f25855f).
     let (state, _dir) = ephemeral_state().await;
     state
         .auth_store
@@ -271,7 +235,9 @@ async fn revoke_last_credential_from_localhost_is_allowed() {
         )
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v["ok"], true);
     let snap = state.auth_store.snapshot().await;
     assert!(snap.credentials.is_empty());
 }

--- a/crates/server/tests/devices.rs
+++ b/crates/server/tests/devices.rs
@@ -247,7 +247,7 @@ async fn revoke_last_credential_from_remote_is_blocked() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::CONFLICT);
     let v = body_json(resp).await;
-    assert_eq!(v["error"]["code"], "last_credential");
+    assert!(v["error"].is_string(), "flat error envelope per Node shape");
 }
 
 #[tokio::test]

--- a/crates/server/tests/devices.rs
+++ b/crates/server/tests/devices.rs
@@ -1,4 +1,4 @@
-//! Integration tests for `/api/auth/devices`.
+//! Integration tests for `/api/credentials`.
 //!
 //! Covers listing, current-device marking, CSRF enforcement, revoke
 //! cascade to sessions, idempotent delete, and the last-credential
@@ -24,7 +24,7 @@ async fn list_devices_requires_auth() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::GET)
-                .uri("/api/auth/devices")
+                .uri("/api/credentials")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -49,7 +49,7 @@ async fn list_devices_returns_is_current_for_remote_caller() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::GET)
-                .uri("/api/auth/devices")
+                .uri("/api/credentials")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .body(Body::empty())
                 .unwrap(),
@@ -84,7 +84,7 @@ async fn list_devices_from_localhost_shows_no_current() {
         .oneshot(
             req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
                 .method(Method::GET)
-                .uri("/api/auth/devices")
+                .uri("/api/credentials")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -118,7 +118,7 @@ async fn list_devices_surfaces_setup_token_id() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::GET)
-                .uri("/api/auth/devices")
+                .uri("/api/credentials")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .body(Body::empty())
                 .unwrap(),
@@ -151,7 +151,7 @@ async fn revoke_device_requires_csrf() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::DELETE)
-                .uri("/api/auth/devices/other")
+                .uri("/api/credentials/other")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .body(Body::empty())
                 .unwrap(),
@@ -174,7 +174,7 @@ async fn revoke_device_cascades_to_sessions() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::DELETE)
-                .uri("/api/auth/devices/target-device")
+                .uri("/api/credentials/target-device")
                 .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
                 .header("x-csrf-token", &csrf)
                 .body(Body::empty())
@@ -216,7 +216,7 @@ async fn revoke_device_is_idempotent() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::DELETE)
-                .uri("/api/auth/devices/never-existed")
+                .uri("/api/credentials/never-existed")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .header("x-csrf-token", &csrf)
                 .body(Body::empty())
@@ -237,7 +237,7 @@ async fn revoke_last_credential_from_remote_is_blocked() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::DELETE)
-                .uri("/api/auth/devices/only-device")
+                .uri("/api/credentials/only-device")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .header("x-csrf-token", &csrf)
                 .body(Body::empty())
@@ -265,7 +265,7 @@ async fn revoke_last_credential_from_localhost_is_allowed() {
         .oneshot(
             req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
                 .method(Method::DELETE)
-                .uri("/api/auth/devices/only-device")
+                .uri("/api/credentials/only-device")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/crates/server/tests/devices.rs
+++ b/crates/server/tests/devices.rs
@@ -1,6 +1,6 @@
 //! Integration tests for `/api/credentials`.
 //!
-//! Covers listing, CSRF-deferred behaviour (CSRF lands in step 5),
+//! Covers listing, CSRF enforcement on revoke (Phase 0a step 5),
 //! revoke cascade to sessions, the 404-on-unknown-id response shape,
 //! and the last-credential guard (remote callers → 403; localhost
 //! bypasses it). Wire shape mirrors Node — list returns `{credentials:
@@ -123,7 +123,7 @@ async fn revoke_device_returns_200_ok_envelope() {
     // Node returns `200 {"ok": true}`; the pre-cutover Rust 204 is
     // gone. Keeps the JS frontend's `data.ok` check honest.
     let (state, _dir) = ephemeral_state().await;
-    let (admin_cookie, _csrf) = seeded_auth(&state, "admin").await;
+    let (admin_cookie, admin_csrf) = seeded_auth(&state, "admin").await;
     let (target_cookie, _target_csrf) = seeded_auth(&state, "target-device").await;
 
     let router = app(state.clone());
@@ -133,6 +133,7 @@ async fn revoke_device_returns_200_ok_envelope() {
                 .method(Method::DELETE)
                 .uri("/api/credentials/target-device")
                 .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
+                .header("x-csrf-token", &admin_csrf)
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -164,7 +165,7 @@ async fn revoke_device_unknown_id_is_404() {
     // means the frontend can distinguish "already gone" from
     // "successfully removed."
     let (state, _dir) = ephemeral_state().await;
-    let (cookie, _csrf) = seeded_auth(&state, "admin").await;
+    let (cookie, csrf) = seeded_auth(&state, "admin").await;
     state
         .auth_store
         .clone()
@@ -177,6 +178,7 @@ async fn revoke_device_unknown_id_is_404() {
                 .method(Method::DELETE)
                 .uri("/api/credentials/never-existed")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -194,13 +196,14 @@ async fn revoke_last_credential_from_remote_is_403_with_literal_message() {
     // credential — would lock you out"). The frontend renders
     // `err.error` verbatim, so the wording is part of the wire.
     let (state, _dir) = ephemeral_state().await;
-    let (cookie, _csrf) = seeded_auth(&state, "only-device").await;
+    let (cookie, csrf) = seeded_auth(&state, "only-device").await;
     let resp = app(state)
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::DELETE)
                 .uri("/api/credentials/only-device")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -217,7 +220,10 @@ async fn revoke_last_credential_from_remote_is_403_with_literal_message() {
 #[tokio::test]
 async fn revoke_last_credential_from_localhost_is_allowed() {
     // Localhost bypasses the guard — physical access trumps lockout
-    // concern (Node scar f25855f).
+    // concern (Node scar f25855f). The CSRF extractor's localhost
+    // bypass (no session, no paired token) means the omitted
+    // `x-csrf-token` header is the right wire shape here, not an
+    // oversight.
     let (state, _dir) = ephemeral_state().await;
     state
         .auth_store
@@ -240,4 +246,71 @@ async fn revoke_last_credential_from_localhost_is_allowed() {
     assert_eq!(v["ok"], true);
     let snap = state.auth_store.snapshot().await;
     assert!(snap.credentials.is_empty());
+}
+
+// ---------------- CSRF (Phase 0a step 5) ----------------
+
+#[tokio::test]
+async fn revoke_device_without_csrf_is_403() {
+    // Step 5 reinstated CSRF on `DELETE /api/credentials/:id`.
+    // A remote caller with a valid cookie but no `x-csrf-token`
+    // header gets 403 — Node's `validateCsrfToken` produces the
+    // same status. Without CSRF, an attacker who phishes the
+    // user into visiting a hostile page could forge a delete
+    // against the tunnel host with the live session cookie.
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "admin").await;
+    state
+        .auth_store
+        .clone()
+        .transact(|s| Ok((s.upsert_credential(stub_credential("target")), ())))
+        .await
+        .unwrap();
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::DELETE)
+                .uri("/api/credentials/target")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let v = body_json(resp).await;
+    // Flat error envelope — Node-compatible. Body content is
+    // human-readable; tests that pin the exact message live in
+    // the CSRF unit suite. Here we just want "the rejection
+    // path fired."
+    assert!(v["error"].is_string());
+}
+
+#[tokio::test]
+async fn revoke_device_with_wrong_csrf_is_403() {
+    // Mismatched header value → 403. Constant-time compare
+    // means the rejection cost doesn't depend on how many bytes
+    // matched (a property the `subtle` crate gives us; this
+    // test asserts the wire shape, not the timing).
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "admin").await;
+    state
+        .auth_store
+        .clone()
+        .transact(|s| Ok((s.upsert_credential(stub_credential("target")), ())))
+        .await
+        .unwrap();
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::DELETE)
+                .uri("/api/credentials/target")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", "not-the-right-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }

--- a/crates/server/tests/index_html.rs
+++ b/crates/server/tests/index_html.rs
@@ -1,0 +1,173 @@
+//! Integration tests for the `/` SPA-shell handler — Phase 0a step 5
+//! conditional CSRF meta-tag injection.
+//!
+//! The handler reads `index.html` from the configured trunk dist
+//! directory. When the request carries a valid session cookie, it
+//! injects `<meta name="csrf-token" content="...">` before the
+//! first `</head>`. The frontend reads this meta on boot and
+//! mirrors the token into `X-Csrf-Token` on every state-changing
+//! fetch. Without a valid session cookie, the handler returns the
+//! HTML untouched — the login page doesn't make CSRF-protected
+//! calls (auth ceremonies are CSRF-exempt), so injecting nothing is
+//! the right wire shape.
+//!
+//! Tests build their own `AppState` per case so each can point
+//! `config.web_dist` at a tempdir-rooted scratch directory. This
+//! avoids racing on a shared `KATULONG_WEB_DIST` env var across
+//! cargo's parallel test threads.
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, StatusCode},
+};
+use common::{cfg, req, seeded_auth};
+use http_body_util::BodyExt;
+use katulong_auth::{AuthStore, WebAuthnService};
+use katulong_server::{
+    app,
+    state::{AppState, ServerConfig},
+};
+use std::path::PathBuf;
+use tempfile::TempDir;
+use tower::util::ServiceExt;
+
+/// Build an `AppState` whose `web_dist` points at a tempdir
+/// containing a stub `index.html`. Returns the state, the auth
+/// tempdir, and the dist tempdir — the caller must keep all three
+/// in scope for the duration of the test or the on-disk backing
+/// store + dist files vanish.
+async fn ephemeral_state_with_dist(html: &str) -> (AppState, TempDir, TempDir) {
+    let auth_dir = TempDir::new().unwrap();
+    let dist_dir = TempDir::new().unwrap();
+    let dist_path: PathBuf = dist_dir.path().into();
+    std::fs::write(dist_path.join("index.html"), html).unwrap();
+
+    let store = AuthStore::open(auth_dir.path().join("auth.json"))
+        .await
+        .unwrap();
+    let webauthn =
+        WebAuthnService::new("katulong.test", "Katulong Test", "https://katulong.test").unwrap();
+    let mut config: ServerConfig = cfg();
+    config.web_dist = dist_path;
+    let state = AppState::new(store, webauthn, config);
+    (state, auth_dir, dist_dir)
+}
+
+/// Pull the response body as a UTF-8 string. `index.html` is
+/// always text/html — never bytes that would fail UTF-8 conversion.
+async fn body_string(resp: axum::response::Response) -> String {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+const STUB_HTML: &str = "<!DOCTYPE html><html><head><title>katulong</title></head><body></body></html>";
+
+#[tokio::test]
+async fn index_without_cookie_omits_csrf_meta() {
+    // Login page case: the request carries no cookie, so there's
+    // no session and no CSRF token to advertise. Returning the
+    // bare HTML matches Node's behaviour at
+    // `lib/routes/app-routes.js:251-260` — the meta tag only
+    // appears once a session exists.
+    let (state, _auth, _dist) = ephemeral_state_with_dist(STUB_HTML).await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::GET)
+                .uri("/")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let content_type = resp
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        content_type.starts_with("text/html"),
+        "index.html must be served as text/html, got {content_type}"
+    );
+    let body = body_string(resp).await;
+    assert!(
+        !body.contains("csrf-token"),
+        "no session cookie → no csrf-token meta; got {body}"
+    );
+    assert!(body.contains("<title>katulong</title>"), "stub HTML present");
+}
+
+#[tokio::test]
+async fn index_with_valid_cookie_injects_csrf_meta() {
+    // Authenticated case: the meta tag carries the session's
+    // paired CSRF token. The frontend reads
+    // `meta[name="csrf-token"].content` to pick this up; the
+    // exact attribute shape is part of the wire contract with
+    // the JS frontend (`public/lib/api-client.js:9`).
+    let (state, _auth, _dist) = ephemeral_state_with_dist(STUB_HTML).await;
+    let (cookie, csrf) = seeded_auth(&state, "admin").await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::GET)
+                .uri("/")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_string(resp).await;
+    let expected = format!("<meta name=\"csrf-token\" content=\"{csrf}\">");
+    assert!(
+        body.contains(&expected),
+        "csrf meta must be present with the session's paired token; body={body}"
+    );
+    // The injection lands inside the head, NOT in the body —
+    // verify by checking the meta appears before the closing
+    // body tag.
+    let meta_idx = body.find("csrf-token").expect("meta present");
+    let body_close_idx = body.find("</body>").expect("body close present");
+    assert!(
+        meta_idx < body_close_idx,
+        "csrf meta must precede </body>"
+    );
+    let head_close_idx = body.find("</head>").expect("head close present");
+    assert!(
+        meta_idx < head_close_idx,
+        "csrf meta must be inside <head>"
+    );
+}
+
+#[tokio::test]
+async fn index_with_unknown_cookie_omits_csrf_meta() {
+    // Stale cookie: the client sends a token the server never
+    // minted (or already pruned). No session lookup hits → no
+    // injection, same as the no-cookie path. The frontend will
+    // re-login and pick up a fresh token then.
+    let (state, _auth, _dist) = ephemeral_state_with_dist(STUB_HTML).await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::GET)
+                .uri("/")
+                .header(
+                    header::COOKIE,
+                    "katulong_session=deadbeefdeadbeefdeadbeefdeadbeef",
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_string(resp).await;
+    assert!(
+        !body.contains("csrf-token"),
+        "unknown cookie must be treated as no cookie; got {body}"
+    );
+}

--- a/crates/server/tests/logout_and_pair.rs
+++ b/crates/server/tests/logout_and_pair.rs
@@ -18,6 +18,7 @@ use axum::{
     body::Body,
     http::{header, Method, StatusCode},
 };
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use common::{body_json, ephemeral_state, json_body, req, seeded_auth, stub_credential};
 use katulong_server::app;
 use serde_json::{json, Value};
@@ -59,7 +60,8 @@ async fn logout_without_csrf_returns_403() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     let v = body_json(resp).await;
-    assert_eq!(v["error"]["code"], "csrf_missing");
+    // Flat error envelope: `{"error": "<message>"}`.
+    assert!(v["error"].is_string());
 }
 
 #[tokio::test]
@@ -80,7 +82,7 @@ async fn logout_with_wrong_csrf_returns_403_mismatch() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     let v = body_json(resp).await;
-    assert_eq!(v["error"]["code"], "csrf_mismatch");
+    assert!(v["error"].is_string());
 }
 
 #[tokio::test]
@@ -390,21 +392,40 @@ async fn pair_start_with_valid_token_returns_challenge() {
         .unwrap();
     assert_eq!(start.status(), StatusCode::OK);
     let v = body_json(start).await;
-    assert!(v["challenge_id"].as_str().is_some_and(|s| s.len() == 32));
-    assert!(v["setup_token_id"].as_str().is_some());
-    assert!(v["options"].is_object());
+    // Bare `CreationChallengeResponse` at the top level —
+    // matches Node's shape. The `setup_token_id` echo is gone:
+    // `pair/verify` takes the plaintext `setup_token` again
+    // and re-resolves the id under the state mutex.
+    assert!(v.get("challenge_id").is_none());
+    assert!(v.get("setup_token_id").is_none());
+    assert!(v.get("options").is_none());
+    assert!(v["publicKey"].is_object());
+    assert!(v["publicKey"]["challenge"].is_string());
 }
 
 #[tokio::test]
-async fn pair_finish_with_unknown_challenge_is_challenge_not_found() {
+async fn pair_finish_with_invalid_token_returns_401() {
+    // The pair_finish handler rejects an unredeemable
+    // setup token before it ever reaches the WebAuthn
+    // ceremony. With the cutover, the body shape is
+    // `{credential, setup_token}` — no `challenge_id`,
+    // no `setup_token_id` echo.
     let (state, _dir) = ephemeral_state().await;
+    let cdj = URL_SAFE_NO_PAD.encode(
+        json!({
+            "type": "webauthn.create",
+            "challenge": "deadbeef",
+            "origin": "https://katulong.test",
+        })
+        .to_string()
+        .as_bytes(),
+    );
     let body = json!({
-        "challenge_id": "deadbeef",
-        "setup_token_id": "any",
-        "response": {
+        "setup_token": "never-issued",
+        "credential": {
             "id": "AAAA",
             "rawId": "AAAA",
-            "response": {"clientDataJSON": "", "attestationObject": ""},
+            "response": {"clientDataJSON": cdj, "attestationObject": ""},
             "type": "public-key",
             "extensions": {}
         }
@@ -422,5 +443,5 @@ async fn pair_finish_with_unknown_challenge_is_challenge_not_found() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     let v = body_json(resp).await;
-    assert_eq!(v["error"]["code"], "challenge_not_found");
+    assert!(v["error"].is_string());
 }

--- a/crates/server/tests/logout_and_pair.rs
+++ b/crates/server/tests/logout_and_pair.rs
@@ -33,7 +33,7 @@ async fn logout_without_auth_returns_401() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/logout")
+                .uri("/auth/logout")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -50,7 +50,7 @@ async fn logout_without_csrf_returns_403() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/logout")
+                .uri("/auth/logout")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .body(Body::empty())
                 .unwrap(),
@@ -70,7 +70,7 @@ async fn logout_with_wrong_csrf_returns_403_mismatch() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/logout")
+                .uri("/auth/logout")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .header("x-csrf-token", "wrong-token")
                 .body(Body::empty())
@@ -91,7 +91,7 @@ async fn logout_with_valid_auth_and_csrf_clears_cookie_and_session() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/logout")
+                .uri("/auth/logout")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .header("x-csrf-token", &csrf)
                 .body(Body::empty())
@@ -128,7 +128,7 @@ async fn logout_from_localhost_is_conflict() {
         .oneshot(
             req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
                 .method(Method::POST)
-                .uri("/api/auth/logout")
+                .uri("/auth/logout")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -146,7 +146,7 @@ async fn list_setup_tokens_requires_auth() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::GET)
-                .uri("/api/auth/setup-tokens")
+                .uri("/api/tokens")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -167,7 +167,7 @@ async fn create_and_list_setup_token_roundtrip() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/setup-tokens")
+                .uri("/api/tokens")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .header("x-csrf-token", &csrf)
                 .header(header::CONTENT_TYPE, "application/json")
@@ -187,7 +187,7 @@ async fn create_and_list_setup_token_roundtrip() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::GET)
-                .uri("/api/auth/setup-tokens")
+                .uri("/api/tokens")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .body(Body::empty())
                 .unwrap(),
@@ -214,7 +214,7 @@ async fn create_setup_token_without_csrf_is_403() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/setup-tokens")
+                .uri("/api/tokens")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from("{}"))
@@ -234,7 +234,7 @@ async fn create_setup_token_rejects_oversized_name() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/setup-tokens")
+                .uri("/api/tokens")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .header("x-csrf-token", &csrf)
                 .header(header::CONTENT_TYPE, "application/json")
@@ -259,7 +259,7 @@ async fn revoke_setup_token_is_idempotent_and_cascades() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/setup-tokens")
+                .uri("/api/tokens")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .header("x-csrf-token", &csrf)
                 .header(header::CONTENT_TYPE, "application/json")
@@ -295,7 +295,7 @@ async fn revoke_setup_token_is_idempotent_and_cascades() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::DELETE)
-                .uri(format!("/api/auth/setup-tokens/{token_id}"))
+                .uri(format!("/api/tokens/{token_id}"))
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .header("x-csrf-token", &csrf)
                 .body(Body::empty())
@@ -319,7 +319,7 @@ async fn revoke_setup_token_is_idempotent_and_cascades() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::DELETE)
-                .uri(format!("/api/auth/setup-tokens/{token_id}"))
+                .uri(format!("/api/tokens/{token_id}"))
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .header("x-csrf-token", &csrf)
                 .body(Body::empty())
@@ -339,7 +339,7 @@ async fn pair_start_with_invalid_token_returns_401() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/pair/start")
+                .uri("/auth/pair/options")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(json_body(&json!({ "setup_token": "never-issued" })))
                 .unwrap(),
@@ -363,7 +363,7 @@ async fn pair_start_with_valid_token_returns_challenge() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/setup-tokens")
+                .uri("/api/tokens")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
                 .header("x-csrf-token", &csrf)
                 .header(header::CONTENT_TYPE, "application/json")
@@ -381,7 +381,7 @@ async fn pair_start_with_valid_token_returns_challenge() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/pair/start")
+                .uri("/auth/pair/options")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(json_body(&json!({ "setup_token": plaintext })))
                 .unwrap(),
@@ -413,7 +413,7 @@ async fn pair_finish_with_unknown_challenge_is_challenge_not_found() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/pair/finish")
+                .uri("/auth/pair/verify")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(json_body(&body))
                 .unwrap(),

--- a/crates/server/tests/logout_and_pair.rs
+++ b/crates/server/tests/logout_and_pair.rs
@@ -178,13 +178,21 @@ async fn create_and_list_setup_token_roundtrip() {
         )
         .await
         .unwrap();
-    assert_eq!(create.status(), StatusCode::CREATED);
+    // Node returns 200 (NOT 201). Body shape:
+    // `{id, name, token, createdAt, expiresAt}`.
+    assert_eq!(create.status(), StatusCode::OK);
     let v = body_json(create).await;
     let token_id = v["id"].as_str().unwrap().to_string();
-    assert!(!v["plaintext"].as_str().unwrap().is_empty());
-    assert!(v["expires_at_millis"].as_u64().unwrap() > 0);
+    assert_eq!(v["name"], "iPad");
+    assert!(
+        !v["token"].as_str().unwrap().is_empty(),
+        "field renamed plaintext → token"
+    );
+    assert!(v["createdAt"].as_u64().unwrap() > 0);
+    assert!(v["expiresAt"].as_u64().unwrap() > 0);
 
-    // List shows it with status=live.
+    // List wraps entries under `{tokens: [...]}` with camelCase
+    // fields and the `credential` join (null until paired).
     let list = router
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
@@ -197,19 +205,31 @@ async fn create_and_list_setup_token_roundtrip() {
         .await
         .unwrap();
     assert_eq!(list.status(), StatusCode::OK);
-    let entries: Value = body_json(list).await;
+    let body: Value = body_json(list).await;
+    let entries = body["tokens"].as_array().expect("tokens array");
     let entry = entries
-        .as_array()
-        .unwrap()
         .iter()
         .find(|e| e["id"] == token_id)
         .expect("created token should appear in list");
     assert_eq!(entry["name"], "iPad");
-    assert_eq!(entry["status"], "live");
+    assert!(entry["createdAt"].is_u64());
+    assert!(entry["expiresAt"].is_u64());
+    assert!(
+        entry["credential"].is_null(),
+        "credential nested-join is null until the token is redeemed"
+    );
+    assert!(
+        entry.get("status").is_none(),
+        "status dropped — Node never exposed it"
+    );
 }
 
 #[tokio::test]
-async fn create_setup_token_without_csrf_is_403() {
+async fn create_setup_token_rejects_missing_name() {
+    // Node treats `name` as required (`!name || !name.trim()` → 400).
+    // The pre-cutover Rust route accepted no name; matching Node now
+    // fails fast with `{"error": "Token name is required"}`. CSRF
+    // enforcement on this route returns in step 5.
     let (state, _dir) = ephemeral_state().await;
     let (cookie, _csrf) = seeded_auth(&state, "c1").await;
     let resp = app(state)
@@ -224,7 +244,9 @@ async fn create_setup_token_without_csrf_is_403() {
         )
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"], "Token name is required");
 }
 
 #[tokio::test]
@@ -246,6 +268,8 @@ async fn create_setup_token_rejects_oversized_name() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"], "Token name too long (max 128 characters)");
 }
 
 #[tokio::test]
@@ -291,7 +315,7 @@ async fn revoke_setup_token_is_idempotent_and_cascades() {
         .await
         .unwrap();
 
-    // First revoke: 204. Paired credential should cascade away.
+    // First revoke: 200 {"ok": true}. Paired credential cascades.
     let first = router
         .clone()
         .oneshot(
@@ -305,7 +329,9 @@ async fn revoke_setup_token_is_idempotent_and_cascades() {
         )
         .await
         .unwrap();
-    assert_eq!(first.status(), StatusCode::NO_CONTENT);
+    assert_eq!(first.status(), StatusCode::OK);
+    let v = body_json(first).await;
+    assert_eq!(v["ok"], true);
     let snap = state.auth_store.snapshot().await;
     assert!(
         snap.find_credential(paired_cred_id).is_none(),
@@ -316,7 +342,9 @@ async fn revoke_setup_token_is_idempotent_and_cascades() {
         "unrelated credential must survive"
     );
 
-    // Second revoke of the same id: 204 (idempotent).
+    // Second revoke of the same id: 404 — Node distinguishes
+    // "successfully removed" from "already gone." The pre-cutover
+    // idempotent-204 was a Rust convenience.
     let second = router
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
@@ -329,7 +357,9 @@ async fn revoke_setup_token_is_idempotent_and_cascades() {
         )
         .await
         .unwrap();
-    assert_eq!(second.status(), StatusCode::NO_CONTENT);
+    assert_eq!(second.status(), StatusCode::NOT_FOUND);
+    let v = body_json(second).await;
+    assert_eq!(v["error"], "Token not found");
 }
 
 // ---------------- pair flow ----------------
@@ -374,7 +404,7 @@ async fn pair_start_with_valid_token_returns_challenge() {
         )
         .await
         .unwrap();
-    let plaintext = body_json(create).await["plaintext"]
+    let plaintext = body_json(create).await["token"]
         .as_str()
         .unwrap()
         .to_string();

--- a/crates/server/tests/logout_and_pair.rs
+++ b/crates/server/tests/logout_and_pair.rs
@@ -363,6 +363,14 @@ async fn revoke_setup_token_is_idempotent_and_cascades() {
 }
 
 // ---------------- pair flow ----------------
+//
+// Phase 0a step 4 merged `/auth/pair/*` into `/auth/register/*`.
+// The pair flow is now selected by sending `setupToken` (camelCase
+// — `RegisterOptionsRequest` / `RegisterFinishRequest` are
+// `rename_all = "camelCase"` to match Node's
+// `JSON.stringify({ setupToken })` in `public/login.js`).
+// First-device-localhost behaviour stays in `auth_routes.rs`; the
+// tests below cover the token-gated (remote-allowed) leg.
 
 #[tokio::test]
 async fn pair_start_with_invalid_token_returns_401() {
@@ -371,9 +379,9 @@ async fn pair_start_with_invalid_token_returns_401() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/auth/pair/options")
+                .uri("/auth/register/options")
                 .header(header::CONTENT_TYPE, "application/json")
-                .body(json_body(&json!({ "setup_token": "never-issued" })))
+                .body(json_body(&json!({ "setupToken": "never-issued" })))
                 .unwrap(),
         )
         .await
@@ -383,9 +391,11 @@ async fn pair_start_with_invalid_token_returns_401() {
 
 #[tokio::test]
 async fn pair_start_with_valid_token_returns_challenge() {
-    // Full pair_start path: seed an admin, mint a setup token via
-    // the HTTP API, then submit its plaintext to pair_start and
-    // confirm it returns a challenge.
+    // Full token-gated register_start path: seed an admin, mint a
+    // setup token via the HTTP API, then submit its plaintext to
+    // `/auth/register/options` and confirm a challenge comes back.
+    // The token branch is not gated on localhost — submit from a
+    // remote peer to prove that.
     let (state, _dir) = ephemeral_state().await;
     let (cookie, csrf) = seeded_auth(&state, "admin-cred").await;
     let router = app(state.clone());
@@ -413,9 +423,9 @@ async fn pair_start_with_valid_token_returns_challenge() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/auth/pair/options")
+                .uri("/auth/register/options")
                 .header(header::CONTENT_TYPE, "application/json")
-                .body(json_body(&json!({ "setup_token": plaintext })))
+                .body(json_body(&json!({ "setupToken": plaintext })))
                 .unwrap(),
         )
         .await
@@ -423,9 +433,9 @@ async fn pair_start_with_valid_token_returns_challenge() {
     assert_eq!(start.status(), StatusCode::OK);
     let v = body_json(start).await;
     // Bare `CreationChallengeResponse` at the top level —
-    // matches Node's shape. The `setup_token_id` echo is gone:
-    // `pair/verify` takes the plaintext `setup_token` again
-    // and re-resolves the id under the state mutex.
+    // matches Node's shape. No `setup_token_id` echo: verify
+    // takes the plaintext `setupToken` again and re-resolves
+    // the id under the state mutex.
     assert!(v.get("challenge_id").is_none());
     assert!(v.get("setup_token_id").is_none());
     assert!(v.get("options").is_none());
@@ -435,11 +445,10 @@ async fn pair_start_with_valid_token_returns_challenge() {
 
 #[tokio::test]
 async fn pair_finish_with_invalid_token_returns_401() {
-    // The pair_finish handler rejects an unredeemable
-    // setup token before it ever reaches the WebAuthn
-    // ceremony. With the cutover, the body shape is
-    // `{credential, setup_token}` — no `challenge_id`,
-    // no `setup_token_id` echo.
+    // The token-gated `register_finish` leg rejects an
+    // unredeemable `setupToken` before the WebAuthn ceremony runs.
+    // Body shape: `{credential, setupToken}` (camelCase) — no
+    // `challenge_id`, no `setup_token_id` echo.
     let (state, _dir) = ephemeral_state().await;
     let cdj = URL_SAFE_NO_PAD.encode(
         json!({
@@ -451,7 +460,7 @@ async fn pair_finish_with_invalid_token_returns_401() {
         .as_bytes(),
     );
     let body = json!({
-        "setup_token": "never-issued",
+        "setupToken": "never-issued",
         "credential": {
             "id": "AAAA",
             "rawId": "AAAA",
@@ -464,7 +473,7 @@ async fn pair_finish_with_invalid_token_returns_401() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/auth/pair/verify")
+                .uri("/auth/register/verify")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(json_body(&body))
                 .unwrap(),

--- a/crates/server/tests/logout_and_pair.rs
+++ b/crates/server/tests/logout_and_pair.rs
@@ -632,3 +632,252 @@ async fn pair_finish_with_invalid_token_returns_401() {
     let v = body_json(resp).await;
     assert!(v["error"].is_string());
 }
+
+// ---------------- /auth/revoke-all (Phase 0a step 6) ----------------
+//
+// "Sign out everywhere" — wipes every session row, broadcasts a
+// close-all event, clears the caller's cookie. Mirrors Node's
+// `lib/routes/auth-routes.js:247-259`. Guards: no auth → 401,
+// auth-without-CSRF (remote) → 403, fresh-install → 400, success
+// → 200 `{"ok": true}` with `Set-Cookie: ...; Max-Age=0`.
+
+#[tokio::test]
+async fn revoke_all_without_auth_returns_401() {
+    let (state, _dir) = ephemeral_state().await;
+    // Seed a credential so we exercise the auth-required path,
+    // not the "Not set up" pre-flight.
+    state
+        .auth_store
+        .clone()
+        .transact(|s| Ok((s.upsert_credential(stub_credential("admin")), ())))
+        .await
+        .unwrap();
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/auth/revoke-all")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn revoke_all_remote_without_csrf_returns_403() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "admin").await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/auth/revoke-all")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn revoke_all_remote_with_csrf_clears_cookie_and_drops_sessions() {
+    // Seed two sessions for the admin so we can prove
+    // "every session" is wiped — not just the caller's. The second
+    // session is created by directly upserting a manually-built
+    // `Session` so we can assert it's gone after the revoke.
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, csrf) = seeded_auth(&state, "admin").await;
+
+    // Mint a second session (from a hypothetical second device of
+    // the same admin) so the wipe-everything assertion is non-
+    // trivial. Use the real `Session::mint` so the hashing path
+    // matches production — we then look up by `find_session(plaintext)`.
+    let (other_cookie, _other_session) = state
+        .auth_store
+        .clone()
+        .transact(|s| {
+            let (plaintext, session) = katulong_auth::Session::mint(
+                "admin",
+                std::time::SystemTime::now(),
+                katulong_auth::SESSION_TTL,
+            );
+            Ok((s.upsert_session(session.clone()), (plaintext, session)))
+        })
+        .await
+        .unwrap();
+
+    // Sanity: both sessions are in the store before the call.
+    {
+        let snap = state.auth_store.snapshot().await;
+        assert!(snap.find_session(&cookie).is_some());
+        assert!(snap.find_session(&other_cookie).is_some());
+    }
+
+    let resp = app(state.clone())
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/auth/revoke-all")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Set-Cookie clears the caller's cookie. Same flag block as
+    // logout — Max-Age=0 + Secure (the test config has cookie_secure
+    // = true).
+    let set_cookie = resp
+        .headers()
+        .get(header::SET_COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        set_cookie.contains("Max-Age=0"),
+        "response must clear the cookie: got {set_cookie}"
+    );
+
+    // Body matches Node: `{"ok": true}`. Phase 0a step 6 returns
+    // 200 with this exact shape — pre-cutover Rust never had this
+    // route at all.
+    let v = body_json(resp).await;
+    assert_eq!(v["ok"], true);
+
+    // Both sessions are gone — the wipe was global, not just the
+    // caller's row.
+    let snap = state.auth_store.snapshot().await;
+    assert!(snap.find_session(&cookie).is_none());
+    assert!(snap.find_session(&other_cookie).is_none());
+    assert!(
+        snap.find_credential("admin").is_some(),
+        "credentials are not collateral damage on revoke-all"
+    );
+}
+
+#[tokio::test]
+async fn revoke_all_subsequent_request_with_old_cookie_is_unauthorized() {
+    // After revoke-all, the caller's previously-valid cookie no
+    // longer authenticates. This is the user-observable invariant
+    // that "Sign out everywhere" is selling — covers it explicitly
+    // so a future regression that, say, soft-tombstones sessions
+    // (instead of removing them) trips this test.
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, csrf) = seeded_auth(&state, "admin").await;
+    let router = app(state);
+
+    let revoke = router
+        .clone()
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/auth/revoke-all")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(revoke.status(), StatusCode::OK);
+
+    // Re-using the same cookie on /api/me must now 401 — the
+    // session row is gone, so the auth middleware can't resolve
+    // it. /api/me is the smoke-test endpoint that runs the full
+    // auth chain, so it's the cheapest place to assert the
+    // negative.
+    let probe = router
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::GET)
+                .uri("/api/me")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(probe.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn revoke_all_localhost_without_csrf_succeeds() {
+    // Localhost peers have no session and no paired CSRF token
+    // (physical-access trust model). The CSRF extractor's
+    // localhost bypass means revoke-all is admissible without
+    // either a cookie or an x-csrf-token header. The instance
+    // must already have a credential — fresh-install is 400
+    // (covered separately).
+    let (state, _dir) = ephemeral_state().await;
+    state
+        .auth_store
+        .clone()
+        .transact(|s| Ok((s.upsert_credential(stub_credential("admin")), ())))
+        .await
+        .unwrap();
+    // Seed a session belonging to that credential so we can
+    // assert it gets wiped even when the call originated from
+    // localhost.
+    let (other_cookie, _) = state
+        .auth_store
+        .clone()
+        .transact(|s| {
+            let (plaintext, session) = katulong_auth::Session::mint(
+                "admin",
+                std::time::SystemTime::now(),
+                katulong_auth::SESSION_TTL,
+            );
+            Ok((s.upsert_session(session.clone()), (plaintext, session)))
+        })
+        .await
+        .unwrap();
+
+    let resp = app(state.clone())
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::POST)
+                .uri("/auth/revoke-all")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v["ok"], true);
+
+    // The remote-device session got wiped too — revoke-all is
+    // global, regardless of who initiated it.
+    let snap = state.auth_store.snapshot().await;
+    assert!(snap.find_session(&other_cookie).is_none());
+}
+
+#[tokio::test]
+async fn revoke_all_on_fresh_install_returns_400_not_set_up() {
+    // No credentials registered → 400 `{"error": "Not set up"}`,
+    // matching Node `lib/routes/auth-routes.js:248-249`. Localhost
+    // is the only access path that even reaches this handler on a
+    // fresh install (remote without auth → 401 above), so we
+    // submit from loopback. The CSRF extractor's localhost bypass
+    // means we don't need a cookie or header.
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::POST)
+                .uri("/auth/revoke-all")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"], "Not set up");
+}

--- a/crates/server/tests/logout_and_pair.rs
+++ b/crates/server/tests/logout_and_pair.rs
@@ -228,16 +228,19 @@ async fn create_and_list_setup_token_roundtrip() {
 async fn create_setup_token_rejects_missing_name() {
     // Node treats `name` as required (`!name || !name.trim()` → 400).
     // The pre-cutover Rust route accepted no name; matching Node now
-    // fails fast with `{"error": "Token name is required"}`. CSRF
-    // enforcement on this route returns in step 5.
+    // fails fast with `{"error": "Token name is required"}`. The CSRF
+    // header is supplied so we exercise the body-validation path
+    // rather than the CSRF rejection — the dedicated CSRF tests live
+    // below.
     let (state, _dir) = ephemeral_state().await;
-    let (cookie, _csrf) = seeded_auth(&state, "c1").await;
+    let (cookie, csrf) = seeded_auth(&state, "c1").await;
     let resp = app(state)
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
                 .uri("/api/tokens")
                 .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from("{}"))
                 .unwrap(),
@@ -360,6 +363,151 @@ async fn revoke_setup_token_is_idempotent_and_cascades() {
     assert_eq!(second.status(), StatusCode::NOT_FOUND);
     let v = body_json(second).await;
     assert_eq!(v["error"], "Token not found");
+}
+
+// ---------------- CSRF on token routes (Phase 0a step 5) ----------------
+
+#[tokio::test]
+async fn create_token_without_csrf_is_403() {
+    // Step 5 reinstated CSRF on `POST /api/tokens`. A remote
+    // caller with a valid cookie but no `x-csrf-token` header
+    // gets 403. Without this, an attacker could trick a logged-in
+    // admin into minting setup tokens against the live cookie.
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "admin").await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/tokens")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "name": "iPad" })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn create_token_with_wrong_csrf_is_403() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, _csrf) = seeded_auth(&state, "admin").await;
+    let resp = app(state)
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/tokens")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", "decoy-value")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "name": "iPad" })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn create_token_from_localhost_skips_csrf() {
+    // Localhost peers have no session and no paired CSRF token
+    // (physical-access trust model). The extractor's localhost
+    // bypass means the call succeeds without an `x-csrf-token`
+    // header — and must, otherwise the localhost UI couldn't
+    // mint setup tokens for the first-device pair flow.
+    let (state, _dir) = ephemeral_state().await;
+    let resp = app(state)
+        .oneshot(
+            req("127.0.0.1:1234".parse().unwrap(), "localhost:3000")
+                .method(Method::POST)
+                .uri("/api/tokens")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "name": "first-token" })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    // Plaintext token field is `token` (NOT `plaintext`) per
+    // step 3's wire reshape — same shape as the remote path.
+    assert!(!v["token"].as_str().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn revoke_token_without_csrf_is_403() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, csrf) = seeded_auth(&state, "admin").await;
+    let router = app(state);
+    // Mint a token first using a valid CSRF, then try to delete
+    // it without one. The two-step shape proves CSRF gates
+    // delete independently of create.
+    let create = router
+        .clone()
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/tokens")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "name": "to-revoke" })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let token_id = body_json(create).await["id"].as_str().unwrap().to_string();
+
+    let resp = router
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::DELETE)
+                .uri(format!("/api/tokens/{token_id}"))
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn rename_token_without_csrf_is_403() {
+    let (state, _dir) = ephemeral_state().await;
+    let (cookie, csrf) = seeded_auth(&state, "admin").await;
+    let router = app(state);
+    let create = router
+        .clone()
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::POST)
+                .uri("/api/tokens")
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header("x-csrf-token", &csrf)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "name": "to-rename" })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let token_id = body_json(create).await["id"].as_str().unwrap().to_string();
+
+    let resp = router
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(Method::PATCH)
+                .uri(format!("/api/tokens/{token_id}"))
+                .header(header::COOKIE, format!("katulong_session={cookie}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(json_body(&json!({ "name": "renamed" })))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 // ---------------- pair flow ----------------

--- a/crates/server/tests/revocation_broadcast.rs
+++ b/crates/server/tests/revocation_broadcast.rs
@@ -53,7 +53,7 @@ async fn direct_device_revoke_emits_broadcast() {
         )
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert_eq!(resp.status(), StatusCode::OK);
 
     let event = timeout(Duration::from_millis(500), rx.recv())
         .await
@@ -87,7 +87,9 @@ async fn device_revoke_on_unknown_id_does_not_emit() {
         )
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    // Unknown-id returns 404 post-cutover (was idempotent-204).
+    // No emission either way — the assertion below proves that.
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
     // Unknown id → no state change → no emission. A short timeout
     // that MUST elapse without a message proves the negative.
@@ -167,7 +169,7 @@ async fn setup_token_revoke_emits_for_paired_credential() {
         )
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert_eq!(resp.status(), StatusCode::OK);
 
     let event = timeout(Duration::from_millis(500), rx.recv())
         .await
@@ -213,7 +215,7 @@ async fn setup_token_revoke_without_paired_credential_does_not_emit() {
         )
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert_eq!(resp.status(), StatusCode::OK);
 
     let result = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(

--- a/crates/server/tests/revocation_broadcast.rs
+++ b/crates/server/tests/revocation_broadcast.rs
@@ -45,7 +45,7 @@ async fn direct_device_revoke_emits_broadcast() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::DELETE)
-                .uri("/api/auth/devices/target")
+                .uri("/api/credentials/target")
                 .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
                 .header("x-csrf-token", &csrf)
                 .body(Body::empty())
@@ -79,7 +79,7 @@ async fn device_revoke_on_unknown_id_does_not_emit() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::DELETE)
-                .uri("/api/auth/devices/never-existed")
+                .uri("/api/credentials/never-existed")
                 .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
                 .header("x-csrf-token", &csrf)
                 .body(Body::empty())
@@ -107,7 +107,7 @@ async fn device_revoke_on_unknown_id_does_not_emit() {
 
 #[tokio::test]
 async fn setup_token_revoke_emits_for_paired_credential() {
-    // The indirect path: DELETE /api/auth/setup-tokens/:id cascades
+    // The indirect path: DELETE /api/tokens/:id cascades
     // to removing the paired credential. That cascade must also
     // publish the revocation broadcast — the credential is
     // functionally revoked from the consumer's point of view.
@@ -122,7 +122,7 @@ async fn setup_token_revoke_emits_for_paired_credential() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/setup-tokens")
+                .uri("/api/tokens")
                 .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
                 .header("x-csrf-token", &csrf)
                 .header(header::CONTENT_TYPE, "application/json")
@@ -159,7 +159,7 @@ async fn setup_token_revoke_emits_for_paired_credential() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::DELETE)
-                .uri(format!("/api/auth/setup-tokens/{token_id}"))
+                .uri(format!("/api/tokens/{token_id}"))
                 .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
                 .header("x-csrf-token", &csrf)
                 .body(Body::empty())
@@ -188,7 +188,7 @@ async fn setup_token_revoke_without_paired_credential_does_not_emit() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::POST)
-                .uri("/api/auth/setup-tokens")
+                .uri("/api/tokens")
                 .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
                 .header("x-csrf-token", &csrf)
                 .header(header::CONTENT_TYPE, "application/json")
@@ -205,7 +205,7 @@ async fn setup_token_revoke_without_paired_credential_does_not_emit() {
         .oneshot(
             req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
                 .method(Method::DELETE)
-                .uri(format!("/api/auth/setup-tokens/{token_id}"))
+                .uri(format!("/api/tokens/{token_id}"))
                 .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
                 .header("x-csrf-token", &csrf)
                 .body(Body::empty())

--- a/crates/server/tests/revocation_broadcast.rs
+++ b/crates/server/tests/revocation_broadcast.rs
@@ -16,6 +16,7 @@ use axum::{
 };
 use common::{ephemeral_state, json_body, req, seeded_auth, stub_credential};
 use katulong_server::app;
+use katulong_server::revocation::RevocationEvent;
 use serde_json::json;
 use std::time::{Duration, SystemTime};
 use tokio::time::timeout;
@@ -59,7 +60,10 @@ async fn direct_device_revoke_emits_broadcast() {
         .await
         .expect("broadcast must fire within 500ms")
         .expect("receiver must get the event");
-    assert_eq!(event.credential_id, "target");
+    match event {
+        RevocationEvent::Credential { credential_id } => assert_eq!(credential_id, "target"),
+        other => panic!("expected Credential variant, got {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -175,7 +179,10 @@ async fn setup_token_revoke_emits_for_paired_credential() {
         .await
         .expect("broadcast must fire within 500ms for the cascade")
         .expect("receiver must get the cascade event");
-    assert_eq!(event.credential_id, paired_cred_id);
+    match event {
+        RevocationEvent::Credential { credential_id } => assert_eq!(credential_id, paired_cred_id),
+        other => panic!("expected Credential variant, got {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -222,4 +229,39 @@ async fn setup_token_revoke_without_paired_credential_does_not_emit() {
         result.is_err(),
         "unused-token revoke must not broadcast — nothing to tear down"
     );
+}
+
+#[tokio::test]
+async fn revoke_all_emits_close_everything_variant() {
+    // The "Sign out everywhere" path: regardless of how many
+    // credentials/sessions live in the store, the broadcast is a
+    // single `All` event. WS handlers see it and close
+    // unconditionally — including localhost-bound connections
+    // that have no credential id to compare against.
+    let (state, _dir) = ephemeral_state().await;
+    let (admin_cookie, csrf) = seeded_auth(&state, "admin").await;
+
+    let mut rx = state.subscribe_revocations();
+    let resp = app(state.clone())
+        .oneshot(
+            req("203.0.113.5:1234".parse().unwrap(), "katulong.test")
+                .method(axum::http::Method::POST)
+                .uri("/auth/revoke-all")
+                .header(header::COOKIE, format!("katulong_session={admin_cookie}"))
+                .header("x-csrf-token", &csrf)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let event = timeout(Duration::from_millis(500), rx.recv())
+        .await
+        .expect("broadcast must fire within 500ms")
+        .expect("receiver must get the event");
+    match event {
+        RevocationEvent::All => {}
+        other => panic!("revoke-all must emit RevocationEvent::All, got {other:?}"),
+    }
 }

--- a/crates/shared/src/wire.rs
+++ b/crates/shared/src/wire.rs
@@ -1,12 +1,21 @@
 //! HTTP wire types for the auth ceremony surface.
 //!
-//! Three flows × two phases each:
-//! - **register** (first-device, localhost-only bootstrap):
+//! Two flows × two phases each:
+//! - **register** (first-device bootstrap OR additional-device
+//!   pairing — same routes, branched server-side on the
+//!   optional `setupToken` body field):
 //!   `register/options` → `register/verify`
 //! - **login** (any device with an enrolled credential):
 //!   `login/options` → `login/verify`
-//! - **pair** (additional device via setup token):
-//!   `pair/options` → `pair/verify`
+//!
+//! Phase 0a step 4 collapsed the dedicated `/auth/pair/*`
+//! routes into `/auth/register/*` so the Node frontend's
+//! single-route-with-optional-token model drives the Rust
+//! server unchanged. The pair-specific `PairStartRequest`
+//! and `PairFinishRequest` types are gone; a `setupToken`
+//! present in the request body switches the handler from
+//! the localhost-only-fresh-install branch to the
+//! token-gated additional-device branch.
 //!
 //! Phase 0a-1 of the cutover reshapes these to match the
 //! Node frontend wire shapes byte-for-byte:
@@ -119,17 +128,44 @@ pub struct AuthFinishResponse {
 
 // --- register flow ---------------------------------------------------
 
+/// Body for `POST /auth/register/options`.
+///
+/// One route serves two purposes (matching Node's
+/// `lib/routes/auth-routes.js:70-113`):
+/// - **First-device bootstrap**: `setupToken` absent. Server
+///   gates on localhost + "no credentials yet" inside its
+///   transact closure.
+/// - **Additional-device pairing**: `setupToken` present.
+///   Server validates the token (must be live, unconsumed,
+///   unexpired) and proceeds without the localhost gate.
+///
+/// `#[serde(default)]` so a request body of `{}` (Node sends
+/// `{setupToken: ""}` when the input is empty; the server
+/// treats empty-string the same as absent) deserialises with
+/// `setup_token = None`. The Content-Type header is still
+/// required by `JsonBody` — callers must POST a JSON body
+/// even on the no-token branch.
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegisterOptionsRequest {
+    /// Plaintext setup token. Absent (or empty after Node's
+    /// `||''` tolerance) selects the first-device branch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub setup_token: Option<String>,
+}
+
 /// Body for `POST /auth/register/verify`. Carries the
 /// credential payload only — the challenge is recovered from
 /// `credential.response.clientDataJSON.challenge` server-side
 /// (same pattern as `@simplewebauthn` and `extractChallenge`
 /// in `lib/auth-handlers.js`).
 ///
-/// `setup_token` is reserved for the follow-up PR that merges
-/// the register and pair flows into a single endpoint; today
-/// it stays `None` on first-device registration. Landing the
-/// field now means the type doesn't need a second wire
-/// migration when that merge happens.
+/// `setup_token` selects the same branch as on the matching
+/// `*/options` call: `None` → first-device finish (localhost
+/// gated), `Some` → token-gated pair finish. The same plaintext
+/// is re-submitted (not an opaque id) so the server can
+/// re-resolve it under the state mutex and close the
+/// revoke-between-start-and-finish TOCTOU window.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegisterFinishRequest {
@@ -157,41 +193,6 @@ pub struct RegisterFinishRequest {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LoginFinishRequest {
     pub credential: PublicKeyCredential,
-}
-
-// --- pair flow (setup-token-gated registration) ----------------------
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct PairStartRequest {
-    /// Plaintext setup token value. The server hashes and
-    /// looks it up; only redeemable (live, unconsumed)
-    /// tokens pass.
-    pub setup_token: String,
-}
-
-/// Body for `POST /auth/pair/verify`.
-///
-/// Carries the plaintext `setup_token` again rather than an
-/// opaque `setup_token_id` echoed from `pair/options`. The
-/// server re-validates redemption under the state mutex —
-/// that re-validation is the authoritative gate, not whether
-/// the client echoed an id correctly. This shape matches the
-/// Node implementation.
-///
-/// The challenge is recovered from
-/// `credential.response.clientDataJSON.challenge` server-side.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PairFinishRequest {
-    pub credential: RegisterPublicKeyCredential,
-    pub setup_token: String,
-    /// Optional human label for the paired credential. Persisted to
-    /// `Credential.name`; defaults to empty when missing.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub device_name: Option<String>,
-    /// Optional User-Agent capture from the pairing browser.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<String>,
 }
 
 // =====================================================================

--- a/crates/shared/src/wire.rs
+++ b/crates/shared/src/wire.rs
@@ -75,7 +75,7 @@ pub enum AccessMethod {
     Remote,
 }
 
-/// Response shape for `GET /api/auth/status`. Public route
+/// Response shape for `GET /auth/status`. Public route
 /// (no auth required) — the WASM client probes this on every
 /// page load to discover the current session state and decide
 /// whether to render the login form, the post-auth view, or a

--- a/crates/shared/src/wire.rs
+++ b/crates/shared/src/wire.rs
@@ -131,10 +131,22 @@ pub struct AuthFinishResponse {
 /// field now means the type doesn't need a second wire
 /// migration when that merge happens.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RegisterFinishRequest {
     pub credential: RegisterPublicKeyCredential,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub setup_token: Option<String>,
+    /// Optional human label for the credential ("Felix iPhone").
+    /// Persisted to `Credential.name` for the device-management
+    /// UI. Defaults to empty when missing — matches Node's
+    /// `deviceName || ''` tolerance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub device_name: Option<String>,
+    /// Optional User-Agent capture from the registering browser.
+    /// Surfaced on the device-management UI so an operator can
+    /// match a passkey row to the device that minted it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_agent: Option<String>,
 }
 
 // --- login flow ------------------------------------------------------
@@ -169,9 +181,17 @@ pub struct PairStartRequest {
 /// The challenge is recovered from
 /// `credential.response.clientDataJSON.challenge` server-side.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PairFinishRequest {
     pub credential: RegisterPublicKeyCredential,
     pub setup_token: String,
+    /// Optional human label for the paired credential. Persisted to
+    /// `Credential.name`; defaults to empty when missing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub device_name: Option<String>,
+    /// Optional User-Agent capture from the pairing browser.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_agent: Option<String>,
 }
 
 // =====================================================================

--- a/crates/shared/src/wire.rs
+++ b/crates/shared/src/wire.rs
@@ -2,44 +2,40 @@
 //!
 //! Three flows × two phases each:
 //! - **register** (first-device, localhost-only bootstrap):
-//!   `register/start` → `register/finish`
+//!   `register/options` → `register/verify`
 //! - **login** (any device with an enrolled credential):
-//!   `login/start` → `login/finish`
+//!   `login/options` → `login/verify`
 //! - **pair** (additional device via setup token):
-//!   `pair/start` → `pair/finish`
+//!   `pair/options` → `pair/verify`
 //!
-//! Register-start and login-start take no request body, so
-//! there's no `RegisterStartRequest` / `LoginStartRequest`
-//! type — those routes parse the `()` body. Pair-start needs
-//! the plaintext setup token, so it has a request struct.
+//! Phase 0a-1 of the cutover reshapes these to match the
+//! Node frontend wire shapes byte-for-byte:
 //!
-//! All three start endpoints return a challenge wrapped in a
-//! generic envelope (`ChallengeStartResponse<T>`). The `T`
-//! varies because register/pair return registration options
-//! (`CreationChallengeResponse`) while login returns
-//! authentication options (`RequestChallengeResponse`).
-//! Concrete aliases are provided for the WASM client where
-//! generic deserialisation is awkward.
+//! - Each `*/options` endpoint returns the bare WebAuthn
+//!   options object at the JSON top level (no
+//!   `challenge_id`, no `options` envelope). Node's handler
+//!   does `res.json(opts)` where `opts` is the
+//!   `@simplewebauthn` options output; we mirror that by
+//!   handing back the raw `CreationChallengeResponse` /
+//!   `RequestChallengeResponse`.
+//! - Each `*/verify` endpoint takes a body that carries only
+//!   the credential payload. The challenge no longer
+//!   round-trips through a server-issued id; instead the
+//!   server recovers it from the credential's
+//!   `clientDataJSON.challenge` at verify time. That's the
+//!   `@simplewebauthn` model and what `extractChallenge` in
+//!   `lib/auth-handlers.js` does on the Node side.
 //!
-//! Pair-start additionally echoes a `setup_token_id` back to
-//! the client so `pair/finish` can reference the redeemable
-//! token without re-submitting the plaintext value. That's
-//! defence in depth (the plaintext transits the network
-//! once), and it's why pair has its own response type rather
-//! than reusing the generic envelope.
+//! Consequence: `ChallengeId` is gone from the public wire,
+//! and so is the `ChallengeStartResponse<T>` envelope. The
+//! types that survive are bodies the Node frontend (and the
+//! WASM frontend, post-cutover) actually exchange.
 //!
-//! All three finish endpoints converge on the same response
+//! All three verify endpoints converge on the same response
 //! shape (`AuthFinishResponse`) — the server has minted a
 //! session cookie via `Set-Cookie` and returns the
 //! credential id (for UI display) and the CSRF token (for
 //! the client to echo on subsequent state-changing requests).
-//!
-//! `ChallengeId` is exposed as a type alias rather than a
-//! newtype because the server side already has its own
-//! `katulong_auth::webauthn::ChallengeId = String` alias and
-//! the wire format is just a string. A newtype here would
-//! force every consumer to convert at the boundary for no
-//! safety gain.
 
 use serde::{Deserialize, Serialize};
 
@@ -52,8 +48,6 @@ pub use webauthn_rs_proto::{
     CreationChallengeResponse, PublicKeyCredential, RegisterPublicKeyCredential,
     RequestChallengeResponse,
 };
-
-pub type ChallengeId = String;
 
 // --- status probe ----------------------------------------------------
 
@@ -75,43 +69,39 @@ pub enum AccessMethod {
     Remote,
 }
 
-/// Response shape for `GET /auth/status`. Public route
-/// (no auth required) — the WASM client probes this on every
-/// page load to discover the current session state and decide
-/// whether to render the login form, the post-auth view, or a
-/// loading state while the probe is in flight.
+/// Response shape for `GET /auth/status`. Public route (no
+/// auth required) — the WASM client probes this on page load
+/// to choose between register / login / pair UIs.
 ///
-/// `has_credentials = false` is the signal for "fresh install
-/// — go to register flow"; `authenticated = true` is the
-/// signal for "session cookie is valid, go to post-auth
-/// view"; the remaining case is "show the login form."
+/// **Wire shape matches Node's `lib/routes/auth-routes.js`:**
+/// `{ setup, accessMethod }`. `setup` is `true` once any
+/// credential exists on the instance; `accessMethod` is the
+/// camelCase mirror of the server's classification (the JSON
+/// frontend reads `accessMethod`, not `access_method`).
+///
+/// Phase 0a-1 of the cutover dropped the `authenticated`
+/// field — Node never returned it and the JS frontend never
+/// read it. Whether the caller has a live session is
+/// recoverable from a separate `/api/me` probe (sibling PR).
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AuthStatusResponse {
+    /// `true` once any credential exists on the instance.
+    /// Mirrors Node's `isSetup()` boolean — drives the
+    /// frontend's "fresh install → register" vs.
+    /// "credentials exist → sign in" branch.
+    pub setup: bool,
+    /// Camel-cased on the wire (`accessMethod`) to match
+    /// Node's `getAccessMethod()` output. The Rust enum stays
+    /// snake-case internally; the rename is at the wire
+    /// boundary only.
+    #[serde(rename = "accessMethod")]
     pub access_method: AccessMethod,
-    pub has_credentials: bool,
-    pub authenticated: bool,
 }
-
-// --- start: shared challenge envelope ---------------------------------
-
-/// Generic envelope for the start phase of every ceremony.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ChallengeStartResponse<T> {
-    pub challenge_id: ChallengeId,
-    pub options: T,
-}
-
-/// The aliases below exist so the WASM client can write
-/// `let start: LoginStartResponse = resp.json().await?` and
-/// have the deserialize call resolve without an explicit
-/// turbofish.
-pub type RegisterStartResponse = ChallengeStartResponse<CreationChallengeResponse>;
-pub type LoginStartResponse = ChallengeStartResponse<RequestChallengeResponse>;
 
 // --- finish: shared session response ---------------------------------
 
-/// Returned by every successful finish endpoint
-/// (register/finish, login/finish, pair/finish). The status
+/// Returned by every successful verify endpoint
+/// (register/verify, login/verify, pair/verify). The status
 /// codes still differ per route (201 on register/pair, 200 on
 /// login) — that's a transport detail handled at the call
 /// site, not part of this type.
@@ -129,18 +119,32 @@ pub struct AuthFinishResponse {
 
 // --- register flow ---------------------------------------------------
 
+/// Body for `POST /auth/register/verify`. Carries the
+/// credential payload only — the challenge is recovered from
+/// `credential.response.clientDataJSON.challenge` server-side
+/// (same pattern as `@simplewebauthn` and `extractChallenge`
+/// in `lib/auth-handlers.js`).
+///
+/// `setup_token` is reserved for the follow-up PR that merges
+/// the register and pair flows into a single endpoint; today
+/// it stays `None` on first-device registration. Landing the
+/// field now means the type doesn't need a second wire
+/// migration when that merge happens.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RegisterFinishRequest {
-    pub challenge_id: ChallengeId,
-    pub response: RegisterPublicKeyCredential,
+    pub credential: RegisterPublicKeyCredential,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub setup_token: Option<String>,
 }
 
 // --- login flow ------------------------------------------------------
 
+/// Body for `POST /auth/login/verify`. The struct exists
+/// purely so the WASM frontend can name it; the wire shape is
+/// `{ "credential": <PublicKeyCredential> }`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LoginFinishRequest {
-    pub challenge_id: ChallengeId,
-    pub response: PublicKeyCredential,
+    pub credential: PublicKeyCredential,
 }
 
 // --- pair flow (setup-token-gated registration) ----------------------
@@ -153,21 +157,21 @@ pub struct PairStartRequest {
     pub setup_token: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct PairStartResponse {
-    pub challenge_id: ChallengeId,
-    /// Server-side opaque id for the redeemable token.
-    /// Echoed back on `pair/finish` so the client doesn't
-    /// re-submit the plaintext token a second time.
-    pub setup_token_id: String,
-    pub options: CreationChallengeResponse,
-}
-
+/// Body for `POST /auth/pair/verify`.
+///
+/// Carries the plaintext `setup_token` again rather than an
+/// opaque `setup_token_id` echoed from `pair/options`. The
+/// server re-validates redemption under the state mutex —
+/// that re-validation is the authoritative gate, not whether
+/// the client echoed an id correctly. This shape matches the
+/// Node implementation.
+///
+/// The challenge is recovered from
+/// `credential.response.clientDataJSON.challenge` server-side.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PairFinishRequest {
-    pub challenge_id: ChallengeId,
-    pub setup_token_id: String,
-    pub response: RegisterPublicKeyCredential,
+    pub credential: RegisterPublicKeyCredential,
+    pub setup_token: String,
 }
 
 // =====================================================================

--- a/crates/shared/tests/wire_round_trip.rs
+++ b/crates/shared/tests/wire_round_trip.rs
@@ -25,9 +25,9 @@
 //! key is part of an HTTP contract.
 
 use katulong_shared::wire::{
-    AccessMethod, AuthFinishResponse, AuthStatusResponse, ChallengeId,
-    LoginFinishRequest, PairFinishRequest, PairStartRequest, PairStartResponse,
-    TileDescriptor, TileId, TileKind, TileLayout,
+    AccessMethod, AuthFinishResponse, AuthStatusResponse, LoginFinishRequest,
+    PairFinishRequest, PairStartRequest, RegisterFinishRequest, TileDescriptor, TileId,
+    TileKind, TileLayout,
 };
 use serde_json::{json, Value};
 
@@ -66,17 +66,12 @@ fn pair_start_request_pins_setup_token_key_and_round_trips() {
 
 #[test]
 fn login_finish_request_envelope_keys_are_snake_case() {
-    // We can't construct a real `PublicKeyCredential` without
-    // a live authenticator. Verify the envelope keys
-    // (`challenge_id`, `response`) by deserializing a
-    // hand-rolled JSON object with a stub credential body
-    // that contains only the unconditionally-required fields
-    // — the proto types use serde defaults / Option for the
-    // rest. If this stops parsing, the proto contract
-    // changed underneath us; if the envelope key changed,
-    // we'd see the failure here in code review.
+    // The cutover collapsed the request shape to
+    // `{ credential: <PublicKeyCredential> }` — the
+    // server-issued `challenge_id` is gone, recovered from
+    // `clientDataJSON.challenge` instead.
     //
-    // The `response` body is a `webauthn-rs-proto`
+    // The `credential` body is a `webauthn-rs-proto`
     // `PublicKeyCredential`. Its required fields per the
     // crate docs: `id` (string), `rawId` (base64url bytes),
     // `response.{authenticatorData, clientDataJSON,
@@ -93,108 +88,98 @@ fn login_finish_request_envelope_keys_are_snake_case() {
     });
 
     let envelope = json!({
-        "challenge_id": "c1",
-        "response": credential_json,
+        "credential": credential_json,
     });
 
-    // Round-trip via deserialize → re-serialize. A future
-    // `#[serde(rename_all = "camelCase")]` on the envelope
-    // would change `challenge_id` to `challengeId` and break
-    // the deserialize step here.
     let parsed: LoginFinishRequest = serde_json::from_value(envelope.clone()).unwrap();
     let re_serialized = serde_json::to_value(&parsed).unwrap();
 
-    // The envelope keys must match. We don't compare the
-    // `response` body byte-for-byte because the proto
-    // struct's serializer may emit a canonical form that
-    // differs from our hand-rolled JSON; instead we assert
-    // the `response` key exists with an object value.
-    assert_eq!(re_serialized["challenge_id"], json!("c1"));
-    assert!(re_serialized["response"].is_object());
+    // Confirm no challenge envelope leaked into the
+    // serialized output, and the `credential` key is intact.
+    assert!(re_serialized.get("challenge_id").is_none());
+    assert!(re_serialized["credential"].is_object());
 }
 
 #[test]
-fn pair_finish_request_envelope_keys_are_snake_case() {
+fn register_finish_request_carries_optional_setup_token() {
+    // `setup_token` is reserved for the follow-up PR that
+    // merges register + pair. Today it stays `None` on
+    // first-device; an absent field deserialises as `None`
+    // (serde default) and serialises out as omitted (per
+    // `skip_serializing_if`) so the wire stays minimal.
     let credential_json = json!({
         "id": "AAAA",
         "rawId": "AAAA",
         "type": "public-key",
         "response": {
-            // RegisterPublicKeyCredential needs the
-            // attestation response shape: clientDataJSON +
-            // attestationObject.
+            "clientDataJSON": "AAAA",
+            "attestationObject": "AAAA",
+        }
+    });
+
+    // Without setup_token: round-trip should NOT emit the field.
+    let envelope = json!({ "credential": credential_json.clone() });
+    let parsed: RegisterFinishRequest = serde_json::from_value(envelope).unwrap();
+    let re_serialized = serde_json::to_value(&parsed).unwrap();
+    assert!(re_serialized.get("setup_token").is_none());
+    assert!(re_serialized["credential"].is_object());
+
+    // With setup_token: round-trips through the field.
+    let envelope = json!({
+        "credential": credential_json,
+        "setup_token": "tok-plaintext",
+    });
+    let parsed: RegisterFinishRequest = serde_json::from_value(envelope).unwrap();
+    let re_serialized = serde_json::to_value(&parsed).unwrap();
+    assert_eq!(re_serialized["setup_token"], json!("tok-plaintext"));
+}
+
+#[test]
+fn pair_finish_request_carries_plaintext_setup_token() {
+    // The cutover swapped the `setup_token_id` echo for a
+    // re-submitted plaintext `setup_token`; the server
+    // re-resolves the id under the state mutex (Node-
+    // compatible).
+    let credential_json = json!({
+        "id": "AAAA",
+        "rawId": "AAAA",
+        "type": "public-key",
+        "response": {
             "clientDataJSON": "AAAA",
             "attestationObject": "AAAA",
         }
     });
 
     let envelope = json!({
-        "challenge_id": "c1",
-        "setup_token_id": "tok-id-1",
-        "response": credential_json,
+        "credential": credential_json,
+        "setup_token": "tok-plaintext",
     });
 
     let parsed: PairFinishRequest = serde_json::from_value(envelope).unwrap();
     let re_serialized = serde_json::to_value(&parsed).unwrap();
 
-    assert_eq!(re_serialized["challenge_id"], json!("c1"));
-    assert_eq!(re_serialized["setup_token_id"], json!("tok-id-1"));
-    assert!(re_serialized["response"].is_object());
-}
-
-#[test]
-fn pair_start_response_envelope_keys_are_snake_case() {
-    // The `options` field carries a real
-    // `CreationChallengeResponse`, which has its own complex
-    // shape. We deserialize an envelope and re-serialize it
-    // to verify the wrapper keys round-trip.
-    //
-    // Construct a minimal `CreationChallengeResponse`
-    // payload — it has `publicKey` (the actual options
-    // object) as the load-bearing field. The other fields
-    // (`mediation`, etc.) are optional.
-    let options_json = json!({
-        "publicKey": {
-            "rp": { "name": "katulong", "id": "katulong.test" },
-            "user": {
-                "id": "AAAA",
-                "name": "u",
-                "displayName": "u",
-            },
-            "challenge": "AAAA",
-            "pubKeyCredParams": [],
-        }
-    });
-
-    let envelope = json!({
-        "challenge_id": "c1",
-        "setup_token_id": "tok-id-1",
-        "options": options_json,
-    });
-
-    let parsed: PairStartResponse = serde_json::from_value(envelope).unwrap();
-    let re_serialized = serde_json::to_value(&parsed).unwrap();
-
-    assert_eq!(re_serialized["challenge_id"], json!("c1"));
-    assert_eq!(re_serialized["setup_token_id"], json!("tok-id-1"));
-    assert!(re_serialized["options"].is_object());
+    assert!(re_serialized.get("challenge_id").is_none());
+    assert!(re_serialized.get("setup_token_id").is_none());
+    assert_eq!(re_serialized["setup_token"], json!("tok-plaintext"));
+    assert!(re_serialized["credential"].is_object());
 }
 
 #[test]
 fn auth_status_response_pins_keys_and_round_trips() {
     let resp = AuthStatusResponse {
+        setup: true,
         access_method: AccessMethod::Localhost,
-        has_credentials: true,
-        authenticated: true,
     };
 
     let value = serde_json::to_value(&resp).unwrap();
+    // Wire shape mirrors Node: `{setup, accessMethod}`
+    // (camelCase). The `authenticated` field is gone; the
+    // `accessMethod` rename is at the wire boundary only.
     assert_eq!(
         value,
         json!({
-            "access_method": "localhost",
-            "has_credentials": true,
-            "authenticated": true,
+            "setup": true,
+            "accessMethod": "localhost",
         })
     );
 
@@ -202,30 +187,17 @@ fn auth_status_response_pins_keys_and_round_trips() {
     // on this string and a missed `Remote => "remote"` case
     // would silently treat tunnel access as localhost.
     let remote = AuthStatusResponse {
+        setup: false,
         access_method: AccessMethod::Remote,
-        has_credentials: false,
-        authenticated: false,
     };
     let v = serde_json::to_value(&remote).unwrap();
-    assert_eq!(v["access_method"], json!("remote"));
+    assert_eq!(v["accessMethod"], json!("remote"));
+    assert_eq!(v["setup"], json!(false));
 
     let s = serde_json::to_string(&resp).unwrap();
     let back: AuthStatusResponse = serde_json::from_str(&s).unwrap();
     assert_eq!(back.access_method, AccessMethod::Localhost);
-    assert!(back.has_credentials);
-    assert!(back.authenticated);
-}
-
-#[test]
-fn challenge_id_serializes_as_bare_string() {
-    // `ChallengeId` is `type ChallengeId = String`. A future
-    // newtype-ification (e.g., `struct ChallengeId(String)`)
-    // could change serialization to a single-element tuple
-    // struct unless `#[serde(transparent)]` is added. Pin
-    // the contract: it must serialize to a bare JSON string.
-    let id: ChallengeId = "challenge-123".to_string();
-    let value: Value = serde_json::to_value(&id).unwrap();
-    assert_eq!(value, json!("challenge-123"));
+    assert!(back.setup);
 }
 
 #[test]

--- a/crates/shared/tests/wire_round_trip.rs
+++ b/crates/shared/tests/wire_round_trip.rs
@@ -26,8 +26,7 @@
 
 use katulong_shared::wire::{
     AccessMethod, AuthFinishResponse, AuthStatusResponse, LoginFinishRequest,
-    PairFinishRequest, PairStartRequest, RegisterFinishRequest, TileDescriptor, TileId,
-    TileKind, TileLayout,
+    RegisterFinishRequest, RegisterOptionsRequest, TileDescriptor, TileId, TileKind, TileLayout,
 };
 use serde_json::{json, Value};
 
@@ -51,17 +50,36 @@ fn auth_finish_response_pins_keys_and_round_trips() {
 }
 
 #[test]
-fn pair_start_request_pins_setup_token_key_and_round_trips() {
-    let req = PairStartRequest {
-        setup_token: "deadbeef".to_string(),
-    };
+fn register_options_request_round_trips_with_and_without_setup_token() {
+    // Phase 0a step 4 collapsed `/auth/pair/options` into
+    // `/auth/register/options`. The server branches on
+    // `setupToken` presence: absent → first-device
+    // localhost-only; present → setup-token-gated pair.
+    //
+    // Wire shape is camelCase (`setupToken`) to match Node's
+    // `public/login.js` which uses `JSON.stringify({ setupToken })`.
+    // An empty body deserialises with `setup_token = None` via
+    // `serde(default)`.
 
+    // Without setup_token: serialises out with the field omitted
+    // (per `skip_serializing_if`).
+    let req = RegisterOptionsRequest::default();
     let value = serde_json::to_value(&req).unwrap();
-    assert_eq!(value, json!({ "setup_token": "deadbeef" }));
+    assert!(value.get("setupToken").is_none());
+    assert!(value.get("setup_token").is_none());
 
-    let s = serde_json::to_string(&req).unwrap();
-    let back: PairStartRequest = serde_json::from_str(&s).unwrap();
-    assert_eq!(back.setup_token, "deadbeef");
+    // An empty `{}` body deserialises into `None`.
+    let parsed: RegisterOptionsRequest = serde_json::from_value(json!({})).unwrap();
+    assert!(parsed.setup_token.is_none());
+
+    // With setup_token: the wire field is camelCase `setupToken`.
+    let req = RegisterOptionsRequest {
+        setup_token: Some("deadbeef".to_string()),
+    };
+    let value = serde_json::to_value(&req).unwrap();
+    assert_eq!(value, json!({ "setupToken": "deadbeef" }));
+    let back: RegisterOptionsRequest = serde_json::from_value(value).unwrap();
+    assert_eq!(back.setup_token.as_deref(), Some("deadbeef"));
 }
 
 #[test]
@@ -102,11 +120,12 @@ fn login_finish_request_envelope_keys_are_snake_case() {
 
 #[test]
 fn register_finish_request_carries_optional_setup_token() {
-    // `setup_token` is reserved for the follow-up PR that
-    // merges register + pair. Today it stays `None` on
-    // first-device; an absent field deserialises as `None`
-    // (serde default) and serialises out as omitted (per
-    // `skip_serializing_if`) so the wire stays minimal.
+    // `RegisterFinishRequest` is `rename_all = "camelCase"`, so the
+    // wire field is `setupToken` (matching Node's
+    // `JSON.stringify({ setupToken })` in `public/login.js`).
+    // Phase 0a step 4 merged the pair flow into this body — `Some`
+    // selects the token-gated pair finish, `None` selects the
+    // first-device localhost-only finish.
     let credential_json = json!({
         "id": "AAAA",
         "rawId": "AAAA",
@@ -117,51 +136,27 @@ fn register_finish_request_carries_optional_setup_token() {
         }
     });
 
-    // Without setup_token: round-trip should NOT emit the field.
+    // Without setupToken: round-trip should NOT emit the field.
     let envelope = json!({ "credential": credential_json.clone() });
     let parsed: RegisterFinishRequest = serde_json::from_value(envelope).unwrap();
     let re_serialized = serde_json::to_value(&parsed).unwrap();
+    assert!(re_serialized.get("setupToken").is_none());
     assert!(re_serialized.get("setup_token").is_none());
     assert!(re_serialized["credential"].is_object());
 
-    // With setup_token: round-trips through the field.
+    // With setupToken: round-trips through the camelCase field.
     let envelope = json!({
         "credential": credential_json,
-        "setup_token": "tok-plaintext",
+        "setupToken": "tok-plaintext",
     });
     let parsed: RegisterFinishRequest = serde_json::from_value(envelope).unwrap();
+    assert_eq!(parsed.setup_token.as_deref(), Some("tok-plaintext"));
     let re_serialized = serde_json::to_value(&parsed).unwrap();
-    assert_eq!(re_serialized["setup_token"], json!("tok-plaintext"));
-}
-
-#[test]
-fn pair_finish_request_carries_plaintext_setup_token() {
-    // The cutover swapped the `setup_token_id` echo for a
-    // re-submitted plaintext `setup_token`; the server
-    // re-resolves the id under the state mutex (Node-
-    // compatible).
-    let credential_json = json!({
-        "id": "AAAA",
-        "rawId": "AAAA",
-        "type": "public-key",
-        "response": {
-            "clientDataJSON": "AAAA",
-            "attestationObject": "AAAA",
-        }
-    });
-
-    let envelope = json!({
-        "credential": credential_json,
-        "setup_token": "tok-plaintext",
-    });
-
-    let parsed: PairFinishRequest = serde_json::from_value(envelope).unwrap();
-    let re_serialized = serde_json::to_value(&parsed).unwrap();
-
+    assert_eq!(re_serialized["setupToken"], json!("tok-plaintext"));
+    // The pair-flow leg of the merged endpoint reads the same field
+    // — no separate `PairFinishRequest` exists post-step-4.
     assert!(re_serialized.get("challenge_id").is_none());
     assert!(re_serialized.get("setup_token_id").is_none());
-    assert_eq!(re_serialized["setup_token"], json!("tok-plaintext"));
-    assert!(re_serialized["credential"].is_object());
 }
 
 #[test]

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Cross-crate wire types — single source of truth for the
-# JSON shapes that flow over /api/auth/*. The server crate
+# JSON shapes that flow over /auth/* + /api/{tokens,credentials}. The server crate
 # uses the same definitions to build responses and parse
 # requests, so a field rename or `#[serde(rename = ...)]`
 # change is caught by the type checker on both sides instead

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -106,7 +106,7 @@ async fn credential_from_promise(
 /// "credential revoked" surfacing different recovery UIs).
 async fn signin() -> Result<(), String> {
     // 1. Ask the server for a challenge.
-    let start_resp = gloo_net::http::Request::post("/api/auth/login/start")
+    let start_resp = gloo_net::http::Request::post("/auth/login/options")
         .send()
         .await
         .map_err(|e| format!("network error contacting server: {e}"))?;
@@ -139,7 +139,7 @@ async fn signin() -> Result<(), String> {
     // 4. Send the assertion back. `login_finish` uses
     //    `JsonBody<T>` so Content-Type *must* be application/json
     //    — `gloo-net`'s `.json(...)` sets that automatically.
-    let finish_resp = gloo_net::http::Request::post("/api/auth/login/finish")
+    let finish_resp = gloo_net::http::Request::post("/auth/login/verify")
         .json(&LoginFinishRequest {
             challenge_id: start.challenge_id,
             response,
@@ -160,7 +160,7 @@ async fn signin() -> Result<(), String> {
 ///
 /// Symmetric to `signin()` but uses the registration variant
 /// of every step:
-///   - POST `/api/auth/pair/start` with the plaintext
+///   - POST `/auth/pair/options` with the plaintext
 ///     setup-token in the body (vs. no body for sign-in)
 ///   - convert `CreationChallengeResponse` →
 ///     `web_sys::CredentialCreationOptions` (vs. request
@@ -169,7 +169,7 @@ async fn signin() -> Result<(), String> {
 ///     `.get(...)`)
 ///   - convert returned credential →
 ///     `RegisterPublicKeyCredential` (vs. assertion type)
-///   - POST `/api/auth/pair/finish` with the
+///   - POST `/auth/pair/verify` with the
 ///     `setup_token_id` echoed alongside the assertion
 ///
 /// The setup-token is moved in (not borrowed) because the
@@ -178,7 +178,7 @@ async fn signin() -> Result<(), String> {
 /// could have given it.
 async fn pair(setup_token: String) -> Result<(), String> {
     // 1. Ask for a registration challenge.
-    let start_resp = gloo_net::http::Request::post("/api/auth/pair/start")
+    let start_resp = gloo_net::http::Request::post("/auth/pair/options")
         .json(&PairStartRequest { setup_token })
         .map_err(|e| format!("could not encode pair-start payload: {e}"))?
         .send()
@@ -210,7 +210,7 @@ async fn pair(setup_token: String) -> Result<(), String> {
 
     // 4. Send the attestation back along with the
     //    `setup_token_id` the server gave us in step 1.
-    let finish_resp = gloo_net::http::Request::post("/api/auth/pair/finish")
+    let finish_resp = gloo_net::http::Request::post("/auth/pair/verify")
         .json(&PairFinishRequest {
             challenge_id: start.challenge_id,
             setup_token_id: start.setup_token_id,
@@ -230,10 +230,10 @@ async fn pair(setup_token: String) -> Result<(), String> {
 /// Same shape as `pair()` (both produce a credential via
 /// `navigator.credentials.create()`), with the differences
 /// concentrated at the HTTP boundaries:
-///   - POST `/api/auth/register/start` with no body (the
+///   - POST `/auth/register/options` with no body (the
 ///     route is localhost-only and fresh-install-only on the
 ///     server; no setup token to submit)
-///   - POST `/api/auth/register/finish` with just the
+///   - POST `/auth/register/verify` with just the
 ///     credential — no `setup_token_id` to echo
 ///
 /// The server's register routes refuse non-localhost callers
@@ -247,7 +247,7 @@ async fn pair(setup_token: String) -> Result<(), String> {
 /// click), the error renders in the standard error region.
 async fn register() -> Result<(), String> {
     // 1. Ask for a registration challenge.
-    let start_resp = gloo_net::http::Request::post("/api/auth/register/start")
+    let start_resp = gloo_net::http::Request::post("/auth/register/options")
         .send()
         .await
         .map_err(|e| format!("network error contacting server: {e}"))?;
@@ -274,7 +274,7 @@ async fn register() -> Result<(), String> {
     // 4. Send the attestation back. No `setup_token_id` here —
     //    register/finish only needs the challenge id and the
     //    credential.
-    let finish_resp = gloo_net::http::Request::post("/api/auth/register/finish")
+    let finish_resp = gloo_net::http::Request::post("/auth/register/verify")
         .json(&RegisterFinishRequest {
             challenge_id: start.challenge_id,
             response,

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -30,8 +30,8 @@
 
 use crate::AuthState;
 use katulong_shared::wire::{
-    LoginFinishRequest, LoginStartResponse, PairFinishRequest, PairStartRequest,
-    PairStartResponse, RegisterFinishRequest, RegisterStartResponse,
+    CreationChallengeResponse, LoginFinishRequest, PairFinishRequest, PairStartRequest,
+    RegisterFinishRequest, RequestChallengeResponse,
 };
 use leptos::*;
 use wasm_bindgen::{JsCast, JsValue};
@@ -111,7 +111,10 @@ async fn signin() -> Result<(), String> {
         .await
         .map_err(|e| format!("network error contacting server: {e}"))?;
     check_ok(&start_resp, "server rejected sign-in challenge")?;
-    let start: LoginStartResponse = start_resp
+    // Bare `RequestChallengeResponse` at the top level — Node's
+    // `lib/routes/auth-routes.js` returns `res.json(opts)` with
+    // no envelope.
+    let start: RequestChallengeResponse = start_resp
         .json()
         .await
         .map_err(|e| format!("server returned malformed challenge: {e}"))?;
@@ -121,7 +124,7 @@ async fn signin() -> Result<(), String> {
     //    with the `wasm` feature does the binary base64url ↔
     //    Uint8Array dance inside the From impl, so we don't
     //    hand-roll it.
-    let options: web_sys::CredentialRequestOptions = start.options.into();
+    let options: web_sys::CredentialRequestOptions = start.into();
 
     // 3. Run the platform ceremony. `credentials.get()` either
     //    resolves with a `PublicKeyCredential` (user confirmed
@@ -134,16 +137,15 @@ async fn signin() -> Result<(), String> {
         .get_with_options(&options)
         .map_err(|e| format!("browser refused credential request: {}", js_err(&e)))?;
     let credential = credential_from_promise(promise).await?;
-    let response: webauthn_rs_proto::PublicKeyCredential = credential.into();
+    let credential: webauthn_rs_proto::PublicKeyCredential = credential.into();
 
     // 4. Send the assertion back. `login_finish` uses
     //    `JsonBody<T>` so Content-Type *must* be application/json
     //    — `gloo-net`'s `.json(...)` sets that automatically.
+    //    The challenge isn't echoed in the request body — the
+    //    server recovers it from `clientDataJSON.challenge`.
     let finish_resp = gloo_net::http::Request::post("/auth/login/verify")
-        .json(&LoginFinishRequest {
-            challenge_id: start.challenge_id,
-            response,
-        })
+        .json(&LoginFinishRequest { credential })
         .map_err(|e| format!("could not encode sign-in payload: {e}"))?
         .send()
         .await
@@ -177,22 +179,28 @@ async fn signin() -> Result<(), String> {
 /// once the click fires, the future may outlive any borrow we
 /// could have given it.
 async fn pair(setup_token: String) -> Result<(), String> {
-    // 1. Ask for a registration challenge.
+    // 1. Ask for a registration challenge. Send the plaintext
+    //    setup token in the request body; the server validates
+    //    it and bails with 401 if it isn't redeemable.
     let start_resp = gloo_net::http::Request::post("/auth/pair/options")
-        .json(&PairStartRequest { setup_token })
+        .json(&PairStartRequest {
+            setup_token: setup_token.clone(),
+        })
         .map_err(|e| format!("could not encode pair-start payload: {e}"))?
         .send()
         .await
         .map_err(|e| format!("network error contacting server: {e}"))?;
     check_ok(&start_resp, "server rejected pair challenge")?;
-    let start: PairStartResponse = start_resp
+    // Bare `CreationChallengeResponse` at the top level —
+    // matches Node's wire shape.
+    let start: CreationChallengeResponse = start_resp
         .json()
         .await
         .map_err(|e| format!("server returned malformed challenge: {e}"))?;
 
     // 2. Convert the wire challenge to the JS shape that
     //    `navigator.credentials.create()` expects.
-    let options: web_sys::CredentialCreationOptions = start.options.into();
+    let options: web_sys::CredentialCreationOptions = start.into();
 
     // 3. Run the platform registration ceremony. `.create()`
     //    either resolves with a `PublicKeyCredential` (user
@@ -206,15 +214,17 @@ async fn pair(setup_token: String) -> Result<(), String> {
         .create_with_options(&options)
         .map_err(|e| format!("browser refused credential creation: {}", js_err(&e)))?;
     let credential = credential_from_promise(promise).await?;
-    let response: webauthn_rs_proto::RegisterPublicKeyCredential = credential.into();
+    let credential: webauthn_rs_proto::RegisterPublicKeyCredential = credential.into();
 
-    // 4. Send the attestation back along with the
-    //    `setup_token_id` the server gave us in step 1.
+    // 4. Send the attestation back along with the plaintext
+    //    `setup_token`. The server re-validates redemption
+    //    under the state mutex (Node does the same) — the
+    //    plaintext travels the network twice but never sits
+    //    around in the client beyond this ceremony.
     let finish_resp = gloo_net::http::Request::post("/auth/pair/verify")
         .json(&PairFinishRequest {
-            challenge_id: start.challenge_id,
-            setup_token_id: start.setup_token_id,
-            response,
+            credential,
+            setup_token,
         })
         .map_err(|e| format!("could not encode pair-finish payload: {e}"))?
         .send()
@@ -252,14 +262,14 @@ async fn register() -> Result<(), String> {
         .await
         .map_err(|e| format!("network error contacting server: {e}"))?;
     check_ok(&start_resp, "server rejected register challenge")?;
-    let start: RegisterStartResponse = start_resp
+    let start: CreationChallengeResponse = start_resp
         .json()
         .await
         .map_err(|e| format!("server returned malformed challenge: {e}"))?;
 
     // 2. Convert the wire challenge to the JS shape that
     //    `navigator.credentials.create()` expects.
-    let options: web_sys::CredentialCreationOptions = start.options.into();
+    let options: web_sys::CredentialCreationOptions = start.into();
 
     // 3. Run the platform registration ceremony.
     let window = web_sys::window().ok_or("browser window unavailable")?;
@@ -269,15 +279,15 @@ async fn register() -> Result<(), String> {
         .create_with_options(&options)
         .map_err(|e| format!("browser refused credential creation: {}", js_err(&e)))?;
     let credential = credential_from_promise(promise).await?;
-    let response: webauthn_rs_proto::RegisterPublicKeyCredential = credential.into();
+    let credential: webauthn_rs_proto::RegisterPublicKeyCredential = credential.into();
 
-    // 4. Send the attestation back. No `setup_token_id` here —
-    //    register/finish only needs the challenge id and the
-    //    credential.
+    // 4. Send the attestation back. No setup token on first-
+    //    device registration; the server recovers the
+    //    challenge from `clientDataJSON.challenge`.
     let finish_resp = gloo_net::http::Request::post("/auth/register/verify")
         .json(&RegisterFinishRequest {
-            challenge_id: start.challenge_id,
-            response,
+            credential,
+            setup_token: None,
         })
         .map_err(|e| format!("could not encode register-finish payload: {e}"))?
         .send()

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -30,8 +30,8 @@
 
 use crate::AuthState;
 use katulong_shared::wire::{
-    CreationChallengeResponse, LoginFinishRequest, PairFinishRequest, PairStartRequest,
-    RegisterFinishRequest, RequestChallengeResponse,
+    CreationChallengeResponse, LoginFinishRequest, RegisterFinishRequest, RegisterOptionsRequest,
+    RequestChallengeResponse,
 };
 use leptos::*;
 use wasm_bindgen::{JsCast, JsValue};
@@ -162,8 +162,11 @@ async fn signin() -> Result<(), String> {
 ///
 /// Symmetric to `signin()` but uses the registration variant
 /// of every step:
-///   - POST `/auth/pair/options` with the plaintext
-///     setup-token in the body (vs. no body for sign-in)
+///   - POST `/auth/register/options` with the plaintext
+///     setup-token in the body (vs. no body for sign-in).
+///     Phase 0a step 4 collapsed `/auth/pair/*` into
+///     `/auth/register/*`; the server branches internally on
+///     `setupToken` presence.
 ///   - convert `CreationChallengeResponse` →
 ///     `web_sys::CredentialCreationOptions` (vs. request
 ///     options for sign-in)
@@ -171,8 +174,8 @@ async fn signin() -> Result<(), String> {
 ///     `.get(...)`)
 ///   - convert returned credential →
 ///     `RegisterPublicKeyCredential` (vs. assertion type)
-///   - POST `/auth/pair/verify` with the
-///     `setup_token_id` echoed alongside the assertion
+///   - POST `/auth/register/verify` with the plaintext
+///     `setupToken` re-submitted alongside the credential
 ///
 /// The setup-token is moved in (not borrowed) because the
 /// dispatched action future has no upper-bounded lifetime —
@@ -182,9 +185,9 @@ async fn pair(setup_token: String) -> Result<(), String> {
     // 1. Ask for a registration challenge. Send the plaintext
     //    setup token in the request body; the server validates
     //    it and bails with 401 if it isn't redeemable.
-    let start_resp = gloo_net::http::Request::post("/auth/pair/options")
-        .json(&PairStartRequest {
-            setup_token: setup_token.clone(),
+    let start_resp = gloo_net::http::Request::post("/auth/register/options")
+        .json(&RegisterOptionsRequest {
+            setup_token: Some(setup_token.clone()),
         })
         .map_err(|e| format!("could not encode pair-start payload: {e}"))?
         .send()
@@ -217,14 +220,14 @@ async fn pair(setup_token: String) -> Result<(), String> {
     let credential: webauthn_rs_proto::RegisterPublicKeyCredential = credential.into();
 
     // 4. Send the attestation back along with the plaintext
-    //    `setup_token`. The server re-validates redemption
+    //    `setupToken`. The server re-validates redemption
     //    under the state mutex (Node does the same) — the
     //    plaintext travels the network twice but never sits
     //    around in the client beyond this ceremony.
-    let finish_resp = gloo_net::http::Request::post("/auth/pair/verify")
-        .json(&PairFinishRequest {
+    let finish_resp = gloo_net::http::Request::post("/auth/register/verify")
+        .json(&RegisterFinishRequest {
             credential,
-            setup_token,
+            setup_token: Some(setup_token),
             // Phase 0a step 3 added optional device_name / user_agent
             // for the device-management UI. The Leptos frontend
             // doesn't surface a name input yet (Node's pair page
@@ -264,7 +267,16 @@ async fn pair(setup_token: String) -> Result<(), String> {
 /// click), the error renders in the standard error region.
 async fn register() -> Result<(), String> {
     // 1. Ask for a registration challenge.
+    //
+    //    Phase 0a step 4 made `/auth/register/options` accept a
+    //    `RegisterOptionsRequest` body; the server uses
+    //    `JsonBody<T>` so the Content-Type and the body shape
+    //    matter. Send `setup_token: None` — that's what selects
+    //    the localhost-only first-device branch on the server
+    //    after the merge with the former `/auth/pair/*` routes.
     let start_resp = gloo_net::http::Request::post("/auth/register/options")
+        .json(&RegisterOptionsRequest { setup_token: None })
+        .map_err(|e| format!("could not encode register-start payload: {e}"))?
         .send()
         .await
         .map_err(|e| format!("network error contacting server: {e}"))?;
@@ -295,8 +307,9 @@ async fn register() -> Result<(), String> {
         .json(&RegisterFinishRequest {
             credential,
             setup_token: None,
-            // See PairFinishRequest above — fields are optional on
-            // the wire, the WASM frontend doesn't capture them yet.
+            // device_name / user_agent are optional on the wire; the
+            // WASM frontend doesn't capture either yet (the Node
+            // login page does — see `public/login.js`).
             device_name: None,
             user_agent: None,
         })

--- a/crates/web/src/login.rs
+++ b/crates/web/src/login.rs
@@ -225,6 +225,13 @@ async fn pair(setup_token: String) -> Result<(), String> {
         .json(&PairFinishRequest {
             credential,
             setup_token,
+            // Phase 0a step 3 added optional device_name / user_agent
+            // for the device-management UI. The Leptos frontend
+            // doesn't surface a name input yet (Node's pair page
+            // does); leaving these `None` matches what Node sends
+            // on a first-pair from a freshly-loaded login page.
+            device_name: None,
+            user_agent: None,
         })
         .map_err(|e| format!("could not encode pair-finish payload: {e}"))?
         .send()
@@ -288,6 +295,10 @@ async fn register() -> Result<(), String> {
         .json(&RegisterFinishRequest {
             credential,
             setup_token: None,
+            // See PairFinishRequest above — fields are optional on
+            // the wire, the WASM frontend doesn't capture them yet.
+            device_name: None,
+            user_agent: None,
         })
         .map_err(|e| format!("could not encode register-finish payload: {e}"))?
         .send()

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -23,7 +23,7 @@
 // components dispatch them via `spawn_local` /
 // `create_action` and react to the resolved value.
 
-use katulong_shared::wire::{AuthStatusResponse, TileLayout};
+use katulong_shared::wire::{AccessMethod, AuthStatusResponse, TileLayout};
 use leptos::*;
 use wasm_bindgen_futures::spawn_local;
 
@@ -102,13 +102,15 @@ pub struct AuthState {
 
 /// Probe `/auth/status` once at App mount.
 ///
-/// Returns the full `AuthStatusResponse` (not just the
-/// `authenticated` bool) so the caller has access to
-/// `has_credentials` and `access_method` without a second
-/// round trip when 9r.5 lands the register flow gate. The
-/// caller currently only consumes `authenticated`; the wider
-/// shape is on the boundary instead of behind it so
-/// downstream code can grow without re-shaping this fn.
+/// Phase 0a-1 of the cutover: the response shape is now
+/// `{setup, accessMethod}` (Node-compatible) and the
+/// `authenticated` field is gone. The probe can no longer
+/// distinguish "session cookie is valid" from "no session"
+/// — that signal moves to a separate `/api/me` probe in a
+/// follow-up PR. Until then, refreshing an already-authed
+/// page lands on the login form, and the user re-runs the
+/// passkey ceremony to recover SignedIn. Acceptable interim
+/// regression per the cutover plan.
 async fn probe_auth_status() -> Result<AuthStatusResponse, String> {
     let resp = gloo_net::http::Request::get("/auth/status")
         .send()
@@ -192,20 +194,20 @@ fn App() -> impl IntoView {
     // putting it in the user-visible string.
     spawn_local(async move {
         match probe_auth_status().await {
-            // Branch order matters: the `authenticated &&
-            // !has_credentials` case is the fresh-install-on-
-            // localhost path (auto-auth gives `authenticated`
-            // before any credential exists). Routing it to
-            // `SignedIn` would land the user on the terminal
-            // stub with no path back to the register flow;
-            // routing to `SignedOut` would show the login
-            // form with no credentials to sign in against.
-            // The dedicated `Register` phase is what makes
-            // this state representable.
-            Ok(status) if status.authenticated && !status.has_credentials => {
+            // `!setup` on a localhost peer is the fresh-install
+            // bootstrap path: no credentials yet AND physical
+            // access, so the first-device register flow is the
+            // only sensible UI.
+            Ok(status)
+                if !status.setup
+                    && matches!(status.access_method, AccessMethod::Localhost) =>
+            {
                 set_phase.set(AuthPhase::Register);
             }
-            Ok(status) if status.authenticated => set_phase.set(AuthPhase::SignedIn),
+            // Everything else routes to SignedOut. Until the
+            // sibling PR adds `/api/me`, the probe can't tell
+            // a live session apart from no session — the user
+            // re-runs the passkey ceremony either way.
             Ok(_) => set_phase.set(AuthPhase::SignedOut),
             Err(message) => {
                 web_sys::console::warn_1(

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -8,7 +8,7 @@
 //   the auth-state-driven swap in <Main/>.
 // Slice 9r.4: status probe + session restore. Auth state
 //   becomes tri-state — None while the initial
-//   `/api/auth/status` probe is in flight, Some(false) when
+//   `/auth/status` probe is in flight, Some(false) when
 //   the server says not authed, Some(true) when authed. The
 //   None branch renders a small "restoring" view, NOT the
 //   login form, so a refresh after sign-in doesn't flash
@@ -64,7 +64,7 @@ pub struct ConnectionStatus {
 /// Phases of the auth state machine driving `<Main/>`'s
 /// view selection.
 ///
-/// - `Restoring` — initial probe to `/api/auth/status` is in
+/// - `Restoring` — initial probe to `/auth/status` is in
 ///   flight. `<Main/>` renders a small "restoring" view here,
 ///   NOT the login form, so a page reload of an already-authed
 ///   user doesn't flash through the sign-in screen.
@@ -72,9 +72,9 @@ pub struct ConnectionStatus {
 ///   localhost auto-auth) but no credentials are registered
 ///   yet. The first-device register UI renders. Distinct
 ///   from `SignedOut` because the next user action differs:
-///   `Register` triggers `/api/auth/register/*` (localhost-
+///   `Register` triggers `/auth/register/*` (localhost-
 ///   only, fresh-install-only); `SignedOut` triggers
-///   `/api/auth/login/*`.
+///   `/auth/login/*`.
 /// - `SignedOut` — probe resolved as unauthenticated AND
 ///   credentials exist on the server. The login form
 ///   renders.
@@ -100,7 +100,7 @@ pub struct AuthState {
     pub set_phase: WriteSignal<AuthPhase>,
 }
 
-/// Probe `/api/auth/status` once at App mount.
+/// Probe `/auth/status` once at App mount.
 ///
 /// Returns the full `AuthStatusResponse` (not just the
 /// `authenticated` bool) so the caller has access to
@@ -110,7 +110,7 @@ pub struct AuthState {
 /// shape is on the boundary instead of behind it so
 /// downstream code can grow without re-shaping this fn.
 async fn probe_auth_status() -> Result<AuthStatusResponse, String> {
-    let resp = gloo_net::http::Request::get("/api/auth/status")
+    let resp = gloo_net::http::Request::get("/auth/status")
         .send()
         .await
         .map_err(|e| format!("network error contacting server: {e}"))?;

--- a/test/e2e-rust/lib/auth-stub.js
+++ b/test/e2e-rust/lib/auth-stub.js
@@ -1,36 +1,29 @@
 /**
- * Stub `/api/auth/status` to look like an unauthenticated
- * remote caller. Slice 9r.4 added a probe-on-mount that
- * reads this endpoint to decide between the login form,
- * post-auth view, and "restoring" placeholder. On localhost
- * the server auto-authenticates EVERY request (security
- * feature: physical access is already root-equivalent), so
- * a real probe returns `authenticated: true` and the login
- * form would never render. Tests that exercise the login UI
- * stub the response to look unauthenticated; tests that
- * exercise the real probe behaviour (slice-9r.4 contract
- * verification) skip the stub and let the probe see the
- * server's actual classification.
+ * Stub `/auth/status` to look like a remote caller with
+ * credentials already enrolled — i.e., the sign-in form
+ * should render. The cutover (phase 0a-1) reshaped this
+ * endpoint to `{setup, accessMethod}` (Node-compatible);
+ * `authenticated` is gone and `has_credentials` was renamed
+ * to `setup`.
+ *
+ * `setup: true` means the WASM probe routes to `SignedOut`
+ * (sign-in form). `setup: false` + `accessMethod:
+ * "localhost"` would route to the first-device register
+ * flow; the unit-test default here picks "remote, signed
+ * out" because that's the path most login-UI tests want.
  *
  * Must be called BEFORE `page.goto()`. Once the WASM has
  * mounted and fired the probe, intercepting won't roll
  * back the in-flight request.
- *
- * `has_credentials: false` reflects the stub's intent for
- * tests that only want the login form to render. When a
- * future slice (9r.5) adds a "no-credentials → register
- * flow" branch in the WASM, this value will need updating
- * to keep these tests on the sign-in path.
  */
 export async function stubUnauthenticated(page) {
-  await page.route("**/api/auth/status", (route) =>
+  await page.route("**/auth/status", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({
-        access_method: "remote",
-        has_credentials: false,
-        authenticated: false,
+        setup: true,
+        accessMethod: "remote",
       }),
     }),
   );


### PR DESCRIPTION
## STATUS: PARKED 2026-05-05 — kept open as documentation, not for merge

The Rust port has been parked. **Do not merge this PR.** It remains open as a reference for the HTTP wire shape between Node frontend and Rust server. `crates/shared/src/wire.rs` on this branch is the clearest articulation of the wire contract that exists.

The parking decision and un-park triggers are documented in the auto-memory file `project_rust_port_parked.md`. Summary of why:

- Pragmatic pivot ("Rust backend serves Node frontend, port features incrementally") didn't change the back-half math: still months of work to reach feature parity, deliverable is the same product Node ships today.
- Node is actively shipping user-visible improvements; every Rust-port hour competes with feature work that benefits users now.
- The strategic motive (tile-SDK as protocol, iframe-sandbox tiles, fleet hub) was never started — phases 0–3 are wire-compat housekeeping, not foundation for the protocol pivot.
- Net wins from this work — the resize-routing fix (#706) and tmux-options gap (#705) — already landed on Node `main`. Value extracted is largely realized.

Un-park triggers (any one):

1. Tile-SDK becomes the next direction (iframe-sandboxed tiles, formal postMessage protocol).
2. A concrete Node limit bites (memory pressure, perf, type-system gap).
3. Federation / fleet-hub gets a concrete consumer (WebRTC peer-links, multi-tenant katulong-rs).

---

## Phase 0a — HTTP wire compat for Node-frontend cutover

Six commits stacked. After this merges, the Rust server's HTTP surface is byte-compatible with the existing Node frontend's auth + token + credential calls. **Does NOT include the WS protocol** — that's Phase 0b in a follow-up PR.

### Commits

1. **Step 1** `f8e4e99` — Rename `/api/auth/*` → `/auth/*` + `/api/credentials` + `/api/tokens` to match Node's URL convention.
2. **Step 2** `27dfa60` — Reshape WebAuthn ceremony wire: challenge keyed by `clientDataJSON.challenge` (no more server-issued `challenge_id`); top-level `CreationChallengeResponse`/`RequestChallengeResponse`; error envelope flipped to `{error: string}`; `/auth/status` returns `{setup, accessMethod}`.
3. **Step 3** `6f90aca` — Reshape `/api/credentials` and `/api/tokens` responses to Node's wrapped-object + camelCase shape; persisted `name` / `userAgent` / `lastUsedAt` on credentials; new `PATCH /api/tokens/:id` route. Also temporarily dropped CSRF on state-mutating routes (restored in step 5).
4. **Step 4** `1e1640f` — Merged `/auth/pair/*` into `/auth/register/*` so a single endpoint pair handles both first-device-localhost AND additional-device-token flows, branching internally on `setup_token`.
5. **Step 5** `9cf005e` — Restored CSRF protection via the `CsrfProtected` extractor (reads `X-CSRF-Token` header, constant-time compare against the session's `csrf_token`, localhost bypass). Injected `<meta name="csrf-token">` into the SPA HTML response at GET `/` so the Node frontend can read its CSRF token at boot.
6. **Step 6** `dc2daf4` — `POST /auth/revoke-all` route. Wipes every persisted session, clears the cookie, broadcasts `RevocationEvent::All` so every active WS terminates. Refactored `RevocationEvent` from struct → enum (`Credential { ... } | All`) — credential-delete WS-close is wired through the same enum.

### Known regressions / deferred (no longer relevant — port parked)

- Rust frontend session-restore-on-reload regressed in step 2.
- WS protocol cutover (CBOR → JSON, message-name renames) is on PR #711 (also parked).

### Test plan

- [x] `cargo build --release --workspace` clean
- [x] `cargo test --release -p katulong-server` green
- [x] `cargo build --target wasm32-unknown-unknown -p katulong-web` clean
- [x] Pre-push hook green on every step
- [ ] Operator smoke test — never executed; not relevant given park.