### PR TITLE
cutover(server): phase 0b — Node-frontend WS wire compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,17 +57,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,36 +72,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "attribute-derive"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1ee502851995027b06f99f5ffbeffa1406b38d0b318a1ebfa469332c6cbafd"
-dependencies = [
- "attribute-derive-macro",
- "derive-where",
- "manyhow",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "attribute-derive-macro"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3601467f634cfe36c4780ca9c75dea9a5b34529c1f2810676a337e7e0997f954"
-dependencies = [
- "collection_literals",
- "interpolator",
- "manyhow",
- "proc-macro-utils 0.8.0",
- "proc-macro2",
- "quote",
- "quote-use",
- "syn",
-]
 
 [[package]]
 name = "autocfg"
@@ -241,12 +200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-
-[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,33 +216,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,65 +223,6 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
-]
-
-[[package]]
-name = "collection_literals"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
-
-[[package]]
-name = "config"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
-dependencies = [
- "convert_case",
- "nom",
- "pathdiff",
- "serde",
- "toml",
-]
-
-[[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "const_format"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
-dependencies = [
- "const_format_proc_macros",
- "konst",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -381,19 +248,6 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -426,17 +280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-where"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,18 +300,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "drain_filter_polyfill"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -536,7 +367,6 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -560,32 +390,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -608,7 +416,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -633,10 +440,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -665,40 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-net"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils",
- "http",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,12 +479,6 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -749,15 +514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "html-escape"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
-dependencies = [
- "utf8-width",
 ]
 
 [[package]]
@@ -977,30 +733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interpolator"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
-
-[[package]]
-name = "inventory"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,8 +744,6 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1044,13 +774,11 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
- "ciborium",
  "futures",
  "http-body-util",
  "katulong-auth",
  "katulong-shared",
  "serde",
- "serde_bytes",
  "serde_json",
  "subtle",
  "tempfile",
@@ -1066,46 +794,10 @@ dependencies = [
 name = "katulong-shared"
 version = "0.1.0"
 dependencies = [
- "ciborium",
  "serde",
- "serde_bytes",
  "serde_json",
  "webauthn-rs-proto",
 ]
-
-[[package]]
-name = "katulong-web"
-version = "0.1.0"
-dependencies = [
- "ciborium",
- "console_error_panic_hook",
- "futures-channel",
- "futures-util",
- "gloo-net",
- "js-sys",
- "katulong-shared",
- "leptos",
- "serde",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webauthn-rs-proto",
-]
-
-[[package]]
-name = "konst"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
-dependencies = [
- "konst_macro_rules",
-]
-
-[[package]]
-name = "konst_macro_rules"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -1118,153 +810,6 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
-name = "leptos"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbb3237c274dadf00dcc27db96c52601b40375117178fb24a991cda073624f0"
-dependencies = [
- "cfg-if",
- "leptos_config",
- "leptos_dom",
- "leptos_macro",
- "leptos_reactive",
- "leptos_server",
- "server_fn",
- "tracing",
- "typed-builder",
- "typed-builder-macro",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "leptos_config"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ed778611380ddea47568ac6ad6ec5158d39b5bd59e6c4dcd24efc15dc3dc0d"
-dependencies = [
- "config",
- "regex",
- "serde",
- "thiserror",
- "typed-builder",
-]
-
-[[package]]
-name = "leptos_dom"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8401c46c86c1f4c16dcb7881ed319fcdca9cda9b9e78a6088955cb423afcf119"
-dependencies = [
- "async-recursion",
- "cfg-if",
- "drain_filter_polyfill",
- "futures",
- "getrandom 0.2.17",
- "html-escape",
- "indexmap",
- "itertools",
- "js-sys",
- "leptos_reactive",
- "once_cell",
- "pad-adapter",
- "paste",
- "rustc-hash",
- "serde",
- "serde_json",
- "server_fn",
- "smallvec",
- "tracing",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "leptos_hot_reload"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb53d4794240b684a2f4be224b84bee9e62d2abc498cf2bcd643cd565e01d96"
-dependencies = [
- "anyhow",
- "camino",
- "indexmap",
- "parking_lot",
- "proc-macro2",
- "quote",
- "rstml",
- "serde",
- "syn",
- "walkdir",
-]
-
-[[package]]
-name = "leptos_macro"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b13bc3db70715cd8218c4535a5af3ae3c0e5fea6f018531fc339377b36bc0e0"
-dependencies = [
- "attribute-derive",
- "cfg-if",
- "convert_case",
- "html-escape",
- "itertools",
- "leptos_hot_reload",
- "prettyplease",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "rstml",
- "server_fn_macro",
- "syn",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "leptos_reactive"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4161acbf80f59219d8d14182371f57302bc7ff81ee41aba8ba1ff7295727f23"
-dependencies = [
- "base64 0.22.1",
- "cfg-if",
- "futures",
- "indexmap",
- "js-sys",
- "oco_ref",
- "paste",
- "pin-project",
- "rustc-hash",
- "self_cell",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "slotmap",
- "thiserror",
- "tracing",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "leptos_server"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a97eb90a13f71500b831c7119ddd3bdd0d7ae0a6b0487cade4fddeed3b8c03f"
-dependencies = [
- "inventory",
- "lazy_static",
- "leptos_macro",
- "leptos_reactive",
- "serde",
- "server_fn",
- "thiserror",
- "tracing",
-]
 
 [[package]]
 name = "libc"
@@ -1298,29 +843,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "manyhow"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91ea592d76c0b6471965708ccff7e6a5d277f676b90ab31f4d3f3fc77fade64"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64621e2c08f2576e4194ea8be11daf24ac01249a4f53cd8befcbb7077120ead"
-dependencies = [
- "proc-macro-utils 0.8.0",
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "matchers"
@@ -1430,16 +952,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oco_ref"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51ebcefb2f0b9a5e0bea115532c8ae4215d1b01eff176d0f4ba4192895c2708"
-dependencies = [
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "oid-registry"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,12 +1005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pad-adapter"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d80efc4b6721e8be2a10a5df21a30fa0b470f1539e53d8b4e6e75faf938b63"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,22 +1039,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pbkdf2"
@@ -1633,72 +1127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
-]
-
-[[package]]
-name = "proc-macro-utils"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,47 +1136,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
- "yansi",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "quote-use"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9619db1197b497a36178cfc736dc96b271fe918875fbf1344c436a7e93d0321e"
-dependencies = [
- "quote",
- "quote-use-macros",
-]
-
-[[package]]
-name = "quote-use-macros"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35"
-dependencies = [
- "proc-macro-utils 0.10.0",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1832,18 +1225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,26 +1240,6 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "rstml"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe542870b8f59dd45ad11d382e5339c9a1047cde059be136a7016095bbdefa77"
-dependencies = [
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn",
- "syn_derive",
- "thiserror",
-]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rusticata-macros"
@@ -1924,15 +1285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,25 +1303,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "self_cell"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
-
-[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "serde"
@@ -1979,27 +1316,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2057,26 +1373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0431a35568651e363364210c91983c1da5eb29404d9f0928b67d4ebcfa7d330c"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,59 +1382,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "server_fn"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fae7a3038a32e5a34ba32c6c45eb4852f8affaf8b794ebfcd4b1099e2d62ebe"
-dependencies = [
- "bytes",
- "ciborium",
- "const_format",
- "dashmap",
- "futures",
- "gloo-net",
- "http",
- "js-sys",
- "once_cell",
- "send_wrapper",
- "serde",
- "serde_json",
- "serde_qs",
- "server_fn_macro_default",
- "thiserror",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "xxhash-rust",
-]
-
-[[package]]
-name = "server_fn_macro"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaaf648c6967aef78177c0610478abb5a3455811f401f3c62d10ae9bd3901a1"
-dependencies = [
- "const_format",
- "convert_case",
- "proc-macro2",
- "quote",
- "syn",
- "xxhash-rust",
-]
-
-[[package]]
-name = "server_fn_macro_default"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2aa8119b558a17992e0ac1fd07f080099564f24532858811ce04f742542440"
-dependencies = [
- "server_fn_macro",
- "syn",
 ]
 
 [[package]]
@@ -2195,16 +1438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "slotmap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
-dependencies = [
- "serde",
- "version_check",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,18 +1474,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2409,47 +1630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2598,26 +1778,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-builder"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77739c880e00693faef3d65ea3aad725f196da38b22fdc7ea6ded6e1ce4d3add"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,12 +1794,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -2665,12 +1819,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf8-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
 
 [[package]]
 name = "utf8_iter"
@@ -2709,16 +1857,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,20 +1889,8 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2822,19 +1948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,16 +1957,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2919,22 +2022,9 @@ checksum = "16a1fb2580ce73baa42d3011a24de2ceab0d428de1879ece06e02e8c416e497c"
 dependencies = [
  "base64 0.21.7",
  "base64urlsafedata",
- "js-sys",
  "serde",
- "serde-wasm-bindgen",
  "serde_json",
  "url",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys",
 ]
 
 [[package]]
@@ -2950,15 +2040,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3077,18 +2158,6 @@ dependencies = [
  "thiserror",
  "time",
 ]
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,18 @@ members = [
     "crates/auth",
     "crates/shared",
     "crates/server",
+]
+# `crates/web` (the Rust+WASM frontend) is FROZEN during the
+# Node-cutover. Phase 0b reshaped the WS wire to be byte-compatible
+# with the Node SPA in `public/lib/...`, which means the WASM
+# client's `crates/web/src/ws.rs` (still on the pre-cutover CBOR/
+# Hello-handshake protocol) no longer compiles against
+# `katulong_shared::wire`. Excluding it from `members` keeps
+# `cargo build --workspace` green for the cutover-critical crates;
+# unexcluded for `cargo build -p katulong-web` so a future
+# frontend slice can opt into the build explicitly when porting
+# the WS code over.
+exclude = [
     "crates/web",
 ]
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -27,23 +27,11 @@ thiserror = { workspace = true }
 # into read/write halves in transport::websocket. axum re-exports
 # the stream trait but not the sink combinators we need.
 futures = { version = "0.3", default-features = false, features = ["std"] }
-# CBOR wire format for session I/O. Uniform binary over both WS and
-# WebRTC DataChannel; no base64 overhead, self-describing for
-# schema evolution. `ciborium` is pure Rust, well-maintained, and
-# integrates with serde (same derives as serde_json). `serde_json`
-# stays in the dep tree because the HTTP API (cookies, error
-# envelopes, tokens, devices) still speaks JSON — CBOR is
-# session-layer only.
-ciborium = "0.2"
-# `serde_bytes` forces `Vec<u8>` fields on `Input`/`Output` messages
-# to serialize as CBOR byte-strings (major type 2) instead of arrays
-# of small integers. Without this annotation a 1 KiB keystroke/paste
-# payload would encode as ~1–2 KiB of integer-element overhead; with
-# it, bytes ride the wire literally. Serde's default for `Vec<u8>` is
-# array-of-int because it has to pick a portable default across
-# codecs — we pick byte-string explicitly because CBOR supports it
-# and we're not using any other codec for session I/O.
-serde_bytes = "0.11"
+# Phase 0b of the Node-cutover dropped `ciborium` and `serde_bytes`:
+# the WS wire is now JSON over text frames so the existing Node
+# SPA in `public/lib/...` can drive the Rust server unmodified.
+# `serde_json` (already present below via the workspace) covers
+# both the HTTP API and the session-protocol encoding now.
 # Static asset serving for the Leptos frontend bundle. `ServeDir`
 # mounts a directory under a route prefix; `fs` feature gates the
 # filesystem-reading bits (the rest of tower-http is feature-

--- a/crates/server/src/session/handler.rs
+++ b/crates/server/src/session/handler.rs
@@ -9,16 +9,23 @@
 //!
 //! # What's in scope
 //!
-//! - **Handshake gate** (slice 9e): `Hello` (server) → `HelloAck`
-//!   (client) → `Attach` (client) → `Attached` (server). The
-//!   phase state machine enforces the order; messages arriving
-//!   in the wrong phase trigger a typed `Error` and clean close.
-//! - **Output forwarding** (slice 9f): after `Attached`, the
-//!   handler subscribes to `state.output_router` for its pane
-//!   and forwards decoded bytes through the coalescer to
-//!   `ServerMessage::Output { data, seq }`. `seq` is per-
-//!   connection-monotonic (Node scar `da6907f` — lets the
-//!   client detect gaps on reconnect).
+//! - **Attach gate**: connection starts in `AwaitingAttach`. The
+//!   first valid client message must be `Attach`; anything else
+//!   in that phase is a protocol violation and closes with
+//!   `error_code::UNEXPECTED_MESSAGE`. Phase 0b of the
+//!   Node-cutover removed the prior `Hello`/`HelloAck` handshake
+//!   — Node's SPA never spoke that, and serving the SPA against
+//!   the Rust server is the cutover goal. Messages now route
+//!   straight from WS-open into the attach state machine.
+//! - **Output forwarding** (slice 9f, updated phase 0b): after
+//!   `Attach`, the handler subscribes to `state.output_router`
+//!   for its pane and forwards decoded bytes through the
+//!   coalescer to `ServerMessage::Output { session, data,
+//!   from_seq, cursor }`. `from_seq` is the byte offset of the
+//!   first byte in `data`; `cursor` is the offset of the byte
+//!   AFTER the last (matches Node's
+//!   `lib/ws-manager.js:127-129` shape). The Node SPA advances
+//!   its `pullManager.cursor` to `cursor` on receipt.
 //! - **Output coalescing** (slice 9f): buffer bursts with a
 //!   2 ms idle / 16 ms cap schedule (Node scars
 //!   `d311168`/`066dab2`). Individual `%output` chunks below
@@ -72,27 +79,31 @@
 //! snap whenever a variant crosses phases without explicit
 //! consent.
 
-use crate::log_util::sanitize_for_log;
 use crate::revocation::RevocationEvent;
 use crate::session::output::Coalescer;
 use crate::session::ring::ReplaySlice;
 use crate::session::router::{OutputChunk, SubscribeError, SubscriberId};
 use crate::state::AppState;
-use crate::transport::{ClientMessage, ServerMessage, TransportHandle, PROTOCOL_VERSION};
+use crate::transport::{ClientMessage, ServerMessage, TransportHandle};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::mpsc;
 use tokio::time::Instant;
 
-/// How long we wait between connection upgrade and receiving
-/// `HelloAck` before closing. WS-level keepalive keeps the socket
+/// How long we wait between WS upgrade and the client's first
+/// `Attach` before closing. WS-level keepalive keeps the socket
 /// alive indefinitely; without this a silent peer can pin a
 /// connection forever. Generous enough that a high-latency real
 /// client completes well within it; short enough that a scraper
 /// probing `/ws` with no cookie (shouldn't happen — auth gates the
 /// upgrade) or a half-open connection is reaped promptly.
-const HANDSHAKE_TIMEOUT_SECS: u64 = 10;
+///
+/// Phase 0b of the Node-cutover renamed this from
+/// `HANDSHAKE_TIMEOUT_SECS`; there is no in-band handshake
+/// anymore (the Node SPA connects and sends `attach` directly).
+/// Same value, same purpose: bound the awaiting-attach phase.
+const ATTACH_TIMEOUT_SECS: u64 = 10;
 
 /// Output-idle window before a pending resize can apply. Node
 /// scar `066dab2`: SIGWINCH arriving mid-render interleaves old
@@ -109,23 +120,21 @@ const RESIZE_GATE: Duration = Duration::from_millis(50);
 /// paused between frames.
 const RESIZE_MAX_DEFER: Duration = Duration::from_millis(500);
 
-/// Cap on the protocol-version string we echo back in error
-/// messages. Far shorter than the Origin cap in `ws.rs` because the
-/// version string is a short identifier (`"katulong/0.1"`) — if a
-/// client sends something larger, it's either buggy or crafted, and
-/// 32 chars is plenty to identify the prefix without letting an
-/// attacker flood logs with per-request megabyte payloads.
-const LOG_PROTOCOL_VERSION_MAX_LEN: usize = 32;
-
 /// Error codes emitted as `ServerMessage::Error.code`. Stable —
 /// clients and scripts key off these strings, so renames require a
 /// protocol version bump.
+///
+/// **Wire-shape note (phase 0b cutover).** Node's `error` frames
+/// are `{type:"error", message:"..."}` with no `code` field; the
+/// SPA's handler in `public/lib/ws-message-handlers.js` only
+/// reads `message`. The Rust server populates `code` opportun-
+/// istically because operator-side logs benefit from the
+/// machine-readable identifier, but the wire shape stays
+/// optional via `#[serde(skip_serializing_if = "Option::is_none")]`
+/// on `ServerMessage::Error.code`.
 pub mod error_code {
-    /// Client's `HelloAck.protocol_version` didn't match what the
-    /// server speaks. The connection closes immediately.
-    pub const PROTOCOL_VERSION_MISMATCH: &str = "protocol_version_mismatch";
     /// Client sent a message that isn't allowed in the current
-    /// handshake phase (e.g., `Input` before `Attached`).
+    /// phase (e.g., `Input` before `Attach`).
     pub const UNEXPECTED_MESSAGE: &str = "unexpected_message";
     /// Client tried to `Attach` to a session name that the
     /// session-name validator rejected.
@@ -137,15 +146,24 @@ pub mod error_code {
     /// No session manager is wired into this server (misconfig or
     /// tmux binary missing). Only surfaces during development.
     pub const NO_SESSION_MANAGER: &str = "no_session_manager";
-    /// Client didn't complete the handshake within
-    /// `HANDSHAKE_TIMEOUT_SECS`. Connection closes.
-    pub const HANDSHAKE_TIMEOUT: &str = "handshake_timeout";
-    /// Client sent `Attach { resume_from_seq: Some(N) }` with
+    /// Client didn't `Attach` within `ATTACH_TIMEOUT_SECS`.
+    /// Connection closes.
+    pub const ATTACH_TIMEOUT: &str = "attach_timeout";
+    /// Phase 0b cutover: the client sent a multi-session message
+    /// (`subscribe`, `switch`, `unsubscribe`, `resync`,
+    /// `set-tab-icon`) or a WebRTC signaling message
+    /// (`rtc-offer`, `rtc-ice-candidate`) that the Rust server
+    /// doesn't implement yet. Phase 1 wires these up; for now
+    /// they get a typed reject so the SPA renders a clear error
+    /// rather than seeing a silent drop.
+    pub const NOT_YET_IMPLEMENTED: &str = "not_yet_implemented";
+    /// Client sent `Attach { from_seq: Some(N) }` with
     /// `N` larger than the pane's `total_written`. A
     /// correctly-implemented client cannot reach this — the seq
-    /// only ever comes from a prior `Attached.last_seq` or
-    /// `Output.seq`, both of which the server assigned. Closing
-    /// on mismatch catches version-skew or client bugs early.
+    /// only ever comes from a prior `seq-init.seq` or
+    /// `Output.cursor`, both of which the server assigned.
+    /// Closing on mismatch catches version-skew or client bugs
+    /// early.
     pub const INVALID_RESUME: &str = "invalid_resume";
     /// Attach rejected because the pane already has the maximum
     /// number of concurrent subscribers (slice 9h multi-device
@@ -181,7 +199,7 @@ pub mod error_code {
     pub const CONNECTION_TERMINATED: &str = "connection_terminated";
 }
 
-/// Handshake phase. Advances on valid messages; any message that
+/// Connection phase. Advances on valid messages; any message that
 /// isn't valid for the current phase is a protocol violation.
 ///
 /// The `Attached` variant is intentionally data-less: the session
@@ -190,17 +208,18 @@ pub mod error_code {
 /// coalescer, the resize timer state) that can't sit in a
 /// clonable phase enum. The phase is the "protocol gate"; the
 /// I/O state is the "active work."
+///
+/// Phase 0b of the Node-cutover removed the `AwaitingHelloAck`
+/// variant — the SPA has no `HelloAck` message, so the connection
+/// starts directly in `AwaitingAttach`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Phase {
-    /// Server has sent `Hello`; waiting for the client to ack with
-    /// a matching protocol version.
-    AwaitingHelloAck,
-    /// Protocol version confirmed; waiting for the client to send
-    /// `Attach` with a session name and dimensions.
+    /// Connection is open; waiting for the client to send `Attach`
+    /// with a session name and dimensions. Initial phase.
     AwaitingAttach,
-    /// Transport is bound to a tmux pane. `Input`/`Resize` are now
-    /// valid. The pane id + session name + output subscription
-    /// live in the coordinator's `AttachedState`.
+    /// Transport is bound to a tmux pane. `Input`/`Resize`/`Pull`
+    /// are now valid. The pane id + session name + output
+    /// subscription live in the coordinator's `AttachedState`.
     Attached,
 }
 
@@ -213,29 +232,46 @@ enum Phase {
 enum Action {
     /// Nothing to emit; keep reading.
     Continue,
-    /// Echo a `Pong` with the given nonce.
-    SendPong(u64),
-    /// Protocol version checked out; reply confirmation is
-    /// implicit (no server message is sent for HelloAck — the
-    /// client's next move is Attach). Just advance phase.
-    AdvanceToAwaitingAttach,
+    /// Echo a `Pong` (the Node-cutover wire has no nonce — the
+    /// app-level ping is keepalive only, not RTT measurement).
+    SendPong,
     /// Create/attach the tmux session, subscribe to its pane,
-    /// then send `Attached` with the clamped dims. If
-    /// `resume_from_seq` is `Some(N)` the coordinator asks the
-    /// router for a replay slice and emits `OutputGap` +
-    /// replay `Output` before going live.
+    /// then send `Attached` + `seq-init`. If `from_seq` is
+    /// `Some(N)` the coordinator asks the router for a replay
+    /// slice and emits `pull-snapshot` (gap) or live `output`
+    /// frames before going live.
     DoAttach {
         session: String,
         cols: u16,
         rows: u16,
-        resume_from_seq: Option<u64>,
+        from_seq: Option<u64>,
     },
-    /// Forward client input bytes to the attached pane.
-    ForwardInput { data: Vec<u8> },
+    /// Forward client input bytes (already UTF-8 string from the
+    /// JSON wire) to the attached pane. The string is decoded
+    /// to bytes at the SessionManager call site.
+    ForwardInput { data: String },
     /// Queue a resize for the attached session — the coordinator
     /// applies immediately or defers based on the resize gate.
     QueueResize { cols: u16, rows: u16 },
-    /// A protocol violation. Coordinator sends `Error` and closes.
+    /// Client `pull` request — coordinator answers with
+    /// `pull-response` or `pull-snapshot` from the ring buffer.
+    /// `from_seq` is the cursor the SPA last saw; the response
+    /// carries everything `(from_seq..total_written]`.
+    HandlePull { from_seq: u64 },
+    /// A non-fatal client mistake or deferred-feature stub.
+    /// Coordinator sends `error` and KEEPS the transport open —
+    /// this is the SPA's normal "Invalid message format" path
+    /// for typos, version skew, and the phase-0b
+    /// not-yet-implemented messages (`subscribe`, `switch`,
+    /// `unsubscribe`, `resync`, `set-tab-icon`, `rtc-offer`,
+    /// `rtc-ice-candidate`). Distinct from `Close` — the SPA
+    /// renders an error toast but the connection stays alive
+    /// because the user's terminal is still working.
+    ReplyError {
+        code: &'static str,
+        message: String,
+    },
+    /// A protocol violation. Coordinator sends `error` and closes.
     /// `code` is one of `error_code::*`; `message` is operator-
     /// visible and MUST NOT include client-controlled bytes raw
     /// (log-injection path — the coordinator sanitizes).
@@ -250,27 +286,19 @@ enum Action {
 /// message, decide what to do next. No awaits, no side effects, no
 /// SessionManager reference — keeps this function easy to test and
 /// impossible to accidentally deadlock.
+///
+/// Phase 0b cutover note: the multi-session messages (`subscribe`,
+/// `switch`, `unsubscribe`, `resync`, `set-tab-icon`) and the WebRTC
+/// signaling stubs (`rtc-offer`, `rtc-ice-candidate`) reply with a
+/// non-fatal `error` rather than closing the transport. Closing on
+/// every unsupported message would mean the SPA reconnects in a
+/// loop — these messages are speculative on the SPA's part, the
+/// terminal works without them.
 fn step(phase: &mut Phase, msg: ClientMessage) -> Action {
     match (phase.clone(), msg) {
         // `Ping` is allowed in every phase. It never changes phase
         // and doesn't touch any session state.
-        (_, ClientMessage::Ping { nonce }) => Action::SendPong(nonce),
-
-        (Phase::AwaitingHelloAck, ClientMessage::HelloAck { protocol_version }) => {
-            if protocol_version == PROTOCOL_VERSION {
-                *phase = Phase::AwaitingAttach;
-                Action::AdvanceToAwaitingAttach
-            } else {
-                Action::Close {
-                    code: error_code::PROTOCOL_VERSION_MISMATCH,
-                    message: format!(
-                        "server speaks {}, client acked {}",
-                        PROTOCOL_VERSION,
-                        sanitize_for_log(&protocol_version, LOG_PROTOCOL_VERSION_MAX_LEN),
-                    ),
-                }
-            }
-        }
+        (_, ClientMessage::Ping) => Action::SendPong,
 
         (
             Phase::AwaitingAttach,
@@ -278,19 +306,51 @@ fn step(phase: &mut Phase, msg: ClientMessage) -> Action {
                 session,
                 cols,
                 rows,
-                resume_from_seq,
+                from_seq,
             },
         ) => Action::DoAttach {
             session,
             cols,
             rows,
-            resume_from_seq,
+            from_seq,
         },
 
-        (Phase::Attached, ClientMessage::Input { data }) => Action::ForwardInput { data },
+        // `session` field is informational on Input/Resize — phase
+        // 0b is single-session, so we use the bound session
+        // regardless. Phase 1 wires it in for multi-session.
+        (Phase::Attached, ClientMessage::Input { data, .. }) => Action::ForwardInput { data },
 
-        (Phase::Attached, ClientMessage::Resize { cols, rows }) => {
+        (Phase::Attached, ClientMessage::Resize { cols, rows, .. }) => {
             Action::QueueResize { cols, rows }
+        }
+
+        (Phase::Attached, ClientMessage::Pull { from_seq, .. }) => {
+            Action::HandlePull { from_seq }
+        }
+
+        // Multi-session messages: deferred to phase 1. Reply with
+        // a non-fatal error so the SPA shows a toast and the
+        // existing terminal keeps working.
+        (
+            _,
+            ClientMessage::Subscribe { .. }
+            | ClientMessage::Unsubscribe { .. }
+            | ClientMessage::Switch { .. }
+            | ClientMessage::Resync { .. }
+            | ClientMessage::SetTabIcon { .. },
+        ) => Action::ReplyError {
+            code: error_code::NOT_YET_IMPLEMENTED,
+            message: "multi-session not yet supported in Rust server".into(),
+        },
+
+        // WebRTC signaling stubs: same treatment. The SPA tries
+        // these speculatively to upgrade WS → DC; failure falls
+        // back to plain WS, which is what we want.
+        (_, ClientMessage::RtcOffer { .. } | ClientMessage::RtcIceCandidate { .. }) => {
+            Action::ReplyError {
+                code: error_code::NOT_YET_IMPLEMENTED,
+                message: "WebRTC signaling not yet supported in Rust server".into(),
+            }
         }
 
         // Any other (phase, message) combination is a protocol
@@ -309,17 +369,23 @@ fn step(phase: &mut Phase, msg: ClientMessage) -> Action {
 
 fn variant_name(msg: &ClientMessage) -> &'static str {
     match msg {
-        ClientMessage::Ping { .. } => "ping",
-        ClientMessage::HelloAck { .. } => "hello_ack",
+        ClientMessage::Ping => "ping",
         ClientMessage::Attach { .. } => "attach",
         ClientMessage::Input { .. } => "input",
         ClientMessage::Resize { .. } => "resize",
+        ClientMessage::Pull { .. } => "pull",
+        ClientMessage::Subscribe { .. } => "subscribe",
+        ClientMessage::Unsubscribe { .. } => "unsubscribe",
+        ClientMessage::Switch { .. } => "switch",
+        ClientMessage::Resync { .. } => "resync",
+        ClientMessage::SetTabIcon { .. } => "set-tab-icon",
+        ClientMessage::RtcOffer { .. } => "rtc-offer",
+        ClientMessage::RtcIceCandidate { .. } => "rtc-ice-candidate",
     }
 }
 
 fn phase_name(phase: &Phase) -> &'static str {
     match phase {
-        Phase::AwaitingHelloAck => "awaiting_hello_ack",
         Phase::AwaitingAttach => "awaiting_attach",
         Phase::Attached => "attached",
     }
@@ -372,10 +438,22 @@ struct AttachedState {
     output_rx: mpsc::Receiver<Arc<OutputChunk>>,
     /// Highest `end_seq` we've seen come out of `output_rx`.
     /// When the coalescer flushes, this becomes the outbound
-    /// `ServerMessage::Output.seq`. Starts at the router's
+    /// `ServerMessage::Output.cursor`. Starts at the router's
     /// `last_seq` snapshot at attach time so a reconnect with
     /// replay doesn't emit seqs below the replay's `last_seq`.
     last_seen_seq: u64,
+    /// The `cursor` value we sent in the most recent
+    /// `Output`/`pull-response`/`pull-snapshot` (or the seed
+    /// from `seq-init` if nothing's been sent yet). The next
+    /// `Output` message uses this as its `from_seq` — together
+    /// with `cursor = last_seen_seq` it tells the SPA exactly
+    /// which byte-range the chunk covers.
+    ///
+    /// Phase 0b cutover need: Node's wire requires both
+    /// `fromSeq` and `cursor` on every `output`. The pre-cutover
+    /// CBOR wire only had `seq` (== end-of-chunk), so the start
+    /// offset wasn't tracked separately. We add it here.
+    last_emitted_cursor: u64,
     /// Coalesces raw bytes from `output_rx` into chunky Output
     /// messages. See `output::Coalescer` for timing.
     coalescer: Coalescer,
@@ -493,31 +571,18 @@ pub async fn serve_session(
     // See `revocation.rs` subscriber contract.
     let mut revocations = state.subscribe_revocations();
 
-    // Send the initial Hello. If this fails, the transport died
-    // between upgrade and now — nothing to do.
-    if handle
-        .send(ServerMessage::Hello {
-            protocol_version: PROTOCOL_VERSION.to_string(),
-        })
-        .await
-        .is_err()
-    {
-        return;
-    }
-
-    let mut phase = Phase::AwaitingHelloAck;
+    // Phase 0b cutover: no Hello/HelloAck. The Node SPA opens the
+    // WS and sends `attach` directly; we wait for it.
+    let mut phase = Phase::AwaitingAttach;
     let mut attached: Option<AttachedState> = None;
-    let handshake_deadline = Instant::now() + Duration::from_secs(HANDSHAKE_TIMEOUT_SECS);
+    let attach_deadline = Instant::now() + Duration::from_secs(ATTACH_TIMEOUT_SECS);
 
     loop {
         // Guard flags for conditional select branches. Assigning
         // to locals reads more clearly than inlining the matches
         // in the select macro (and rustc has been known to
         // misjudge `if matches!(...)` in select guards).
-        let in_handshake = matches!(
-            phase,
-            Phase::AwaitingHelloAck | Phase::AwaitingAttach
-        );
+        let in_attach_wait = matches!(phase, Phase::AwaitingAttach);
         let coalesce_deadline = attached.as_ref().and_then(|a| a.coalesce_deadline());
         let resize_deadline = attached.as_ref().and_then(|a| a.resize_deadline());
 
@@ -530,11 +595,14 @@ pub async fn serve_session(
             // arrives alongside the revoke event.
             revoke = revocations.recv() => handle_revoke(revoke, credential_id.as_deref()),
 
-            // Handshake-timer branch: only active while we're
-            // still awaiting HelloAck or Attach.
-            _ = tokio::time::sleep_until(handshake_deadline), if in_handshake => Action::Close {
-                code: error_code::HANDSHAKE_TIMEOUT,
-                message: "client did not complete handshake in time".into(),
+            // Attach-timer branch: only active while we're still
+            // awaiting the client's first `attach`. Phase 0b
+            // cutover renamed this from "handshake timeout" — the
+            // Node SPA has no handshake message, so the only thing
+            // we wait for is the first `attach`.
+            _ = tokio::time::sleep_until(attach_deadline), if in_attach_wait => Action::Close {
+                code: error_code::ATTACH_TIMEOUT,
+                message: "client did not attach in time".into(),
             },
 
             // Coalescer flush: elapsed idle or cap deadline.
@@ -593,18 +661,38 @@ pub async fn serve_session(
             let now = Instant::now();
             if a.coalesce_deadline().is_some_and(|d| now >= d) && !a.coalescer.is_empty() {
                 let bytes = a.coalescer.take();
-                // `last_seen_seq` already equals the end-seq of
-                // the most recent chunk we folded into the
-                // coalescer — by construction that's the end-seq
-                // of the flushed batch's last byte.
-                let seq = a.last_seen_seq;
+                // `last_seen_seq` is the cumulative byte offset
+                // AFTER the most recent chunk we folded in — i.e.,
+                // the cursor at the end of the flushed batch. The
+                // FROM offset is whatever cursor the SPA last saw
+                // (`last_emitted_cursor`); together they pin the
+                // exact byte-range so the SPA's `pullManager` can
+                // drop duplicates and detect gaps.
+                //
+                // `from_utf8_lossy` matches Node's behavior:
+                // `lib/parser.js` decodes tmux's octal-escape
+                // control-mode encoding into UTF-8 strings before
+                // buffering, replacing invalid bytes with U+FFFD.
+                // The Rust `OutputChunk.data` is the byte vector
+                // from `parser::parse_output`; lossy decode here
+                // is the matching boundary.
+                let data = String::from_utf8_lossy(&bytes).into_owned();
+                let from_seq = a.last_emitted_cursor;
+                let cursor = a.last_seen_seq;
+                let session = a.session.clone();
                 if handle
-                    .send(ServerMessage::Output { data: bytes, seq })
+                    .send(ServerMessage::Output {
+                        session,
+                        data,
+                        from_seq,
+                        cursor,
+                    })
                     .await
                     .is_err()
                 {
                     break;
                 }
+                a.last_emitted_cursor = cursor;
             }
             if a.resize_deadline().is_some_and(|d| now >= d) {
                 let pending = a
@@ -618,21 +706,16 @@ pub async fn serve_session(
         match action {
             Action::Continue => continue,
             Action::Exit => break,
-            Action::SendPong(nonce) => {
-                if handle.send(ServerMessage::Pong { nonce }).await.is_err() {
+            Action::SendPong => {
+                if handle.send(ServerMessage::Pong).await.is_err() {
                     break;
                 }
-            }
-            Action::AdvanceToAwaitingAttach => {
-                // No server message; the client already has Hello
-                // and its next move is Attach.
-                continue;
             }
             Action::DoAttach {
                 session,
                 cols,
                 rows,
-                resume_from_seq,
+                from_seq,
             } => {
                 // Clamp once at the coordinator before dispatch.
                 // SessionManager clamps internally too as
@@ -648,19 +731,43 @@ pub async fn serve_session(
                     break;
                 };
                 let attach_outcome =
-                    try_attach(sessions, &state, &session, cols, rows, resume_from_seq).await;
+                    try_attach(sessions, &state, &session, cols, rows, from_seq).await;
                 match attach_outcome {
                     Ok(outcome) => {
                         let last_seq = outcome.last_seq();
                         let replay = outcome.replay;
                         attached = Some(outcome.new_state);
                         phase = Phase::Attached;
+                        // Phase 0b cutover wire shape:
+                        //   1. `attached { session, data: "" }`
+                        //      — data is empty because the Rust
+                        //      server has no Node-style headless
+                        //      serializer yet. The post-attach
+                        //      Ctrl-L nudge in `try_attach`
+                        //      causes the shell to repaint, so
+                        //      the SPA sees its prompt within
+                        //      milliseconds via the live `output`
+                        //      stream.
+                        //   2. `seq-init { session, seq: last_seq }`
+                        //      — seeds the SPA's `pullManager`
+                        //      cursor.
+                        //   3. Replay (if reconnecting): goes
+                        //      out as `pull-snapshot` (gap) or
+                        //      live `output` (in-range).
                         if handle
                             .send(ServerMessage::Attached {
-                                session,
-                                cols,
-                                rows,
-                                last_seq,
+                                session: session.clone(),
+                                data: String::new(),
+                            })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                        if handle
+                            .send(ServerMessage::SeqInit {
+                                session: session.clone(),
+                                seq: last_seq,
                             })
                             .await
                             .is_err()
@@ -668,10 +775,21 @@ pub async fn serve_session(
                             break;
                         }
                         // Replay any missed bytes. Must happen
-                        // AFTER Attached so the client's clear-
-                        // on-OutputGap logic fires in the right
-                        // order.
-                        if send_replay(&handle, replay).await.is_err() {
+                        // AFTER seq-init so the SPA's pullManager
+                        // is initialised when the bytes land.
+                        if send_replay(&handle, &session, replay).await.is_err() {
+                            break;
+                        }
+                        // Nudge the SPA to issue its first pull —
+                        // covers any output that may have landed
+                        // during the async attach. Matches Node
+                        // ws-manager.js's post-attach
+                        // `data-available` send.
+                        if handle
+                            .send(ServerMessage::DataAvailable { session })
+                            .await
+                            .is_err()
+                        {
                             break;
                         }
                     }
@@ -692,7 +810,24 @@ pub async fn serve_session(
                     .as_ref()
                     .expect("Attached phase implies attached is Some");
                 let sessions = require_sessions(&state);
-                if let Err(err) = sessions.send_input(a.pane_id, &data).await {
+                // Phase 0b cutover: `data` is a UTF-8 string from
+                // the JSON wire. The SessionManager wants raw
+                // bytes (it hex-encodes for `send-keys`), so we
+                // hand off `data.as_bytes()`. The SPA caps input
+                // at 8192 chars (`lib/websocket-validation.js`);
+                // we mirror that cap here so an oversize frame
+                // gets a non-fatal error reply rather than a
+                // silent drop.
+                if data.len() > 8192 {
+                    let _ = handle
+                        .send(ServerMessage::Error {
+                            message: "input data exceeds 8192-char cap".into(),
+                            code: None,
+                        })
+                        .await;
+                    continue;
+                }
+                if let Err(err) = sessions.send_input(a.pane_id, data.as_bytes()).await {
                     // Forwarding failure is operator-visible but
                     // not a reason to close — a glitchy write may
                     // be followed by success on the next input,
@@ -740,6 +875,113 @@ pub async fn serve_session(
                         rows,
                         queued_at,
                     });
+                }
+            }
+            Action::HandlePull { from_seq } => {
+                let a = attached
+                    .as_mut()
+                    .expect("Attached phase implies attached is Some");
+                // Read the ring under the router lock — same
+                // shape as Node's `session.pullFrom(fromSeq)`.
+                let replay = state.output_router.peek_resume(a.pane_id, from_seq);
+                let session = a.session.clone();
+                match replay {
+                    ReplaySlice::Fresh { end_seq } | ReplaySlice::UpToDate { end_seq } => {
+                        // Nothing missed; the SPA's pull manager
+                        // gets an empty response and unsticks.
+                        if handle
+                            .send(ServerMessage::PullResponse {
+                                session,
+                                data: String::new(),
+                                cursor: end_seq,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                        a.last_emitted_cursor = end_seq;
+                    }
+                    ReplaySlice::InRange { data, end_seq } => {
+                        let s = String::from_utf8_lossy(&data).into_owned();
+                        if handle
+                            .send(ServerMessage::PullResponse {
+                                session,
+                                data: s,
+                                cursor: end_seq,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                        a.last_emitted_cursor = end_seq;
+                    }
+                    ReplaySlice::Gap {
+                        data,
+                        end_seq,
+                        ..
+                    } => {
+                        // Cursor evicted from ring — fall back to
+                        // a snapshot. Phase 0b sends the
+                        // `pull-snapshot` carrying whatever bytes
+                        // still are in the ring; since the Rust
+                        // server has no Node-style headless, this
+                        // is the best we can do until phase 1
+                        // wires up a real headless serializer.
+                        let s = String::from_utf8_lossy(&data).into_owned();
+                        if handle
+                            .send(ServerMessage::PullSnapshot {
+                                session,
+                                data: s,
+                                cursor: end_seq,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                        a.last_emitted_cursor = end_seq;
+                    }
+                    ReplaySlice::Future => {
+                        // Client is asking for bytes past our
+                        // total_written — typically a stale
+                        // cursor across server restart. Send an
+                        // empty pull-snapshot from cursor 0 so
+                        // the SPA clears its terminal and
+                        // realigns.
+                        if handle
+                            .send(ServerMessage::PullSnapshot {
+                                session,
+                                data: String::new(),
+                                cursor: 0,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                        a.last_emitted_cursor = 0;
+                    }
+                }
+            }
+            Action::ReplyError { code, message } => {
+                // Non-fatal: the SPA shows a toast and the
+                // existing terminal keeps running. Used for
+                // phase-0b deferred messages (multi-session,
+                // WebRTC signaling) and for input-validation
+                // errors that don't warrant tearing down the
+                // socket.
+                tracing::debug!(code, message = %message, "replying with error; transport stays open");
+                if handle
+                    .send(ServerMessage::Error {
+                        message,
+                        code: Some(code.into()),
+                    })
+                    .await
+                    .is_err()
+                {
+                    break;
                 }
             }
             Action::Close { code, message } => {
@@ -1027,6 +1269,8 @@ async fn try_attach(
                     subscriber_id,
                     output_rx: rx,
                     last_seen_seq: baseline,
+
+                    last_emitted_cursor: baseline,
                     coalescer: Coalescer::new(),
                     last_output_at: None,
                     pending_resize: None,
@@ -1089,6 +1333,8 @@ async fn try_attach(
                                 subscriber_id,
                                 output_rx: rx,
                                 last_seen_seq: 0,
+
+                                last_emitted_cursor: 0,
                                 coalescer: Coalescer::new(),
                                 last_output_at: None,
                                 pending_resize: None,
@@ -1165,6 +1411,8 @@ async fn try_attach(
                             subscriber_id,
                             output_rx: rx,
                             last_seen_seq: baseline,
+
+                            last_emitted_cursor: baseline,
                             coalescer: Coalescer::new(),
                             last_output_at: None,
                             pending_resize: None,
@@ -1176,17 +1424,33 @@ async fn try_attach(
     }
 }
 
-/// Emit `OutputGap` + replay `Output` frames between `Attached`
-/// and the first live flush. Returns `Err(())` if the transport
-/// is already gone — caller breaks the serve loop.
+/// Emit replay frames between `attached`/`seq-init` and the first
+/// live flush. Returns `Err(())` if the transport is already gone
+/// — caller breaks the serve loop.
+///
+/// **Phase 0b cutover wire shapes.** The pre-cutover code emitted
+/// a typed `OutputGap` followed by `Output`. The Node SPA has no
+/// `OutputGap` handler — it expects `pull-snapshot` for the gap
+/// case (cursor evicted from ring) and `output` for in-range
+/// replay. We translate accordingly:
+///
+/// - `InRange { data, end_seq }` → one `output` carrying
+///   `from_seq = (end_seq - data.len())`, `cursor = end_seq`.
+///   The SPA writes to xterm and advances its pull cursor.
+/// - `Gap { data, end_seq, .. }` → one `pull-snapshot` carrying
+///   `data` + `cursor = end_seq`. The SPA REPLACES its terminal
+///   contents with `data` (this is the cursor-evicted recovery
+///   path; the gap is unrecoverable, so a snapshot is the
+///   semantically-correct response).
+/// - `Fresh` / `UpToDate` / `Future` → nothing to emit. `Future`
+///   shouldn't reach here (rejected at attach time); included for
+///   exhaustiveness.
 async fn send_replay(
     handle: &TransportHandle,
+    session: &str,
     replay: ReplaySlice,
 ) -> Result<(), ()> {
     match replay {
-        // Nothing to emit — fresh attach, up-to-date reconnect,
-        // or defensive Future (rejected earlier; shouldn't
-        // reach here).
         ReplaySlice::Fresh { .. }
         | ReplaySlice::UpToDate { .. }
         | ReplaySlice::Future => Ok(()),
@@ -1194,36 +1458,33 @@ async fn send_replay(
             if data.is_empty() {
                 return Ok(());
             }
+            let from_seq = end_seq - data.len() as u64;
+            let s = String::from_utf8_lossy(&data).into_owned();
             handle
                 .send(ServerMessage::Output {
-                    data,
-                    seq: end_seq,
+                    session: session.to_string(),
+                    data: s,
+                    from_seq,
+                    cursor: end_seq,
                 })
                 .await
                 .map_err(|_| ())
         }
         ReplaySlice::Gap {
-            available_from_seq,
-            data,
-            end_seq,
+            data, end_seq, ..
         } => {
-            // Order matters: OutputGap first so the client
-            // clears its terminal before applying the replay
-            // bytes. If either send fails, caller closes.
+            // Cursor evicted: emit `pull-snapshot` with whatever
+            // we still have in the ring. The SPA replaces its
+            // terminal contents — the lost bytes can't be
+            // reconstructed, so a snapshot of the current ring
+            // contents is the closest we can come to the
+            // pre-cutover `OutputGap + Output` semantics.
+            let s = String::from_utf8_lossy(&data).into_owned();
             handle
-                .send(ServerMessage::OutputGap {
-                    available_from_seq,
-                    last_seq: end_seq,
-                })
-                .await
-                .map_err(|_| ())?;
-            if data.is_empty() {
-                return Ok(());
-            }
-            handle
-                .send(ServerMessage::Output {
-                    data,
-                    seq: end_seq,
+                .send(ServerMessage::PullSnapshot {
+                    session: session.to_string(),
+                    data: s,
+                    cursor: end_seq,
                 })
                 .await
                 .map_err(|_| ())
@@ -1383,7 +1644,7 @@ fn handle_revoke(
 async fn send_error_and_close(handle: &TransportHandle, code: &str, message: String) {
     let _ = handle
         .send(ServerMessage::Error {
-            code: code.into(),
+            code: Some(code.to_string()),
             message,
         })
         .await;
@@ -1447,39 +1708,7 @@ mod tests {
 
     use super::*;
 
-    fn ack_v1() -> ClientMessage {
-        ClientMessage::HelloAck {
-            protocol_version: PROTOCOL_VERSION.into(),
-        }
-    }
-
-    // ---------- Phase machine (unchanged from slice 9e) ----------
-
-    #[test]
-    fn hello_ack_advances_phase() {
-        let mut phase = Phase::AwaitingHelloAck;
-        let action = step(&mut phase, ack_v1());
-        assert_eq!(action, Action::AdvanceToAwaitingAttach);
-        assert_eq!(phase, Phase::AwaitingAttach);
-    }
-
-    #[test]
-    fn mismatched_protocol_version_closes() {
-        let mut phase = Phase::AwaitingHelloAck;
-        let action = step(
-            &mut phase,
-            ClientMessage::HelloAck {
-                protocol_version: "katulong/999.0".into(),
-            },
-        );
-        match action {
-            Action::Close { code, .. } => {
-                assert_eq!(code, error_code::PROTOCOL_VERSION_MISMATCH);
-            }
-            other => panic!("expected close, got {other:?}"),
-        }
-        assert_eq!(phase, Phase::AwaitingHelloAck);
-    }
+    // ---------- Phase machine (post phase 0b cutover) ----------
 
     #[test]
     fn input_before_attached_is_protocol_violation() {
@@ -1487,7 +1716,8 @@ mod tests {
         let action = step(
             &mut phase,
             ClientMessage::Input {
-                data: vec![0x61, 0x62, 0x63],
+                data: "abc".into(),
+                session: None,
             },
         );
         match action {
@@ -1508,6 +1738,7 @@ mod tests {
             ClientMessage::Resize {
                 cols: 80,
                 rows: 24,
+                session: None,
             },
         );
         match action {
@@ -1517,25 +1748,11 @@ mod tests {
     }
 
     #[test]
-    fn hello_ack_in_attached_phase_is_protocol_violation() {
-        let mut phase = Phase::Attached;
-        let action = step(&mut phase, ack_v1());
-        match action {
-            Action::Close { code, .. } => assert_eq!(code, error_code::UNEXPECTED_MESSAGE),
-            other => panic!("expected close, got {other:?}"),
-        }
-    }
-
-    #[test]
     fn ping_is_allowed_in_every_phase() {
-        for mut phase in [
-            Phase::AwaitingHelloAck,
-            Phase::AwaitingAttach,
-            Phase::Attached,
-        ] {
+        for mut phase in [Phase::AwaitingAttach, Phase::Attached] {
             let before = phase.clone();
-            let action = step(&mut phase, ClientMessage::Ping { nonce: 7 });
-            assert_eq!(action, Action::SendPong(7));
+            let action = step(&mut phase, ClientMessage::Ping);
+            assert_eq!(action, Action::SendPong);
             assert_eq!(phase, before, "ping must not change phase in {before:?}");
         }
     }
@@ -1549,7 +1766,7 @@ mod tests {
                 session: "main".into(),
                 cols: 120,
                 rows: 40,
-                resume_from_seq: None,
+                from_seq: None,
             },
         );
         assert_eq!(
@@ -1558,7 +1775,7 @@ mod tests {
                 session: "main".into(),
                 cols: 120,
                 rows: 40,
-                resume_from_seq: None,
+                from_seq: None,
             }
         );
         assert_eq!(
@@ -1572,7 +1789,7 @@ mod tests {
     #[test]
     fn attach_with_resume_carries_seq_to_action() {
         // Forward-safety: if the pattern match on Attach ever
-        // loses the resume_from_seq field, the coordinator would
+        // loses the from_seq field, the coordinator would
         // silently default to fresh-attach for every reconnect.
         let mut phase = Phase::AwaitingAttach;
         let action = step(
@@ -1581,7 +1798,7 @@ mod tests {
                 session: "main".into(),
                 cols: 80,
                 rows: 24,
-                resume_from_seq: Some(42),
+                from_seq: Some(42),
             },
         );
         assert_eq!(
@@ -1590,21 +1807,24 @@ mod tests {
                 session: "main".into(),
                 cols: 80,
                 rows: 24,
-                resume_from_seq: Some(42),
+                from_seq: Some(42),
             }
         );
     }
 
     #[test]
-    fn attach_in_wrong_phase_is_violation() {
-        let mut phase = Phase::AwaitingHelloAck;
+    fn attach_in_attached_phase_is_violation() {
+        // Phase 0b: there's no `AwaitingHelloAck` to land in
+        // anymore; the only "wrong phase for attach" is
+        // already-attached.
+        let mut phase = Phase::Attached;
         let action = step(
             &mut phase,
             ClientMessage::Attach {
                 session: "main".into(),
                 cols: 80,
                 rows: 24,
-                resume_from_seq: None,
+                from_seq: None,
             },
         );
         match action {
@@ -1619,13 +1839,14 @@ mod tests {
         let action = step(
             &mut phase,
             ClientMessage::Input {
-                data: vec![0x41, 0x42],
+                data: "AB".into(),
+                session: None,
             },
         );
         assert_eq!(
             action,
             Action::ForwardInput {
-                data: vec![0x41, 0x42],
+                data: "AB".into(),
             }
         );
     }
@@ -1638,6 +1859,7 @@ mod tests {
             ClientMessage::Resize {
                 cols: 100,
                 rows: 30,
+                session: None,
             },
         );
         assert_eq!(
@@ -1650,24 +1872,48 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_error_truncates_control_chars() {
-        let mut phase = Phase::AwaitingHelloAck;
-        let crafted = "evil\r\n[WARN] forged_line";
+    fn pull_after_attached_issues_handle_pull() {
+        let mut phase = Phase::Attached;
         let action = step(
             &mut phase,
-            ClientMessage::HelloAck {
-                protocol_version: crafted.into(),
+            ClientMessage::Pull {
+                from_seq: 17,
+                session: None,
+            },
+        );
+        assert_eq!(action, Action::HandlePull { from_seq: 17 });
+    }
+
+    #[test]
+    fn subscribe_replies_with_not_yet_implemented_error() {
+        // Phase 0b cutover: multi-session deferred. The handler
+        // sends an error reply but keeps the transport open so
+        // the SPA's existing single session keeps working.
+        let mut phase = Phase::Attached;
+        let action = step(
+            &mut phase,
+            ClientMessage::Subscribe {
+                session: "alt".into(),
             },
         );
         match action {
-            Action::Close { message, .. } => {
-                assert!(
-                    !message.contains('\r') && !message.contains('\n'),
-                    "log-bound error message must strip control chars; got {message:?}"
-                );
+            Action::ReplyError { code, .. } => {
+                assert_eq!(code, error_code::NOT_YET_IMPLEMENTED);
             }
-            other => panic!("expected close, got {other:?}"),
+            other => panic!("expected ReplyError, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn rtc_offer_replies_with_not_yet_implemented_error() {
+        let mut phase = Phase::Attached;
+        let action = step(
+            &mut phase,
+            ClientMessage::RtcOffer {
+                sdp: "v=0".into(),
+            },
+        );
+        assert!(matches!(action, Action::ReplyError { .. }));
     }
 
     // ---------- Revocation ----------
@@ -1746,12 +1992,12 @@ mod tests {
     #[test]
     fn error_codes_are_distinct() {
         let all = [
-            error_code::PROTOCOL_VERSION_MISMATCH,
             error_code::UNEXPECTED_MESSAGE,
             error_code::INVALID_SESSION,
             error_code::SESSION_ERROR,
             error_code::NO_SESSION_MANAGER,
-            error_code::HANDSHAKE_TIMEOUT,
+            error_code::ATTACH_TIMEOUT,
+            error_code::NOT_YET_IMPLEMENTED,
             error_code::INVALID_RESUME,
             error_code::SESSION_OVERSUBSCRIBED,
             error_code::ROUTER_AT_CAPACITY,
@@ -1780,6 +2026,7 @@ mod tests {
             subscriber_id: SubscriberId::testing(0),
             output_rx: rx,
             last_seen_seq: 0,
+            last_emitted_cursor: 0,
             coalescer: Coalescer::new(),
             last_output_at: None,
             pending_resize: None,
@@ -1871,17 +2118,21 @@ mod tests {
     #[tokio::test]
     async fn send_replay_fresh_sends_nothing() {
         let (h, mut rx) = capture_handle();
-        send_replay(&h, ReplaySlice::Fresh { end_seq: 0 })
+        send_replay(&h, "main", ReplaySlice::Fresh { end_seq: 0 })
             .await
             .expect("fresh is ok");
         assert!(rx.try_recv().is_err(), "Fresh must emit no messages");
     }
 
     #[tokio::test]
-    async fn send_replay_in_range_sends_one_output() {
+    async fn send_replay_in_range_sends_one_output_with_from_seq_and_cursor() {
+        // Phase 0b wire shape: replay bytes ride a single
+        // `output { session, data, fromSeq, cursor }` frame.
+        // `from_seq` is end_seq - data.len(), `cursor` is end_seq.
         let (h, mut rx) = capture_handle();
         send_replay(
             &h,
+            "main",
             ReplaySlice::InRange {
                 data: b"resume-bytes".to_vec(),
                 end_seq: 12,
@@ -1890,9 +2141,16 @@ mod tests {
         .await
         .unwrap();
         match rx.recv().await.unwrap() {
-            ServerMessage::Output { data, seq } => {
-                assert_eq!(data, b"resume-bytes");
-                assert_eq!(seq, 12);
+            ServerMessage::Output {
+                session,
+                data,
+                from_seq,
+                cursor,
+            } => {
+                assert_eq!(session, "main");
+                assert_eq!(data, "resume-bytes");
+                assert_eq!(from_seq, 0);
+                assert_eq!(cursor, 12);
             }
             other => panic!("expected Output, got {other:?}"),
         }
@@ -1900,15 +2158,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_replay_gap_sends_output_gap_before_output() {
-        // Order matters: the client's clear-terminal handler
-        // MUST fire before the replay bytes are applied.
-        // Regressing this ordering silently re-corrupts the
-        // terminal across reconnect gaps — this test is the
-        // canary.
+    async fn send_replay_gap_sends_pull_snapshot() {
+        // Phase 0b cutover: gap replay translates to a single
+        // `pull-snapshot` frame the SPA replaces its terminal
+        // contents with — there's no `OutputGap` in the Node
+        // wire. The lost-bytes-clear-then-apply ordering of the
+        // pre-cutover wire is preserved at the SPA level: the
+        // Node `pull-snapshot` handler clears xterm before
+        // writing the new bytes.
         let (h, mut rx) = capture_handle();
         send_replay(
             &h,
+            "main",
             ReplaySlice::Gap {
                 available_from_seq: 100,
                 data: b"tail-bytes".to_vec(),
@@ -1918,29 +2179,29 @@ mod tests {
         .await
         .unwrap();
         match rx.recv().await.unwrap() {
-            ServerMessage::OutputGap {
-                available_from_seq,
-                last_seq,
+            ServerMessage::PullSnapshot {
+                session,
+                data,
+                cursor,
             } => {
-                assert_eq!(available_from_seq, 100);
-                assert_eq!(last_seq, 150);
+                assert_eq!(session, "main");
+                assert_eq!(data, "tail-bytes");
+                assert_eq!(cursor, 150);
             }
-            other => panic!("first must be OutputGap, got {other:?}"),
+            other => panic!("expected PullSnapshot, got {other:?}"),
         }
-        match rx.recv().await.unwrap() {
-            ServerMessage::Output { data, seq } => {
-                assert_eq!(data, b"tail-bytes");
-                assert_eq!(seq, 150);
-            }
-            other => panic!("second must be Output, got {other:?}"),
-        }
+        assert!(rx.try_recv().is_err());
     }
 
     #[tokio::test]
-    async fn send_replay_gap_with_empty_data_sends_gap_only() {
+    async fn send_replay_gap_with_empty_data_still_sends_snapshot() {
+        // Empty-data gap is the cursor-evicted-but-ring-empty
+        // case (server restart). The SPA still needs the
+        // snapshot frame so its terminal clears.
         let (h, mut rx) = capture_handle();
         send_replay(
             &h,
+            "main",
             ReplaySlice::Gap {
                 available_from_seq: 0,
                 data: Vec::new(),
@@ -1951,8 +2212,8 @@ mod tests {
         .unwrap();
         assert!(matches!(
             rx.recv().await.unwrap(),
-            ServerMessage::OutputGap { .. }
+            ServerMessage::PullSnapshot { .. }
         ));
-        assert!(rx.try_recv().is_err(), "no Output after empty-data Gap");
+        assert!(rx.try_recv().is_err());
     }
 }

--- a/crates/server/src/transport/handle.rs
+++ b/crates/server/src/transport/handle.rs
@@ -85,13 +85,16 @@ pub enum TransportError {
     /// decides whether to close on decode failure.
     #[error("malformed client message: {0}")]
     DecodeFailed(String),
-    /// Peer sent a text frame when we accept only CBOR-encoded
-    /// binary. Distinct from `DecodeFailed` because a text frame
-    /// is the right-shape-wrong-encoding case — often a
-    /// wrong-client-version probe rather than corruption. The WS
-    /// impl rejects text frames without attempting to decode.
-    #[error("text frames are not accepted; protocol is CBOR over binary frames")]
-    UnexpectedText,
+    /// Peer sent a binary frame when we accept only JSON-encoded
+    /// text. Phase 0b of the Node-cutover flipped this from the
+    /// inverse rejection (binary-only / reject-text): the Node
+    /// SPA in `public/lib/ws-message-handlers.js` sends
+    /// `JSON.stringify` over text frames, and the Rust server
+    /// matches. A binary frame today is either a stale Rust WASM
+    /// client (frozen during cutover) or a probe; reject cleanly
+    /// and let the consumer decide.
+    #[error("binary frames are not accepted; protocol is JSON over text frames")]
+    UnexpectedBinary,
     /// Underlying I/O error from the transport. After this, the
     /// inbound channel closes.
     #[error("transport I/O: {0}")]
@@ -157,7 +160,7 @@ mod tests {
         // Simulate the pump task exiting: drop the outbound receiver.
         drop(outbound_rx);
         let err = handle
-            .send(ServerMessage::Pong { nonce: 1 })
+            .send(ServerMessage::Pong)
             .await
             .unwrap_err();
         assert!(matches!(err, TransportSendError::Closed));

--- a/crates/server/src/transport/message.rs
+++ b/crates/server/src/transport/message.rs
@@ -1,16 +1,24 @@
 //! Session protocol types — server-side facade over
 //! `katulong_shared::wire`.
 //!
-//! The actual `ClientMessage` / `ServerMessage` / `PROTOCOL_VERSION`
-//! definitions live in the shared crate so the WASM client can
-//! import the same types. This module re-exports them so existing
-//! server-internal call sites (`use crate::transport::message::*`)
-//! keep working without churn.
+//! The actual `ClientMessage` / `ServerMessage` definitions live in
+//! the shared crate so the WASM client can import the same types.
+//! This module re-exports them so existing server-internal call
+//! sites (`use crate::transport::message::*`) keep working without
+//! churn.
 //!
 //! See `katulong_shared::wire` for the full protocol documentation
-//! (CBOR wire format, `serde_bytes` byte-string contract, handshake,
-//! strictness flags). Tests for the protocol shape live in
-//! `crates/shared/tests/session_message.rs` so they ride alongside
-//! the type definitions.
+//! (JSON-over-text-frames wire format, no handshake, message-name
+//! contract with the Node SPA). Tests for the protocol shape live
+//! in `crates/shared/tests/session_message.rs` so they ride
+//! alongside the type definitions.
+//!
+//! Note: phase 0b of the Node-cutover removed the
+//! `PROTOCOL_VERSION` constant. The Node SPA has no
+//! Hello/HelloAck handshake; the server now starts in the
+//! awaiting-attach phase the moment the WS opens. If a future
+//! protocol-versioning slice lands, it should pick a different
+//! mechanism (e.g., a header on the WS upgrade) rather than
+//! resurrecting the in-band handshake.
 
-pub use katulong_shared::wire::{ClientMessage, ServerMessage, PROTOCOL_VERSION};
+pub use katulong_shared::wire::{ClientMessage, ServerMessage};

--- a/crates/server/src/transport/mod.rs
+++ b/crates/server/src/transport/mod.rs
@@ -9,12 +9,16 @@
 //! Slice 9d moved all session wire formats to CBOR. Slice 9e added
 //! the terminal-message variants (`HelloAck`, `Attach`, `Input`,
 //! `Resize`, `Attached`, `Output`, `Error`) that the handshake
-//! state machine in `session::handler` drives. WebRTC impl is
-//! whichever slice actually ships a client that wants it.
+//! state machine in `session::handler` drives. Phase 0b of the
+//! Node-cutover replaced the CBOR-binary wire with JSON over text
+//! frames so the existing Node SPA in `public/lib/...` can drive
+//! the Rust server unmodified, and removed the in-band
+//! Hello/HelloAck handshake (Node's SPA never spoke that). WebRTC
+//! impl is whichever slice actually ships a client that wants it.
 
 pub mod handle;
 pub mod message;
 pub mod websocket;
 
 pub use handle::{TransportError, TransportHandle, TransportKind, TransportSendError};
-pub use message::{ClientMessage, ServerMessage, PROTOCOL_VERSION};
+pub use message::{ClientMessage, ServerMessage};

--- a/crates/server/src/transport/websocket.rs
+++ b/crates/server/src/transport/websocket.rs
@@ -1,47 +1,42 @@
-//! WebSocket → `TransportHandle` adapter with CBOR wire format.
+//! WebSocket → `TransportHandle` adapter with JSON wire format.
 //!
 //! Wraps an axum `WebSocket` in two pump tasks and returns the
 //! consumer-facing `TransportHandle`. The terminal handler takes
 //! that handle and never sees `axum::extract::ws::*`.
 //!
-//! # Why CBOR, not JSON
+//! # Why JSON, not CBOR
 //!
-//! katulong is one-user-many-devices and performance-sensitive
-//! (the whole WS → WebRTC progressive enhancement exists to save
-//! milliseconds). CBOR gives us:
+//! The Node-cutover plan (phase 0b — this rewrite) moves the live
+//! frontend from the partly-built Rust+WASM bundle back to the
+//! existing Node SPA in `public/`. That SPA has spoken JSON over
+//! text WS frames since day one (`public/lib/ws-message-handlers.js`
+//! reads with `JSON.parse(event.data)` and writes with
+//! `JSON.stringify`). Asking the SPA to learn CBOR would spread
+//! cutover risk across both server and client; cheaper to make the
+//! Rust server speak JSON and revisit a binary wire later if
+//! profiling shows it actually matters.
 //!
-//! - **No base64 overhead** on byte payloads (image paste, raw
-//!   terminal input/output). JSON forces string encoding for any
-//!   binary field; CBOR's byte-string type carries bytes directly.
-//! - **Smaller wire** — typically 30-50% of JSON size for mixed
-//!   structured + byte data.
-//! - **Uniform wire across transports**. WS binary frames and
-//!   WebRTC DataChannel are both native binary; CBOR is the
-//!   single encoding that works on both without per-transport
-//!   shims.
-//! - **Schema evolution**. Self-describing format + serde means
-//!   new fields + new variants migrate the same way they did
-//!   under JSON.
-//!
-//! Lost: human-readable frames in Wireshark. The trade is
-//! deliberate — CBOR has well-understood debug tooling
-//! (`cbor.me`, `cborcli`) and our operator debugging surface is
-//! structured logs anyway, not wire captures.
+//! Lost: the `serde_bytes`-backed CBOR byte-string encoding that
+//! kept large pastes off the array-of-int overhead. The SPA's
+//! input-cap is 8 KiB (`lib/websocket-validation.js`), and the
+//! server-side outbound coalescer keeps `output` chunks small;
+//! today's traffic fits comfortably under the 64 KiB frame cap
+//! even with JSON's overhead.
 //!
 //! # Wire-level responsibilities
 //!
 //! Two pump tasks:
 //!
 //! - `input_pump`: reads `WebSocket::recv()` frames, decodes each
-//!   binary frame as a `ClientMessage` via CBOR, forwards to the
-//!   inbound channel. Rejects text frames (wrong encoding) and
-//!   binary frames above the size cap. Reports decode/frame
-//!   errors via `Result<ClientMessage, TransportError>` so the
-//!   consumer can decide whether to close. Exits on peer Close
-//!   or disconnect.
+//!   text frame as a `ClientMessage` via `serde_json::from_str`,
+//!   forwards to the inbound channel. Rejects binary frames
+//!   (wrong encoding for the Node SPA) and text frames above the
+//!   size cap. Reports decode/frame errors via
+//!   `Result<ClientMessage, TransportError>` so the consumer can
+//!   decide whether to close. Exits on peer Close or disconnect.
 //! - `output_pump`: drains the outbound channel, serializes each
-//!   `ServerMessage` to CBOR, sends as binary frame. Exits when
-//!   the channel closes (consumer dropped the handle).
+//!   `ServerMessage` to JSON, sends as text frame. Exits when the
+//!   channel closes (consumer dropped the handle).
 //!
 //! Protocol keep-alive (WS-level `Ping`/`Pong` frames, distinct
 //! from the app-level `ClientMessage::Ping`/`ServerMessage::Pong`)
@@ -70,17 +65,15 @@ const OUTBOUND_BUFFER: usize = 64;
 /// alternative is an unbounded channel growing toward OOM.
 const INBOUND_BUFFER: usize = 64;
 
-/// Hard size cap on an individual inbound binary frame, applied
-/// BEFORE CBOR decode. Without this, an authenticated attacker
+/// Hard size cap on an individual inbound text frame, applied
+/// BEFORE JSON decode. Without this, an authenticated attacker
 /// could push multi-megabyte frames through a connection that's
 /// already past the auth gate; the axum `DefaultBodyLimit` layer
 /// covers HTTP bodies, not WS frames once upgrade has completed.
-/// 64 KiB is well above any current message and still comfortably
-/// above the terminal messages envisioned for slice 9e/9f
-/// (keystroke input, resize, session-id strings, small output
-/// chunks after coalescing). Large paste payloads that exceed
-/// this get fragmented at the client; the CBOR-native byte-string
-/// type keeps that overhead minimal without needing base64.
+/// 64 KiB sits well above any current message — Node's
+/// `validateMessage` caps `input.data` at 8192 chars, and our
+/// outbound coalescer keeps `output.data` chunks small. A real
+/// paste larger than the inner cap is chunked client-side.
 const MAX_INBOUND_FRAME_BYTES: usize = 64 * 1024;
 
 /// The pump tasks spawned by `into_transport`. Returned alongside
@@ -134,26 +127,24 @@ async fn input_pump(
     use futures::StreamExt;
     while let Some(frame) = ws_rx.next().await {
         let decoded = match frame {
-            Ok(Message::Binary(bytes)) => {
-                if bytes.len() > MAX_INBOUND_FRAME_BYTES {
+            Ok(Message::Text(text)) => {
+                if text.len() > MAX_INBOUND_FRAME_BYTES {
                     Err(TransportError::DecodeFailed(format!(
                         "frame too large: {} bytes exceeds {} byte limit",
-                        bytes.len(),
+                        text.len(),
                         MAX_INBOUND_FRAME_BYTES
                     )))
                 } else {
-                    ciborium::de::from_reader::<ClientMessage, _>(&bytes[..])
+                    serde_json::from_str::<ClientMessage>(&text)
                         .map_err(|e| TransportError::DecodeFailed(e.to_string()))
                 }
             }
-            // Text frames are rejected: CBOR is the sole wire format.
-            // A client sending text is either wrong-version or
-            // probing; reject cleanly and let the consumer decide.
-            // This rejection is permanent — if a future debug
-            // surface wants human-readable wire traffic, it lives
-            // as a separate HTTP route (e.g. `/api/debug/ws-trace`),
-            // not as a mode flag on the session transport.
-            Ok(Message::Text(_)) => Err(TransportError::UnexpectedText),
+            // Binary frames are rejected: JSON over text is the
+            // sole wire format. A client sending binary is either
+            // a stale WASM build (the Rust frontend's WS code is
+            // frozen during cutover) or a probe; reject cleanly
+            // and let the consumer decide what to do.
+            Ok(Message::Binary(_)) => Err(TransportError::UnexpectedBinary),
             Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {
                 // WS-level keepalive. axum auto-responds to Ping;
                 // we just drop them from the inbound stream so the
@@ -179,17 +170,21 @@ async fn output_pump(
 ) {
     use futures::SinkExt;
     while let Some(msg) = outbound.recv().await {
-        let mut buf = Vec::new();
-        if let Err(e) = ciborium::ser::into_writer(&msg, &mut buf) {
-            // `ServerMessage` is a closed set of serde-derived
-            // types; CBOR encoding can't fail on any of them today.
-            // If it ever does, that's a bug in the type definition
-            // — log and skip rather than poisoning the transport
-            // for every subsequent message.
-            tracing::error!(error = %e, "ServerMessage CBOR encoding failed; dropping frame");
-            continue;
-        }
-        if ws_tx.send(Message::Binary(buf)).await.is_err() {
+        let json = match serde_json::to_string(&msg) {
+            Ok(s) => s,
+            Err(e) => {
+                // `ServerMessage` is a closed set of serde-derived
+                // types; JSON encoding can't fail on any of them
+                // today (no `Map` keys with non-string types, no
+                // `f32`/`f64` NaN). If it ever does, that's a bug
+                // in the type definition — log and skip rather
+                // than poisoning the transport for every
+                // subsequent message.
+                tracing::error!(error = %e, "ServerMessage JSON encoding failed; dropping frame");
+                continue;
+            }
+        };
+        if ws_tx.send(Message::Text(json)).await.is_err() {
             break;
         }
     }
@@ -203,58 +198,50 @@ mod tests {
     #[test]
     fn max_inbound_frame_bytes_is_generous_vs_current_messages() {
         // Paranoia test: the cap must sit comfortably above the
-        // largest `ClientMessage` today. Ping serializes to ~10
-        // bytes in CBOR; 64 KiB is 6000x that. If slice 9e/9f adds
-        // a variant that could legitimately approach this limit,
-        // this test is the signal to document an explicit limit
-        // on THAT variant rather than just bumping the global cap.
-        let ping = ClientMessage::Ping { nonce: u64::MAX };
-        let mut buf = Vec::new();
-        ciborium::ser::into_writer(&ping, &mut buf).unwrap();
+        // largest `ClientMessage` today. Ping serializes to ~16
+        // bytes in JSON; 64 KiB is 4000x that. If a future variant
+        // approaches this limit, this test is the signal to
+        // document an explicit limit on THAT variant rather than
+        // just bumping the global cap.
+        let ping = ClientMessage::Ping;
+        let json = serde_json::to_string(&ping).unwrap();
         assert!(
-            buf.len() < MAX_INBOUND_FRAME_BYTES / 100,
+            json.len() < MAX_INBOUND_FRAME_BYTES / 100,
             "max frame bytes must leave 100x headroom over current \
              messages; Ping encoded to {} bytes vs cap {}",
-            buf.len(),
+            json.len(),
             MAX_INBOUND_FRAME_BYTES
         );
     }
 
     #[test]
-    fn cbor_is_smaller_than_json_for_ping() {
-        // Not a correctness check; a sanity check that the wire
-        // benefit we're trading JSON readability for actually
-        // shows up. If this ever fails, CBOR encoding changed
-        // behavior and the trade needs re-examination.
-        //
-        // NOTE: CBOR integer encoding scales with the magnitude
-        // of the value (a 1-byte header + up to 8 payload bytes
-        // for u64::MAX). JSON encodes integers as ASCII digits
-        // (20 chars for u64::MAX). At `nonce: 42` CBOR is
-        // unambiguously smaller; for very large nonces CBOR's
-        // 9-byte integer vs JSON's 20-char digit string still
-        // favors CBOR, but the margin shrinks. Keep the test
-        // value small so the assertion stays a clean statement
-        // about the encoding's typical shape, not a claim about
-        // every u64 value.
-        let ping = ClientMessage::Ping { nonce: 42 };
-        let mut cbor = Vec::new();
-        ciborium::ser::into_writer(&ping, &mut cbor).unwrap();
-        let json = serde_json::to_string(&ping).unwrap();
-        assert!(
-            cbor.len() < json.len(),
-            "CBOR ({} bytes) should be smaller than JSON ({} bytes) for Ping",
-            cbor.len(),
-            json.len()
-        );
+    fn json_roundtrip_preserves_message() {
+        let original = ClientMessage::Resize {
+            cols: 80,
+            rows: 24,
+            session: None,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let back: ClientMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, original);
     }
 
     #[test]
-    fn cbor_roundtrip_preserves_message() {
-        let original = ClientMessage::Ping { nonce: 12345 };
-        let mut buf = Vec::new();
-        ciborium::ser::into_writer(&original, &mut buf).unwrap();
-        let back: ClientMessage = ciborium::de::from_reader(&buf[..]).unwrap();
-        assert_eq!(back, original);
+    fn output_message_serializes_with_camelcase_from_seq() {
+        // Wire-shape canary: the Node SPA reads `msg.fromSeq`, not
+        // `msg.from_seq`. If a future serde refactor flips the
+        // rename annotation off, this test fires before the
+        // operator finds out via a broken terminal.
+        let msg = ServerMessage::Output {
+            session: "main".into(),
+            data: "hello".into(),
+            from_seq: 0,
+            cursor: 5,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(
+            json.contains(r#""fromSeq":0"#),
+            "outbound JSON must use camelCase fromSeq; got {json}"
+        );
     }
 }

--- a/crates/server/tests/ws_node_frontend.rs
+++ b/crates/server/tests/ws_node_frontend.rs
@@ -1,0 +1,422 @@
+//! Phase 0b contract test: the Rust server's WS protocol must be
+//! byte-compatible with the Node SPA's existing client in
+//! `public/lib/ws-message-handlers.js`.
+//!
+//! What this file tests
+//! --------------------
+//!
+//! These tests pin the JSON wire shape of every message the Node
+//! SPA sends or expects. They DO NOT spin up tmux or drive
+//! `serve_session` end-to-end (that lives behind `#[ignore]` in
+//! `session::handler` and `session::manager` because it needs a
+//! real tmux binary). What they DO is round-trip every wire frame
+//! through `serde_json` against a concrete byte-string the SPA
+//! actually emits — if the rename annotation, variant tag, or
+//! field order ever drifts, this file fires before an operator
+//! finds out via a broken terminal.
+//!
+//! End-to-end coverage of the attach→input→output flow with a
+//! real tmux is the operator-smoke test plan in the PR
+//! description; the unit-level JSON-shape coverage here is the
+//! cheap regression net that catches the nine-of-ten ways the
+//! wire could drift without operator-time setup.
+
+use katulong_shared::wire::{ClientMessage, ServerMessage};
+use serde_json::{from_str, json, to_string, Value};
+
+/// Reads a Node-SPA-style frame and confirms the Rust enum
+/// deserialises to the expected variant + fields. The closure
+/// pattern keeps each test focused on the wire bytes; the
+/// destructuring is in one place per test.
+fn assert_decodes<F: FnOnce(ClientMessage)>(json: &str, check: F) {
+    let m: ClientMessage = from_str(json)
+        .unwrap_or_else(|e| panic!("decode failed for {json:?}: {e}"));
+    check(m);
+}
+
+// ---------- Inbound frames the SPA sends ----------
+
+#[test]
+fn spa_attach_decodes() {
+    // Shape from `public/lib/ws-message-handlers.js`'s
+    // attach call. No `fromSeq` on a fresh attach; cols/rows
+    // from the xterm fit-addon.
+    let frame = r#"{"type":"attach","session":"main","cols":120,"rows":40}"#;
+    assert_decodes(frame, |m| {
+        assert!(matches!(
+            m,
+            ClientMessage::Attach {
+                session,
+                cols: 120,
+                rows: 40,
+                from_seq: None,
+            } if session == "main"
+        ));
+    });
+}
+
+#[test]
+fn spa_attach_with_resume_cursor_decodes() {
+    let frame =
+        r#"{"type":"attach","session":"main","cols":80,"rows":24,"fromSeq":12345}"#;
+    assert_decodes(frame, |m| {
+        let ClientMessage::Attach { from_seq, .. } = m else {
+            panic!("expected Attach");
+        };
+        assert_eq!(from_seq, Some(12345));
+    });
+}
+
+#[test]
+fn spa_input_decodes_with_string_data() {
+    // The SPA sends `{type, data}` where `data` is the
+    // keystroke string. Note the JSON-escaped `[` for ANSI
+    // escape: `JSON.stringify("[A")` produces `"[A"`.
+    let frame = r#"{"type":"input","data":"\u001b[A"}"#;
+    assert_decodes(frame, |m| {
+        let ClientMessage::Input { data, session } = m else {
+            panic!("expected Input");
+        };
+        assert_eq!(data, "\u{1b}[A");
+        assert!(session.is_none());
+    });
+}
+
+#[test]
+fn spa_input_with_explicit_session_decodes() {
+    // The SPA sends an explicit `session` when it has multiple
+    // tabs open (per `lib/ws-manager.js:404-406`).
+    let frame = r#"{"type":"input","data":"ls\n","session":"work"}"#;
+    assert_decodes(frame, |m| {
+        let ClientMessage::Input { data, session } = m else {
+            panic!("expected Input");
+        };
+        assert_eq!(data, "ls\n");
+        assert_eq!(session.as_deref(), Some("work"));
+    });
+}
+
+#[test]
+fn spa_resize_decodes() {
+    let frame = r#"{"type":"resize","cols":100,"rows":30}"#;
+    assert_decodes(frame, |m| {
+        assert!(matches!(
+            m,
+            ClientMessage::Resize {
+                cols: 100,
+                rows: 30,
+                session: None,
+            }
+        ));
+    });
+}
+
+#[test]
+fn spa_pull_decodes_with_camelcase_from_seq() {
+    let frame = r#"{"type":"pull","fromSeq":42,"session":"main"}"#;
+    assert_decodes(frame, |m| {
+        let ClientMessage::Pull { from_seq, session } = m else {
+            panic!("expected Pull");
+        };
+        assert_eq!(from_seq, 42);
+        assert_eq!(session.as_deref(), Some("main"));
+    });
+}
+
+#[test]
+fn spa_subscribe_decodes() {
+    assert_decodes(r#"{"type":"subscribe","session":"alt"}"#, |m| {
+        assert!(matches!(m, ClientMessage::Subscribe { session } if session == "alt"));
+    });
+}
+
+#[test]
+fn spa_unsubscribe_decodes() {
+    assert_decodes(r#"{"type":"unsubscribe","session":"alt"}"#, |m| {
+        assert!(matches!(m, ClientMessage::Unsubscribe { session } if session == "alt"));
+    });
+}
+
+#[test]
+fn spa_switch_decodes() {
+    let frame = r#"{"type":"switch","session":"alt","cols":80,"rows":24}"#;
+    assert_decodes(frame, |m| {
+        assert!(matches!(
+            m,
+            ClientMessage::Switch {
+                session,
+                cols: 80,
+                rows: 24,
+            } if session == "alt"
+        ));
+    });
+}
+
+#[test]
+fn spa_resync_decodes() {
+    assert_decodes(r#"{"type":"resync","session":"main"}"#, |m| {
+        assert!(matches!(m, ClientMessage::Resync { session } if session == "main"));
+    });
+}
+
+#[test]
+fn spa_set_tab_icon_decodes_with_literal_hyphen() {
+    // CRITICAL: the wire uses a literal HYPHEN, not snake_case
+    // (`set-tab-icon`, not `set_tab_icon`). `lib/websocket-validation.js`
+    // hard-codes the hyphenated form.
+    assert_decodes(
+        r#"{"type":"set-tab-icon","session":"main","icon":"🐛"}"#,
+        |m| {
+            let ClientMessage::SetTabIcon { session, icon } = m else {
+                panic!("expected SetTabIcon");
+            };
+            assert_eq!(session, "main");
+            assert_eq!(icon.as_deref(), Some("\u{1f41b}"));
+        },
+    );
+}
+
+#[test]
+fn spa_set_tab_icon_null_decodes() {
+    assert_decodes(
+        r#"{"type":"set-tab-icon","session":"main","icon":null}"#,
+        |m| {
+            let ClientMessage::SetTabIcon { icon, .. } = m else {
+                panic!("expected SetTabIcon");
+            };
+            assert!(icon.is_none());
+        },
+    );
+}
+
+#[test]
+fn spa_ping_decodes_without_nonce() {
+    // Phase 0b cutover dropped the `nonce` field — Node's
+    // app-level ping is keepalive only. The wire shape is
+    // `{type:"ping"}` and the response is `{type:"pong"}`.
+    assert_decodes(r#"{"type":"ping"}"#, |m| {
+        assert!(matches!(m, ClientMessage::Ping));
+    });
+}
+
+#[test]
+fn spa_rtc_offer_decodes_as_stub() {
+    // Phase 0b stubs WebRTC signaling so the SPA's speculative
+    // upgrade attempts get a clean error reply rather than a
+    // protocol-violation close.
+    assert_decodes(r#"{"type":"rtc-offer","sdp":"v=0\r\n"}"#, |m| {
+        assert!(matches!(m, ClientMessage::RtcOffer { .. }));
+    });
+}
+
+#[test]
+fn spa_rtc_ice_candidate_decodes_as_stub() {
+    let frame = r#"{"type":"rtc-ice-candidate","candidate":{"candidate":"candidate:1 1 UDP 2122252543 192.0.2.1 50000 typ host","sdpMid":"0"}}"#;
+    assert_decodes(frame, |m| {
+        assert!(matches!(m, ClientMessage::RtcIceCandidate { .. }));
+    });
+}
+
+#[test]
+fn unknown_type_fails_decode() {
+    // The Node validator rejects unrecognised types; the Rust
+    // parser does the same via serde's tagged-enum exhaustive
+    // match.
+    assert!(from_str::<ClientMessage>(r#"{"type":"output"}"#).is_err());
+    assert!(from_str::<ClientMessage>(r#"{"type":""}"#).is_err());
+    assert!(from_str::<ClientMessage>(r#"{}"#).is_err());
+}
+
+// ---------- Outbound frames the SPA expects ----------
+
+#[test]
+fn server_attached_emits_session_and_string_data() {
+    let json = to_string(&ServerMessage::Attached {
+        session: "main".into(),
+        data: String::new(),
+    })
+    .unwrap();
+    let v: Value = from_str(&json).unwrap();
+    assert_eq!(v["type"], "attached");
+    assert_eq!(v["session"], "main");
+    assert_eq!(v["data"], "");
+    // No `cols`/`rows`/`last_seq` — the SPA reads only `data`
+    // (and `session` for routing). Pre-cutover wire carried
+    // `last_seq`; phase 0b moved that to a separate `seq-init`.
+    assert!(v.get("cols").is_none());
+    assert!(v.get("rows").is_none());
+    assert!(v.get("last_seq").is_none());
+}
+
+#[test]
+fn server_seq_init_emits_session_and_seq() {
+    let json = to_string(&ServerMessage::SeqInit {
+        session: "main".into(),
+        seq: 42,
+    })
+    .unwrap();
+    let v: Value = from_str(&json).unwrap();
+    assert_eq!(v["type"], "seq-init");
+    assert_eq!(v["session"], "main");
+    assert_eq!(v["seq"], 42);
+}
+
+#[test]
+fn server_output_emits_camelcase_from_seq_and_cursor() {
+    // Wire-shape canary: pinned to `lib/ws-manager.js:127-129`.
+    // Renaming `fromSeq`/`cursor` is a wire break with the SPA.
+    let json = to_string(&ServerMessage::Output {
+        session: "main".into(),
+        data: "hi".into(),
+        from_seq: 10,
+        cursor: 12,
+    })
+    .unwrap();
+    let v: Value = from_str(&json).unwrap();
+    assert_eq!(v["type"], "output");
+    assert_eq!(v["session"], "main");
+    assert_eq!(v["data"], "hi");
+    assert_eq!(v["fromSeq"], 10);
+    assert_eq!(v["cursor"], 12);
+    // No `seq` — pre-cutover wire used `seq` (== end-of-chunk).
+    assert!(v.get("seq").is_none());
+}
+
+#[test]
+fn server_data_available_emits_session() {
+    let json = to_string(&ServerMessage::DataAvailable {
+        session: "main".into(),
+    })
+    .unwrap();
+    let v: Value = from_str(&json).unwrap();
+    assert_eq!(v["type"], "data-available");
+    assert_eq!(v["session"], "main");
+}
+
+#[test]
+fn server_pull_response_emits_session_data_cursor() {
+    let json = to_string(&ServerMessage::PullResponse {
+        session: "main".into(),
+        data: "tail".into(),
+        cursor: 100,
+    })
+    .unwrap();
+    let v: Value = from_str(&json).unwrap();
+    assert_eq!(v["type"], "pull-response");
+    assert_eq!(v["session"], "main");
+    assert_eq!(v["data"], "tail");
+    assert_eq!(v["cursor"], 100);
+}
+
+#[test]
+fn server_pull_snapshot_emits_session_data_cursor() {
+    let json = to_string(&ServerMessage::PullSnapshot {
+        session: "main".into(),
+        data: "fresh".into(),
+        cursor: 999,
+    })
+    .unwrap();
+    let v: Value = from_str(&json).unwrap();
+    assert_eq!(v["type"], "pull-snapshot");
+    assert_eq!(v["session"], "main");
+    assert_eq!(v["data"], "fresh");
+    assert_eq!(v["cursor"], 999);
+}
+
+#[test]
+fn server_exit_emits_session_and_code() {
+    let json = to_string(&ServerMessage::Exit {
+        session: "main".into(),
+        code: -1,
+    })
+    .unwrap();
+    let v: Value = from_str(&json).unwrap();
+    assert_eq!(v["type"], "exit");
+    assert_eq!(v["session"], "main");
+    assert_eq!(v["code"], -1);
+}
+
+#[test]
+fn server_error_omits_code_when_none() {
+    // The Node SPA's error handler reads `msg.message`; the
+    // `code` field is server-side metadata only. Optional via
+    // `skip_serializing_if`.
+    let json = to_string(&ServerMessage::Error {
+        message: "Invalid message format".into(),
+        code: None,
+    })
+    .unwrap();
+    let v: Value = from_str(&json).unwrap();
+    assert_eq!(v["type"], "error");
+    assert_eq!(v["message"], "Invalid message format");
+    assert!(v.get("code").is_none());
+}
+
+#[test]
+fn server_error_includes_code_when_some() {
+    let json = to_string(&ServerMessage::Error {
+        message: "not yet implemented".into(),
+        code: Some("not_yet_implemented".into()),
+    })
+    .unwrap();
+    let v: Value = from_str(&json).unwrap();
+    assert_eq!(v["code"], "not_yet_implemented");
+}
+
+#[test]
+fn server_pong_emits_no_nonce() {
+    // Phase 0b dropped the `nonce` field on both ping and pong
+    // — they're keepalive-only now. If this test fires, the
+    // SPA's `pong` handler will still work (it doesn't read
+    // any field), but the test pins the contract.
+    let json = to_string(&ServerMessage::Pong).unwrap();
+    let v: Value = from_str(&json).unwrap();
+    assert_eq!(v["type"], "pong");
+    assert!(v.as_object().unwrap().len() == 1);
+}
+
+// ---------- Smoke: SPA → server → SPA round-trips ----------
+
+#[test]
+fn spa_can_decode_server_attached_then_seq_init_then_output() {
+    // End-to-end JSON-only smoke: build the three frames the
+    // Rust server emits on a fresh attach (`attached`,
+    // `seq-init`, then live `output` once the shell repaints),
+    // confirm they decode as the expected SPA shapes via
+    // serde_json::Value (the SPA's JSON.parse equivalent).
+    let attached = json!({"type": "attached", "session": "main", "data": ""});
+    let seq_init = json!({"type": "seq-init", "session": "main", "seq": 0});
+    let output = json!({
+        "type": "output",
+        "session": "main",
+        "data": "$ ",
+        "fromSeq": 0,
+        "cursor": 2,
+    });
+
+    // The Rust server must produce frames whose JSON.stringify
+    // matches the SPA's expectations. We round-trip through
+    // ServerMessage + back to Value to confirm the shape.
+    let from_rust = to_string(&ServerMessage::Attached {
+        session: "main".into(),
+        data: String::new(),
+    })
+    .unwrap();
+    assert_eq!(from_str::<Value>(&from_rust).unwrap(), attached);
+
+    let from_rust = to_string(&ServerMessage::SeqInit {
+        session: "main".into(),
+        seq: 0,
+    })
+    .unwrap();
+    assert_eq!(from_str::<Value>(&from_rust).unwrap(), seq_init);
+
+    let from_rust = to_string(&ServerMessage::Output {
+        session: "main".into(),
+        data: "$ ".into(),
+        from_seq: 0,
+        cursor: 2,
+    })
+    .unwrap();
+    assert_eq!(from_str::<Value>(&from_rust).unwrap(), output);
+}

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -20,16 +20,12 @@ serde = { workspace = true }
 # means the WASM build sees the bridge impls without forcing
 # them onto the server build.
 webauthn-rs-proto = "0.5"
-# `serde_bytes` for the byte-string CBOR encoding on
-# `ClientMessage::Input.data` and `ServerMessage::Output.data` —
-# see the session protocol section in `wire.rs`. Without this
-# annotation, `Vec<u8>` payloads encode as CBOR arrays of small
-# integers (1-2 bytes overhead per byte), which doubles a 1 KiB
-# paste's wire size. The annotation is part of the protocol's
-# wire contract; the contract pinning is in
-# `tests/session_message.rs::cbor_input_encodes_data_as_byte_string`.
-serde_bytes = "0.11"
+# `serde_json::Value` is used as the typed home for
+# `ClientMessage::RtcIceCandidate.candidate` — phase 0b parses
+# the candidate as opaque JSON because the signaling handler
+# is a stub today (multi-session / WebRTC lands in phase 1).
+# A dedicated `IceCandidate` struct can replace it then.
+serde_json = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
-ciborium = "0.2"

--- a/crates/shared/src/wire.rs
+++ b/crates/shared/src/wire.rs
@@ -372,187 +372,337 @@ impl TileLayout {
 // class of bug at parse time; we just have to be disciplined about
 // not reintroducing `Value` as an escape hatch.
 //
-// **Wire format: CBOR.** Messages encode via CBOR (`ciborium`) into
-// binary frames. JSON is used only for the HTTP API (cookies, error
-// envelopes, token CRUD). Uniform binary over both WS and (future)
-// WebRTC DataChannel; no base64 overhead for byte payloads; smaller
-// wire; same serde derives.
+// **Wire format: JSON over text frames.** Phase 0b of the cutover
+// (this rewrite) drops the CBOR/binary wire that the WASM frontend
+// briefly used; the server now speaks the same JSON-over-text
+// protocol the Node frontend has spoken since day one. Reasons:
+// the cutover plan moves the live frontend from Rust+WASM back to
+// the existing Node SPA bundle, and that SPA's WS code (in
+// `public/lib/ws-message-handlers.js`) sends `JSON.parse`/
+// `JSON.stringify` over text frames. Asking the SPA to learn CBOR
+// would spread cutover risk across both server and client; cheaper
+// to make the Rust server speak JSON for now and revisit a binary
+// wire later if performance demands it.
 //
-// **Byte-string encoding for `Input`/`Output`.** `Input { data }` and
-// `Output { data }` carry raw terminal bytes. Their `data` fields are
-// annotated `#[serde(with = "serde_bytes")]` so CBOR emits a major-
-// type-2 byte string instead of the serde-default array of small
-// integers. Without the annotation, a 1 KiB paste would encode as
-// ~1–2 KiB of integer elements; with it the payload rides the wire
-// literally.
+// **`data` fields are UTF-8 strings, not bytes.** Node's tmux
+// control-mode parser decodes the octal-escape encoding into UTF-8
+// strings BEFORE buffering, so by the time anything reaches the WS
+// layer, `output.data` is already a JS string. The Rust server
+// matches this: `String::from_utf8_lossy` at the PTY-output boundary
+// turns the decoded bytes into a `String` whose ANSI escapes
+// (`\x1b[...`) survive verbatim through `serde_json::to_string`.
+// Input keystrokes from the client arrive as a `String` with at most
+// 8192 chars (matching Node's `validateMessage` cap in
+// `lib/websocket-validation.js`).
 //
 // **Strictness flags.**
-// - `#[serde(tag = "type", rename_all = "snake_case")]` — every
-//   message carries a `type` discriminator and snake_case field
-//   names. Missing discriminator fails parsing.
-// - `#[serde(deny_unknown_fields)]` on `ClientMessage` only — inbound
-//   strictness is a security property; outbound `ServerMessage` stays
-//   lenient so older Rust consumers (tests, federation relays) can
-//   deserialize newer-server output without hard-failing on unknown
-//   fields.
+// - `#[serde(tag = "type")]` — every message carries a `type`
+//   discriminator. Missing discriminator fails parsing.
+// - Inbound message names match Node's strings exactly (some are
+//   snake_case like `set-tab-icon` — note the literal hyphen — so
+//   we use explicit `#[serde(rename = "...")]` annotations rather
+//   than a global `rename_all`).
+// - `#[serde(deny_unknown_fields)]` is deliberately NOT on the
+//   client enum: the Node validator silently ignores extra fields
+//   on a recognized `type`, and the SPA does send some (`session`
+//   on `input` is sometimes absent, sometimes present). Strictness
+//   on a JSON wire we don't fully control would just kick the user.
+//   The defense in depth lives in the per-handler validators
+//   downstream, not at the parser.
 //
-// **Handshake.** Three-step gate before terminal I/O is valid:
-//   1. Server → Client: `Hello { protocol_version }` on upgrade.
-//   2. Client → Server: `HelloAck { protocol_version }`. Server re-
-//      validates; mismatch → `Error { code:
-//      "protocol_version_mismatch", ... }` and close.
-//   3. Client → Server: `Attach { session, cols, rows }`. Server
-//      replies `Attached`.
-// Only after `Attached` are `Input`/`Resize` accepted.
-// `Ping`/`Pong` is allowed in every phase (liveness is orthogonal).
+// **No handshake.** Phase 0b removed the Hello/HelloAck handshake
+// the Rust transport used to require. The Node SPA connects and
+// immediately sends `attach`/`subscribe`; the server now starts in
+// the `AwaitingAttach` phase the moment the WS opens. Protocol
+// version negotiation lives in the auth/cookie surface (the SPA
+// asset bundle is served by the same Rust server, so frontend and
+// server ship together).
 //
 // **Why these types live in `shared`.** Server (sends + receives) and
 // WASM client (sends + receives) both consume them. Originally lived
 // in `crates/server/src/transport/message.rs`; moved here so the
 // types are the single source of truth and a server schema change
-// can't drift from a hand-rolled WASM mirror.
+// can't drift from a hand-rolled WASM mirror. The WASM consumer in
+// `crates/web/src/ws.rs` is FROZEN during the cutover — phase 0b
+// adapts the server side only; the WASM frontend will be updated in
+// a later slice (it doesn't drive the live UI today).
 // =====================================================================
-
-/// Current protocol version. Clients check this against their
-/// expected value and refuse to proceed on mismatch. Bumped when a
-/// non-backwards-compatible change lands (new required field, removed
-/// variant, changed semantics).
-pub const PROTOCOL_VERSION: &str = "katulong/0.1";
 
 /// Messages sent by the client to the server.
 ///
-/// Deserialized from each inbound CBOR binary frame. Text frames are
-/// rejected by the transport layer. Byte payloads (terminal input,
-/// future image paste) carry directly via CBOR's byte-string type —
-/// no base64 wrapper needed.
+/// Deserialized from each inbound text WS frame. Binary frames are
+/// rejected by the transport layer.
+///
+/// **Wire-shape contract.** The variant order, `serde(rename = "...")`
+/// strings, and field names are part of the public protocol the
+/// Node SPA depends on. Any rename or restructure here is a
+/// cross-repo wire break — drive it through both
+/// `lib/ws-manager.js` (Node, dispatch) and
+/// `public/lib/ws-message-handlers.js` (Node, frontend handlers)
+/// in lockstep.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+#[serde(tag = "type")]
 pub enum ClientMessage {
-    /// Client heartbeat. Server echoes with `Pong` carrying the same
-    /// `nonce` — lets the client measure round-trip latency without
-    /// assuming a specific transport's heartbeat primitive (WS Ping
-    /// frames vs WebRTC DC keep-alives differ).
-    Ping { nonce: u64 },
+    /// Application-level heartbeat. Distinct from the WS-protocol
+    /// Ping/Pong frames so a non-WS transport (WebRTC DC) can use
+    /// the same shape. Server replies with `Pong`.
+    #[serde(rename = "ping")]
+    Ping,
 
-    /// Acknowledge the server's `Hello` and confirm the client speaks
-    /// the same protocol version. Sent exactly once, as the first
-    /// message after the client receives `Hello`. The server re-
-    /// checks the version and closes on mismatch.
-    HelloAck { protocol_version: String },
-
-    /// Bind this transport to a tmux session. `session` is the tmux
-    /// session name (validated by `SessionManager`); `cols`/`rows`
-    /// are the client's current window dimensions (clamped
-    /// defensively server-side per `session::dims`). Sent exactly
-    /// once after `HelloAck`. The server creates the session if it
-    /// doesn't exist (or attaches to the existing one) and replies
-    /// with `Attached`.
+    /// Bind this transport to a tmux session. The Node SPA sends
+    /// this immediately after WS open. `cols`/`rows` are the
+    /// client's current dimensions; the server clamps defensively
+    /// per `session::dims`.
     ///
-    /// `resume_from_seq`: reconnect hint. Absent (or `None`) means
-    /// "fresh attach — I have no prior state." `Some(N)` means "I
-    /// last received bytes through seq N; please replay bytes
-    /// `(N..last_seq]` if you still have them." If the server's ring
-    /// has lost bytes below `N`, it emits `OutputGap` before the
-    /// replay so the client clears its terminal first. Omit on first
-    /// attach; echo the seq from `Attached.last_seq` on reconnect.
+    /// `from_seq` (camelCase `fromSeq` on the wire) is the optional
+    /// reconnect cursor: `Some(N)` means "I last received bytes
+    /// through seq N; please replay `(N..last_seq]` if still in
+    /// ring." Absent on first attach.
+    ///
+    /// **Wire field name caveat.** Node's
+    /// `public/lib/ws-message-handlers.js` keeps the cursor in
+    /// `pullManager` and re-issues it on `pull { fromSeq }` rather
+    /// than on `attach`. We accept both spellings on attach so
+    /// either client (Node SPA via pull, WASM client via direct
+    /// resume) can drive the protocol; the `from_seq` field stays
+    /// optional and defaults to `None`.
+    #[serde(rename = "attach")]
     Attach {
         session: String,
         cols: u16,
         rows: u16,
-        #[serde(default)]
-        resume_from_seq: Option<u64>,
+        #[serde(default, rename = "fromSeq", alias = "from_seq")]
+        from_seq: Option<u64>,
     },
 
-    /// Keystroke / paste input destined for the PTY. Only valid after
-    /// `Attached`.
+    /// Keystroke / paste input destined for the PTY. Node's
+    /// `validateMessage` caps `data.length` at 8192 chars; the
+    /// Rust server enforces the same cap at handler time, not
+    /// here at the parser (a hard cap in serde would close the
+    /// transport on the first oversize frame; the handler can
+    /// error-reply and stay open).
+    ///
+    /// `session` is optional — Node treats absence as "the
+    /// client's currently-active session." The Rust server in
+    /// phase 0b accepts only the bound-session form (multi-
+    /// session is phase 1) and ignores the field when present
+    /// but matching the bound session.
+    #[serde(rename = "input")]
     Input {
-        #[serde(with = "serde_bytes")]
-        data: Vec<u8>,
+        data: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session: Option<String>,
     },
 
-    /// Window-resize notification. Only valid after `Attached`.
-    /// Forwarded to the session manager, which clamps and issues a
-    /// tmux `refresh-client -C`. Do NOT send on every keystroke — see
-    /// `session::dims` for the SIGWINCH-storm history.
-    Resize { cols: u16, rows: u16 },
+    /// Window-resize notification. Forwarded to the session
+    /// manager via `refresh-client -C cols x rows` through the
+    /// per-tile CM. See `session::dims` for the SIGWINCH-storm
+    /// history.
+    #[serde(rename = "resize")]
+    Resize {
+        cols: u16,
+        rows: u16,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session: Option<String>,
+    },
+
+    /// Pull missed bytes since `from_seq` (camelCase `fromSeq`).
+    /// In phase 0b the server streams `output` eagerly so the
+    /// SPA's pull-on-`data-available` flow is a backpressure
+    /// helper rather than the primary data path; the server
+    /// answers each `pull` with `pull-response` from the ring.
+    /// If `from_seq` is older than the ring's tail, the answer
+    /// is `pull-snapshot` instead.
+    #[serde(rename = "pull")]
+    Pull {
+        #[serde(rename = "fromSeq")]
+        from_seq: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session: Option<String>,
+    },
+
+    /// Subscribe to a session WITHOUT making it the active one.
+    /// Phase 0b deferred — handler returns an `error`. Multi-
+    /// session lands in phase 1 (issue #101).
+    #[serde(rename = "subscribe")]
+    Subscribe { session: String },
+
+    /// Inverse of `subscribe`. Phase 0b deferred.
+    #[serde(rename = "unsubscribe")]
+    Unsubscribe { session: String },
+
+    /// Switch the active session of an already-attached
+    /// connection. Phase 0b deferred — handler returns an
+    /// `error`.
+    #[serde(rename = "switch")]
+    Switch {
+        session: String,
+        cols: u16,
+        rows: u16,
+    },
+
+    /// Drift recovery: client detected its terminal contents
+    /// disagree with a `state-check` fingerprint and asks for a
+    /// fresh snapshot. Phase 0b deferred — handler returns an
+    /// `error`.
+    #[serde(rename = "resync")]
+    Resync { session: String },
+
+    /// Set the icon shown on a session's tab. Note the literal
+    /// HYPHEN in the wire string — Node's
+    /// `lib/websocket-validation.js` keys this exact form.
+    /// Phase 0b deferred.
+    #[serde(rename = "set-tab-icon")]
+    SetTabIcon {
+        session: String,
+        icon: Option<String>,
+    },
+
+    /// WebRTC SDP offer. Phase 0b stub: the parser accepts the
+    /// shape, the handler returns an `error` saying signaling is
+    /// not yet implemented. Required so unknown-message-type
+    /// validation works against the real Node SPA, which sends
+    /// these speculatively.
+    #[serde(rename = "rtc-offer")]
+    RtcOffer { sdp: String },
+
+    /// WebRTC ICE candidate. Phase 0b stub, see `RtcOffer`.
+    #[serde(rename = "rtc-ice-candidate")]
+    RtcIceCandidate {
+        #[serde(default)]
+        candidate: serde_json::Value,
+    },
 }
 
 /// Messages sent by the server to the client.
 ///
-/// Serialized as CBOR binary frames. Clients treat any message with
-/// an unknown `type` field as a forward-compat signal and log but
-/// don't reject — we want server → client additions to be deployable
-/// without client pinning.
+/// Serialized as JSON onto each outbound text WS frame. The Node
+/// SPA dispatches by reading `msg.type` (see
+/// `public/lib/ws-message-handlers.js`); any new variant is
+/// invisible to it without a corresponding frontend handler.
 ///
-/// **Asymmetry with `ClientMessage`.** `deny_unknown_fields` is
-/// deliberately OMITTED here. The strict boundary is INBOUND: the
-/// server rejects unknown client input because that's untrusted data.
-/// Outbound messages from the server are produced by our own code;
-/// relaxing this direction lets older Rust clients deserialize
-/// newer-server output without hard-failing on fields they don't
-/// understand.
+/// **Asymmetry with `ClientMessage`.** Outbound messages are
+/// produced by our own code, so we don't need the
+/// inbound-side strictness. The variant set here is the
+/// minimum-viable cutover surface — the rich Node-side
+/// broadcasts (`session-removed`, `session-renamed`,
+/// `child-count-update`, etc.) are deferred to phase 1 along
+/// with multi-session support; the SPA's session reconciler
+/// catches their absence on the next `/sessions` poll.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type")]
 pub enum ServerMessage {
-    /// Sent immediately after a successful transport upgrade. Tells
-    /// the client the connection is live and which protocol version
-    /// the server speaks. The client can refuse to proceed if the
-    /// version doesn't match its own expectation.
-    Hello { protocol_version: String },
+    /// Application-level heartbeat reply.
+    #[serde(rename = "pong")]
+    Pong,
 
-    /// Response to a client `Ping`. Echoes the same nonce.
-    Pong { nonce: u64 },
-
-    /// Confirms that this transport is bound to `session`, which has
-    /// been resized to the clamped `cols`/`rows`. The client should
-    /// use these (not what it requested) as the authoritative
-    /// dimensions for its local renderer.
+    /// Confirms the transport is bound to `session` and carries
+    /// the snapshot UTF-8 the SPA writes to xterm.js verbatim.
+    /// `data` is the shared headless's serialized contents at
+    /// attach time — already includes ANSI escapes for cursor,
+    /// color, scroll region.
     ///
-    /// `last_seq` is the pane's current `total_written` — the byte
-    /// counter the ring is at when this `Attached` ships. Fresh-
-    /// attach client seeds its local seq from here. Reconnect client
-    /// uses it as the upper bound of the replay they're about to
-    /// receive. `0` on a fresh pane (no output ever produced).
-    Attached {
+    /// **Wire-shape note.** The Rust server today doesn't
+    /// maintain a Node-style headless serializer; on a fresh
+    /// attach `data` is empty and the SPA's xterm.js renders an
+    /// empty buffer that the per-tile shell repopulates via the
+    /// post-attach Ctrl-L nudge (see `handler::serve_session`
+    /// for that flow). Reconnect with `from_seq` is the same
+    /// shape as Node's `pull-response`: the missed bytes come
+    /// down as `pull-response`, not as part of `attached`.
+    #[serde(rename = "attached")]
+    Attached { session: String, data: String },
+
+    /// Pull-cursor seed. Sent immediately after `attached` so
+    /// the SPA's `pullManager` knows where its byte counter
+    /// starts. Without this, the first `pull` request would
+    /// either re-fetch from byte 0 or skip live output.
+    #[serde(rename = "seq-init")]
+    SeqInit { session: String, seq: u64 },
+
+    /// Live PTY output. `from_seq` (`fromSeq` on the wire) is
+    /// the byte offset of the FIRST byte in `data`; `cursor` is
+    /// the offset of the byte AFTER the last (== `from_seq +
+    /// data.len()`). The SPA advances its pull cursor to
+    /// `cursor` on receipt.
+    ///
+    /// Field naming matches Node's
+    /// `lib/ws-manager.js:127-129`: `fromSeq` (camelCase) for
+    /// the first-byte offset, `cursor` for the next-byte offset.
+    /// Don't unify them under a single name; the Node SPA
+    /// reads both keys.
+    #[serde(rename = "output")]
+    Output {
         session: String,
-        cols: u16,
-        rows: u16,
-        last_seq: u64,
+        data: String,
+        #[serde(rename = "fromSeq")]
+        from_seq: u64,
+        cursor: u64,
     },
 
-    /// PTY output chunk. `seq` is the pane's `total_written`
-    /// (cumulative decoded byte offset) at the end of this chunk — a
-    /// per-PANE monotonic counter that continues across subscriber
-    /// displace/reconnect boundaries.
-    ///
-    /// **Seq contract.** `seq` is 1-based at the first-byte level:
-    /// the first outbound byte of a pane carries `end_seq = 1`; seq =
-    /// 0 is reserved to mean "no output produced yet" (used in
-    /// `Attached.last_seq` on a cold pane). Clients counting gaps see
-    /// monotonic progress across reconnect as long as the server
-    /// process has not restarted; a decrease means a fresh server
-    /// instance and the client must treat it as a hard reset.
-    Output {
-        #[serde(with = "serde_bytes")]
-        data: Vec<u8>,
+    /// Backpressure / catch-up nudge. Server emits when there's
+    /// new output that the client should pull. The SPA responds
+    /// with `pull { fromSeq: pullManager.cursor }`. Phase 0b
+    /// emits this at most once after `seq-init` (the SPA needs
+    /// it to kick its initial pull); subsequent live output
+    /// flows as direct `output` messages without the
+    /// notification.
+    #[serde(rename = "data-available")]
+    DataAvailable { session: String },
+
+    /// Reply to a client `pull`. `data` is the missed bytes;
+    /// `cursor` is the new cursor position. If `data` is the
+    /// empty string the cursor still advances (Node uses this
+    /// for the backpressure-bypass case).
+    #[serde(rename = "pull-response")]
+    PullResponse {
+        session: String,
+        data: String,
+        cursor: u64,
+    },
+
+    /// Reply to a client `pull` whose cursor was older than the
+    /// ring's tail, OR reply to a client `resync`. `data` is a
+    /// full pane snapshot the SPA replaces its terminal contents
+    /// with; `cursor` seeds the pull manager.
+    #[serde(rename = "pull-snapshot")]
+    PullSnapshot {
+        session: String,
+        data: String,
+        cursor: u64,
+    },
+
+    /// PTY exited. `code` is the wait-status (-1 if unknown).
+    /// The SPA shows an "exited" banner.
+    #[serde(rename = "exit")]
+    Exit { session: String, code: i32 },
+
+    /// Drift detection fingerprint. Phase 0b doesn't emit these
+    /// (no shared headless yet); the variant exists for the SPA
+    /// dispatcher's exhaustive match. Phase 1 wires it up.
+    #[serde(rename = "state-check")]
+    StateCheck {
+        session: String,
+        fingerprint: String,
         seq: u64,
     },
 
-    /// Protocol-level error. The server sends this right before
-    /// closing the transport so the client sees a concrete reason in
-    /// logs rather than an opaque WS close frame.
-    Error { code: String, message: String },
+    /// Server tells siblings to resize. Phase 0b doesn't emit
+    /// these (no multi-device support yet); variant exists for
+    /// dispatcher completeness.
+    #[serde(rename = "resize-sync")]
+    ResizeSync { cols: u16, rows: u16 },
 
-    /// Reconnect replay had a gap: the client's `resume_from_seq` was
-    /// older than the oldest byte still in the pane's ring.
-    /// `available_from_seq` is the oldest byte we can replay (>
-    /// the client's request); `last_seq` matches `Attached.last_seq`
-    /// for convenience. The client MUST clear its terminal / restart
-    /// its renderer before applying any subsequent `Output` — cursor
-    /// positions and in-flight escape sequences from the lost window
-    /// can't be inferred.
-    OutputGap {
-        available_from_seq: u64,
-        last_seq: u64,
+    /// Generic error envelope the SPA renders into its
+    /// connection-status UI. The Node server uses this for both
+    /// validation failures (`"Invalid message format"`) and
+    /// per-handler errors; Rust matches the loose contract.
+    /// `code` is omitted from the wire when not present so we
+    /// match Node's exact `{ type, message }` shape.
+    #[serde(rename = "error")]
+    Error {
+        message: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
     },
 }

--- a/crates/shared/tests/session_message.rs
+++ b/crates/shared/tests/session_message.rs
@@ -1,86 +1,86 @@
 //! Wire-shape regression tests for the session protocol types.
 //!
-//! These tests cover the serde behaviors documented in the
-//! `katulong_shared::wire` session-protocol section: tagged-enum
-//! shape, snake_case field names, `deny_unknown_fields` on inbound
-//! messages, byte-string encoding via `serde_bytes`, and CBOR
-//! round-trips that match what actually rides the wire.
+//! Phase 0b of the Node-cutover dropped CBOR for JSON over text
+//! frames so the existing Node SPA in `public/lib/...` can drive
+//! the Rust server unchanged. These tests pin the JSON shape — if
+//! a future refactor changes a field name, a `#[serde(rename = ...)]`
+//! string, or the variant tag, this file is the canary.
 //!
-//! Most assertions use JSON because it's human-readable; the serde
-//! attributes under test are format-agnostic, so a behavior proven
-//! with JSON also holds on CBOR. Two CBOR-specific tests at the end
-//! lock in the production encoding (the `serde_bytes` annotation
-//! flips byte-payload encoding format, so its contract has to be
-//! checked through CBOR specifically).
+//! The Node-side contract these mirror lives in:
+//! - `lib/ws-manager.js:124-585` (server → client message dispatch)
+//! - `lib/websocket-validation.js:33-109` (inbound validators)
+//! - `public/lib/ws-message-handlers.js:9-227` (frontend handlers)
 
-use katulong_shared::wire::{ClientMessage, ServerMessage, PROTOCOL_VERSION};
+use katulong_shared::wire::{ClientMessage, ServerMessage};
 use serde_json::{from_str, to_string};
+
+// ---------- ClientMessage ----------
 
 #[test]
 fn client_ping_serde_roundtrip() {
-    let m = ClientMessage::Ping { nonce: 42 };
+    let m = ClientMessage::Ping;
     let s = to_string(&m).unwrap();
-    assert_eq!(s, r#"{"type":"ping","nonce":42}"#);
+    assert_eq!(s, r#"{"type":"ping"}"#);
     let back: ClientMessage = from_str(&s).unwrap();
     assert_eq!(back, m);
 }
 
 #[test]
-fn server_hello_and_pong_serde_roundtrip() {
-    let hello = ServerMessage::Hello {
-        protocol_version: PROTOCOL_VERSION.into(),
-    };
-    let s = to_string(&hello).unwrap();
-    assert!(s.contains(r#""type":"hello""#));
-    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), hello);
-
-    let pong = ServerMessage::Pong { nonce: 7 };
-    let s = to_string(&pong).unwrap();
-    assert_eq!(s, r#"{"type":"pong","nonce":7}"#);
-    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), pong);
-}
-
-#[test]
-fn client_hello_ack_serde_roundtrip() {
-    let m = ClientMessage::HelloAck {
-        protocol_version: PROTOCOL_VERSION.into(),
-    };
-    let s = to_string(&m).unwrap();
-    assert!(s.contains(r#""type":"hello_ack""#));
-    assert_eq!(from_str::<ClientMessage>(&s).unwrap(), m);
-}
-
-#[test]
 fn client_attach_fresh_serde_roundtrip() {
+    // Node SPA's first frame after WS-open: `{type, session, cols, rows}`.
+    // No `fromSeq` on a fresh attach.
     let m = ClientMessage::Attach {
         session: "main".into(),
         cols: 120,
         rows: 40,
-        resume_from_seq: None,
+        from_seq: None,
     };
     let s = to_string(&m).unwrap();
     assert!(s.contains(r#""type":"attach""#));
+    assert!(s.contains(r#""session":"main""#));
+    assert!(s.contains(r#""cols":120"#));
+    assert!(s.contains(r#""rows":40"#));
     assert_eq!(from_str::<ClientMessage>(&s).unwrap(), m);
 }
 
 #[test]
-fn client_attach_resume_serde_roundtrip() {
-    let m = ClientMessage::Attach {
-        session: "main".into(),
-        cols: 80,
-        rows: 24,
-        resume_from_seq: Some(12345),
+fn client_attach_accepts_camelcase_from_seq_on_wire() {
+    // The SPA's pull manager keeps the cursor under `fromSeq` —
+    // matching `lib/ws-manager.js`'s `pull` handler. We accept
+    // the same spelling on `attach` so a reconnecting client can
+    // resume in one round-trip.
+    let m: ClientMessage = from_str(
+        r#"{"type":"attach","session":"main","cols":80,"rows":24,"fromSeq":12345}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        m,
+        ClientMessage::Attach {
+            session: "main".into(),
+            cols: 80,
+            rows: 24,
+            from_seq: Some(12345),
+        }
+    );
+}
+
+#[test]
+fn client_attach_accepts_snake_case_alias() {
+    // Forward-compat with the WASM frontend (frozen during
+    // cutover) which still emits `from_seq`. Once that crate is
+    // updated, the alias can be dropped.
+    let m: ClientMessage = from_str(
+        r#"{"type":"attach","session":"main","cols":80,"rows":24,"from_seq":7}"#,
+    )
+    .unwrap();
+    let ClientMessage::Attach { from_seq, .. } = m else {
+        panic!("expected Attach");
     };
-    let s = to_string(&m).unwrap();
-    assert!(s.contains(r#""resume_from_seq":12345"#));
-    assert_eq!(from_str::<ClientMessage>(&s).unwrap(), m);
+    assert_eq!(from_seq, Some(7));
 }
 
 #[test]
 fn client_attach_missing_resume_field_defaults_to_none() {
-    // Forward-compat: an older client that doesn't know about
-    // reconnect deserialises cleanly. `#[serde(default)]` on
-    // `Option` fills in `None`.
     let m: ClientMessage =
         from_str(r#"{"type":"attach","session":"main","cols":80,"rows":24}"#).unwrap();
     assert_eq!(
@@ -89,42 +89,46 @@ fn client_attach_missing_resume_field_defaults_to_none() {
             session: "main".into(),
             cols: 80,
             rows: 24,
-            resume_from_seq: None,
+            from_seq: None,
         }
     );
 }
 
 #[test]
-fn server_attached_serde_roundtrip() {
-    let m = ServerMessage::Attached {
-        session: "main".into(),
-        cols: 120,
-        rows: 40,
-        last_seq: 42,
+fn client_input_is_utf8_string_not_bytes() {
+    // The Node SPA sends `{type:"input", data: "<keystroke>"}` as
+    // a JS string. Pre-cutover Rust used `Vec<u8>` + serde_bytes
+    // for CBOR efficiency; phase 0b reverts to plain `String` so
+    // the SPA's `JSON.stringify` produces a string field, not an
+    // array of small integers. ANSI escapes are JSON-escaped as
+    // `\u001b...` on the wire; serde_json decodes them back to
+    // the U+001B code point.
+    let json = r#"{"type":"input","data":"\u001b[A"}"#;
+    let m: ClientMessage = from_str(json).unwrap();
+    let ClientMessage::Input { data, session } = m else {
+        panic!("expected Input");
     };
-    let s = to_string(&m).unwrap();
-    assert!(s.contains(r#""type":"attached""#));
-    assert!(s.contains(r#""last_seq":42"#));
-    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
+    assert_eq!(data, "\u{1b}[A"); // ANSI cursor-up — survives JSON unchanged
+    assert!(session.is_none());
 }
 
 #[test]
-fn server_output_gap_serde_roundtrip() {
-    let m = ServerMessage::OutputGap {
-        available_from_seq: 100,
-        last_seq: 500,
+fn client_input_with_optional_session_round_trips() {
+    let m = ClientMessage::Input {
+        data: "ls\n".into(),
+        session: Some("work".into()),
     };
     let s = to_string(&m).unwrap();
-    assert!(s.contains(r#""type":"output_gap""#));
-    assert!(s.contains(r#""available_from_seq":100"#));
-    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
+    let back: ClientMessage = from_str(&s).unwrap();
+    assert_eq!(back, m);
 }
 
 #[test]
-fn client_resize_serde_roundtrip() {
+fn client_resize_round_trips() {
     let m = ClientMessage::Resize {
         cols: 80,
         rows: 24,
+        session: None,
     };
     let s = to_string(&m).unwrap();
     assert!(s.contains(r#""type":"resize""#));
@@ -132,127 +136,246 @@ fn client_resize_serde_roundtrip() {
 }
 
 #[test]
-fn server_error_serde_roundtrip() {
-    let m = ServerMessage::Error {
-        code: "protocol_version_mismatch".into(),
-        message: "expected katulong/0.1, got katulong/0.2".into(),
-    };
-    let s = to_string(&m).unwrap();
-    assert!(s.contains(r#""type":"error""#));
-    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
-}
-
-#[test]
-fn unknown_type_is_rejected() {
-    // Server adds a new variant; an older client shouldn't see a
-    // silent "ClientMessage::Unknown" — it should fail to parse, so
-    // the server knows the client doesn't speak this protocol
-    // version.
-    let err = from_str::<ClientMessage>(r#"{"type":"output","data":[1,2,3],"seq":1}"#);
-    assert!(err.is_err(), "unknown type must fail deserialization");
-}
-
-#[test]
-fn extra_fields_are_rejected() {
-    // `deny_unknown_fields` catches clients that send extras. This is
-    // the Node `9dc7c78` scar: untrusted JSON flowing into business
-    // logic is how type-confusion bugs sneak in.
-    let err = from_str::<ClientMessage>(r#"{"type":"ping","nonce":1,"extra":2}"#);
-    assert!(err.is_err(), "unknown fields must fail deserialization");
-}
-
-#[test]
-fn missing_type_tag_is_rejected() {
-    let err = from_str::<ClientMessage>(r#"{"nonce":1}"#);
-    assert!(err.is_err(), "missing type discriminator must fail");
-}
-
-#[test]
-fn wrong_field_type_is_rejected() {
-    // `nonce` is u64 — a string must not coerce.
-    let err = from_str::<ClientMessage>(r#"{"type":"ping","nonce":"42"}"#);
-    assert!(err.is_err(), "string where u64 expected must fail");
-}
-
-#[test]
-fn resize_oversize_value_parses_then_server_clamps() {
-    // Serde deserializes any u16 value; clamping is the session
-    // layer's responsibility via `session::dims::clamp_dims`. This
-    // test is a reminder that the PARSER accepts the number — any
-    // out-of-range value must be caught downstream, not here.
-    let m: ClientMessage = from_str(r#"{"type":"resize","cols":9999,"rows":9999}"#).unwrap();
+fn client_pull_uses_camelcase_from_seq_on_wire() {
+    let m: ClientMessage = from_str(r#"{"type":"pull","fromSeq":42}"#).unwrap();
     assert_eq!(
         m,
-        ClientMessage::Resize {
-            cols: 9999,
-            rows: 9999
+        ClientMessage::Pull {
+            from_seq: 42,
+            session: None,
+        }
+    );
+    let s = to_string(&m).unwrap();
+    assert!(
+        s.contains(r#""fromSeq":42"#),
+        "outbound JSON must use camelCase fromSeq; got {s}"
+    );
+}
+
+#[test]
+fn client_set_tab_icon_uses_literal_hyphen() {
+    // `lib/websocket-validation.js` keys the type as the literal
+    // string `"set-tab-icon"` — a hyphen, not snake_case. The
+    // serde rename annotation enforces the wire shape.
+    let m: ClientMessage = from_str(
+        r#"{"type":"set-tab-icon","session":"main","icon":"🐛"}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        m,
+        ClientMessage::SetTabIcon {
+            session: "main".into(),
+            icon: Some("\u{1f41b}".into()),
         }
     );
 }
 
 #[test]
-fn cbor_client_message_roundtrip() {
-    // Production-wire check. CBOR is what actually rides the
-    // transport; JSON is only the test-readability medium for the
-    // other cases.
-    let original = ClientMessage::Ping { nonce: 0xDEAD_BEEF };
-    let mut buf = Vec::new();
-    ciborium::ser::into_writer(&original, &mut buf).unwrap();
-    let back: ClientMessage = ciborium::de::from_reader(&buf[..]).unwrap();
-    assert_eq!(back, original);
-}
-
-#[test]
-fn cbor_server_message_roundtrip() {
-    let original = ServerMessage::Hello {
-        protocol_version: PROTOCOL_VERSION.to_string(),
+fn client_set_tab_icon_accepts_null_icon() {
+    let m: ClientMessage = from_str(
+        r#"{"type":"set-tab-icon","session":"main","icon":null}"#,
+    )
+    .unwrap();
+    let ClientMessage::SetTabIcon { icon, .. } = m else {
+        panic!("expected SetTabIcon");
     };
-    let mut buf = Vec::new();
-    ciborium::ser::into_writer(&original, &mut buf).unwrap();
-    let back: ServerMessage = ciborium::de::from_reader(&buf[..]).unwrap();
-    assert_eq!(back, original);
-
-    let original = ServerMessage::Pong { nonce: 17 };
-    let mut buf = Vec::new();
-    ciborium::ser::into_writer(&original, &mut buf).unwrap();
-    let back: ServerMessage = ciborium::de::from_reader(&buf[..]).unwrap();
-    assert_eq!(back, original);
+    assert!(icon.is_none());
 }
 
 #[test]
-fn cbor_input_encodes_data_as_byte_string() {
-    // The `serde_bytes` annotation is load-bearing for wire
-    // efficiency: without it, `Vec<u8>` encodes as a CBOR array of
-    // small integers (each byte takes 1–2 bytes of overhead). With
-    // it, CBOR major-type-2 byte-string carries the payload
-    // literally.
-    //
-    // Empirical check: a 256-byte payload should encode to well
-    // under 300 bytes total (a few bytes of envelope + the 256 raw
-    // bytes + small length prefix). Array encoding would land north
-    // of 400 bytes because each 0..255 integer takes 1–2 bytes.
-    let data = vec![0xABu8; 256];
-    let original = ClientMessage::Input { data: data.clone() };
-    let mut buf = Vec::new();
-    ciborium::ser::into_writer(&original, &mut buf).unwrap();
-    assert!(
-        buf.len() < 300,
-        "Input data field must encode as byte-string, \
-         not array-of-int; encoded {} bytes for 256 payload bytes",
-        buf.len()
+fn client_subscribe_round_trips() {
+    let m = ClientMessage::Subscribe {
+        session: "main".into(),
+    };
+    let s = to_string(&m).unwrap();
+    assert_eq!(s, r#"{"type":"subscribe","session":"main"}"#);
+    assert_eq!(from_str::<ClientMessage>(&s).unwrap(), m);
+}
+
+#[test]
+fn client_switch_round_trips() {
+    let m = ClientMessage::Switch {
+        session: "alt".into(),
+        cols: 100,
+        rows: 30,
+    };
+    let s = to_string(&m).unwrap();
+    assert_eq!(from_str::<ClientMessage>(&s).unwrap(), m);
+}
+
+#[test]
+fn client_resync_round_trips() {
+    let m = ClientMessage::Resync {
+        session: "main".into(),
+    };
+    let s = to_string(&m).unwrap();
+    assert_eq!(s, r#"{"type":"resync","session":"main"}"#);
+    assert_eq!(from_str::<ClientMessage>(&s).unwrap(), m);
+}
+
+#[test]
+fn client_unknown_type_is_rejected() {
+    // The Node validator rejects unrecognised types with
+    // `"Invalid message format"`; the Rust parser does the same
+    // implicitly via serde's tagged-enum rejection.
+    let err = from_str::<ClientMessage>(r#"{"type":"output","data":"x"}"#);
+    assert!(err.is_err(), "unknown type must fail deserialization");
+}
+
+#[test]
+fn client_missing_type_tag_is_rejected() {
+    let err = from_str::<ClientMessage>(r#"{"nonce":1}"#);
+    assert!(err.is_err(), "missing type discriminator must fail");
+}
+
+#[test]
+fn client_wrong_field_type_is_rejected() {
+    // `cols` is u16 — a string must not coerce.
+    let err = from_str::<ClientMessage>(
+        r#"{"type":"attach","session":"main","cols":"80","rows":24}"#,
     );
-    let back: ClientMessage = ciborium::de::from_reader(&buf[..]).unwrap();
-    assert_eq!(back, ClientMessage::Input { data });
+    assert!(err.is_err(), "string where u16 expected must fail");
 }
 
 #[test]
-fn cbor_output_roundtrip_preserves_seq_and_bytes() {
-    let original = ServerMessage::Output {
-        data: vec![0x01, 0x1b, 0x5b, 0x48],
+fn client_resize_oversize_value_parses_then_handler_clamps() {
+    // Serde accepts any u16 value; clamping is handler-side via
+    // `session::dims::clamp_dims`. This test pins that contract:
+    // the parser does NOT range-check.
+    let m: ClientMessage =
+        from_str(r#"{"type":"resize","cols":9999,"rows":9999}"#).unwrap();
+    assert!(matches!(
+        m,
+        ClientMessage::Resize {
+            cols: 9999,
+            rows: 9999,
+            ..
+        }
+    ));
+}
+
+// ---------- ServerMessage ----------
+
+#[test]
+fn server_pong_round_trips() {
+    let m = ServerMessage::Pong;
+    let s = to_string(&m).unwrap();
+    assert_eq!(s, r#"{"type":"pong"}"#);
+    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
+}
+
+#[test]
+fn server_attached_carries_string_data() {
+    // The SPA reads `msg.data` and writes it directly into
+    // xterm.js — so it must be a JSON string with raw ANSI
+    // escapes preserved.
+    let m = ServerMessage::Attached {
+        session: "main".into(),
+        data: "\u{1b}[2J$ ".into(),
+    };
+    let s = to_string(&m).unwrap();
+    assert!(s.contains(r#""type":"attached""#));
+    assert!(s.contains(r#""session":"main""#));
+    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
+}
+
+#[test]
+fn server_seq_init_round_trips() {
+    let m = ServerMessage::SeqInit {
+        session: "main".into(),
         seq: 42,
     };
-    let mut buf = Vec::new();
-    ciborium::ser::into_writer(&original, &mut buf).unwrap();
-    let back: ServerMessage = ciborium::de::from_reader(&buf[..]).unwrap();
-    assert_eq!(back, original);
+    let s = to_string(&m).unwrap();
+    assert_eq!(s, r#"{"type":"seq-init","session":"main","seq":42}"#);
+    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
+}
+
+#[test]
+fn server_output_uses_camelcase_from_seq_and_cursor() {
+    // Pinned to `lib/ws-manager.js:127-129`: `fromSeq` (camelCase)
+    // and `cursor`. Renaming either is a wire break with the SPA.
+    let m = ServerMessage::Output {
+        session: "main".into(),
+        data: "hi".into(),
+        from_seq: 10,
+        cursor: 12,
+    };
+    let s = to_string(&m).unwrap();
+    assert!(
+        s.contains(r#""fromSeq":10"#),
+        "outbound JSON must use camelCase fromSeq; got {s}"
+    );
+    assert!(s.contains(r#""cursor":12"#));
+    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
+}
+
+#[test]
+fn server_data_available_round_trips() {
+    let m = ServerMessage::DataAvailable {
+        session: "main".into(),
+    };
+    let s = to_string(&m).unwrap();
+    assert_eq!(s, r#"{"type":"data-available","session":"main"}"#);
+    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
+}
+
+#[test]
+fn server_pull_response_round_trips() {
+    let m = ServerMessage::PullResponse {
+        session: "main".into(),
+        data: "tail".into(),
+        cursor: 100,
+    };
+    let s = to_string(&m).unwrap();
+    assert!(s.contains(r#""type":"pull-response""#));
+    assert!(s.contains(r#""cursor":100"#));
+    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
+}
+
+#[test]
+fn server_pull_snapshot_round_trips() {
+    let m = ServerMessage::PullSnapshot {
+        session: "main".into(),
+        data: "fresh".into(),
+        cursor: 999,
+    };
+    let s = to_string(&m).unwrap();
+    assert!(s.contains(r#""type":"pull-snapshot""#));
+    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
+}
+
+#[test]
+fn server_exit_round_trips() {
+    let m = ServerMessage::Exit {
+        session: "main".into(),
+        code: -1,
+    };
+    let s = to_string(&m).unwrap();
+    assert_eq!(s, r#"{"type":"exit","session":"main","code":-1}"#);
+    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
+}
+
+#[test]
+fn server_error_omits_code_when_none() {
+    // Node's error frames are `{type, message}` with no `code`
+    // field. We `skip_serializing_if = "Option::is_none"` so the
+    // null-vs-absent distinction matches the wire that the SPA
+    // is parsing.
+    let m = ServerMessage::Error {
+        message: "Invalid message format".into(),
+        code: None,
+    };
+    let s = to_string(&m).unwrap();
+    assert_eq!(s, r#"{"type":"error","message":"Invalid message format"}"#);
+}
+
+#[test]
+fn server_error_with_code_round_trips() {
+    let m = ServerMessage::Error {
+        message: "oversubscribed".into(),
+        code: Some("session_oversubscribed".into()),
+    };
+    let s = to_string(&m).unwrap();
+    assert!(s.contains(r#""code":"session_oversubscribed""#));
+    assert_eq!(from_str::<ServerMessage>(&s).unwrap(), m);
 }

--- a/test/e2e-rust/webauthn.e2e.js
+++ b/test/e2e-rust/webauthn.e2e.js
@@ -407,7 +407,17 @@ test.describe.serial("WebAuthn UI happy paths", () => {
     await context.close();
   });
 
-  test("an active session restores after a page reload", async ({
+  // Skipped during the Node-cutover (phase 0b). This test
+  // exercises the Rust WASM frontend's WS handshake + xterm
+  // attach flow; phase 0b reshaped the Rust server's WS
+  // protocol to be byte-compatible with the Node SPA in
+  // `public/lib/...`, which means the WASM client's
+  // `crates/web/src/ws.rs` (still on the pre-cutover CBOR /
+  // Hello-handshake protocol) no longer talks to the server.
+  // The WASM frontend is FROZEN during the cutover; this test
+  // resumes once a future slice ports its WS code to the JSON
+  // wire.
+  test.skip("an active session restores after a page reload", async ({
     browser,
     baseURL,
   }) => {


### PR DESCRIPTION
## STATUS: PARKED 2026-05-05 — kept open as documentation, not for merge

The Rust port has been parked. **Do not merge this PR.** It depends on PR #707 (also parked). Both are kept open as a reference for the wire contract between Node frontend and Rust server. `crates/shared/src/wire.rs` on this branch is the clearest articulation of the WS protocol that exists.

See PR #707's description (or the auto-memory file `project_rust_port_parked.md`) for the parking rationale and un-park triggers.

---

## Summary

Phase 0b of the Node→Rust cutover: rewrite the Rust server's `/ws` endpoint to be byte-compatible with the Node SPA's WS client in `public/lib/ws-message-handlers.js`. After this lands, the existing Node frontend can connect to the Rust server unmodified and drive a terminal end-to-end.

**Depends on PR #707 (`cutover/phase-0a`) merging first.** This branch is `cutover/phase-0b` off `cutover/phase-0a`'s HEAD; the PR base is `cutover/phase-0a` so the diff stays focused on the WS work.

### What changes

- **Wire encoding flips CBOR → JSON over text frames.** Node's SPA sends/receives JSON; the Rust server now matches. `serde_bytes`-backed `Vec<u8>` byte-strings on `Input`/`Output`/etc. become plain `String` (UTF-8) — Node's parser already decodes tmux's octal-escape encoding into JS strings before buffering, so the wire has always carried strings.
- **Hello/HelloAck handshake removed.** Node's SPA never spoke that; the connection now starts in `AwaitingAttach` the moment the WS opens. `PROTOCOL_VERSION` constant gone.
- **Message catalog renamed to Node's exact strings.** `attach`, `attached`, `output { fromSeq, cursor }` (camelCase), `seq-init`, `data-available`, `pull-response`, `pull-snapshot`, `set-tab-icon` (literal hyphen), `pong` (no nonce), etc.
- **`Pull` is wired** as a real handler (reads ring via `OutputRouter::peek_resume`, replies `pull-response` or `pull-snapshot`). Multi-session messages (`subscribe`, `switch`, `unsubscribe`, `resync`, `set-tab-icon`) and WebRTC signaling stubs reply with a non-fatal `error { code: not_yet_implemented }` and keep the transport open.
- **WASM frontend (`crates/web`) excluded from workspace `members`.** Frozen during cutover; its `crates/web/src/ws.rs` still speaks the pre-cutover protocol and doesn't compile against the new shared types.
- **Rust e2e**: `test/e2e-rust/webauthn.e2e.js`'s "session-restore-on-reload" test is `test.skip`-ed.

Three commits to keep the diff reviewable:

1. `phase 0b step 1 — JSON wire + Node message names` — types, transport pump, dependencies.
2. `phase 0b step 2 — handler speaks Node-frontend wire` — `serve_session` state machine, replay translation, Pull handler, error reply paths.
3. `phase 0b step 3 — wire-shape tests + freeze WASM crate` — contract tests, e2e skip, workspace exclusion.

## Test plan

- [x] `cargo build --release --workspace` clean (with `crates/web` excluded as documented).
- [x] `cargo test --release -p katulong-server` — 171 lib tests + 5 websocket integration tests + 24 auth-routes tests + 27 new ws_node_frontend contract tests, all green.
- [x] `cargo test -p katulong-shared` — 28 protocol-shape tests including the new JSON wire pinning, all green.
- [x] Pre-push hook (full Node test suite) passed on push.
- [ ] Operator smoke test — never executed; not relevant given park.

## Caveats (no longer relevant — port parked)

- Phase 0b sends `attached { data: "" }` with empty data; the post-attach Ctrl-L nudge repaints the prompt within milliseconds.
- Multi-session is out of scope (would have been phase 1).
- WebRTC signaling returns `error { code: not_yet_implemented }`.