### PR TITLE
feat(summaries): move session summary history to disk-backed JSONL store

### DIFF
--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -907,6 +907,25 @@ export function createAppRoutes(ctx) {
           agent: meta.agent || null,
         });
       }
+      if (suffix === "summaries") {
+        // Disk-backed timeline lives outside session.meta (see
+        // lib/session-summary-store.js). Read on demand — the history
+        // tile is the only consumer and it only mounts when the user
+        // explicitly opens it, so paying the file read here costs less
+        // than shipping the array on every status payload.
+        const url = new URL(req.url, "http://localhost");
+        const limitRaw = url.searchParams.get("limit");
+        let limit;
+        if (limitRaw !== null) {
+          const n = parseInt(limitRaw, 10);
+          if (!Number.isFinite(n) || n < 1 || n > 1000) {
+            return json(res, 400, { error: "Invalid limit (1-1000)" });
+          }
+          limit = n;
+        }
+        const summaries = sessionManager.summaryStore.read(session.id, { limit });
+        return json(res, 200, { summaries });
+      }
       if (suffix !== "output") return json(res, 404, { error: "Not found" });
 
       const url = new URL(req.url, "http://localhost");

--- a/lib/routes/app-routes.js
+++ b/lib/routes/app-routes.js
@@ -923,7 +923,7 @@ export function createAppRoutes(ctx) {
           }
           limit = n;
         }
-        const summaries = sessionManager.summaryStore.read(session.id, { limit });
+        const summaries = sessionManager.readSummaries(session.id, { limit });
         return json(res, 200, { summaries });
       }
       if (suffix !== "output") return json(res, 404, { error: "Not found" });

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -446,11 +446,24 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
 
   return {
     /**
-     * Disk-backed per-session summary timeline. Exposed so the summarizer
-     * can append (without touching `session.meta`) and the REST surface
-     * can read on demand. See `lib/session-summary-store.js`.
+     * Append a `{ title, summary, at }` entry to the session's
+     * disk-backed timeline (lib/session-summary-store.js). Used by the
+     * summarizer; mediated through the manager so the raw store stays
+     * internal and callers can't accidentally invoke `remove` /
+     * `pruneExcept` from places that don't own session lifecycle.
      */
-    summaryStore,
+    appendSummary(sessionId, entry) {
+      summaryStore.append(sessionId, entry);
+    },
+
+    /**
+     * Read summary history for a session, oldest→newest. Optional
+     * `{ limit }` returns the most recent N. Used by the REST surface
+     * to lazy-load the history tile on demand.
+     */
+    readSummaries(sessionId, opts) {
+      return summaryStore.read(sessionId, opts);
+    },
 
     /**
      * List all sessions.
@@ -861,13 +874,21 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
             // disk-backed summary store, then drop the meta key. Sessions
             // restored before this change carry the cap-busting array; once
             // it's gone, the meta bucket fits comfortably under the 4 KB
-            // limit and pane/agent updates start landing again. Migration
-            // requires a stable id — without one, the legacy entries are
-            // dropped (rare, and the in-meta copy was already broken).
+            // limit and pane/agent updates start landing again.
+            //
+            // Only strip the meta key if the disk write succeeded OR the
+            // session has no stable id to migrate under (the in-meta copy
+            // was already broken in that case). A transient disk error
+            // would otherwise silently delete history that's still in
+            // meta — keep it around for the next restart to retry.
             if (Array.isArray(persistedMeta?.summaryHistory)) {
-              if (persistedId) summaryStore.migrate(persistedId, persistedMeta.summaryHistory);
-              const { summaryHistory: _drop, ...rest } = persistedMeta;
-              persistedMeta = rest;
+              const migrated = persistedId
+                ? summaryStore.migrate(persistedId, persistedMeta.summaryHistory)
+                : true;
+              if (migrated) {
+                const { summaryHistory: _drop, ...rest } = persistedMeta;
+                persistedMeta = rest;
+              }
             }
           }
         }

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -20,6 +20,7 @@ import { createOutputCoalescer } from "./output-coalescer.js";
 import { driftLog, driftLogLevel } from "./drift-log.js";
 import { createSessionStore } from "./session-persistence.js";
 import { createScrollbackStore } from "./scrollback-store.js";
+import { createSummaryStore } from "./session-summary-store.js";
 import { startChildCountMonitor } from "./session-child-counter.js";
 import { Session } from "./session.js";
 import { sessionId, SESSION_ID_PATTERN } from "./id.js";
@@ -107,6 +108,14 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
   // JSON blob. Falls back to a no-op store when dataDir isn't supplied
   // (test fixtures, ephemeral runs).
   const scrollbackStore = createScrollbackStore({ dataDir });
+
+  // Per-session summary history (auto-generated `{ title, summary, at }`
+  // entries from session-summarizer). Lives outside session.meta because
+  // a 4 KB meta cap can't hold a useful timeline; once history grew past
+  // ~12 entries every other setMeta call (pane monitor, agent flips,
+  // etc.) failed and the status pill bar went dark. JSONL on disk so it
+  // survives restarts and grows independently of the meta budget.
+  const summaryStore = createSummaryStore({ dataDir });
 
   // Multi-session subscriptions: clientId -> Set<sessionName>
   // Allows a client to receive output for multiple sessions simultaneously.
@@ -353,7 +362,10 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
       // unreachable (no future session will ever rehydrate from this id).
       // Detach keeps the tmux session alive and re-adoptable on restart,
       // so we keep the file in that case.
-      if (session.id) scrollbackStore.remove(session.id);
+      if (session.id) {
+        scrollbackStore.remove(session.id);
+        summaryStore.remove(session.id);
+      }
     }
     const action = detachOnly ? "detached" : "deleted";
     sessions.delete(name);
@@ -433,6 +445,13 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
   // --- Public API ---
 
   return {
+    /**
+     * Disk-backed per-session summary timeline. Exposed so the summarizer
+     * can append (without touching `session.meta`) and the REST surface
+     * can read on demand. See `lib/session-summary-store.js`.
+     */
+    summaryStore,
+
     /**
      * List all sessions.
      * @returns {{ sessions: object[] }}
@@ -838,6 +857,18 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
             // on write, and those are always re-derived by the child-count
             // monitor.
             persistedMeta = persistableMeta(entry.meta);
+            // Migrate legacy `meta.summaryHistory` (when present) onto the
+            // disk-backed summary store, then drop the meta key. Sessions
+            // restored before this change carry the cap-busting array; once
+            // it's gone, the meta bucket fits comfortably under the 4 KB
+            // limit and pane/agent updates start landing again. Migration
+            // requires a stable id — without one, the legacy entries are
+            // dropped (rare, and the in-meta copy was already broken).
+            if (Array.isArray(persistedMeta?.summaryHistory)) {
+              if (persistedId) summaryStore.migrate(persistedId, persistedMeta.summaryHistory);
+              const { summaryHistory: _drop, ...rest } = persistedMeta;
+              persistedMeta = rest;
+            }
           }
         }
         if (!tmuxName) continue;
@@ -916,6 +947,9 @@ export function createSessionManager({ bridge, shell, home, dataDir }) {
         if (s.id) activeIds.push(s.id);
       }
       scrollbackStore.pruneExcept(activeIds);
+      // Same prune for summary files — sessions that didn't make it back
+      // would otherwise leak their .jsonl(.old) pair into the data dir.
+      summaryStore.pruneExcept(activeIds);
     },
 
     /**

--- a/lib/session-summarizer.js
+++ b/lib/session-summarizer.js
@@ -167,8 +167,8 @@ export function createSessionSummarizer({
   if (typeof callOllama !== "function") {
     throw new Error("createSessionSummarizer: callOllama is required");
   }
-  if (!sessionManager.summaryStore || typeof sessionManager.summaryStore.append !== "function") {
-    throw new Error("createSessionSummarizer: sessionManager.summaryStore is required");
+  if (typeof sessionManager.appendSummary !== "function") {
+    throw new Error("createSessionSummarizer: sessionManager.appendSummary is required");
   }
 
   // Per-session state: { lastHash, inFlight, lastCursor,
@@ -293,7 +293,7 @@ export function createSessionSummarizer({
         && st.lastEntry.summary === parsed.summary;
       if (!duplicate && live.id) {
         const next = { title: parsed.title, summary: parsed.summary, at };
-        sessionManager.summaryStore.append(live.id, next);
+        sessionManager.appendSummary(live.id, next);
         st.lastEntry = next;
       }
       st.lastHash = hash;

--- a/lib/session-summarizer.js
+++ b/lib/session-summarizer.js
@@ -3,14 +3,17 @@
  * summary for every live katulong session based on its recent terminal
  * output. On each distinct cycle the summarizer writes three meta keys:
  *
- *   - `meta.autoTitle`      — short tab label.
- *   - `meta.summary`        — `{ short, long, updatedAt }` for the tab tooltip.
- *   - `meta.summaryHistory` — rolling ring (cap MAX_HISTORY_ENTRIES) of
- *                             every distinct prior `{ title, summary, at }`
- *                             tuple, so the history tile can show "what
- *                             was I doing an hour ago." Duplicates are
- *                             skipped — consecutive identical outputs
- *                             don't inflate the ring.
+ *   - `meta.autoTitle` — short tab label.
+ *   - `meta.summary`   — `{ short, long, updatedAt }` for the tab tooltip.
+ *
+ * The rolling timeline of past summaries (so the history tile can show
+ * "what was I doing an hour ago") is appended to a disk-backed JSONL
+ * store (lib/session-summary-store.js) instead of `session.meta`. The
+ * meta bucket has a 4 KB cap; once history grew past ~12 entries every
+ * subsequent setMeta call (pane monitor, agent flips, etc.) failed and
+ * the status pill bar went dark. Moving history out of meta is what
+ * makes pane updates land again. Duplicates are skipped — consecutive
+ * identical outputs don't inflate the file.
  *
  * Why this exists: tab labels default to the tmux session name
  * (`kat_xxx…`), which is useless as a hint of "what is this tab for."
@@ -78,10 +81,6 @@ const DEFAULT_MIN_CONTENT_CHARS = 400;
 const DEFAULT_MIN_NEW_BYTES_PER_SUMMARY = 200;
 const MAX_TITLE_LEN = 60;
 const MAX_SUMMARY_LEN = 300;
-// Cap the ring so an always-on session doesn't grow meta.summaryHistory
-// unbounded. 40 entries at a 30s cycle is ~20 minutes of distinct work
-// phases, which is the window the user actually forgets over.
-const MAX_HISTORY_ENTRIES = 40;
 
 const SYSTEM_PROMPT =
   "You describe the purpose of a terminal session from its recent " +
@@ -145,7 +144,7 @@ export function parseSummaryResponse(raw) {
  * Build a session summarizer bound to a session manager + Ollama client.
  *
  * @param {object} opts
- * @param {object} opts.sessionManager - must expose listSessions(), getSession(name)
+ * @param {object} opts.sessionManager - must expose listSessions(), getSession(name), and `summaryStore`
  * @param {function} opts.callOllama    - async (userPrompt, { systemPrompt }) => string
  * @param {number} [opts.pollIntervalMs=30000]
  * @param {number} [opts.windowBytes=8000] - max tail bytes fed into the hash + prompt
@@ -167,6 +166,9 @@ export function createSessionSummarizer({
   }
   if (typeof callOllama !== "function") {
     throw new Error("createSessionSummarizer: callOllama is required");
+  }
+  if (!sessionManager.summaryStore || typeof sessionManager.summaryStore.append !== "function") {
+    throw new Error("createSessionSummarizer: sessionManager.summaryStore is required");
   }
 
   // Per-session state: { lastHash, inFlight, lastCursor,
@@ -276,22 +278,23 @@ export function createSessionSummarizer({
       live.setMeta("autoTitle", parsed.title);
 
       // Append to the rolling history so a user who forgets "what was
-      // I doing 10 minutes ago" can scroll back. We append only when
-      // the title OR summary actually changed — consecutive identical
-      // outputs on the same content window happen when Ollama is
-      // stable, and recording them would flood the ring with dupes.
-      const history = Array.isArray(live.meta?.summaryHistory)
-        ? live.meta.summaryHistory
-        : [];
-      const last = history.length > 0 ? history[history.length - 1] : null;
-      const duplicate = last
-        && last.title === parsed.title
-        && last.summary === parsed.summary;
-      if (!duplicate) {
-        const next = history.concat([{ title: parsed.title, summary: parsed.summary, at }]);
-        // Ring: drop oldest once we exceed the cap.
-        while (next.length > MAX_HISTORY_ENTRIES) next.shift();
-        live.setMeta("summaryHistory", next);
+      // I doing 10 minutes ago" can scroll back. We append only when the
+      // title OR summary actually changed — consecutive identical outputs
+      // on the same content window happen when Ollama is stable, and
+      // recording them would flood the file with dupes.
+      //
+      // Dedupe key lives in the in-memory per-session state so we never
+      // re-read the JSONL just to peek at the tail. On server restart the
+      // cache resets and the first post-restart summary may duplicate the
+      // last pre-restart entry — acceptable, the user sees one extra row
+      // at most and the file's still bounded by rotation.
+      const duplicate = st.lastEntry
+        && st.lastEntry.title === parsed.title
+        && st.lastEntry.summary === parsed.summary;
+      if (!duplicate && live.id) {
+        const next = { title: parsed.title, summary: parsed.summary, at };
+        sessionManager.summaryStore.append(live.id, next);
+        st.lastEntry = next;
       }
       st.lastHash = hash;
       log.info("session-summarizer: summary updated", {

--- a/lib/session-summary-store.js
+++ b/lib/session-summary-store.js
@@ -52,19 +52,29 @@ const ROTATE_BYTES = 256 * 1024;
 // a slack for the final entry that crossed the threshold.
 const MAX_FILE_BYTES = ROTATE_BYTES * 2;
 
-// Match scrollback-store's id format. Same threat model: a hostile
-// sessions.json or adopted tmux session name must not path-traverse out
-// of the summaries dir.
+// Session ids are produced by lib/id.js (alnum, length 21) but adopted
+// external tmux session names also flow through here. The adopt path
+// validates against /^[A-Za-z0-9_-]+$/ with length ≤ 128; match that
+// here so a hostile sessions.json cannot path-traverse out of the
+// summaries dir or write to absolute paths via id like "/etc/passwd".
 const VALID_ID = /^[A-Za-z0-9_-]+$/;
 
 function isValidId(id) {
   return typeof id === "string" && id.length > 0 && id.length <= 128 && VALID_ID.test(id);
 }
 
+// Defense-in-depth length caps. The summarizer already clamps title
+// (60) and summary (300) before calling append, but `migrate()` accepts
+// legacy `meta.summaryHistory` entries from older installs that were
+// never trimmed. Bound them at the boundary so a corrupt sessions.json
+// can't push pathologically long strings through to the JSONL.
+const MAX_TITLE_BYTES = 256;
+const MAX_SUMMARY_BYTES = 1024;
+
 function isValidEntry(e) {
   return e
-    && typeof e.title === "string"
-    && typeof e.summary === "string"
+    && typeof e.title === "string" && e.title.length <= MAX_TITLE_BYTES
+    && typeof e.summary === "string" && e.summary.length <= MAX_SUMMARY_BYTES
     && Number.isFinite(e.at);
 }
 
@@ -96,6 +106,11 @@ export function createSummaryStore({ dataDir }) {
   const dir = join(dataDir, SUMMARIES_SUBDIR);
   try {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
+    // mkdirSync with recursive:true does NOT enforce the mode on a dir
+    // that already exists — it silently no-ops. Re-apply explicitly so
+    // a directory carried over from a looser-permissioned install is
+    // locked down. Best-effort: a read-only volume or unowned dir will
+    // throw, which we accept (the file mode 0o600 is the primary defense).
     try { chmodSync(dir, 0o700); } catch { /* readonly volume etc. */ }
   } catch (err) {
     log.warn("Failed to create summaries dir", { dir, error: err.message });
@@ -129,7 +144,10 @@ export function createSummaryStore({ dataDir }) {
       at: entry.at,
     }) + "\n";
     try {
-      appendFileSync(filePath, line, { encoding: "utf-8", mode: 0o600 });
+      // `flag: "a"` is the appendFileSync default; specifying it explicitly
+      // matches the O_APPEND atomicity claim in the file header so a future
+      // reader doesn't have to hunt down whether the default is preserved.
+      appendFileSync(filePath, line, { encoding: "utf-8", mode: 0o600, flag: "a" });
     } catch (err) {
       log.warn("Failed to append summary entry", { sessionId, error: err.message });
       return;
@@ -175,8 +193,10 @@ export function createSummaryStore({ dataDir }) {
   }
 
   function migrate(sessionId, entries) {
-    if (!isValidId(sessionId)) return;
-    if (!Array.isArray(entries) || entries.length === 0) return;
+    if (!isValidId(sessionId)) return false;
+    if (!Array.isArray(entries) || entries.length === 0) return true;
+    const filePath = pathFor(sessionId);
+    const oldPath = oldPathFor(sessionId);
     // Single appendFileSync of the whole batch is faster than N individual
     // appends and atomically lands as one block — no risk of a half-migrated
     // session if the process dies mid-loop. Validate per-entry so a single
@@ -185,14 +205,20 @@ export function createSummaryStore({ dataDir }) {
       .filter(isValidEntry)
       .map((e) => JSON.stringify({ title: e.title, summary: e.summary, at: e.at }))
       .join("\n");
-    if (!lines) return;
+    // All entries failed validation — nothing to write, but the legacy
+    // copy is still safe to drop (it carried no useful data).
+    if (!lines) return true;
     try {
-      appendFileSync(pathFor(sessionId), lines + "\n", { encoding: "utf-8", mode: 0o600 });
+      appendFileSync(filePath, lines + "\n", { encoding: "utf-8", mode: 0o600, flag: "a" });
     } catch (err) {
       log.warn("Failed to migrate summary history", { sessionId, error: err.message });
-      return;
+      // Signal failure so the caller can keep the legacy meta key around
+      // for a retry on the next restart. Otherwise a transient disk error
+      // would silently delete history that's still in meta.
+      return false;
     }
-    rotateIfNeeded(pathFor(sessionId), oldPathFor(sessionId));
+    rotateIfNeeded(filePath, oldPath);
+    return true;
   }
 
   function remove(sessionId) {

--- a/lib/session-summary-store.js
+++ b/lib/session-summary-store.js
@@ -1,0 +1,221 @@
+/**
+ * Session summary persistence store.
+ *
+ * Per-session append-only history of `{ title, summary, at }` records
+ * produced by the summarizer. Lives on disk so it survives server
+ * restarts, and lives outside `session.meta` so it cannot pressure the
+ * 4 KB meta cap (which previously caused every `setMeta` call to fail
+ * once a session had ~12 summary entries — including the pane monitor's
+ * meta.pane writes, killing the status pill bar).
+ *
+ * File layout: `<dataDir>/summaries/<sessionId>.jsonl` — one JSON record
+ * per line, oldest→newest. A rotated generation lives next to it as
+ * `<sessionId>.jsonl.old` so a session that crosses the rotation cap
+ * still shows older context until it cycles out.
+ *
+ * Why JSONL: append is one `appendFileSync` per cycle, no read-modify-
+ * write window, naturally durable to mid-write crash (worst case: a
+ * partial trailing line that the parser drops). Rotation is a `rename`
+ * (atomic on POSIX), so a reader that interleaves with a rotation sees
+ * either the pre- or post-rotation file but never a mid-state.
+ *
+ * Concurrency: each entry serializes to a few hundred bytes, well under
+ * the POSIX PIPE_BUF (4096 B), so an `appendFileSync(O_APPEND)` is atomic
+ * with respect to other writers in this process and across processes.
+ * Two writers racing on the rotation threshold can both decide to rotate;
+ * the second rename just overwrites the first's `.old`, which is benign
+ * (one extra rotation, not data loss beyond what the cap already implies).
+ *
+ * Files are owner-only (0o600) because summaries can include excerpts of
+ * terminal output (filenames, branch names, sometimes full commands).
+ */
+
+import {
+  mkdirSync, chmodSync, appendFileSync, readFileSync, renameSync,
+  unlinkSync, readdirSync, statSync,
+} from "node:fs";
+import { join } from "node:path";
+import { log } from "./log.js";
+
+const SUMMARIES_SUBDIR = "summaries";
+
+// Per-session size cap. When a file crosses this on append, we rotate
+// it to `.jsonl.old` and start a fresh primary. Two generations means a
+// session keeps roughly 2× this worth of recent history available; older
+// entries age out as new ones land. 256 KB ≈ ~1000 entries at the typical
+// 250 B per record, which is far more "what was I doing" context than any
+// user actually scrolls back through.
+const ROTATE_BYTES = 256 * 1024;
+
+// Hard read ceiling — refuse to slurp anything pathologically large into
+// memory. Two generations × ROTATE_BYTES is the legitimate maximum, plus
+// a slack for the final entry that crossed the threshold.
+const MAX_FILE_BYTES = ROTATE_BYTES * 2;
+
+// Match scrollback-store's id format. Same threat model: a hostile
+// sessions.json or adopted tmux session name must not path-traverse out
+// of the summaries dir.
+const VALID_ID = /^[A-Za-z0-9_-]+$/;
+
+function isValidId(id) {
+  return typeof id === "string" && id.length > 0 && id.length <= 128 && VALID_ID.test(id);
+}
+
+function isValidEntry(e) {
+  return e
+    && typeof e.title === "string"
+    && typeof e.summary === "string"
+    && Number.isFinite(e.at);
+}
+
+/**
+ * Create a summary store bound to a data directory.
+ *
+ * @param {object} opts
+ * @param {string|null} opts.dataDir - Parent dir. If null/empty, the store is
+ *   a no-op (used by tests that don't want disk side effects).
+ * @returns {{
+ *   append: (sessionId: string, entry: { title: string, summary: string, at: number }) => void,
+ *   read: (sessionId: string, opts?: { limit?: number }) => Array<{ title: string, summary: string, at: number }>,
+ *   migrate: (sessionId: string, entries: Array<object>) => void,
+ *   remove: (sessionId: string) => void,
+ *   pruneExcept: (activeIds: Iterable<string>) => void,
+ * }}
+ */
+export function createSummaryStore({ dataDir }) {
+  if (!dataDir) {
+    return {
+      append: () => {},
+      read: () => [],
+      migrate: () => {},
+      remove: () => {},
+      pruneExcept: () => {},
+    };
+  }
+
+  const dir = join(dataDir, SUMMARIES_SUBDIR);
+  try {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try { chmodSync(dir, 0o700); } catch { /* readonly volume etc. */ }
+  } catch (err) {
+    log.warn("Failed to create summaries dir", { dir, error: err.message });
+  }
+
+  function pathFor(sessionId) {
+    return join(dir, `${sessionId}.jsonl`);
+  }
+
+  function oldPathFor(sessionId) {
+    return join(dir, `${sessionId}.jsonl.old`);
+  }
+
+  function rotateIfNeeded(filePath, oldPath) {
+    let size = 0;
+    try { size = statSync(filePath).size; } catch { return; }
+    if (size < ROTATE_BYTES) return;
+    try {
+      renameSync(filePath, oldPath);
+    } catch (err) {
+      log.warn("Failed to rotate summary file", { filePath, error: err.message });
+    }
+  }
+
+  function append(sessionId, entry) {
+    if (!isValidId(sessionId) || !isValidEntry(entry)) return;
+    const filePath = pathFor(sessionId);
+    const line = JSON.stringify({
+      title: entry.title,
+      summary: entry.summary,
+      at: entry.at,
+    }) + "\n";
+    try {
+      appendFileSync(filePath, line, { encoding: "utf-8", mode: 0o600 });
+    } catch (err) {
+      log.warn("Failed to append summary entry", { sessionId, error: err.message });
+      return;
+    }
+    rotateIfNeeded(filePath, oldPathFor(sessionId));
+  }
+
+  function readFile(filePath) {
+    let stat;
+    try { stat = statSync(filePath); } catch { return []; }
+    if (stat.size > MAX_FILE_BYTES) {
+      log.warn("Summary file exceeds size limit, ignoring", {
+        filePath, size: stat.size, limit: MAX_FILE_BYTES,
+      });
+      return [];
+    }
+    let raw;
+    try { raw = readFileSync(filePath, "utf-8"); } catch { return []; }
+    const out = [];
+    // Split on newlines and silently drop unparseable / partial trailing
+    // lines. A crash mid-write may leave one truncated record at the tail;
+    // the rest of the history is still useful, so we don't fail the read.
+    for (const line of raw.split("\n")) {
+      if (!line) continue;
+      try {
+        const e = JSON.parse(line);
+        if (isValidEntry(e)) out.push(e);
+      } catch { /* drop unparseable line */ }
+    }
+    return out;
+  }
+
+  function read(sessionId, { limit } = {}) {
+    if (!isValidId(sessionId)) return [];
+    // Concatenate rotated → primary so the caller sees a continuous
+    // oldest-to-newest stream across the rotation boundary. The .old file
+    // is always older than the primary because rotation is rename.
+    const all = [...readFile(oldPathFor(sessionId)), ...readFile(pathFor(sessionId))];
+    if (Number.isFinite(limit) && limit > 0 && all.length > limit) {
+      return all.slice(all.length - limit);
+    }
+    return all;
+  }
+
+  function migrate(sessionId, entries) {
+    if (!isValidId(sessionId)) return;
+    if (!Array.isArray(entries) || entries.length === 0) return;
+    // Single appendFileSync of the whole batch is faster than N individual
+    // appends and atomically lands as one block — no risk of a half-migrated
+    // session if the process dies mid-loop. Validate per-entry so a single
+    // bad legacy record can't poison the whole batch.
+    const lines = entries
+      .filter(isValidEntry)
+      .map((e) => JSON.stringify({ title: e.title, summary: e.summary, at: e.at }))
+      .join("\n");
+    if (!lines) return;
+    try {
+      appendFileSync(pathFor(sessionId), lines + "\n", { encoding: "utf-8", mode: 0o600 });
+    } catch (err) {
+      log.warn("Failed to migrate summary history", { sessionId, error: err.message });
+      return;
+    }
+    rotateIfNeeded(pathFor(sessionId), oldPathFor(sessionId));
+  }
+
+  function remove(sessionId) {
+    if (!isValidId(sessionId)) return;
+    try { unlinkSync(pathFor(sessionId)); } catch { /* missing is fine */ }
+    try { unlinkSync(oldPathFor(sessionId)); } catch { /* missing is fine */ }
+  }
+
+  function pruneExcept(activeIds) {
+    let entries;
+    try { entries = readdirSync(dir); } catch { return; }
+    const active = new Set(activeIds);
+    for (const entry of entries) {
+      // Strip both possible suffixes to recover the session id.
+      let id = null;
+      if (entry.endsWith(".jsonl")) id = entry.slice(0, -".jsonl".length);
+      else if (entry.endsWith(".jsonl.old")) id = entry.slice(0, -".jsonl.old".length);
+      else continue;
+      if (!isValidId(id)) continue;
+      if (active.has(id)) continue;
+      try { unlinkSync(join(dir, entry)); } catch { /* concurrent unlink */ }
+    }
+  }
+
+  return { append, read, migrate, remove, pruneExcept };
+}

--- a/public/lib/tile-renderers/history.js
+++ b/public/lib/tile-renderers/history.js
@@ -3,11 +3,18 @@
  *
  * Renders the rolling timeline of auto-generated summaries for a
  * terminal session, so the user can answer "what was I doing an hour
- * ago?" at a glance. The summarizer (lib/session-summarizer.js) writes
- * each new distinct summary to `session.meta.summaryHistory`; this
- * tile subscribes to the session store and re-renders on every
- * session-updated broadcast, so new entries land live without
- * per-tile polling.
+ * ago?" at a glance. The summarizer (lib/session-summarizer.js) appends
+ * each new distinct summary to a disk-backed JSONL store; this tile
+ * fetches from `/sessions/by-id/:id/summaries` on mount and re-fetches
+ * on every session-updated broadcast (debounced) so new entries land
+ * live without per-tile polling.
+ *
+ * History used to live in `session.meta.summaryHistory` so the tile
+ * could read it from the in-memory session object directly. That broke
+ * the 4 KB meta cap once history grew past ~12 entries (every other
+ * setMeta — pane, agent — failed and the status pill bar went dark);
+ * the timeline is durable on disk now, and the tile pays a small fetch
+ * on mount + change in exchange for unbounded honest history.
  *
  * Props:
  *   sessionName: string  — the session to describe. Falsy → "pick a
@@ -16,6 +23,7 @@
  */
 
 import { escapeHtml, formatRelativeTime } from "/lib/utils.js";
+import { api, resolveSessionId } from "/lib/api-client.js";
 
 // Module-scoped dep stash; populated by `init()` at renderer-registry
 // boot. Mirrors fileBrowserRenderer / clusterRenderer / terminalRenderer,
@@ -79,6 +87,36 @@ export const historyRenderer = {
 
     let destroyed = false;
     let relTimer = null;
+    let history = [];
+    // Coalesce rapid session-updated bursts (Claude streaming a long
+    // turn fires many of them) into one fetch — the timeline only
+    // changes ~once per 30s summarizer cycle, so 250 ms debounce is
+    // ample and keeps refresh cost off the hot path.
+    let refetchTimer = null;
+
+    async function refetch() {
+      if (destroyed || !sessionName) return;
+      try {
+        const sessionId = await resolveSessionId(sessionName);
+        if (destroyed) return;
+        const data = await api.get(`/sessions/by-id/${encodeURIComponent(sessionId)}/summaries`);
+        if (destroyed) return;
+        history = Array.isArray(data?.summaries) ? data.summaries : [];
+        render();
+      } catch {
+        // Session not found / network blip — keep the previous render
+        // rather than blanking the tile. The next session-updated tick
+        // will retry.
+      }
+    }
+
+    function scheduleRefetch() {
+      if (refetchTimer) return;
+      refetchTimer = setTimeout(() => {
+        refetchTimer = null;
+        refetch();
+      }, 250);
+    }
 
     function render() {
       if (destroyed) return;
@@ -93,9 +131,6 @@ export const historyRenderer = {
       }
 
       const session = findSession(store, sessionName);
-      const history = Array.isArray(session?.meta?.summaryHistory)
-        ? session.meta.summaryHistory
-        : [];
       const currentTitle = session?.meta?.autoTitle
         || session?.meta?.summary?.short
         || sessionName;
@@ -135,13 +170,19 @@ export const historyRenderer = {
       `;
     }
 
+    // Initial render shows the "no history yet" / autoTitle skeleton
+    // immediately while the fetch is in flight; refetch fills it in.
     render();
+    refetch();
 
-    // Subscribe for live updates. Session store broadcasts a full
-    // sessions array on every change, so we just re-render — the cost
-    // is a single innerHTML assignment, negligible next to the live
-    // terminal.
-    const unsubscribe = store?.subscribe ? store.subscribe(render) : null;
+    // Subscribe for live updates. The session store still drives the
+    // current-title header, and a session-updated tick is also our
+    // signal that a new summary may have landed — schedule a debounced
+    // refetch rather than a synchronous re-render.
+    const unsubscribe = store?.subscribe ? store.subscribe(() => {
+      render();
+      scheduleRefetch();
+    }) : null;
 
     // Refresh the relative timestamps once a minute. Cheap: re-render
     // a small DOM subtree; no network, no computation.
@@ -151,6 +192,7 @@ export const historyRenderer = {
       unmount() {
         destroyed = true;
         if (relTimer) { clearInterval(relTimer); relTimer = null; }
+        if (refetchTimer) { clearTimeout(refetchTimer); refetchTimer = null; }
         unsubscribe?.();
         root.remove();
       },

--- a/test/session-summarizer.test.js
+++ b/test/session-summarizer.test.js
@@ -64,26 +64,20 @@ function makeFakeSessionWithCursor({ name, buffer, alive = true, id = `id_${name
   };
 }
 
-// In-memory summaryStore stand-in. The real store writes JSONL to disk;
-// the summarizer only ever calls `append(id, entry)`, so the fake just
-// records calls per session-id for assertions.
-function makeFakeSummaryStore() {
+// In-memory summary timeline stand-in. Real implementation writes JSONL
+// to disk via createSummaryStore; the summarizer only ever calls
+// `appendSummary(id, entry)`, so the fake just records calls per session
+// id for assertions. `readSummaries` round-trips for test inspection.
+function makeFakeManager(sessions) {
+  const byName = new Map(sessions.map((s) => [s.name, s]));
   const byId = new Map();
   return {
-    append(id, entry) {
+    appendSummary(id, entry) {
       const list = byId.get(id) || [];
       list.push(entry);
       byId.set(id, list);
     },
-    read(id) { return byId.get(id) || []; },
-    migrate() {}, remove() {}, pruneExcept() {},
-  };
-}
-
-function makeFakeManager(sessions) {
-  const byName = new Map(sessions.map((s) => [s.name, s]));
-  return {
-    summaryStore: makeFakeSummaryStore(),
+    readSummaries(id) { return byId.get(id) || []; },
     listSessions() {
       return { sessions: [...byName.values()].map((s) => ({ name: s.name, alive: s.alive })) };
     },
@@ -191,7 +185,7 @@ describe("createSessionSummarizer", () => {
     await new Promise((r) => setImmediate(r));
     await new Promise((r) => setImmediate(r));
 
-    let history = mgr.summaryStore.read(session.id);
+    let history = mgr.readSummaries(session.id);
     assert.strictEqual(history.length, 1);
     assert.strictEqual(history[0].title, "Phase A");
     assert.ok(Number.isFinite(history[0].at));
@@ -205,7 +199,7 @@ describe("createSessionSummarizer", () => {
     await new Promise((r) => setImmediate(r));
     await new Promise((r) => setImmediate(r));
 
-    history = mgr.summaryStore.read(session.id);
+    history = mgr.readSummaries(session.id);
     assert.strictEqual(history.length, 2);
     assert.strictEqual(history[1].title, "Phase B");
 
@@ -231,7 +225,7 @@ describe("createSessionSummarizer", () => {
     await s.runOnce();
     await new Promise((r) => setImmediate(r));
 
-    assert.strictEqual(mgr.summaryStore.read(session.id).length, 1);
+    assert.strictEqual(mgr.readSummaries(session.id).length, 1);
     s.stop();
   });
 
@@ -251,7 +245,7 @@ describe("createSessionSummarizer", () => {
     await new Promise((r) => setImmediate(r));
 
     assert.ok(session.meta.summary, "current summary should still be written");
-    assert.strictEqual(mgr.summaryStore.read(null).length, 0);
+    assert.strictEqual(mgr.readSummaries(null).length, 0);
     s.stop();
   });
 

--- a/test/session-summarizer.test.js
+++ b/test/session-summarizer.test.js
@@ -15,10 +15,11 @@ import {
   parseSummaryResponse,
 } from "../lib/session-summarizer.js";
 
-function makeFakeSession({ name, buffer, alive = true }) {
+function makeFakeSession({ name, buffer, alive = true, id = `id_${name}` }) {
   const meta = {};
   return {
     name,
+    id,
     alive,
     meta,
     pullTail(maxBytes) {
@@ -36,12 +37,13 @@ function makeFakeSession({ name, buffer, alive = true }) {
 // activity- and volume-gate paths in the summarizer are exercised.
 // `appendBytes` simulates new PTY output: it grows the buffer (so
 // pullTail returns updated content) and advances the cursor.
-function makeFakeSessionWithCursor({ name, buffer, alive = true }) {
+function makeFakeSessionWithCursor({ name, buffer, alive = true, id = `id_${name}` }) {
   const meta = {};
   let _buffer = buffer;
   let _cursor = buffer.length;
   return {
     name,
+    id,
     alive,
     meta,
     get cursor() {
@@ -62,9 +64,26 @@ function makeFakeSessionWithCursor({ name, buffer, alive = true }) {
   };
 }
 
+// In-memory summaryStore stand-in. The real store writes JSONL to disk;
+// the summarizer only ever calls `append(id, entry)`, so the fake just
+// records calls per session-id for assertions.
+function makeFakeSummaryStore() {
+  const byId = new Map();
+  return {
+    append(id, entry) {
+      const list = byId.get(id) || [];
+      list.push(entry);
+      byId.set(id, list);
+    },
+    read(id) { return byId.get(id) || []; },
+    migrate() {}, remove() {}, pruneExcept() {},
+  };
+}
+
 function makeFakeManager(sessions) {
   const byName = new Map(sessions.map((s) => [s.name, s]));
   return {
+    summaryStore: makeFakeSummaryStore(),
     listSessions() {
       return { sessions: [...byName.values()].map((s) => ({ name: s.name, alive: s.alive })) };
     },
@@ -151,7 +170,7 @@ describe("createSessionSummarizer", () => {
     s.stop();
   });
 
-  it("appends each distinct summary to meta.summaryHistory", async () => {
+  it("appends each distinct summary to the disk-backed summary store", async () => {
     const session = makeFakeSession({
       name: "kat_hist",
       buffer: "first buffer content\n".repeat(30),
@@ -172,10 +191,13 @@ describe("createSessionSummarizer", () => {
     await new Promise((r) => setImmediate(r));
     await new Promise((r) => setImmediate(r));
 
-    assert.ok(Array.isArray(session.meta.summaryHistory));
-    assert.strictEqual(session.meta.summaryHistory.length, 1);
-    assert.strictEqual(session.meta.summaryHistory[0].title, "Phase A");
-    assert.ok(Number.isFinite(session.meta.summaryHistory[0].at));
+    let history = mgr.summaryStore.read(session.id);
+    assert.strictEqual(history.length, 1);
+    assert.strictEqual(history[0].title, "Phase A");
+    assert.ok(Number.isFinite(history[0].at));
+    // History must NOT live in meta — it pressured the 4 KB cap and broke
+    // every other setMeta. This assertion is the regression guard.
+    assert.strictEqual(session.meta.summaryHistory, undefined);
 
     // Mutate the window so the hash changes, then second cycle → Phase B appended.
     session.pullTail = (n) => ({ data: ("second content\n".repeat(50)).slice(-n), cursor: 0 });
@@ -183,8 +205,9 @@ describe("createSessionSummarizer", () => {
     await new Promise((r) => setImmediate(r));
     await new Promise((r) => setImmediate(r));
 
-    assert.strictEqual(session.meta.summaryHistory.length, 2);
-    assert.strictEqual(session.meta.summaryHistory[1].title, "Phase B");
+    history = mgr.summaryStore.read(session.id);
+    assert.strictEqual(history.length, 2);
+    assert.strictEqual(history[1].title, "Phase B");
 
     s.stop();
   });
@@ -197,8 +220,8 @@ describe("createSessionSummarizer", () => {
     const mgr = makeFakeManager([session]);
     // Ollama returns identical content both times. Hash-dedup should
     // skip the second call entirely, but even if a future change makes
-    // it call again, duplicate-guard in summaryHistory must prevent
-    // duplicate entries.
+    // it call again, the in-memory dedupe key (st.lastEntry) must
+    // prevent duplicate appends to the store.
     const callOllama = okOllama('{"title":"Same","summary":"Same summary."}');
 
     const s = createSessionSummarizer({ sessionManager: mgr, callOllama, minContentChars: 100 });
@@ -208,34 +231,27 @@ describe("createSessionSummarizer", () => {
     await s.runOnce();
     await new Promise((r) => setImmediate(r));
 
-    assert.strictEqual(session.meta.summaryHistory.length, 1);
+    assert.strictEqual(mgr.summaryStore.read(session.id).length, 1);
     s.stop();
   });
 
-  it("caps meta.summaryHistory at MAX_HISTORY_ENTRIES (ring behaviour)", async () => {
-    const session = makeFakeSession({
-      name: "kat_cap",
-      buffer: "seed content\n".repeat(30),
-    });
+  it("does not append history for a session without a stable id", async () => {
+    // Edge case: an in-memory-only session (no surrogate id assigned)
+    // can't be keyed against the disk store. The summarizer still writes
+    // meta.summary / meta.autoTitle (those are name-keyed, ephemeral)
+    // but skips the store append rather than persisting under an
+    // unstable key.
+    const session = makeFakeSession({ name: "kat_no_id", buffer: "x\n".repeat(60), id: null });
     const mgr = makeFakeManager([session]);
+    const callOllama = okOllama('{"title":"Anywhere","summary":"Anywhere doing anything."}');
 
-    // Pre-seed history near the cap so the test doesn't need 40+ cycles.
-    const seed = [];
-    for (let i = 0; i < 40; i += 1) {
-      seed.push({ title: `old ${i}`, summary: `s ${i}`, at: i });
-    }
-    session.meta.summaryHistory = seed;
-
-    const callOllama = okOllama('{"title":"Fresh","summary":"Fresh summary."}');
     const s = createSessionSummarizer({ sessionManager: mgr, callOllama, minContentChars: 100 });
     await s.runOnce();
     await new Promise((r) => setImmediate(r));
     await new Promise((r) => setImmediate(r));
 
-    assert.strictEqual(session.meta.summaryHistory.length, 40);
-    // Oldest pushed out, newest landed at the tail.
-    assert.strictEqual(session.meta.summaryHistory[0].title, "old 1");
-    assert.strictEqual(session.meta.summaryHistory[39].title, "Fresh");
+    assert.ok(session.meta.summary, "current summary should still be written");
+    assert.strictEqual(mgr.summaryStore.read(null).length, 0);
     s.stop();
   });
 

--- a/test/session-summary-store.test.js
+++ b/test/session-summary-store.test.js
@@ -1,0 +1,203 @@
+/**
+ * Session Summary Store Tests
+ *
+ * Append-only JSONL persistence for `{ title, summary, at }` records,
+ * with bytes-based rotation to a `.jsonl.old` generation. Covers:
+ * round-trip, validation, rotation, migration, prune, malformed input.
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { createSummaryStore } from "../lib/session-summary-store.js";
+
+let dataDir;
+let store;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "kat-summary-"));
+  store = createSummaryStore({ dataDir });
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+const entry = (title, summary, at) => ({ title, summary, at });
+
+describe("session summary store", () => {
+  describe("append / read round trip", () => {
+    it("appends one record and reads it back", () => {
+      store.append("sid_a", entry("Build feature", "Wrote the JSONL store", 100));
+      assert.deepStrictEqual(store.read("sid_a"), [
+        { title: "Build feature", summary: "Wrote the JSONL store", at: 100 },
+      ]);
+    });
+
+    it("preserves order across multiple appends", () => {
+      store.append("sid_a", entry("first", "1", 100));
+      store.append("sid_a", entry("second", "2", 200));
+      store.append("sid_a", entry("third", "3", 300));
+      const got = store.read("sid_a");
+      assert.deepStrictEqual(got.map((e) => e.title), ["first", "second", "third"]);
+    });
+
+    it("returns an empty array for a session with no file", () => {
+      assert.deepStrictEqual(store.read("never_written"), []);
+    });
+
+    it("respects the limit option and returns the most recent N", () => {
+      for (let i = 0; i < 50; i++) store.append("sid_a", entry(`t${i}`, `s${i}`, i));
+      const got = store.read("sid_a", { limit: 5 });
+      assert.deepStrictEqual(got.map((e) => e.title), ["t45", "t46", "t47", "t48", "t49"]);
+    });
+  });
+
+  describe("entry validation", () => {
+    it("ignores entries missing required fields", () => {
+      store.append("sid_a", { title: "no summary", at: 1 });
+      store.append("sid_a", { summary: "no title", at: 1 });
+      store.append("sid_a", { title: "no at", summary: "x" });
+      store.append("sid_a", null);
+      assert.deepStrictEqual(store.read("sid_a"), []);
+    });
+
+    it("ignores entries when fields have wrong types", () => {
+      store.append("sid_a", { title: 7, summary: "x", at: 1 });
+      store.append("sid_a", { title: "x", summary: 7, at: 1 });
+      store.append("sid_a", { title: "x", summary: "y", at: "not a number" });
+      assert.deepStrictEqual(store.read("sid_a"), []);
+    });
+  });
+
+  describe("id validation", () => {
+    it("rejects path-traversal attempts in session id", () => {
+      store.append("../etc/passwd", entry("title", "sum", 1));
+      // Nothing should have been written under the data dir; read returns [].
+      assert.deepStrictEqual(store.read("../etc/passwd"), []);
+    });
+
+    it("rejects ids with characters outside [A-Za-z0-9_-]", () => {
+      store.append("bad id", entry("t", "s", 1));
+      store.append("bad/id", entry("t", "s", 1));
+      assert.deepStrictEqual(store.read("bad id"), []);
+      assert.deepStrictEqual(store.read("bad/id"), []);
+    });
+  });
+
+  describe("rotation", () => {
+    it("rotates the primary file to .jsonl.old once it crosses the byte cap", () => {
+      // Each entry is ~250 bytes; 2000 entries comfortably exceeds the
+      // 256 KB rotation threshold, forcing at least one rotation.
+      const longSummary = "x".repeat(220);
+      for (let i = 0; i < 2000; i++) store.append("sid_a", entry(`t${i}`, longSummary, i));
+
+      const primary = join(dataDir, "summaries", "sid_a.jsonl");
+      const rotated = join(dataDir, "summaries", "sid_a.jsonl.old");
+      assert.ok(existsSync(primary), "primary file should exist after rotation");
+      assert.ok(existsSync(rotated), "rotated .old file should exist");
+
+      // Read returns oldest-rotated → newest-primary as a continuous stream.
+      const all = store.read("sid_a");
+      assert.strictEqual(all.length, 2000);
+      assert.strictEqual(all[0].title, "t0");
+      assert.strictEqual(all[all.length - 1].title, "t1999");
+    });
+  });
+
+  describe("migrate", () => {
+    it("appends a batch in one write and is a no-op for empty arrays", () => {
+      const batch = [entry("a", "1", 1), entry("b", "2", 2), entry("c", "3", 3)];
+      store.migrate("sid_a", batch);
+      assert.deepStrictEqual(store.read("sid_a").map((e) => e.title), ["a", "b", "c"]);
+
+      store.migrate("sid_a", []);
+      store.migrate("sid_b", null);
+      assert.deepStrictEqual(store.read("sid_a").length, 3);
+      assert.deepStrictEqual(store.read("sid_b"), []);
+    });
+
+    it("filters invalid entries out of the batch", () => {
+      const batch = [
+        entry("ok", "yes", 1),
+        { title: "bad", summary: 42, at: 2 },
+        entry("ok2", "yes", 3),
+      ];
+      store.migrate("sid_a", batch);
+      assert.deepStrictEqual(store.read("sid_a").map((e) => e.title), ["ok", "ok2"]);
+    });
+
+    it("appends migrated entries before any subsequent live appends", () => {
+      store.migrate("sid_a", [entry("legacy", "old", 1)]);
+      store.append("sid_a", entry("fresh", "new", 2));
+      assert.deepStrictEqual(store.read("sid_a").map((e) => e.title), ["legacy", "fresh"]);
+    });
+  });
+
+  describe("read tolerance", () => {
+    it("drops a partial trailing line written by a crashed appender", () => {
+      const filePath = join(dataDir, "summaries", "sid_a.jsonl");
+      // First a valid record, then a truncated-mid-line second one.
+      const valid = JSON.stringify(entry("ok", "complete", 1)) + "\n";
+      const partial = "{\"title\":\"truncated\""; // no closing brace, no newline
+      writeFileSync(filePath, valid + partial, { mode: 0o600 });
+
+      assert.deepStrictEqual(store.read("sid_a").map((e) => e.title), ["ok"]);
+    });
+  });
+
+  describe("remove and prune", () => {
+    it("removes both primary and rotated files for a session", () => {
+      const longSummary = "x".repeat(220);
+      for (let i = 0; i < 2000; i++) store.append("sid_a", entry(`t${i}`, longSummary, i));
+      const primary = join(dataDir, "summaries", "sid_a.jsonl");
+      const rotated = join(dataDir, "summaries", "sid_a.jsonl.old");
+      assert.ok(existsSync(primary) && existsSync(rotated));
+
+      store.remove("sid_a");
+      assert.ok(!existsSync(primary), "primary should be gone after remove");
+      assert.ok(!existsSync(rotated), "rotated should be gone after remove");
+    });
+
+    it("pruneExcept deletes files for ids not in the active set", () => {
+      store.append("sid_a", entry("a", "1", 1));
+      store.append("sid_b", entry("b", "2", 2));
+      store.append("sid_c", entry("c", "3", 3));
+
+      store.pruneExcept(["sid_b"]);
+
+      assert.deepStrictEqual(store.read("sid_a"), []);
+      assert.deepStrictEqual(store.read("sid_b").map((e) => e.title), ["b"]);
+      assert.deepStrictEqual(store.read("sid_c"), []);
+    });
+
+    it("pruneExcept ignores files that are not summary files", () => {
+      writeFileSync(join(dataDir, "summaries", "README"), "not ours\n", { mode: 0o600 });
+      store.append("sid_a", entry("a", "1", 1));
+      store.pruneExcept([]); // no active sessions
+      assert.ok(existsSync(join(dataDir, "summaries", "README")), "non-summary file should be left alone");
+    });
+  });
+
+  describe("file permissions", () => {
+    it("creates files with mode 0o600 (owner-only)", () => {
+      store.append("sid_a", entry("a", "1", 1));
+      const mode = statSync(join(dataDir, "summaries", "sid_a.jsonl")).mode & 0o777;
+      assert.strictEqual(mode, 0o600);
+    });
+  });
+
+  describe("no-op store", () => {
+    it("returns a working but inert store when dataDir is null", () => {
+      const noop = createSummaryStore({ dataDir: null });
+      noop.append("sid_a", entry("a", "1", 1));
+      assert.deepStrictEqual(noop.read("sid_a"), []);
+      noop.migrate("sid_a", [entry("a", "1", 1)]);
+      noop.remove("sid_a");
+      noop.pruneExcept(["sid_a"]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Move per-session `summaryHistory` out of `meta` and into an append-only JSONL store at `~/.katulong/summaries/<sessionId>.jsonl` (with bytes-based rotation to a `.jsonl.old` generation at 256 KB).
- Fixes the regression where the status pill bar went dark on long-lived sessions: once `meta.summaryHistory` crossed ~12 entries the 4 KB `MAX_META_BYTES` cap was breached, and every subsequent `setMeta` call (pane monitor, agent flips, claude enrichment) threw — silently caught and logged. 333× cap-exceeded warnings on a single host before this fix.
- New `GET /sessions/by-id/:id/summaries?limit=N` endpoint reads on demand. History tile re-renders from this fetch on mount and on every session-updated tick (debounced 250 ms).
- One-shot migration on Session restore: legacy `meta.summaryHistory` entries are appended to the JSONL and the meta key is dropped, so existing sessions get their pills back without manual intervention.

## Why this shape (and not just bumping `MAX_META_BYTES`)

The 4 KB cap exists to keep meta cheap on every WS broadcast and persistence write. History is unbounded-by-usefulness, append-only, and survives restarts — wrong shape for an in-memory budget. JSONL with one `appendFileSync` per cycle has no read-modify-write window, is naturally durable to mid-write crash (worst case: one truncated trailing line that the parser drops), and rotates atomically (`rename` is POSIX-atomic).

## Files

- `lib/session-summary-store.js` (new) — store with `append`, `read`, `migrate`, `remove`, `pruneExcept`. Owner-only (0o600). Same id-validation regex as `scrollback-store.js`.
- `lib/session-summarizer.js` — writes via `summaryStore.append(live.id, entry)` instead of `setMeta("summaryHistory", ...)`. Dedupe key cached in per-session in-memory state.
- `lib/session-manager.js` — owns the store; migration in restore path; prune in `pruneExcept`; remove on hard-delete.
- `lib/routes/app-routes.js` — `GET /sessions/by-id/:id/summaries?limit=N` (limit clamped 1-1000).
- `public/lib/tile-renderers/history.js` — fetches from new endpoint instead of reading `session.meta.summaryHistory`.
- `test/session-summary-store.js` (new, 18 tests) + `test/session-summarizer.test.js` (3 affected tests rewired to fake store; regression assertion that `meta.summaryHistory` stays undefined after a successful append).

## Test plan

- [x] `node --test test/session-summary-store.test.js` — 18/18
- [x] `node --test test/session-summarizer.test.js` — 22/22
- [x] Pre-push hook (full unit + integration + smoke E2E + parallel reviewers) — passed
- [ ] After deploy: confirm `~/.katulong/launchd-stderr.log` stops emitting `setMeta: serialized meta exceeds 4096B cap`
- [ ] Confirm `meta.pane` populates on existing long-lived sessions (status pills return)
- [ ] Open the history tile on a restored session and verify entries are present (migration ran)