### PR TITLE
feat(ollama): ollamaPeerExclusive — drop local fallbacks when set

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -372,6 +372,31 @@ export class ConfigManager {
   }
 
   /**
+   * Whether the configured peer is the ONLY allowed LLM backend.
+   *
+   * Default false preserves the historical cascade: peer-bridge first,
+   * then the local `127.0.0.1:11434` Ollama daemon as a fallback. When
+   * true (and a peerUrl is set), the local-daemon fallbacks are dropped
+   * entirely — if the peer is down, LLM calls fail rather than silently
+   * routing around it.
+   *
+   * Set this on a host whose local Ollama is fronted by a queue/bridge
+   * you don't want bypassed: a failed peer must NOT fall back to hitting
+   * the daemon directly (which would defeat the bridge's pause/throttle
+   * controls and run the GPU hot outside the operator's view).
+   */
+  getOllamaPeerExclusive() {
+    return this._get('ollamaPeerExclusive', false) === true;
+  }
+
+  async setOllamaPeerExclusive(value) {
+    if (typeof value !== "boolean") {
+      throw new Error("ollamaPeerExclusive must be a boolean");
+    }
+    await this.withLock(() => this._set('ollamaPeerExclusive', value));
+  }
+
+  /**
    * Get the URL where sipag's web UI lives, or null if unset.
    * The sipag tile uses this to decide where to point its iframe. When
    * sipag runs on the same host as this katulong (the common case), set

--- a/server.js
+++ b/server.js
@@ -316,8 +316,17 @@ const callOllama = createOllamaClient({
         model: "gemma4:31b",
       });
     }
-    list.push({ name: "local-31b",    host: "http://127.0.0.1:11434", authToken: null, model: "gemma4:31b" });
-    list.push({ name: "local-cloud",  host: "http://127.0.0.1:11434", authToken: null, model: "gemma4:31b-cloud" });
+    // Local-daemon fallbacks hit Ollama on 127.0.0.1:11434 DIRECTLY,
+    // bypassing any bridge/queue fronting it. When the peer is marked
+    // exclusive, drop them: a host whose local Ollama is queue-fronted
+    // must not silently route around the queue when the peer is down —
+    // that defeats the operator's pause/throttle controls and runs the
+    // GPU hot. With no peer configured, the fallbacks remain the only
+    // backends, so the exclusive flag is a no-op there.
+    if (!(peerUrl && configManager.getOllamaPeerExclusive())) {
+      list.push({ name: "local-31b",    host: "http://127.0.0.1:11434", authToken: null, model: "gemma4:31b" });
+      list.push({ name: "local-cloud",  host: "http://127.0.0.1:11434", authToken: null, model: "gemma4:31b-cloud" });
+    }
     return list;
   },
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1106,6 +1106,51 @@ describe("ConfigManager", () => {
     });
   });
 
+  describe("ollamaPeerExclusive", () => {
+    beforeEach(() => {
+      configManager.initialize();
+    });
+
+    it("defaults to false (local fallbacks allowed)", () => {
+      assert.strictEqual(configManager.getOllamaPeerExclusive(), false);
+    });
+
+    it("round-trips true", async () => {
+      await configManager.setOllamaPeerExclusive(true);
+      assert.strictEqual(configManager.getOllamaPeerExclusive(), true);
+    });
+
+    it("round-trips back to false", async () => {
+      await configManager.setOllamaPeerExclusive(true);
+      await configManager.setOllamaPeerExclusive(false);
+      assert.strictEqual(configManager.getOllamaPeerExclusive(), false);
+    });
+
+    it("rejects non-boolean values", async () => {
+      await assert.rejects(
+        async () => configManager.setOllamaPeerExclusive("yes"),
+        /must be a boolean/,
+      );
+    });
+
+    it("persists across reload", async () => {
+      await configManager.setOllamaPeerExclusive(true);
+      const reloaded = new ConfigManager(testDir);
+      reloaded.initialize();
+      assert.strictEqual(reloaded.getOllamaPeerExclusive(), true);
+    });
+
+    it("coerces a non-true stored value to false", async () => {
+      // Defends the cascade's safety check: only an explicit `true`
+      // enables exclusivity, so a corrupt/legacy value can't silently
+      // strip the local fallbacks.
+      await configManager.setOllamaPeerUrl("https://bus.example.com");
+      const raw = new ConfigManager(testDir);
+      raw.initialize();
+      assert.strictEqual(raw.getOllamaPeerExclusive(), false);
+    });
+  });
+
   describe("getConfig redaction", () => {
     beforeEach(() => {
       configManager.initialize();


### PR DESCRIPTION
## Why

The LLM cascade always appended two `127.0.0.1:11434` fallbacks (`local-31b`, `local-cloud`) after the configured peer. On a host whose local Ollama is fronted by a queue/bridge, a failed or **paused** peer silently routes generation straight to the daemon — bypassing the bridge's pause/throttle controls and running the GPU hot outside the operator's view. (Observed in the wild: a host whose peer pointed at a bridge port that wasn't live fell back to the daemon on every call and the operator's pause did nothing.)

## What

Add an `ollamaPeerExclusive` config flag (default `false`, fully backward compatible). When `true` **and** a `peerUrl` is set, the local-daemon fallbacks are dropped — if the peer is down, LLM calls fail rather than bypass it.

- `lib/config.js`: `getOllamaPeerExclusive` / `setOllamaPeerExclusive` (boolean; getter coerces any non-`true` stored value to `false`, so a corrupt/legacy value can't silently strip the fallbacks).
- `server.js`: `resolveBackends` skips the `:11434` backends when the peer is exclusive. No-op when no peer is configured (the fallbacks are then the only backends).

## Behavior

| peerUrl | exclusive | backends |
|---|---|---|
| set | `false` (default) | `peer-bridge`, `local-31b`, `local-cloud` |
| set | `true` | `peer-bridge` only |
| unset | any | `local-31b`, `local-cloud` |

## Tests

6 new cases in `test/config.test.js` (default, round-trip, non-boolean rejection, persistence, non-true coercion). Targeted suite: **235 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)