### PR TITLE
fix(tmux): printable separator in format strings — fixes dark chip bar on Apple Silicon

### DIFF
--- a/lib/session-child-counter.js
+++ b/lib/session-child-counter.js
@@ -50,12 +50,22 @@ export { isClaudeCommand };
  * process like Claude holds the pane — callers that need Claude's
  * working directory should prefer `meta.claude.cwd` when available.
  *
- * Fields are tab-separated in the format string so paths containing
- * spaces parse cleanly without ambiguity against the command name.
+ * Fields are separated by `|@|` — a printable multi-char sentinel chosen
+ * because tmux on Apple Silicon Homebrew (3.6a) silently rewrites the C0
+ * control characters in format strings (tab `\t` becomes `_`), turning
+ * `#{pane_pid}\t#{cmd}\t#{cwd}` into a single un-splittable blob and
+ * making every monitor tick fall through to the all-null early-exit
+ * silently. The same tmux 3.6a build on Intel preserves the tab, which
+ * is why the chip bar worked on some hosts and not others. `|@|` stays
+ * inside the printable ASCII range (0x20–0x7E) and is vanishingly
+ * unlikely to appear inside a pid (digits only), command name, or
+ * absolute path. See PR #710 for the full diagnosis.
  *
  * @param {string} tmuxName
  * @returns {Promise<{ childCount: number, currentCommand: string | null, panePid: number | null, paneCwd: string | null }>}
  */
+const FIELD_SEP = "|@|";
+
 export function inspectTmuxPane(tmuxName) {
   return new Promise((resolve) => {
     execFile(
@@ -63,7 +73,7 @@ export function inspectTmuxPane(tmuxName) {
       [
         ...tmuxSocketArgs(),
         "list-panes", "-t", tmuxName,
-        "-F", "#{pane_pid}\t#{pane_current_command}\t#{pane_current_path}",
+        "-F", `#{pane_pid}${FIELD_SEP}#{pane_current_command}${FIELD_SEP}#{pane_current_path}`,
       ],
       { timeout: 5000 },
       (err, stdout) => {
@@ -72,7 +82,7 @@ export function inspectTmuxPane(tmuxName) {
         // always have exactly one pane. An externally-adopted multi-pane
         // session still resolves to the first pane's foreground.
         const firstLine = stdout.trim().split("\n")[0];
-        const parts = firstLine.split("\t");
+        const parts = firstLine.split(FIELD_SEP);
         const panePidStr = parts[0] || "";
         const currentCommand = (parts[1] || "").trim() || null;
         const paneCwd = (parts[2] || "").trim() || null;

--- a/lib/tmux.js
+++ b/lib/tmux.js
@@ -410,17 +410,24 @@ export async function tmuxListSessions() {
 
 /**
  * List tmux sessions that have non-control-mode clients attached.
+ *
+ * Field separator is `|@|` (printable multi-char sentinel), not `\t`,
+ * because tmux on Apple Silicon Homebrew (3.6a) silently rewrites C0
+ * control characters in format strings — tab becomes `_` — making
+ * tab-separated fields un-splittable. See `inspectTmuxPane` in
+ * lib/session-child-counter.js for the full diagnosis (PR #710).
+ *
  * @returns {Promise<Set<string>>} Set of session names with external clients (e.g. SSH, terminal)
  */
 export async function tmuxListSessionsDetailed() {
   // Get all clients with their session + flags
   const { code, stdout } = await tmuxExec([
-    "list-clients", "-F", "#{client_session}\t#{client_flags}"
+    "list-clients", "-F", "#{client_session}|@|#{client_flags}"
   ]);
   const externalSessions = new Set();
   if (code === 0 && stdout.trim()) {
     for (const line of stdout.trim().split("\n")) {
-      const [session, flags] = line.split("\t");
+      const [session, flags] = line.split("|@|");
       if (session && flags && !flags.includes("control-mode")) {
         externalSessions.add(session);
       }

--- a/test/inspect-tmux-pane.test.js
+++ b/test/inspect-tmux-pane.test.js
@@ -1,0 +1,105 @@
+/**
+ * Tests for inspectTmuxPane — the function that drives the chip bar.
+ *
+ * Why this test exists: in May 2026 the chip bar quietly broke on every
+ * Apple Silicon host (mini, mac2024 in the user's mesh) for weeks. Root
+ * cause: the format string used `\t` as the field separator, but tmux
+ * 3.6a built against the Apple Silicon Homebrew toolchain silently
+ * rewrites C0 control characters in format strings (tab → `_`), turning
+ * `82724\t2.1.123\t/path` into `82724_2.1.123_/path`. The split fails,
+ * the pid regex check fails, the function falls through to the
+ * all-nulls early-exit silently. The same tmux 3.6a on Intel preserves
+ * the tab, so the fix worked on some hosts and not others — perfect
+ * recipe for "works on my machine."
+ *
+ * The lasting fix is to use a printable multi-char sentinel (`|@|`)
+ * that's vanishingly unlikely to appear inside a pid (digits only),
+ * command name, or absolute path. This test pins both halves of that
+ * contract:
+ *   1. The format string passed to tmux uses `|@|`, not `\t`.
+ *   2. The parser splits on `|@|` and produces correct fields.
+ *
+ * Future-proofing: if anyone changes the separator back to `\t` (or any
+ * non-printable byte that some tmux build might strip), this test
+ * fails. The commit message of PR #710 has the full diagnosis.
+ */
+
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+
+const execCalls = [];
+let execResponses = [];
+
+mock.module("node:child_process", {
+  namedExports: {
+    execFile: (cmd, args, opts, cb) => {
+      if (typeof opts === "function") cb = opts;
+      execCalls.push({ cmd, args: [...args] });
+      const response = execResponses.shift() || { err: null, stdout: "", stderr: "" };
+      if (cb) cb(response.err, response.stdout, response.stderr);
+    },
+  },
+});
+
+const { inspectTmuxPane } = await import("../lib/session-child-counter.js");
+
+describe("inspectTmuxPane field separator", () => {
+  beforeEach(() => {
+    execCalls.length = 0;
+    execResponses = [];
+  });
+
+  it("uses a printable multi-char sentinel, not a C0 control char", async () => {
+    // Simulate tmux returning nothing — we only care about the args this round.
+    execResponses = [{ err: null, stdout: "" }];
+    await inspectTmuxPane("kat_test");
+
+    const tmuxCall = execCalls.find((c) => c.cmd === "tmux");
+    assert.ok(tmuxCall, "expected an execFile('tmux', ...) call");
+
+    const formatArg = tmuxCall.args[tmuxCall.args.indexOf("-F") + 1];
+    assert.ok(formatArg, "expected -F format argument");
+
+    // The actual contract: every byte of the separator must be printable
+    // ASCII (0x20–0x7E). Tabs, newlines, and other C0 controls are
+    // rewritten by some tmux builds (see file header). This rule
+    // catches ANY future regression to a stripped byte, not just a
+    // revert to `\t`.
+    const sep = formatArg.replace(/#\{[^}]+\}/g, "");
+    for (let i = 0; i < sep.length; i++) {
+      const code = sep.charCodeAt(i);
+      assert.ok(
+        code >= 0x20 && code <= 0x7E,
+        `format-string separator byte 0x${code.toString(16)} at index ${i} ` +
+        `is outside printable ASCII (0x20–0x7E). Some tmux builds rewrite ` +
+        `non-printable bytes (notably \\t → _) in format strings, which ` +
+        `silently breaks parsing. See PR #710.`
+      );
+    }
+  });
+
+  it("parses tmux output split by the same sentinel", async () => {
+    // Drive the function with a real-shaped tmux response using the
+    // `|@|` sentinel. If anyone changes the format string but forgets
+    // to update the split, this catches it.
+    execResponses = [
+      { err: null, stdout: "12345|@|claude|@|/Users/me/proj\n" },
+      { err: null, stdout: "" }, // pgrep returns no children
+    ];
+    const result = await inspectTmuxPane("kat_test");
+
+    assert.equal(result.panePid, 12345);
+    assert.equal(result.currentCommand, "claude");
+    assert.equal(result.paneCwd, "/Users/me/proj");
+    assert.equal(result.childCount, 0);
+  });
+
+  it("returns all nulls when tmux fails", async () => {
+    execResponses = [{ err: new Error("tmux not found"), stdout: "" }];
+    const result = await inspectTmuxPane("kat_test");
+    assert.equal(result.panePid, null);
+    assert.equal(result.currentCommand, null);
+    assert.equal(result.paneCwd, null);
+    assert.equal(result.childCount, 0);
+  });
+});


### PR DESCRIPTION
## Summary

The bottom chip bar (cwd / git branch / agent) has been quietly dark on every Apple Silicon host in the mesh for weeks, while working fine on Intel hosts. Same release, same code, same `tmux 3.6a` reported by `tmux -V`.

Root cause: `inspectTmuxPane` and `tmuxListSessionsDetailed` use `\t` (0x09) as the field separator in tmux format strings. The Apple Silicon Homebrew build of tmux 3.6a silently rewrites C0 control characters in format-string output to `_` (0x5F) — verified at byte level. The Intel build doesn't. Resulting blob fails the pid regex check, the function returns all nulls, the monitor's reconcilers see `paneCwd: null` and skip writing meta, the chip bar renders nothing.

End-to-end verified: with the patched module deployed against mini's live tmux, `inspectTmuxPane` now returns valid data instead of all-nulls.

## What changed

- `lib/session-child-counter.js#inspectTmuxPane` — separator `\t` → `|@|`
- `lib/tmux.js#tmuxListSessionsDetailed` — same fix (would have bitten the moment anyone attached an external tmux client on an Apple Silicon host)
- `test/inspect-tmux-pane.test.js` (new) — pins the contract: the format-string separator must be printable ASCII (0x20–0x7E), not just specifically not-tab. Catches any future revert to a stripped byte.

There were *zero* existing tests for `inspectTmuxPane` before this PR — combined with the silent error swallowing, that's why this regression went undetected for weeks.

## Test plan

- [x] `npm run test:unit` — 2848/2851 (3 pre-existing skips), no new failures
- [x] New regression test passes (3 new assertions)
- [x] End-to-end verified against mini's live tmux: `{childCount:1, currentCommand:"2.1.123", panePid:82724, paneCwd:"/Users/felixflores/Projects/nerdnest/levee"}` (was all-nulls before)