### PR TITLE
docs(session-meta): document the meta-stays-small rule

### DIFF
--- a/lib/session-meta-filter.js
+++ b/lib/session-meta-filter.js
@@ -15,6 +15,17 @@
  * Kept in its own module so both `session-manager.js` (WS `session-updated`
  * push) and `routes/app-routes.js` (REST responses) can share the filter
  * without one importing from the other.
+ *
+ * **Meta is for small ephemeral state, not for histories or logs.** The
+ * whole bucket gets serialized and broadcast on every `session-updated`
+ * tick, so every byte costs WS bandwidth × all subscribers × every
+ * mutation. The 4 KB cap in `Session.setMeta` enforces this. Anything
+ * that grows over time (summary history, scrollback, transcripts) goes
+ * to a disk-backed store — see `lib/session-summary-store.js` and
+ * `lib/scrollback-store.js`. Crossing the cap doesn't just fail the one
+ * write; it fails every other meta writer (pane monitor, agent flips,
+ * claude enrichment) too, because they all share the same bucket. PR
+ * #708 has the full diagnosis of what that looked like in production.
  */
 
 export const PRIVATE_META_KEYS = new Set(["transcriptPath"]);

--- a/lib/session.js
+++ b/lib/session.js
@@ -731,6 +731,14 @@ export class Session {
    * Throws RangeError if the serialized bucket would exceed MAX_META_BYTES —
    * this is an internal contract, not an HTTP error.
    *
+   * **What belongs in meta:** small, ephemeral, broadcast-on-every-tick
+   * metadata — current title, agent presence flag, pane cwd/branch. Anything
+   * append-only or unbounded (history, logs, transcripts) belongs in a
+   * disk-backed store. See `lib/session-summary-store.js` and
+   * `lib/scrollback-store.js` for the pattern. The 4 KB cap is the guardrail:
+   * cross it and every other meta writer (pane monitor, agent flips, claude
+   * enrichment) starts throwing too — see PR #708 for the cautionary tale.
+   *
    * @param {string} namespace - non-empty string, e.g. "claude"
    * @param {*} value - JSON-serializable value, or null/undefined to remove
    */
@@ -746,7 +754,12 @@ export class Session {
     }
     const bytes = Buffer.byteLength(JSON.stringify(next), "utf8");
     if (bytes > MAX_META_BYTES) {
-      throw new RangeError(`setMeta: serialized meta (${bytes}B) exceeds ${MAX_META_BYTES}B cap`);
+      throw new RangeError(
+        `setMeta('${namespace}'): meta is for small ephemeral state ` +
+        `(serialized ${bytes}B exceeds ${MAX_META_BYTES}B cap). Move growing ` +
+        `or large data to a disk-backed store — see lib/session-summary-store.js ` +
+        `or lib/scrollback-store.js for the pattern.`
+      );
     }
     this.meta = next;
     if (this._onChange) {


### PR DESCRIPTION
## Summary

Make the rule that PR #708 implicitly enforced (meta is for small ephemeral state; growing data goes to disk) explicit in the code, so the next contributor doesn't have to re-learn it from a production incident.

Three small, doc-only edits — no behavior change:

- **`Session.setMeta` jsdoc** — spell out what meta is for, point at `session-summary-store.js` / `scrollback-store.js` as the disk-backed pattern, cite PR #708.
- **`session-meta-filter.js` top doc** — explain *why* the cap matters (every byte costs WS bandwidth × subscribers × mutations), so a future reviewer doesn't bump `MAX_META_BYTES` as the "fix" the next time someone hits it.
- **Sharper `RangeError` message** — name the namespace, name the lesson, point at the alternatives. The old message named the symptom but not the lesson, and the 333 cap-exceeded warnings sat in stderr for weeks before anyone noticed.

## Why not a structural refactor?

PR #708 already moved the offending consumer out of meta. The runtime cap is the guardrail; the regression test it added (`assert.strictEqual(session.meta.summaryHistory, undefined)` in `test/session-summarizer.test.js`) fails fast if a future change re-introduces the pattern. This PR is just making sure the next contributor reads the lesson before writing the next cap-busting consumer, not building scaffolding to enforce it mechanically.

## Test plan

- [x] `node --test test/session.test.js` — 135/135 pass (the existing `throws RangeError` test doesn't pin the message, so it's backwards-compatible)
- [x] `node --test test/session-summarizer.test.js test/app-routes-meta.test.js test/claude-session-discovery.test.js` — all green